### PR TITLE
feat(source): persist authenticated source selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable user-facing changes are recorded here. CodeNib follows
 
 ## [Unreleased]
 
-## [0.2.2] - 2026-08-20
+## [0.2.2] - 2026-08-21
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,43 @@ All notable user-facing changes are recorded here. CodeNib follows
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-08-20
+
+### Added
+
+- Persistent, exact repository-relative source exclusions through
+  `--exclude-dir` and `--clear-exclude-dirs`, with one recorded policy reused
+  by CodeGraph, indexing, MCP, Wiki, Web, and public compiler entry points.
+- Manifest 1.2 source-selection identities and builder receipts, while retaining
+  strict read compatibility for manifest 1.1 artifacts.
+- Authenticated optional SCIP occurrence-sidecar receipts bound to the same
+  owned symbol-graph generation as `graph.pkl`.
+
+### Changed
+
+- Authenticated indexing now accepts absolute symbolic links only when their
+  lexical target remains inside the same pinned repository authority. Expo,
+  CocoaPods, and pnpm-style contained link layouts no longer require a broad
+  default-ignore rule.
+- CodeGraph status reports the effective source selection, and Wiki, publish,
+  doctor, and toolchain flows reuse it instead of silently widening the source
+  surface.
+- Manifest-bound C and C++ queries temporarily use the verified persisted
+  symbol graph instead of consuming project-local clangd postings directly.
+
+### Security
+
+- Source paths, graph artifacts, native query routes, and retained manifests
+  are checked against the same authenticated source selection before they can
+  be published or served. Unproven native routes fail closed to the persisted
+  graph.
+- Zoekt builds use a fixed commit-tree contract, private generation
+  publication, and an authenticated shard-tree receipt; custom exclusions are
+  rejected until the backend can prove that narrower surface end to end.
+- Authenticated MCP `search_zoekt` serving uses a retained Linux `/proc`
+  descriptor snapshot. Other platforms fail closed until they have an
+  equivalent immutable runtime handoff.
+
 ## [0.2.1] - 2026-08-14
 
 ### Added
@@ -156,7 +193,8 @@ All notable user-facing changes are recorded here. CodeNib follows
 - Prepared secretless PyPI publishing through a dedicated GitHub Actions OIDC
   workflow.
 
-[Unreleased]: https://github.com/sysevol-ai/CodeNib/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/sysevol-ai/CodeNib/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/sysevol-ai/CodeNib/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/sysevol-ai/CodeNib/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/sysevol-ai/CodeNib/compare/v0.1.0...v0.2.0
 [0.2.0a2]: https://github.com/sysevol-ai/CodeNib/compare/620a82d...78e12ac

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ SPDX-License-Identifier: Apache-2.0
     <a href="https://docs.codenib.ai/codegraph/#one-command-setup"><img src="https://img.shields.io/badge/Codex-000?logo=openai&amp;logoColor=fff" alt="Codex supported"></a>
     <a href="https://github.com/sysevol-ai/CodeNib/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0"></a>
     <a href="https://github.com/sysevol-ai/CodeNib/blob/main/pyproject.toml"><img src="https://img.shields.io/badge/Python-3.10%2B-3776AB.svg" alt="Python 3.10+"></a>
-    <img src="https://img.shields.io/badge/Release-0.2.1-2563EB.svg" alt="CodeNib 0.2.1">
+    <img src="https://img.shields.io/badge/Release-0.2.2-2563EB.svg" alt="CodeNib 0.2.2">
   </p>
 </div>
 
 ```bash
-python -m pip install "codenib[graph,mcp]==0.2.1"
+python -m pip install "codenib[graph,mcp]==0.2.2"
 codenib codegraph init /path/to/your/repo
 ```
 
@@ -56,6 +56,11 @@ does not write configuration or indexes into the target repository.
 
 ## News
 
+- **2026-08-20 — CodeNib 0.2.2 repository source authority.** Authenticated
+  indexing now admits absolute symlinks only when they resolve inside the same
+  pinned checkout, and exact root-relative exclusions persist across indexing,
+  CodeGraph, MCP, Wiki, and Web runtimes.
+  [Release notes](https://docs.codenib.ai/releases/0.2.2/)
 - **2026-08-13 — CodeNib 0.2.1 CodeGraph onboarding.** One command prepares a
   repository graph and connects it to Codex and Claude Code, with idempotent
   status, safe uninstall, and installed-wheel MCP graph verification.
@@ -89,23 +94,23 @@ does not write configuration or indexes into the target repository.
 
 | Layer | Responsibility |
 |---|---|
-| Incremental compiler | Chunk source and materialize BM25, dense, graph, and navigation views; reuse or repair supported artifacts and rebuild when an update cannot be admitted |
+| View compiler | Chunk source and materialize BM25, dense, graph, and navigation views; reuse current artifacts and atomically rebuild affected views |
 | View manifest | Record repository identity, source fingerprint, builder profile, capabilities, status, and artifact location independently for each view |
 | Context serving | Execute lexical, semantic, hybrid, reranked, and structural query plans while preserving repository-relative source locations |
 | Agent runtime | Expose capability-aware MCP and LSP-shaped tools, assemble bounded evidence, and return citations that agents and humans can inspect |
 
 ```text
 repository change
-  -> materialize or repair affected views
+  -> reuse current views or rebuild affected views
   -> publish a capability-bearing manifest
   -> plan repository queries
   -> deliver bounded, source-linked context
 ```
 
-On a later commit, CodeNib can reuse unchanged vector content and patch
-supported graph transitions at file or symbol granularity. Unsupported,
-inconsistent, or unverified transitions fall back to a fresh build instead of
-publishing a partially updated view.
+On a later commit, CodeNib reuses views whose source and builder identities are
+still current. A requested view affected by source or policy changes currently
+rebuilds in an isolated generation; file- and symbol-level delta repair remains
+disabled until it can use the same pinned source authority.
 
 ## Quickstart
 
@@ -113,7 +118,7 @@ Requires Python 3.10+ and Git. For an agent-ready CodeGraph with no model or API
 key, install the graph and MCP extras and run one command:
 
 ```bash
-python -m pip install "codenib[graph,mcp]==0.2.1"
+python -m pip install "codenib[graph,mcp]==0.2.2"
 codenib codegraph init /path/to/repository
 ```
 
@@ -124,16 +129,42 @@ Run `codenib codegraph status /path/to/repository` to diagnose the complete
 path or `codenib codegraph uninstall /path/to/repository` to remove only the
 managed client registrations. The index remains reusable.
 
+Repositories can persist exact root-relative subtree exclusions when generated
+or vendored content should not be indexed:
+
+```bash
+codenib codegraph init /path/to/repository \
+  --exclude-dir ios/Pods \
+  --exclude-dir generated/api
+```
+
+Paths use repository-relative POSIX spelling (`/`) and name exact subtrees,
+not globs. Repeat `--exclude-dir` to replace the complete custom exclusion set. Later
+`init` and `index` runs reuse that policy from the manifest; use
+`--clear-exclude-dirs` to return to the default source surface. CodeNib does not
+implicitly treat `.gitignore` as an indexing policy, because tracked and local
+ignored source can still be intentional input.
+
+Zoekt supports the default source policy only when its fixed commit tree
+exactly matches the authenticated checkout and contains no tracked path that
+the default policy excludes. It does not currently support a non-empty custom
+exclusion set. A command that explicitly requests the `zoekt` view, including
+`--preset full`, fails closed when either condition is unmet; use the
+CodeGraph, `fast`, or semantic paths instead.
+In 0.2.2 the authenticated MCP `search_zoekt` runtime requires Linux `/proc`
+so the child process can inherit the exact retained shard generation; other
+platforms fail closed instead of reopening a mutable shard path.
+
 For a browser Wiki with hybrid BM25+dense retrieval, install the semantic extra:
 
 ```bash
-python -m pip install "codenib[semantic]==0.2.1"
+python -m pip install "codenib[semantic]==0.2.2"
 codenib wiki /path/to/repository
 ```
 
 Both paths keep reusable state under `~/.codenib/repositories` and leave the
 target checkout unchanged. Set `CODENIB_HOME` to relocate state. The
-[0.2.1 release notes](https://docs.codenib.ai/releases/0.2.1/) record the
+[0.2.2 release notes](https://docs.codenib.ai/releases/0.2.2/) record the
 upgrade boundary and installed-product evidence.
 
 Preview the CodeGraph operations without installing, indexing, or configuring
@@ -148,7 +179,7 @@ only their package-level providers; operating-system and project prerequisites
 remain explicit:
 
 ```bash
-python -m pip install "codenib[graph]==0.2.1"
+python -m pip install "codenib[graph]==0.2.2"
 codenib toolchain install /path/to/repository --scope graph
 codenib doctor /path/to/repository --require graph
 ```
@@ -166,7 +197,7 @@ provider credential; interactive Ask and runtime graph exploration remain on
 the local or MCP serving path.
 
 For a repository-hosted Wiki, CodeNib also ships a reusable GitHub workflow
-that incrementally builds the same manifest, deploys the static site to Pages,
+that builds or reuses the same manifest, deploys the static site to Pages,
 and uploads the matching commit-addressed context artifact. Its default
 `semantic` route builds BM25 and vector views with a cached local Hugging Face
 model and needs no API key. An explicit `fast` route avoids the model download;
@@ -190,7 +221,7 @@ The recommended path configures installed Codex and Claude Code clients through
 their native CLIs:
 
 ```bash
-python -m pip install "codenib[graph,mcp]==0.2.1"
+python -m pip install "codenib[graph,mcp]==0.2.2"
 codenib codegraph init /path/to/repository
 ```
 
@@ -220,7 +251,7 @@ capabilities, loaded views, fusion, graph, and reranking trace.
 
 | Surface | Purpose |
 |---|---|
-| Incremental compiler | Build independently managed views, reuse unchanged content, repair supported transitions, and conservatively rebuild outside those boundaries |
+| View compiler | Build independently managed views, reuse current generations, and atomically rebuild changed views under one source identity |
 | Agent context runtime | Plan capability-aware retrieval and navigation, then assemble bounded source-linked evidence |
 | Retrieval | BM25, dense-vector, regex/trigram, Zoekt, fusion, and reranking paths; see the [validated model matrix](https://docs.codenib.ai/rag_ops/#validated-models) |
 | Structural context | SCIP/LSP-backed symbol graphs with source locations and typed edges |
@@ -269,7 +300,7 @@ running the credential- or toolchain-dependent tiers.
 
 ## Status
 
-CodeNib `0.2.1` is a beta release. The CLI and manifest format are usable, but
+CodeNib `0.2.2` is a beta release. The CLI and manifest format are usable, but
 public interfaces may still change before a stable release. Historical
 research artifacts retain their published dataset identifiers; the maintained
 package, import namespace, commands, and repository use `CodeNib`. See

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ does not write configuration or indexes into the target repository.
 
 ## News
 
-- **2026-08-20 — CodeNib 0.2.2 repository source authority.** Authenticated
+- **2026-08-21 — CodeNib 0.2.2 repository source authority.** Authenticated
   indexing now admits absolute symlinks only when they resolve inside the same
   pinned checkout, and exact root-relative exclusions persist across indexing,
   CodeGraph, MCP, Wiki, and Web runtimes.

--- a/codenib/_contained_source.py
+++ b/codenib/_contained_source.py
@@ -15,7 +15,7 @@ import sys
 import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Iterable, Iterator, Sequence
 
 from ._windows_fs_authority import (
@@ -535,15 +535,16 @@ def _normalize_link_target(
     if os.path.isabs(target):
         if not allow_absolute:
             raise ValueError("source symlink target must be relative")
-        normalized_target = Path(os.path.normpath(target))
-        try:
-            target = normalized_target.relative_to(root).as_posix()
-        except ValueError as exc:
-            raise ValueError("source symlink resolves outside the repository") from exc
+        root_parts = root.parts
+        absolute_parts = Path(target).parts
+        if absolute_parts[: len(root_parts)] != root_parts:
+            raise ValueError("source symlink resolves outside the repository")
+        target_parts = absolute_parts[len(root_parts) :]
         resolved: list[str] = []
     else:
         resolved = list(prefix)
-    for part in target.split("/"):
+        target_parts = target.split("/")
+    for part in target_parts:
         if part in {"", "."}:
             continue
         if part == "..":
@@ -1318,10 +1319,70 @@ def _windows_open_child(
         _raise_with_cleanup(primary, selected_cleanup)
 
 
+def _strip_windows_symlink_namespace(path: str) -> str:
+    """Map supported DOS/UNC namespaces to ordinary absolute syntax."""
+
+    folded = path.casefold()
+    if folded.startswith("\\??\\unc\\"):
+        return "\\\\" + path[8:]
+    if folded.startswith("\\??\\"):
+        candidate = path[4:]
+        if not _windows_is_drive_absolute(candidate):
+            raise ValueError("Windows absolute symlink has an unsupported namespace")
+        return candidate
+    if folded.startswith("\\\\?\\unc\\"):
+        return "\\\\" + path[8:]
+    if folded.startswith("\\\\?\\"):
+        candidate = path[4:]
+        if not _windows_is_drive_absolute(candidate):
+            raise ValueError("Windows absolute symlink has an unsupported namespace")
+        return candidate
+    return path
+
+
+def _windows_is_drive_absolute(path: str) -> bool:
+    return (
+        len(path) >= 3
+        and path[0] in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+        and path[1] == ":"
+        and path[2] == "\\"
+    )
+
+
+def _windows_absolute_path_parts(path: str) -> tuple[str, ...]:
+    """Return lexical components for one supported DOS or UNC absolute path."""
+
+    candidate = PureWindowsPath(_strip_windows_symlink_namespace(path))
+    if not candidate.is_absolute():
+        raise ValueError("Windows absolute symlink has a relative target")
+    drive = candidate.drive
+    if drive.startswith("\\\\"):
+        authority = drive[2:].split("\\")
+        if len(authority) != 2 or any(
+            not part or part in {".", "?"} or ":" in part for part in authority
+        ):
+            raise ValueError("Windows absolute symlink has an unsupported namespace")
+    elif not (
+        len(drive) == 2
+        and drive[0] in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+        and drive[1] == ":"
+    ):
+        raise ValueError("Windows absolute symlink has an unsupported namespace")
+    for part in candidate.parts[1:]:
+        if part in {"", ".", ".."}:
+            continue
+        if ":" in part:
+            raise ValueError("Windows source symlink contains a stream component")
+        _windows_simple_child_name(part)
+    return candidate.parts
+
+
 def _normalize_windows_link_target(
     root: Path,
     prefix: tuple[str, ...],
     point: _WindowsReparsePoint,
+    *,
+    allow_absolute: bool,
 ) -> tuple[str, ...]:
     """Normalize one Windows SYMLINK payload into pinned-root components."""
 
@@ -1340,7 +1401,23 @@ def _normalize_windows_link_target(
         resolved: list[str] = list(prefix)
         target_parts = target.replace("\\", "/").split("/")
     else:
-        raise ValueError("Windows source symlink target must be relative")
+        if not allow_absolute:
+            raise ValueError("Windows source symlink target must be relative")
+        if "/" in target:
+            raise ValueError("Windows absolute symlink has an unsupported namespace")
+        root_parts = _windows_absolute_path_parts(os.fspath(root))
+        target_parts_absolute = _windows_absolute_path_parts(target)
+        if len(target_parts_absolute) < len(root_parts) or any(
+            observed.casefold() != expected.casefold()
+            for observed, expected in zip(
+                target_parts_absolute,
+                root_parts,
+                strict=False,
+            )
+        ):
+            raise ValueError("Windows source symlink resolves outside the repository")
+        resolved = []
+        target_parts = list(target_parts_absolute[len(root_parts) :])
 
     for part in target_parts:
         if part in {"", "."}:
@@ -1703,8 +1780,10 @@ def _open_windows_resolution_at(
     expected_root_identity: tuple[object, ...],
     expected_final_identity: tuple[object, ...] | None,
     expected_final_link_target: str | None = None,
+    expected_final_reparse_point: _WindowsReparsePoint | None = None,
     allow_stable_unresolved: bool,
     api: _WindowsKernelApi,
+    allow_absolute_symlinks: bool = False,
     owns_root_authority: bool = False,
     cleanup_slot: _SourceCleanupSlot | None = None,
 ) -> _WindowsResolutionBinding:
@@ -1715,6 +1794,23 @@ def _open_windows_resolution_at(
     )
     if cleanup_slot is not None:
         cleanup_slot.own(construction)
+    try:
+        supplied_root = _windows_absolute_path_parts(os.fspath(root))
+        authority_root = _windows_absolute_path_parts(os.fspath(root_authority.path))
+        if len(supplied_root) != len(authority_root) or any(
+            supplied.casefold() != authenticated.casefold()
+            for supplied, authenticated in zip(
+                supplied_root,
+                authority_root,
+                strict=True,
+            )
+        ):
+            raise ValueError(
+                "Windows repository root differs from its retained authority"
+            )
+    except BaseException as primary:  # noqa: B036 - retain owned authority
+        _raise_with_cleanup(primary, cleanup_slot or construction)
+    authenticated_root = root_authority.path
     cleanup = construction.handles
     owned_root = 0
     try:
@@ -1749,7 +1845,7 @@ def _open_windows_resolution_at(
         def common_kwargs() -> dict[str, object]:
             return {
                 "api": api,
-                "root": root,
+                "root": authenticated_root,
                 "root_authority": root_authority,
                 "owns_root_authority": owns_root_authority,
                 "root_handle": owned_root,
@@ -1808,6 +1904,14 @@ def _open_windows_resolution_at(
                     raise ValueError(
                         "Windows source symlink target differs from its initial observation"
                     )
+                if (
+                    is_lexical_final
+                    and expected_final_reparse_point is not None
+                    and point != expected_final_reparse_point
+                ):
+                    raise ValueError(
+                        "Windows source symlink payload differs from its initial observation"
+                    )
             observation = _WindowsPathObservation(
                 parent_handle=current_handle,
                 parent_identity=parent_identity,
@@ -1843,9 +1947,10 @@ def _open_windows_resolution_at(
                     return binding
                 seen_links.add(opened.file_id_128)
                 target_parts = _normalize_windows_link_target(
-                    root,
+                    authenticated_root,
                     resolved_prefix,
                     point,
+                    allow_absolute=allow_absolute_symlinks,
                 )
                 if len(target_parts) + len(pending) > _MAX_COMPONENTS:
                     raise ValueError(
@@ -1931,6 +2036,7 @@ def _resolved_windows_repository_file_at(
     expected_root_identity: tuple[object, ...],
     expected_final_identity: tuple[object, ...],
     expected_final_link_target: str | None = None,
+    expected_final_reparse_point: _WindowsReparsePoint | None = None,
     api: _WindowsKernelApi | None = None,
 ) -> Iterator[_WindowsResolutionBinding]:
     """Resolve one source entry through a caller-owned pinned Windows root."""
@@ -1945,8 +2051,10 @@ def _resolved_windows_repository_file_at(
         expected_root_identity=expected_root_identity,
         expected_final_identity=expected_final_identity,
         expected_final_link_target=expected_final_link_target,
+        expected_final_reparse_point=expected_final_reparse_point,
         allow_stable_unresolved=True,
         api=selected,
+        allow_absolute_symlinks=True,
         cleanup_slot=cleanup_slot,
     )
     try:
@@ -1968,7 +2076,9 @@ def _open_windows_repository_file(
     *,
     expected_final_identity: tuple[object, ...] | None = None,
     expected_final_link_target: str | None = None,
+    expected_final_reparse_point: _WindowsReparsePoint | None = None,
     allow_stable_unresolved: bool = False,
+    allow_absolute_symlinks: bool = False,
 ) -> _WindowsResolutionBinding:
     cleanup_slot = _SourceCleanupSlot()
     api, root_authority, root_identity = _open_windows_pinned_repository_root(
@@ -1982,8 +2092,10 @@ def _open_windows_repository_file(
         expected_root_identity=root_identity,
         expected_final_identity=expected_final_identity,
         expected_final_link_target=expected_final_link_target,
+        expected_final_reparse_point=expected_final_reparse_point,
         allow_stable_unresolved=allow_stable_unresolved,
         api=api,
+        allow_absolute_symlinks=allow_absolute_symlinks,
         owns_root_authority=True,
         cleanup_slot=cleanup_slot,
     )
@@ -2144,6 +2256,7 @@ def resolved_repository_file(
             _relative_parts(relative),
             expected_final_identity=expected_final_identity,
             allow_stable_unresolved=True,
+            allow_absolute_symlinks=True,
         )
         try:
             yield binding
@@ -2199,6 +2312,7 @@ def _resolved_repository_file_at(
         expected_final_identity=expected_final_identity,
         expected_final_link_target=expected_final_link_target,
         allow_stable_unresolved=True,
+        allow_absolute_symlinks=True,
         pinned_root_descriptor=root_descriptor,
         expected_root_identity=expected_root_identity,
         cleanup_slot=cleanup_slot,

--- a/codenib/agent/lsp_provider.py
+++ b/codenib/agent/lsp_provider.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional, Sequence
 
+from ..repository_source_selection import RepositorySourceSelection
 from ..types import QueriedNode
 from .lsp_graph import lsp_definition, lsp_references, lsp_route
 from .route_context import fingerprint_lsp_route_nodes, summarize_lsp_route_nodes
@@ -574,6 +575,7 @@ def select_checkout_lsp_provider(
     project_root: str,
     languages: Iterable[str],
     symbol_graph: Any = None,
+    source_selection: RepositorySourceSelection | None = None,
     allow_native: bool = True,
     native_disabled_reason: str = "native_provider_not_authorized",
 ) -> tuple[Any, dict[str, Any]]:
@@ -597,8 +599,20 @@ def select_checkout_lsp_provider(
     )
     mode = "auto"
     fallback_reason: Optional[str] = None
+    if source_selection is not None and (
+        type(source_selection) is not RepositorySourceSelection
+    ):
+        raise TypeError("source_selection must be a RepositorySourceSelection")
     if not allow_native:
         fallback_reason = native_disabled_reason or "native_provider_not_authorized"
+    elif source_selection is not None:
+        # A RepositorySourceSelection identifies both the built-in source
+        # policy and any custom exclusions.  Native clangd indexes currently
+        # have neither an authenticated generation receipt nor an allowed-file
+        # proof, so even an empty custom list cannot prove that default-hidden
+        # trees such as ``build`` were excluded.  Manifest-bound callers must
+        # use the centrally filtered persisted graph until that proof exists.
+        fallback_reason = "repository_source_policy_requires_persisted_graph"
     elif canonical_languages != {"cpp"} or has_unknown_language:
         fallback_reason = (
             "mixed_language_requires_persisted_graph"

--- a/codenib/agent/runner.py
+++ b/codenib/agent/runner.py
@@ -38,6 +38,7 @@ from ..llm.litellm_chat import LiteLLMChat, RetryConfig
 from ..llm.usage import UsageTracker
 from ..log_utils import get_logger
 from ..paths import repo_index_dir
+from ..repository_source_selection import RepositorySourceSelection
 from ..source_fingerprint import is_secure_source_fingerprint_v2
 from .agent_types import AgentResult, ToolCallRecord
 from .boundary import from_agent_repr_arg, is_line_bearing, to_agent_repr
@@ -2119,6 +2120,7 @@ def compile_repo(
     cache_dir: Optional[str] = None,
     embedding_model: str = DEFAULT_EMBEDDING_MODEL,
     embedding_dimension: int = DEFAULT_EMBEDDING_DIMENSION,
+    source_selection: RepositorySourceSelection | None = None,
 ) -> "RepoManifest":
     """Compile indexes for *repo_path* ahead of time and return the manifest.
 
@@ -2150,9 +2152,11 @@ def compile_repo(
         register_default_builders,
     )
     from ..compiler.index_compiler import IndexCompiler, IndexCompilerConfig
+    from ..compiler.manifest_source import resolve_compiler_source_selection
 
     if cache_dir is None:
         cache_dir = str(repo_index_dir(repo_path))
+    selected = resolve_compiler_source_selection(cache_dir, source_selection)
 
     builder_registry = IndexBuilderRegistry()
     register_default_builders(
@@ -2160,12 +2164,14 @@ def compile_repo(
         languages=list(languages),
         embedding_model=embedding_model,
         embedding_dimension=embedding_dimension,
+        source_selection=selected,
     )
 
     cfg = IndexCompilerConfig(
         cache_dir_name=Path(cache_dir).name,
         index_types=list(index_types),
         languages=list(languages),
+        source_selection=selected,
     )
     compiler = IndexCompiler(builder_registry, cfg)
     return compiler.compile_repo(

--- a/codenib/artifacts/runtime.py
+++ b/codenib/artifacts/runtime.py
@@ -27,13 +27,26 @@ from .._atomic_directory import (
 from .._bounded_json import iter_bounded_json_array
 from .._contained_source import _attach_source_cleanup_owner
 from ..compiler.checkout_identity import checkout_commit
-from ..compiler.manifest import MANIFEST_FILENAME, MANIFEST_VERSION, RepoManifest
+from ..compiler.manifest import (
+    MANIFEST_FILENAME,
+    MANIFEST_VERSION,
+    SUPPORTED_MANIFEST_VERSIONS,
+    RepoManifest,
+)
+from ..compiler.manifest_source import (
+    capture_repository_source_for_manifest as capture_repository_source,
+)
+from ..compiler.manifest_source import require_manifest_source_identity
 from ..compiler.snapshot_store import normalize_repo
+from ..repository_filters import (
+    REPOSITORY_FILTER_POLICY_VERSION,
+    repository_path_is_visible,
+)
+from ..repository_source_selection import DEFAULT_REPOSITORY_SOURCE_SELECTION
 from ..source_fingerprint import (
     RepositorySourceBinding,
     _SourceLifecycleRLock,
     _SourceLockLease,
-    capture_repository_source,
     is_secure_source_fingerprint_v2,
     lexical_repository_path,
 )
@@ -580,6 +593,7 @@ def _document_source_paths(
     *,
     label: str,
     max_bytes: int,
+    require_file: bool,
 ) -> set[str]:
     result: set[str] = set()
     with reader.open_file(relative, max_bytes=max_bytes) as source:
@@ -593,7 +607,12 @@ def _document_source_paths(
                     f"{label} document {index} has invalid content or metadata"
                 )
             raw_file = metadata.get("file")
-            if raw_file is not None and raw_file != "":
+            if raw_file is None or raw_file == "":
+                if require_file:
+                    raise ValueError(
+                        f"{label} document {index} must declare a source file"
+                    )
+            else:
                 result.add(
                     _source_path(
                         raw_file,
@@ -615,6 +634,7 @@ def _validate_view_payloads(
     inventory: Mapping[str, tuple[int, str]],
     *,
     views: tuple[str, ...],
+    require_document_source_paths: bool,
 ) -> tuple[str, ...]:
     source_paths: set[str] = set()
     inventory_paths = set(inventory)
@@ -639,6 +659,7 @@ def _validate_view_payloads(
                 documents_relative,
                 label="portable BM25 documents",
                 max_bytes=_MAX_DOCUMENTS_BYTES,
+                require_file=require_document_source_paths,
             )
         )
 
@@ -667,6 +688,7 @@ def _validate_view_payloads(
                     path,
                     label=f"portable vector documents {relative}",
                     max_bytes=_MAX_DOCUMENTS_BYTES,
+                    require_file=require_document_source_paths,
                 )
             )
     return tuple(sorted(source_paths))
@@ -681,7 +703,16 @@ def _validate_manifest(
     source_fingerprint: str,
     views: tuple[str, ...],
     inventoried_paths: set[str],
+    expected_manifest_version: str | None,
 ) -> tuple[Path, RepoManifest]:
+    if expected_manifest_version is not None and (
+        type(expected_manifest_version) is not str
+        or expected_manifest_version not in SUPPORTED_MANIFEST_VERSIONS
+    ):
+        raise ValueError(
+            "expected context artifact manifest version is unsupported: "
+            f"{expected_manifest_version!r}"
+        )
     manifest_record = metadata.get("manifest")
     if not isinstance(manifest_record, dict):
         raise ValueError("context artifact manifest descriptor must be an object")
@@ -709,10 +740,13 @@ def _validate_manifest(
         manifest = RepoManifest.from_dict(manifest_payload)
     except (KeyError, TypeError, ValueError) as exc:
         raise ValueError("context artifact repository manifest is invalid") from exc
-    if manifest.version != MANIFEST_VERSION:
+    if (
+        expected_manifest_version is not None
+        and manifest.version != expected_manifest_version
+    ):
         raise ValueError(
             "context artifact repository manifest version is incompatible: "
-            f"expected {MANIFEST_VERSION}, found {manifest.version}"
+            f"expected {expected_manifest_version}, found {manifest.version}"
         )
     if manifest.repo_path != "source":
         raise ValueError("portable repository manifest path must be 'source'")
@@ -751,10 +785,15 @@ def _validate_manifest(
         "commit": commit,
     }:
         raise ValueError("context artifact source-location contract is unsupported")
+    artifact_manifest_version = (
+        manifest.version
+        if expected_manifest_version is None
+        else expected_manifest_version
+    )
     builder = metadata.get("builder")
     if (
         not isinstance(builder, dict)
-        or builder.get("manifest_version") != MANIFEST_VERSION
+        or builder.get("manifest_version") != artifact_manifest_version
         or not isinstance(builder.get("codenib_version"), str)
         or not isinstance(builder.get("compiled_at"), str)
     ):
@@ -768,6 +807,56 @@ def _validate_manifest(
             raise ValueError(f"context artifact view is not current: {view}")
         if entry.index_type != view:
             raise ValueError(f"context artifact view type differs from its key: {view}")
+        expected_filter_policy = (
+            REPOSITORY_FILTER_POLICY_VERSION
+            if manifest.version == MANIFEST_VERSION
+            else 3
+        )
+        if entry.config.get("repository_filter_policy") != expected_filter_policy:
+            raise ValueError(
+                f"context artifact {view} config has a mismatched repository "
+                "filter policy"
+            )
+        if manifest.version == MANIFEST_VERSION:
+            if (
+                manifest.source_selection is None
+                or entry.config.get("source_selection_digest")
+                != manifest.source_selection.digest
+            ):
+                raise ValueError(
+                    f"context artifact {view} config has a mismatched "
+                    "source-selection identity"
+                )
+        elif "source_selection_digest" in entry.config:
+            raise ValueError(
+                f"legacy context artifact {view} config records a current "
+                "source-selection identity"
+            )
+
+        if (
+            "repository_filter_policy" in entry.metadata
+            and entry.metadata["repository_filter_policy"] != expected_filter_policy
+        ):
+            raise ValueError(
+                f"context artifact {view} metadata has a mismatched repository "
+                "filter policy"
+            )
+        if "source_selection_digest" in entry.metadata:
+            if manifest.version == MANIFEST_VERSION:
+                if entry.metadata.get("source_selection_digest") != (
+                    manifest.source_selection.digest
+                    if manifest.source_selection is not None
+                    else None
+                ):
+                    raise ValueError(
+                        f"context artifact {view} metadata has a mismatched "
+                        "source-selection identity"
+                    )
+            else:
+                raise ValueError(
+                    f"legacy context artifact {view} metadata records a "
+                    "current source-selection identity"
+                )
         expected_view_path = f"views/{view}"
         if entry.path != expected_view_path:
             raise ValueError(
@@ -848,6 +937,7 @@ def _verify_context_artifact_reader(
     expected_commit: str | None,
     max_files: int,
     max_bytes: int,
+    expected_manifest_version: str | None,
     capture_final: Callable[[], object],
 ) -> VerifiedContextArtifact:
     metadata_path = root / CONTEXT_ARTIFACT_MANIFEST
@@ -897,13 +987,33 @@ def _verify_context_artifact_reader(
             source_fingerprint=source_fingerprint,
             views=views,
             inventoried_paths=set(inventory),
+            expected_manifest_version=expected_manifest_version,
         )
         source_paths = _validate_view_payloads(
             root,
             reader,
             inventory,
             views=views,
+            require_document_source_paths=manifest.version == MANIFEST_VERSION,
         )
+        source_selection = (
+            manifest.source_selection
+            if manifest.source_selection is not None
+            else DEFAULT_REPOSITORY_SOURCE_SELECTION
+        )
+        excluded_source_paths = [
+            path
+            for path in source_paths
+            if not repository_path_is_visible(
+                path,
+                selection=source_selection,
+            )
+        ]
+        if excluded_source_paths:
+            raise ValueError(
+                "context artifact view contains source paths excluded by "
+                "its repository manifest: " + ", ".join(excluded_source_paths[:5])
+            )
         if expected_repository is not None:
             expected = normalize_repo(expected_repository)
             if repository != expected:
@@ -950,6 +1060,7 @@ def verify_context_artifact_reader(
     *,
     expected_repository: str | None = None,
     expected_commit: str | None = None,
+    expected_manifest_version: str | None = MANIFEST_VERSION,
     max_files: int = _DEFAULT_MAX_FILES,
     max_bytes: int = _DEFAULT_MAX_BYTES,
 ) -> VerifiedContextArtifact:
@@ -974,6 +1085,7 @@ def verify_context_artifact_reader(
         expected_commit=expected_commit,
         max_files=max_files,
         max_bytes=max_bytes,
+        expected_manifest_version=expected_manifest_version,
         capture_final=lambda: publication.capture_ownership(
             entry_policy=policy_factory(),
         ),
@@ -985,6 +1097,7 @@ def verify_context_artifact(
     *,
     expected_repository: str | None = None,
     expected_commit: str | None = None,
+    expected_manifest_version: str | None = MANIFEST_VERSION,
     max_files: int = _DEFAULT_MAX_FILES,
     max_bytes: int = _DEFAULT_MAX_BYTES,
 ) -> VerifiedContextArtifact:
@@ -1024,6 +1137,7 @@ def verify_context_artifact(
             expected_commit=expected_commit,
             max_files=max_files,
             max_bytes=max_bytes,
+            expected_manifest_version=expected_manifest_version,
             capture_final=lambda: publication.capture_ownership(
                 entry_policy=policy_factory(),
             ),
@@ -1053,6 +1167,7 @@ def bind_context_artifact(
         root,
         expected_repository=expected_repository,
         expected_commit=expected_commit,
+        expected_manifest_version=None,
     )
     cleanup_owner = SourceBindingCleanupOwner()
 
@@ -1065,6 +1180,7 @@ def bind_context_artifact(
         repo = lexical_repository_path(repo_path)
         source = capture_repository_source(
             repo,
+            manifest=artifact.manifest,
             exclude_roots=(artifact.root,),
             _source_owner=cleanup_owner.retain,
         )
@@ -1074,14 +1190,14 @@ def bind_context_artifact(
         actual_commit = checkout_commit(repo)
         source_identity = source.authenticated_identity_snapshot()
         authenticated_repo = source_identity.root
-        if source_identity.fingerprint != artifact.source_fingerprint:
-            raise ValueError(
+        require_manifest_source_identity(
+            source_identity,
+            artifact.manifest,
+            label="context artifact repository",
+            mismatch_message=(
                 "repository source files do not match the context artifact fingerprint"
-            )
-        if source_identity.file_count != artifact.manifest.file_count:
-            raise ValueError(
-                "repository file count does not match the context artifact manifest"
-            )
+            ),
+        )
         source_records = {record.path for record in source_identity.file_records}
         missing_source_paths = sorted(set(artifact.source_paths) - source_records)
         if missing_source_paths:
@@ -1164,6 +1280,7 @@ def query_context_artifact(
         root,
         expected_repository=expected_repository,
         expected_commit=expected_commit,
+        expected_manifest_version=None,
     )
     return ContextArtifactBinding(
         artifact=artifact,

--- a/codenib/artifacts/strict_context.py
+++ b/codenib/artifacts/strict_context.py
@@ -443,6 +443,8 @@ def _validate_manifest_identity(inputs: _FrozenContextInputs) -> RepoManifest:
         raise ValueError("strict context manifest belongs to another source generation")
     if manifest.file_count != source.file_count:
         raise ValueError("strict context manifest file count differs from its source")
+    if manifest.source_selection != source.source_selection:
+        raise ValueError("strict context manifest selection differs from its source")
     if not all(isinstance(language, str) for language in manifest.languages):
         raise ValueError("strict context manifest languages must be text")
     selected = tuple(name for name, _owner in inputs.view_generations)
@@ -585,7 +587,7 @@ def _planned_view(
     records = tuple(directory_ownership_file_records(ownership))  # type: ignore[arg-type]
     if records != tuple(sorted(records, key=lambda item: item.path)):
         raise RuntimeError(f"strict context {view} records are not canonical")
-    entry = manifest.indexes[view].to_dict()
+    entry = manifest.indexes[view].to_dict(manifest_version=manifest.version)
     config = entry.get("config")
     if not isinstance(config, dict):
         raise ValueError(f"strict context {view} config must be an object")

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -30,7 +30,11 @@ from .provider_routes import (
     resolve_embedding_artifact_route,
     resolve_inference_route,
 )
-from .repository_filters import DEFAULT_IGNORED_DIRS
+from .repository_filters import walk_repository_files
+from .repository_source_selection import (
+    DEFAULT_REPOSITORY_SOURCE_SELECTION,
+    RepositorySourceSelection,
+)
 from .web.ports import argparse_tcp_port, validate_local_wiki_ports
 
 _PRESET_VIEWS = {
@@ -64,6 +68,15 @@ class _ResolvedModelBackend:
     api_base: str | None
     api_key: str | None = field(default=None, repr=False)
     auth_source: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _ResolvedRepositorySourceSelection:
+    """One canonical source-selection decision for a CLI transaction."""
+
+    selection: RepositorySourceSelection
+    action: str
+    manifest_present: bool
 
 
 def _optional_int(value: object, *, source: str) -> int | None:
@@ -252,6 +265,7 @@ def _detect_languages_for_surface(
     repo_path: str | os.PathLike[str],
     *,
     surface: str,
+    source_selection: RepositorySourceSelection = (DEFAULT_REPOSITORY_SOURCE_SELECTION),
 ) -> list[str]:
     """Detect registered source languages for one capability surface."""
     from .languages import extension_to_language_map
@@ -261,17 +275,10 @@ def _detect_languages_for_surface(
     extension_map = extension_to_language_map(surface)
     counts: Counter[str] = Counter()
 
-    for _current_root, dirs, files in os.walk(root):
-        dirs[:] = sorted(
-            directory
-            for directory in dirs
-            if directory not in DEFAULT_IGNORED_DIRS
-            and not directory.startswith(".codenib")
-        )
-        for filename in files:
-            language = extension_map.get(Path(filename).suffix.lower())
-            if language:
-                counts[language] += 1
+    for path in walk_repository_files(root, selection=source_selection):
+        language = extension_map.get(path.suffix.lower())
+        if language:
+            counts[language] += 1
 
     return [
         language
@@ -282,10 +289,18 @@ def _detect_languages_for_surface(
     ]
 
 
-def detect_languages(repo_path: str | os.PathLike[str]) -> list[str]:
+def detect_languages(
+    repo_path: str | os.PathLike[str],
+    *,
+    source_selection: RepositorySourceSelection = (DEFAULT_REPOSITORY_SOURCE_SELECTION),
+) -> list[str]:
     """Detect chunkable source languages, ordered by source-file count."""
 
-    return _detect_languages_for_surface(repo_path, surface="chunker")
+    return _detect_languages_for_surface(
+        repo_path,
+        surface="chunker",
+        source_selection=source_selection,
+    )
 
 
 def normalize_languages(values: Iterable[str]) -> list[str]:
@@ -361,11 +376,85 @@ def _is_regular_file_nofollow(path: Path) -> bool:
     return stat.S_ISREG(metadata.st_mode)
 
 
-def _selected_languages(repo_path: Path, explicit: Iterable[str]) -> list[str]:
+def _resolve_repository_source_selection(
+    repo_path: Path,
+    args: argparse.Namespace,
+) -> _ResolvedRepositorySourceSelection:
+    """Resolve one explicit or persisted exact-subtree selection.
+
+    An explicit CLI policy replaces the complete custom exclusion set.  With
+    no policy flags, a current manifest is the sole persisted authority.  A
+    legacy v1.1 manifest deliberately migrates to the current empty v4 policy
+    instead of pretending that its policy-3 identity was already equivalent.
+    """
+
+    from .compiler.manifest import MANIFEST_FILENAME, RepoManifest
+    from .paths import repo_index_dir
+
+    exclude_dirs = getattr(args, "exclude_dir", None)
+    clear = bool(getattr(args, "clear_exclude_dirs", False))
+    if exclude_dirs is not None and clear:
+        raise CLIError("--exclude-dir and --clear-exclude-dirs are mutually exclusive")
+    if clear:
+        return _ResolvedRepositorySourceSelection(
+            selection=RepositorySourceSelection(),
+            action="clear",
+            manifest_present=False,
+        )
+    if exclude_dirs is not None:
+        try:
+            selection = RepositorySourceSelection(exclude_dirs)
+        except (TypeError, ValueError) as exc:
+            raise CLIError(f"invalid --exclude-dir: {exc}") from exc
+        return _ResolvedRepositorySourceSelection(
+            selection=selection,
+            action="replace",
+            manifest_present=False,
+        )
+
+    manifest_path = repo_index_dir(repo_path) / MANIFEST_FILENAME
+    if not _is_regular_file_nofollow(manifest_path):
+        return _ResolvedRepositorySourceSelection(
+            selection=RepositorySourceSelection(),
+            action="default",
+            manifest_present=False,
+        )
+    try:
+        manifest = RepoManifest.load(manifest_path)
+    except (OSError, TypeError, ValueError, KeyError, json.JSONDecodeError) as exc:
+        raise CLIError(
+            "the existing manifest source selection cannot be read; pass "
+            "--exclude-dir to replace it or --clear-exclude-dirs to clear it"
+        ) from exc
+    if manifest.source_selection is None:
+        return _ResolvedRepositorySourceSelection(
+            selection=RepositorySourceSelection(),
+            action="migrate",
+            manifest_present=True,
+        )
+    return _ResolvedRepositorySourceSelection(
+        selection=RepositorySourceSelection(
+            manifest.source_selection.exclude_subtrees,
+        ),
+        action="reuse",
+        manifest_present=True,
+    )
+
+
+def _source_selection_display(selection: RepositorySourceSelection) -> str:
+    return ", ".join(selection.exclude_subtrees) or "none"
+
+
+def _selected_languages(
+    repo_path: Path,
+    explicit: Iterable[str],
+    *,
+    source_selection: RepositorySourceSelection = (DEFAULT_REPOSITORY_SOURCE_SELECTION),
+) -> list[str]:
     languages = normalize_languages(explicit)
     if languages:
         return languages
-    languages = detect_languages(repo_path)
+    languages = detect_languages(repo_path, source_selection=source_selection)
     if not languages:
         raise CLIError(
             "no supported source language was detected; pass --language explicitly"
@@ -376,6 +465,8 @@ def _selected_languages(repo_path: Path, explicit: Iterable[str]) -> list[str]:
 def _selected_codegraph_languages(
     repo_path: Path,
     explicit: Iterable[str],
+    *,
+    source_selection: RepositorySourceSelection = (DEFAULT_REPOSITORY_SOURCE_SELECTION),
 ) -> list[str]:
     """Select only languages with a registered symbol-graph backend."""
 
@@ -394,7 +485,11 @@ def _selected_codegraph_languages(
 
     languages = [
         language
-        for language in _detect_languages_for_surface(repo_path, surface="graph")
+        for language in _detect_languages_for_surface(
+            repo_path,
+            surface="graph",
+            source_selection=source_selection,
+        )
         if graph_indexer_path(language) is not None
     ]
     if not languages:
@@ -448,6 +543,7 @@ def index_repository(
     *,
     languages: Sequence[str],
     views: Sequence[str],
+    source_selection: RepositorySourceSelection = (DEFAULT_REPOSITORY_SOURCE_SELECTION),
     rebuild: bool = False,
     embedding_provider: str = "huggingface",
     embedding_model: str | None = None,
@@ -485,12 +581,14 @@ def index_repository(
         embedding_credential_env=embedding_credential_env,
         allow_partial_graph_languages=allow_partial_graph_languages,
         allow_graph_project_preparation=allow_graph_project_preparation,
+        source_selection=source_selection,
     )
     compiler = IndexCompiler(
         registry,
         IndexCompilerConfig(
             index_types=list(views),
             languages=list(languages),
+            source_selection=source_selection,
         ),
     )
     cache_dir = repo_index_dir(repo_path)
@@ -519,6 +617,9 @@ def _print_index_summary(manifest, views: Sequence[str]) -> None:
     manifest_path = repo_index_dir(manifest.repo_path) / MANIFEST_FILENAME
     print(f"Repository: {manifest.repo_path}")
     print(f"Languages:  {', '.join(manifest.languages)}")
+    source_selection = getattr(manifest, "source_selection", None)
+    if source_selection is not None:
+        print("Excluded:   " + _source_selection_display(source_selection))
     print(f"Manifest:   {manifest_path}")
     print("Views:")
     for view in views:
@@ -546,7 +647,12 @@ def _run_index(
     selected_views: Sequence[str] | None = None,
 ) -> int:
     repo_path = resolve_repo_path(args.repo)
-    languages = _selected_languages(repo_path, args.language)
+    resolved_selection = _resolve_repository_source_selection(repo_path, args)
+    languages = _selected_languages(
+        repo_path,
+        args.language,
+        source_selection=resolved_selection.selection,
+    )
     views = (
         list(selected_views)
         if selected_views is not None
@@ -565,6 +671,7 @@ def _run_index(
     index_kwargs = {
         "languages": languages,
         "views": views,
+        "source_selection": resolved_selection.selection,
         "rebuild": args.rebuild,
     }
     if embedding_route is not None:
@@ -676,12 +783,16 @@ def _publication_environment(credential_env: str | None = None) -> dict[str, str
     return environment
 
 
-def _require_clean_artifact_checkout(repo_path: Path) -> None:
+def _require_clean_artifact_checkout(
+    repo_path: Path,
+    *,
+    source_selection: RepositorySourceSelection = (DEFAULT_REPOSITORY_SOURCE_SELECTION),
+) -> None:
     """Require portable artifacts to describe the checked-out Git commit."""
 
     from .source_fingerprint import repository_source_is_dirty
 
-    if repository_source_is_dirty(repo_path):
+    if repository_source_is_dirty(repo_path, selection=source_selection):
         raise CLIError(
             "portable context artifacts require a clean Git checkout at HEAD. "
             "Commit or stash source-visible changes, or use `codenib wiki` or "
@@ -753,12 +864,18 @@ def _validate_publish_outputs(
 
 def _run_artifact_pack(args: argparse.Namespace) -> int:
     repo_path = resolve_repo_path(args.repo)
-    _require_clean_artifact_checkout(repo_path)
+    _artifact_checkout_commit(repo_path, None)
     manifest_path = resolve_manifest_path(str(repo_path))
     from .artifacts import stage_context_artifact
     from .compiler.manifest import RepoManifest
 
     manifest = RepoManifest.load(manifest_path)
+    _require_clean_artifact_checkout(
+        repo_path,
+        source_selection=(
+            manifest.source_selection or DEFAULT_REPOSITORY_SOURCE_SELECTION
+        ),
+    )
     output_dir = (
         Path(os.path.abspath(os.fspath(Path(args.output).expanduser())))
         if args.output
@@ -795,7 +912,8 @@ def _artifact_checkout_commit(repo_path: Path, explicit: str | None) -> str:
     commit = (explicit or checkout_commit(repo_path) or "").strip().lower()
     if not re.fullmatch(r"[0-9a-f]{40}", commit):
         raise CLIError(
-            "artifact operations require a Git checkout with a full resolved HEAD"
+            "artifact operations require a clean Git checkout with a full "
+            "resolved HEAD"
         )
     return commit
 
@@ -2430,7 +2548,11 @@ def _run_publish(args: argparse.Namespace) -> int:
         site_output=site_output,
         context_output=context_output,
     )
-    _require_clean_artifact_checkout(repo_path)
+    resolved_selection = _resolve_repository_source_selection(repo_path, args)
+    _require_clean_artifact_checkout(
+        repo_path,
+        source_selection=resolved_selection.selection,
+    )
 
     selected_views = _selected_views_for_args(args)
     unsupported = sorted(set(selected_views) - {"bm25", "vector"})
@@ -2631,7 +2753,17 @@ def _run_wiki(args: argparse.Namespace) -> int:
         raise CLIError(str(exc)) from exc
 
     repo_path = resolve_repo_path(args.repo)
-    languages = _selected_languages(repo_path, args.language)
+    resolved_selection = _resolve_repository_source_selection(repo_path, args)
+    if args.no_index and resolved_selection.action in {"replace", "clear"}:
+        raise CLIError(
+            "--exclude-dir and --clear-exclude-dirs require indexing; "
+            "remove --no-index"
+        )
+    languages = _selected_languages(
+        repo_path,
+        args.language,
+        source_selection=resolved_selection.selection,
+    )
     if args.no_index and args.preset == "auto" and not _split_values(args.view):
         views = list(_PRESET_VIEWS["fast"])
         print("Auto preset: reuse manifest capabilities")
@@ -2677,6 +2809,7 @@ def _run_wiki(args: argparse.Namespace) -> int:
         index_kwargs = {
             "languages": languages,
             "views": views,
+            "source_selection": resolved_selection.selection,
             "rebuild": args.rebuild,
         }
         if build_embedding_route is not None:
@@ -3235,7 +3368,12 @@ def _run_doctor(args: argparse.Namespace) -> int:
         from .graph.setup import diagnose_graph_setup
 
         repo_path = resolve_repo_path(args.repo)
-        languages = _selected_languages(repo_path, args.language)
+        resolved_selection = _resolve_repository_source_selection(repo_path, args)
+        languages = _selected_languages(
+            repo_path,
+            args.language,
+            source_selection=resolved_selection.selection,
+        )
         graph_report = diagnose_graph_setup(repo_path, languages)
     if args.probe_model:
         rows["agent"].extend(_probe_doctor_model(args))
@@ -3289,7 +3427,12 @@ def _toolchain_plan_for_args(args: argparse.Namespace):
     from .toolchains import plan_repository_toolchain
 
     repo_path = resolve_repo_path(args.repo)
-    languages = _selected_languages(repo_path, args.language)
+    resolved_selection = _resolve_repository_source_selection(repo_path, args)
+    languages = _selected_languages(
+        repo_path,
+        args.language,
+        source_selection=resolved_selection.selection,
+    )
     return plan_repository_toolchain(
         repo_path,
         languages,
@@ -3405,11 +3548,19 @@ def _codegraph_languages_for_init(
     repo_path: Path,
     args: argparse.Namespace,
     receipt,
+    *,
+    source_selection: RepositorySourceSelection = (DEFAULT_REPOSITORY_SOURCE_SELECTION),
 ) -> tuple[str, ...]:
     del receipt
     # An omitted --language always means auto-detect the current checkout. This
     # keeps repeated onboarding in sync when a repository adds another language.
-    return tuple(_selected_codegraph_languages(repo_path, args.language))
+    return tuple(
+        _selected_codegraph_languages(
+            repo_path,
+            args.language,
+            source_selection=source_selection,
+        )
+    )
 
 
 def _codegraph_preflight_clients(
@@ -3511,6 +3662,7 @@ def _run_codegraph_init(args: argparse.Namespace) -> int:
     from .toolchains import install_requirements
 
     repo_path = resolve_repo_path(args.repo)
+    resolved_selection = _resolve_repository_source_selection(repo_path, args)
     server, receipt = _codegraph_spec_for_args(repo_path, args)
     try:
         server_inspection = inspect_server_command(server, repo_path)
@@ -3521,7 +3673,12 @@ def _run_codegraph_init(args: argparse.Namespace) -> int:
             "CodeGraph MCP command is not this CodeNib runtime: "
             + server_inspection.detail
         )
-    languages = _codegraph_languages_for_init(repo_path, args, receipt)
+    languages = _codegraph_languages_for_init(
+        repo_path,
+        args,
+        receipt,
+        source_selection=resolved_selection.selection,
+    )
     clients = _codegraph_clients_for_init(args)
     observed = _codegraph_preflight_clients(
         repo_path,
@@ -3548,6 +3705,11 @@ def _run_codegraph_init(args: argparse.Namespace) -> int:
             raise CLIError(str(exc)) from exc
         print(f"Repository: {repo_path}")
         print(f"Languages:  {', '.join(languages)}")
+        print(
+            "Source selection: "
+            f"{resolved_selection.action} "
+            f"({_source_selection_display(resolved_selection.selection)})"
+        )
         print("Planned CodeGraph actions:")
         for command in commands:
             print(f"  toolchain: {shlex.join(command)}")
@@ -3605,6 +3767,7 @@ def _run_codegraph_init(args: argparse.Namespace) -> int:
             repo_path,
             languages=languages,
             views=("bm25", "symbol_graph"),
+            source_selection=resolved_selection.selection,
             rebuild=args.rebuild,
             allow_graph_project_preparation=False,
             allow_partial_graph_languages=False,
@@ -3663,6 +3826,7 @@ def _run_codegraph_init(args: argparse.Namespace) -> int:
     print("\nCodeGraph is ready for coding agents.")
     print(f"MCP server: {server.name}")
     print(f"Clients:    {', '.join(clients)}")
+    print("Excluded:   " + _source_selection_display(resolved_selection.selection))
     print(f"Status:     codenib codegraph status {shlex.quote(str(repo_path))}")
     print(
         "Try asking your agent to use explore_context before editing and "
@@ -3683,6 +3847,8 @@ def _codegraph_index_report(repo_path: Path) -> dict[str, object]:
     manifest_path = repo_index_dir(repo_path) / MANIFEST_FILENAME
     report: dict[str, object] = {
         "manifest": str(manifest_path),
+        "manifest_present": False,
+        "manifest_version": None,
         "bm25": False,
         "bm25_manifest_current": False,
         "bm25_artifact_matches": False,
@@ -3691,12 +3857,25 @@ def _codegraph_index_report(repo_path: Path) -> dict[str, object]:
         "symbol_graph_artifact_matches": False,
         "symbol_graph_complete": False,
         "source_matches": False,
+        "source_selection": {
+            "recorded": False,
+            "exclude_subtrees": [],
+            "digest": None,
+        },
         "languages": [],
         "detail": "manifest not found",
     }
     try:
         manifest = RepoManifest.load(manifest_path)
+        report["manifest_present"] = True
+        report["manifest_version"] = manifest.version
         report["languages"] = list(manifest.languages)
+        if manifest.source_selection is not None:
+            report["source_selection"] = {
+                "recorded": True,
+                "exclude_subtrees": list(manifest.source_selection.exclude_subtrees),
+                "digest": manifest.source_selection_digest,
+            }
         bm25_entry = manifest.indexes.get("bm25")
         graph_entry = manifest.indexes.get("symbol_graph")
         report["bm25_manifest_current"] = manifest.index_is_current("bm25")
@@ -3750,6 +3929,11 @@ def _codegraph_index_report(repo_path: Path) -> dict[str, object]:
         )
         report["source_matches"] = True
         blockers: list[str] = []
+        if manifest.source_selection is None:
+            blockers.append(
+                "manifest has no repository source-selection contract; "
+                "run codegraph init to migrate it"
+            )
         if not report["bm25_manifest_current"]:
             blockers.append("bm25 manifest entry is missing, failed, or stale")
         elif not report["bm25_artifact_matches"]:
@@ -3768,7 +3952,10 @@ def _codegraph_index_report(repo_path: Path) -> dict[str, object]:
     except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
         report["detail"] = " ".join(str(exc).split())[:400]
     report["ready"] = bool(
-        report["bm25"] and report["symbol_graph_complete"] and report["source_matches"]
+        report["bm25"]
+        and report["symbol_graph_complete"]
+        and report["source_matches"]
+        and report["source_selection"]["recorded"]
     )
     return report
 
@@ -3916,6 +4103,18 @@ def _run_codegraph_status(args: argparse.Namespace) -> int:
             else str(index["detail"])
         )
     )
+    source_selection = index.get(
+        "source_selection",
+        {"recorded": False, "exclude_subtrees": [], "digest": None},
+    )
+    if source_selection["recorded"]:
+        print(
+            "Excluded:   " + (", ".join(source_selection["exclude_subtrees"]) or "none")
+        )
+    elif index.get("manifest_present"):
+        print("Excluded:   unrecorded legacy policy")
+    else:
+        print("Excluded:   unrecorded (manifest missing)")
     toolchain = report["toolchain"]
     toolchain_detail = "ready"
     if not toolchain["ready"]:
@@ -4053,6 +4252,25 @@ def _add_embedding_route_arguments(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_source_selection_arguments(parser: argparse.ArgumentParser) -> None:
+    selection = parser.add_mutually_exclusive_group()
+    selection.add_argument(
+        "--exclude-dir",
+        action="append",
+        default=None,
+        metavar="PATH",
+        help=(
+            "replace persisted custom exclusions with this exact "
+            "repository-relative subtree; repeat for multiple paths"
+        ),
+    )
+    selection.add_argument(
+        "--clear-exclude-dirs",
+        action="store_true",
+        help="clear persisted custom subtree exclusions",
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="codenib",
@@ -4088,8 +4306,9 @@ def build_parser() -> argparse.ArgumentParser:
     index_parser.add_argument(
         "--rebuild",
         action="store_true",
-        help="rebuild instead of incrementally updating an existing manifest",
+        help="force a clean rebuild even when an existing view is current",
     )
+    _add_source_selection_arguments(index_parser)
     _add_embedding_route_arguments(index_parser)
     index_parser.set_defaults(handler=_run_index)
 
@@ -4102,7 +4321,12 @@ def build_parser() -> argparse.ArgumentParser:
     wiki_parser.add_argument("--preset", choices=_PRESET_CHOICES, default="auto")
     wiki_parser.add_argument("--language", action="append", default=[])
     wiki_parser.add_argument("--view", action="append", default=[])
-    wiki_parser.add_argument("--rebuild", action="store_true")
+    wiki_parser.add_argument(
+        "--rebuild",
+        action="store_true",
+        help="force a clean rebuild even when an existing view is current",
+    )
+    _add_source_selection_arguments(wiki_parser)
     _add_embedding_route_arguments(wiki_parser)
     wiki_parser.add_argument(
         "--no-index",
@@ -4404,7 +4628,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     publish_parser.add_argument("--language", action="append", default=[])
     publish_parser.add_argument("--view", action="append", default=[])
-    publish_parser.add_argument("--rebuild", action="store_true")
+    publish_parser.add_argument(
+        "--rebuild",
+        action="store_true",
+        help="force a clean rebuild even when an existing view is current",
+    )
+    _add_source_selection_arguments(publish_parser)
     _add_embedding_route_arguments(publish_parser)
     publish_parser.add_argument("--site-output")
     publish_parser.add_argument("--context-output")
@@ -4502,8 +4731,9 @@ def build_parser() -> argparse.ArgumentParser:
     codegraph_init_parser.add_argument(
         "--rebuild",
         action="store_true",
-        help="rebuild graph views instead of incrementally updating them",
+        help="force a clean rebuild of the graph views",
     )
+    _add_source_selection_arguments(codegraph_init_parser)
     codegraph_init_parser.add_argument(
         "--dry-run",
         action="store_true",

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -3893,9 +3893,9 @@ def _codegraph_index_report(repo_path: Path) -> dict[str, object]:
                 ),
             )
         if report["symbol_graph_manifest_current"] and graph_entry is not None:
-            report[
-                "symbol_graph_artifact_matches"
-            ] = authenticated_graph_artifact_matches(graph_entry)
+            report["symbol_graph_artifact_matches"] = (
+                authenticated_graph_artifact_matches(graph_entry)
+            )
         report["bm25"] = bool(
             report["bm25_manifest_current"] and report["bm25_artifact_matches"]
         )

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -2310,7 +2310,10 @@ def _run_artifact_import_cache(args: argparse.Namespace) -> int:
         _run_context_with_cleanup_actions,
     )
     from .artifacts.runtime import SourceBindingCleanupOwner
-    from .compiler.cache_import import import_compiler_cache_bm25
+    from .compiler.cache_import import (
+        compiler_cache_source_selection,
+        import_compiler_cache_bm25,
+    )
     from .source_fingerprint import capture_repository_source
     from .storage import LocalCAS, SQLiteCatalog
 
@@ -2361,6 +2364,7 @@ def _run_artifact_import_cache(args: argparse.Namespace) -> int:
     )
     summary: tuple[str, str, int] | None = None
     try:
+        source_selection = compiler_cache_source_selection(topology.cache_dir)
         bm25_owner = _new_retained_output_receipt_owner()
         context_owner = _new_retained_output_receipt_owner()
         source_owner = SourceBindingCleanupOwner()
@@ -2407,6 +2411,7 @@ def _run_artifact_import_cache(args: argparse.Namespace) -> int:
             repository_source = capture_repository_source(
                 paths.repo_path,
                 exclude_roots=source_exclusions,
+                selection=source_selection,
                 _source_owner=source_owner.retain,
             )
             object_store = object_store_owner.acquire(
@@ -3836,11 +3841,9 @@ def _run_codegraph_init(args: argparse.Namespace) -> int:
 
 
 def _codegraph_index_report(repo_path: Path) -> dict[str, object]:
-    from .compiler.artifact_fingerprints import (
-        bm25_artifact_files_match,
-        regular_file_fingerprint,
-    )
+    from .compiler.artifact_fingerprints import bm25_artifact_files_match
     from .compiler.checkout_identity import validate_checkout_identity
+    from .compiler.graph_artifact import authenticated_graph_artifact_matches
     from .compiler.manifest import MANIFEST_FILENAME, RepoManifest
     from .paths import repo_index_dir
 
@@ -3890,25 +3893,9 @@ def _codegraph_index_report(repo_path: Path) -> dict[str, object]:
                 ),
             )
         if report["symbol_graph_manifest_current"] and graph_entry is not None:
-            expected_graph = graph_entry.config.get("graph_artifact")
-            if (
-                type(expected_graph) is dict
-                and set(expected_graph) == {"relative_path", "size", "sha256"}
-                and expected_graph.get("relative_path") == "graph.pkl"
-                and type(expected_graph.get("size")) is int
-                and expected_graph["size"] >= 0
-                and type(expected_graph.get("sha256")) is str
-            ):
-                try:
-                    observed_graph = regular_file_fingerprint(
-                        Path(graph_entry.path) / "graph.pkl"
-                    )
-                except (OSError, ValueError):
-                    observed_graph = None
-                report["symbol_graph_artifact_matches"] = observed_graph == {
-                    "size": expected_graph["size"],
-                    "sha256": expected_graph["sha256"],
-                }
+            report[
+                "symbol_graph_artifact_matches"
+            ] = authenticated_graph_artifact_matches(graph_entry)
         report["bm25"] = bool(
             report["bm25_manifest_current"] and report["bm25_artifact_matches"]
         )

--- a/codenib/clients/_manifest.py
+++ b/codenib/clients/_manifest.py
@@ -12,9 +12,9 @@ from pathlib import Path
 from typing import Callable
 
 from codenib.compiler.manifest import MANIFEST_FILENAME, RepoManifest
+from codenib.compiler.manifest_source import fingerprint_repository_for_manifest
 from codenib.paths import legacy_repo_index_dir, repo_index_dir
 from codenib.source_fingerprint import (
-    fingerprint_repository,
     is_secure_source_fingerprint_v2,
     lexical_repository_path,
 )
@@ -67,7 +67,11 @@ def _validate_source_identity(
         )
 
     excluded = (repo_index_dir(repo), legacy_repo_index_dir(repo))
-    observed = fingerprint_repository(repo, exclude_roots=excluded).value
+    observed = fingerprint_repository_for_manifest(
+        repo,
+        manifest,
+        exclude_roots=excluded,
+    ).value
     if observed != manifest.source_fingerprint:
         raise ValueError(
             f"{integration_name} checkout source fingerprint does not match the "

--- a/codenib/clients/execution/sandbox.py
+++ b/codenib/clients/execution/sandbox.py
@@ -11,6 +11,10 @@ import subprocess
 from pathlib import Path, PurePosixPath
 from typing import Mapping
 
+from ...repository_source_selection import (
+    DEFAULT_REPOSITORY_SOURCE_SELECTION,
+    RepositorySourceSelection,
+)
 from ...sandbox import ExecRequest, SandboxPolicy, SandboxProvider, SandboxSpec
 from ...sandbox.protocol import SandboxError
 from .process import ProcessLaunchError, ProcessRequest, ProcessResult
@@ -62,6 +66,9 @@ class SandboxProcessRunner:
         staged_files: Mapping[str | PurePosixPath, bytes] | None = None,
         environment: Mapping[str, str] | None = None,
         task_id_prefix: str = "guardian",
+        source_selection: RepositorySourceSelection = (
+            DEFAULT_REPOSITORY_SOURCE_SELECTION
+        ),
     ) -> None:
         self._provider = provider
         self._image = image
@@ -73,6 +80,11 @@ class SandboxProcessRunner:
         }
         self._environment = dict(environment or {})
         self._task_id_prefix = task_id_prefix
+        if type(source_selection) is not RepositorySourceSelection:
+            raise TypeError("source_selection must be a RepositorySourceSelection")
+        self._source_selection = RepositorySourceSelection(
+            source_selection.exclude_subtrees
+        )
 
     @staticmethod
     def _container_argv(request: ProcessRequest) -> tuple[str, ...]:
@@ -90,6 +102,7 @@ class SandboxProcessRunner:
             platform=self._platform,
             task_id=f"{self._task_id_prefix}-{revision[:12]}",
             policy=self._policy,
+            source_selection=self._source_selection,
         )
 
         def execute() -> ProcessResult:

--- a/codenib/code_chunker.py
+++ b/codenib/code_chunker.py
@@ -24,6 +24,10 @@ from .languages import (
 from .log_utils import get_logger
 from .paths import user_state_dir
 from .repository_filters import DEFAULT_IGNORED_DIRS, repository_path_is_visible
+from .repository_source_selection import (
+    RepositorySourceSelection,
+    repository_relative_source_path,
+)
 from .utils import is_test_file
 
 logger = get_logger(__name__)
@@ -53,6 +57,9 @@ class RepoChunkingConfig:
     # Directory filtering
     ignore_dirs: Set[str] = None
     include_dirs: Set[str] = None  # If specified, only these dirs will be processed
+    source_selection: RepositorySourceSelection = field(
+        default_factory=RepositorySourceSelection
+    )
 
     # File filtering
     ignore_patterns: Set[str] = None
@@ -63,6 +70,14 @@ class RepoChunkingConfig:
 
     def __post_init__(self):
         """Initialize default values."""
+        if type(self.source_selection) is not RepositorySourceSelection:
+            raise TypeError("source_selection must be a RepositorySourceSelection")
+        # Retain a detached snapshot.  RepositorySourceSelection is frozen, but
+        # callers can still bypass dataclass guards with object.__setattr__.
+        self.source_selection = RepositorySourceSelection(
+            self.source_selection.exclude_subtrees
+        )
+
         if not self.languages:
             self.languages = []
 
@@ -259,13 +274,21 @@ class CodeChunker:
         if not repo_path.is_dir():
             raise ValueError(f"Repository path is not a directory: {repo_path}")
 
-        languages = self.repo_config.languages or self._detect_repo_language(repo_path)
+        source_selection = self._source_selection_snapshot()
+        languages = self.repo_config.languages or self._detect_repo_language(
+            repo_path,
+            source_selection=source_selection,
+        )
 
         logger.info(f"Chunking repository: {repo_path}")
         logger.info(f"Target languages: {', '.join(languages)}")
 
         # Discover files
-        files_to_process = self._discover_files(repo_path, languages)
+        files_to_process = self._discover_files(
+            repo_path,
+            languages,
+            source_selection=source_selection,
+        )
         logger.info(f"Found {len(files_to_process)} files to process")
 
         # Process files
@@ -286,6 +309,12 @@ class CodeChunker:
                     ) from e
                 logger.warning(f"Failed to process {file_path}: {e}")
                 continue
+
+        self._require_selected_chunks(
+            all_chunks,
+            source_selection,
+            repository_root=repo_path,
+        )
 
         logger.info(
             f"Successfully processed {processed_count}/{len(files_to_process)} files"
@@ -313,8 +342,16 @@ class CodeChunker:
         if not repo_path.exists():
             raise ValueError(f"Repository path does not exist: {repo_path}")
 
-        languages = self.repo_config.languages or self._detect_repo_language(repo_path)
-        files_to_process = self._discover_files(repo_path, languages)
+        source_selection = self._source_selection_snapshot()
+        languages = self.repo_config.languages or self._detect_repo_language(
+            repo_path,
+            source_selection=source_selection,
+        )
+        files_to_process = self._discover_files(
+            repo_path,
+            languages,
+            source_selection=source_selection,
+        )
 
         stats = {
             "repo_path": str(repo_path),
@@ -378,7 +415,13 @@ class CodeChunker:
             rel_path = Path(file_path).name  # Just show filename for brevity
             logger.info(f"  {rel_path}: {len(file_chunks)} chunks")
 
-    def _discover_files(self, repo_path: Path, languages: List[str]) -> List[tuple]:
+    def _discover_files(
+        self,
+        repo_path: Path,
+        languages: List[str],
+        *,
+        source_selection: Optional[RepositorySourceSelection] = None,
+    ) -> List[tuple]:
         """
         Discover all relevant code files in the repository.
 
@@ -390,6 +433,13 @@ class CodeChunker:
             List of (file_path, language) tuples
         """
         files_to_process = []
+        selected = (
+            self._source_selection_snapshot()
+            if source_selection is None
+            else source_selection
+        )
+        if type(selected) is not RepositorySourceSelection:
+            raise TypeError("source_selection must be a RepositorySourceSelection")
 
         extension_to_language: Dict[str, str] = {}
         for language in languages:
@@ -409,7 +459,10 @@ class CodeChunker:
             dirs[:] = [
                 directory
                 for directory in dirs
-                if repository_path_is_visible(
+                if selected.allows(
+                    (root_path / directory).relative_to(repo_path).as_posix()
+                )
+                and repository_path_is_visible(
                     (root_path / directory).relative_to(repo_path)
                 )
                 and self._should_include_directory(root_path / directory)
@@ -419,9 +472,12 @@ class CodeChunker:
             for file_name in files:
                 file_path = root_path / file_name
 
-                if repository_path_is_visible(
-                    file_path.relative_to(repo_path)
-                ) and self._should_process_file(file_path, extension_to_language):
+                relative_path = file_path.relative_to(repo_path)
+                if (
+                    selected.allows(relative_path.as_posix())
+                    and repository_path_is_visible(relative_path)
+                    and self._should_process_file(file_path, extension_to_language)
+                ):
                     language = extension_to_language[file_path.suffix]
                     files_to_process.append((file_path, language))
 
@@ -549,7 +605,7 @@ class CodeChunker:
 
         # Calculate relative path if repo_path is provided
         if repo_path:
-            relative_path = str(file_path.relative_to(repo_path))
+            relative_path = file_path.relative_to(repo_path).as_posix()
             # Pass relative path to chunker for proper node_id generation
             return chunker.chunk_file(
                 str(file_path),
@@ -630,7 +686,12 @@ class CodeChunker:
 
         return result
 
-    def _detect_repo_language(self, repo_path: Path) -> List[str]:
+    def _detect_repo_language(
+        self,
+        repo_path: Path,
+        *,
+        source_selection: Optional[RepositorySourceSelection] = None,
+    ) -> List[str]:
         """
         Auto-detect the primary programming language(s) in a repository.
 
@@ -640,6 +701,14 @@ class CodeChunker:
         Returns:
             List of detected languages
         """
+        selected = (
+            self._source_selection_snapshot()
+            if source_selection is None
+            else source_selection
+        )
+        if type(selected) is not RepositorySourceSelection:
+            raise TypeError("source_selection must be a RepositorySourceSelection")
+
         language_extensions = {
             language: self._extensions_for_chunker_language(language)
             for language in chunker_languages()
@@ -654,7 +723,10 @@ class CodeChunker:
             dirs[:] = [
                 directory
                 for directory in dirs
-                if repository_path_is_visible(
+                if selected.allows(
+                    (root_path / directory).relative_to(repo_path).as_posix()
+                )
+                and repository_path_is_visible(
                     (root_path / directory).relative_to(repo_path)
                 )
                 and self._should_include_directory(root_path / directory)
@@ -662,8 +734,10 @@ class CodeChunker:
 
             for file in files:
                 file_path = root_path / file
+                relative_path = file_path.relative_to(repo_path)
                 if (
-                    repository_path_is_visible(file_path.relative_to(repo_path))
+                    selected.allows(relative_path.as_posix())
+                    and repository_path_is_visible(relative_path)
                     and file_path.suffix
                 ):
                     extension_counts[file_path.suffix] = (
@@ -682,6 +756,44 @@ class CodeChunker:
         result = list(detected_languages)
         logger.info(f"Detected languages: {result}")
         return result
+
+    def _source_selection_snapshot(self) -> RepositorySourceSelection:
+        """Capture the exact source policy used for one repository operation."""
+
+        selected = self.repo_config.source_selection
+        if type(selected) is not RepositorySourceSelection:
+            raise TypeError("source_selection must be a RepositorySourceSelection")
+        return RepositorySourceSelection(selected.exclude_subtrees)
+
+    @staticmethod
+    def _require_selected_chunks(
+        chunks: List[CodeChunk],
+        source_selection: RepositorySourceSelection,
+        *,
+        repository_root: Path,
+    ) -> None:
+        """Reject any chunk whose lexical repository path escaped selection."""
+
+        if not source_selection.exclude_subtrees:
+            return
+        for chunk in chunks:
+            source_path = getattr(chunk, "file", None)
+            try:
+                relative_path = repository_relative_source_path(
+                    repository_root,
+                    source_path,
+                )
+                allowed = source_selection.allows(relative_path)
+            except (TypeError, ValueError) as exc:
+                raise RuntimeError(
+                    "repository chunk has a non-canonical source path: "
+                    f"{source_path!r}"
+                ) from exc
+            if not allowed:
+                raise RuntimeError(
+                    "repository source selection leaked excluded chunk: "
+                    f"{relative_path}"
+                )
 
     def _get_chunk_summary_dict(self, chunks: List[CodeChunk]) -> Dict[str, Any]:
         """Get a dictionary summary of chunks (for JSON serialization)."""

--- a/codenib/compiler/artifact_quality.py
+++ b/codenib/compiler/artifact_quality.py
@@ -21,7 +21,15 @@ from ..native_index_authorization import (
     require_native_index_authorization,
     require_native_index_authorization_preflight,
 )
-from ..types import NODE_TYPE_DIRECTORY, NODE_TYPE_FILE, ROOT_NODE, is_symbol_node
+from ..repository_filters import repository_path_is_visible
+from ..repository_source_selection import RepositorySourceSelection
+from ..types import (
+    NODE_TYPE_DIRECTORY,
+    NODE_TYPE_FILE,
+    ROOT_NODE,
+    is_symbol_node,
+    node_has_definition,
+)
 
 ARTIFACT_QUALITY_SCHEMA_VERSION = 1
 
@@ -211,6 +219,288 @@ def constrain_graph_to_source_surface(
         "outside_paths_after": list(after_classes["outside"]),
         "invalid_paths_before": list(invalid_paths_before),
         "invalid_paths_after": list(invalid_paths_after),
+    }
+
+
+def _canonical_selected_path(
+    value: object,
+    source_selection: RepositorySourceSelection,
+) -> str | None:
+    """Return one canonical selected repository path, or ``None``.
+
+    Source-selection identities are defined over canonical POSIX paths. The
+    Git-surface normalizer intentionally accepts ``./`` and backslashes for
+    older artifacts, but a newly published selected graph must not retain
+    those aliases because the selection policy cannot authenticate them.
+    """
+
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        normalized = normalize_repository_path(value)
+        if normalized != value or not repository_path_is_visible(
+            normalized,
+            selection=source_selection,
+        ):
+            return None
+    except (TypeError, ValueError):
+        return None
+    return normalized
+
+
+def _selection_path_state(
+    value: object,
+    source_selection: RepositorySourceSelection,
+) -> tuple[str | None, str]:
+    """Classify a repository path as selected, excluded, absent, or invalid."""
+
+    if value is None or value == "":
+        return None, "absent"
+    if not isinstance(value, str):
+        return None, "invalid"
+    try:
+        normalized = normalize_repository_path(value)
+    except ValueError:
+        return None, "invalid"
+    if normalized != value:
+        return normalized, "invalid"
+    try:
+        return normalized, (
+            "selected"
+            if repository_path_is_visible(normalized, selection=source_selection)
+            else "excluded"
+        )
+    except (TypeError, ValueError):
+        return normalized, "invalid"
+
+
+def constrain_graph_to_source_selection(
+    graph: CodeGraph,
+    source_selection: RepositorySourceSelection,
+) -> dict[str, Any]:
+    """Enforce an exact source selection over every repository graph record.
+
+    Backend exclusion patterns are only an optimization. This function is the
+    publication gate: it removes excluded or non-canonical file/symbol nodes,
+    anchored edges, and SCIP/LSP occurrences, prunes directories without a
+    selected represented descendant, and rebuilds all derived graph indexes.
+    External reference-only symbols without a repository path remain valid.
+    """
+
+    if type(source_selection) is not RepositorySourceSelection:
+        raise TypeError("source_selection must be a RepositorySourceSelection")
+    selection = RepositorySourceSelection(source_selection.exclude_subtrees)
+
+    before_nodes = graph.graph.vcount()
+    before_edges = graph.graph.ecount()
+    excluded_before: set[str] = set()
+    invalid_before: set[str] = set()
+    selected_paths: set[str] = set()
+
+    def observe(value: object, owner: str, *, required: bool = False) -> None:
+        path, state = _selection_path_state(value, selection)
+        if state == "selected" and path is not None:
+            selected_paths.add(path)
+        elif state == "excluded" and path is not None:
+            excluded_before.add(path)
+        elif state == "invalid" or (required and state == "absent"):
+            invalid_before.add(f"{owner}={value!r}")
+
+    for vertex in graph.graph.vs:
+        attrs = vertex.attributes()
+        node_type = attrs.get("type")
+        if node_type == NODE_TYPE_DIRECTORY:
+            observe(attrs.get("name"), f"vertex[{vertex.index}].name", required=True)
+        elif node_type == NODE_TYPE_FILE:
+            observe(attrs.get("name"), f"vertex[{vertex.index}].name", required=True)
+        elif node_type != "root" and attrs.get("name") != ROOT_NODE:
+            observe(
+                attrs.get("file"),
+                f"vertex[{vertex.index}].file",
+                required=is_symbol_node(node_type) and node_has_definition(attrs),
+            )
+    for edge in graph.graph.es:
+        observe(edge.attributes().get("anchor_file"), f"edge[{edge.index}].anchor_file")
+    occurrence_index = getattr(graph, "lsp_occurrence_index", None)
+    if occurrence_index is not None:
+        for index, occurrence in enumerate(occurrence_index.occurrences):
+            observe(
+                occurrence.file_path,
+                f"occurrence[{index}].file_path",
+                required=True,
+            )
+
+    def keep_vertex(attrs: Mapping[str, Any]) -> bool:
+        node_type = attrs.get("type")
+        name = attrs.get("name")
+        if node_type == "root" or name == ROOT_NODE:
+            return True
+        if node_type == NODE_TYPE_DIRECTORY:
+            directory = _canonical_selected_path(name, selection)
+            return bool(
+                directory
+                and any(path.startswith(f"{directory}/") for path in selected_paths)
+            )
+        if node_type == NODE_TYPE_FILE:
+            return _canonical_selected_path(name, selection) is not None
+
+        raw_path = attrs.get("file")
+        if raw_path is None or raw_path == "":
+            return not (is_symbol_node(node_type) and node_has_definition(attrs))
+        return _canonical_selected_path(raw_path, selection) is not None
+
+    keep_vertices = [
+        vertex.index for vertex in graph.graph.vs if keep_vertex(vertex.attributes())
+    ]
+    if len(keep_vertices) != before_nodes:
+        graph.graph = graph.graph.subgraph(keep_vertices)
+
+    remove_edges = []
+    for edge in graph.graph.es:
+        raw_anchor = edge.attributes().get("anchor_file")
+        if (
+            raw_anchor is not None
+            and raw_anchor != ""
+            and (_canonical_selected_path(raw_anchor, selection) is None)
+        ):
+            remove_edges.append(edge.index)
+    if remove_edges:
+        graph.graph.delete_edges(remove_edges)
+
+    if occurrence_index is not None:
+        from ..scip_interface.lsp_occurrence_index import SCIPOccurrenceIndex
+
+        graph.lsp_occurrence_index = SCIPOccurrenceIndex(
+            (
+                occurrence
+                for occurrence in occurrence_index.occurrences
+                if _canonical_selected_path(occurrence.file_path, selection) is not None
+            ),
+            position_encoding=occurrence_index.position_encoding,
+        )
+
+    surviving_paths: set[str] = set()
+    for vertex in graph.graph.vs:
+        attrs = vertex.attributes()
+        if attrs.get("type") == NODE_TYPE_FILE:
+            value = attrs.get("name")
+        elif attrs.get("type") not in {"root", NODE_TYPE_DIRECTORY}:
+            value = attrs.get("file")
+        else:
+            value = None
+        if (path := _canonical_selected_path(value, selection)) is not None:
+            surviving_paths.add(path)
+    for edge in graph.graph.es:
+        if (
+            path := _canonical_selected_path(
+                edge.attributes().get("anchor_file"), selection
+            )
+        ) is not None:
+            surviving_paths.add(path)
+    final_occurrence_index = getattr(graph, "lsp_occurrence_index", None)
+    if final_occurrence_index is not None:
+        surviving_paths.update(
+            path
+            for occurrence in final_occurrence_index.occurrences
+            if (path := _canonical_selected_path(occurrence.file_path, selection))
+            is not None
+        )
+    keep_after_pruning = [
+        vertex.index
+        for vertex in graph.graph.vs
+        if vertex.attributes().get("type") != NODE_TYPE_DIRECTORY
+        or (
+            (
+                directory := _canonical_selected_path(
+                    vertex.attributes().get("name"), selection
+                )
+            )
+            is not None
+            and any(path.startswith(f"{directory}/") for path in surviving_paths)
+        )
+    ]
+    if len(keep_after_pruning) != graph.graph.vcount():
+        graph.graph = graph.graph.subgraph(keep_after_pruning)
+
+    graph.name_to_vertex = {
+        name: vertex.index
+        for vertex in graph.graph.vs
+        if isinstance((name := vertex.attributes().get("name")), str) and name
+    }
+    graph.symbol_ranges = {
+        name: value
+        for name, value in graph.symbol_ranges.items()
+        if name in graph.name_to_vertex
+    }
+    graph.invalidate_caches()
+    graph.build_range_indexes()
+
+    excluded_after: set[str] = set()
+    invalid_after: set[str] = set()
+
+    def verify(value: object, owner: str, *, required: bool = False) -> None:
+        path, state = _selection_path_state(value, selection)
+        if state == "excluded" and path is not None:
+            excluded_after.add(path)
+        elif state == "invalid" or (required and state == "absent"):
+            invalid_after.add(f"{owner}={value!r}")
+
+    represented_after: set[str] = set()
+    for vertex in graph.graph.vs:
+        attrs = vertex.attributes()
+        node_type = attrs.get("type")
+        if node_type == NODE_TYPE_DIRECTORY:
+            verify(attrs.get("name"), f"vertex[{vertex.index}].name", required=True)
+        elif node_type == NODE_TYPE_FILE:
+            value = attrs.get("name")
+            verify(value, f"vertex[{vertex.index}].name", required=True)
+            if (path := _canonical_selected_path(value, selection)) is not None:
+                represented_after.add(path)
+        elif node_type != "root" and attrs.get("name") != ROOT_NODE:
+            value = attrs.get("file")
+            verify(
+                value,
+                f"vertex[{vertex.index}].file",
+                required=is_symbol_node(node_type) and node_has_definition(attrs),
+            )
+            if (path := _canonical_selected_path(value, selection)) is not None:
+                represented_after.add(path)
+    for edge in graph.graph.es:
+        value = edge.attributes().get("anchor_file")
+        verify(value, f"edge[{edge.index}].anchor_file")
+        if (path := _canonical_selected_path(value, selection)) is not None:
+            represented_after.add(path)
+    final_occurrence_index = getattr(graph, "lsp_occurrence_index", None)
+    if final_occurrence_index is not None:
+        for index, occurrence in enumerate(final_occurrence_index.occurrences):
+            value = occurrence.file_path
+            verify(value, f"occurrence[{index}].file_path", required=True)
+            if (path := _canonical_selected_path(value, selection)) is not None:
+                represented_after.add(path)
+
+    dangling_directories = sorted(
+        name
+        for vertex in graph.graph.vs
+        if vertex.attributes().get("type") == NODE_TYPE_DIRECTORY
+        and isinstance((name := vertex.attributes().get("name")), str)
+        and not any(path.startswith(f"{name}/") for path in represented_after)
+    )
+    if dangling_directories:
+        invalid_after.update(
+            f"directory_without_selected_descendant={path!r}"
+            for path in dangling_directories
+        )
+
+    return {
+        "source_selection_digest": selection.digest,
+        "nodes_before": before_nodes,
+        "nodes_after": graph.graph.vcount(),
+        "edges_before": before_edges,
+        "edges_after": graph.graph.ecount(),
+        "removed_excluded_paths": sorted(excluded_before),
+        "excluded_paths_after": sorted(excluded_after),
+        "invalid_paths_before": sorted(invalid_before),
+        "invalid_paths_after": sorted(invalid_after),
     }
 
 
@@ -585,6 +875,7 @@ __all__ = [
     "ARTIFACT_QUALITY_SCHEMA_VERSION",
     "assess_vector_artifact",
     "constrain_and_assess_graph_artifact",
+    "constrain_graph_to_source_selection",
     "constrain_graph_to_source_surface",
     "graph_file_paths",
     "graph_source_paths",

--- a/codenib/compiler/cache_import.py
+++ b/codenib/compiler/cache_import.py
@@ -44,6 +44,10 @@ from ..artifacts.strict_context import (
     _portable_capabilities,
     stage_context_artifact_strict,
 )
+from ..repository_source_selection import (
+    DEFAULT_REPOSITORY_SOURCE_SELECTION,
+    RepositorySourceSelection,
+)
 from ..source_fingerprint import (
     RepositorySourceBinding,
     RepositorySourceIdentitySnapshot,
@@ -445,6 +449,32 @@ def _parse_exact_manifest(payload: bytes, *, max_manifest_bytes: int) -> RepoMan
     if exact != data:
         raise ValueError("compiler cache repository manifest is not exact v1.1 data")
     return manifest
+
+
+def compiler_cache_source_selection(
+    cache_dir: str | Path,
+    *,
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+) -> RepositorySourceSelection:
+    """Return the exact source selection recorded by one compiler cache.
+
+    The CLI needs this identity axis before it captures the retained repository
+    source.  The import coordinator authenticates the same manifest again under
+    its longer-lived cache lock, so a manifest replacement between these two
+    reads can only make the later import fail closed.
+    """
+
+    cache = lexical_directory_path(Path(cache_dir))
+    bounded_limit = _manifest_limit(max_manifest_bytes)
+    with compiler_cache_lock(cache, create=False):
+        manifest = _parse_exact_manifest(
+            _read_manifest(cache, max_manifest_bytes=bounded_limit),
+            max_manifest_bytes=bounded_limit,
+        )
+    selection = manifest.source_selection
+    if selection is None:
+        return DEFAULT_REPOSITORY_SOURCE_SELECTION
+    return RepositorySourceSelection(selection.exclude_subtrees)
 
 
 def _require_manifest_source(

--- a/codenib/compiler/checkout_identity.py
+++ b/codenib/compiler/checkout_identity.py
@@ -10,11 +10,11 @@ import subprocess
 from pathlib import Path
 
 from ..source_fingerprint import (
-    fingerprint_repository,
     is_secure_source_fingerprint_v2,
     lexical_repository_path,
 )
 from .manifest import RepoManifest
+from .manifest_source import fingerprint_repository_for_manifest
 
 
 def checkout_commit(repo_path: Path) -> str | None:
@@ -51,8 +51,9 @@ def validate_checkout_identity(
             "(including a missing value). Rebuild the index before serving or "
             "publishing context."
         )
-    actual_source = fingerprint_repository(
+    actual_source = fingerprint_repository_for_manifest(
         repo_path,
+        manifest,
         exclude_roots=excluded_roots,
     ).value
     if actual_source != expected_source:

--- a/codenib/compiler/graph_artifact.py
+++ b/codenib/compiler/graph_artifact.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authenticated loading for persisted symbol-graph artifacts."""
+
+from __future__ import annotations
+
+import re
+import tempfile
+from contextlib import ExitStack
+from pathlib import Path
+from typing import Any, BinaryIO, Mapping
+
+from .._atomic_directory import (
+    PublicationDirectoryReader,
+    capture_directory_ownership,
+    directory_ownership_file_records,
+    reopen_authenticated_directory,
+)
+from ..graph.code_graph import CodeGraph
+
+_GRAPH_FILENAME = "graph.pkl"
+_LSP_OCCURRENCE_FILENAME = "lsp_index.pkl"
+_LSP_OCCURRENCE_RECEIPT_KEY = "lsp_occurrence_artifact"
+_GRAPH_RECEIPT_KEYS = frozenset({"relative_path", "size", "sha256"})
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
+_MAX_GRAPH_ARTIFACT_BYTES = 8 << 30
+_MAX_LSP_OCCURRENCE_ARTIFACT_BYTES = 8 << 30
+_ARTIFACT_COPY_MEMORY_BYTES = 32 << 20
+
+
+def _entry_graph_receipt(entry: Any) -> dict[str, Any]:
+    config = getattr(entry, "config", None)
+    if not isinstance(config, Mapping):
+        raise ValueError("symbol graph manifest entry has no artifact contract")
+    receipt = config.get("graph_artifact")
+    if type(receipt) is not dict:
+        raise ValueError("symbol graph manifest entry has no exact graph receipt")
+    return receipt
+
+
+def _entry_lsp_occurrence_receipt(entry: Any) -> dict[str, Any] | None:
+    config = getattr(entry, "config", None)
+    if not isinstance(config, Mapping):
+        raise ValueError("symbol graph manifest entry has no artifact contract")
+    if _LSP_OCCURRENCE_RECEIPT_KEY not in config:
+        return None
+    receipt = config[_LSP_OCCURRENCE_RECEIPT_KEY]
+    if receipt is None:
+        return None
+    if type(receipt) is not dict:
+        raise ValueError(
+            "symbol graph manifest entry has no exact LSP occurrence receipt"
+        )
+    return receipt
+
+
+def _graph_receipt(receipt: Mapping[str, Any]) -> tuple[int, str]:
+    if type(receipt) is not dict or set(receipt) != _GRAPH_RECEIPT_KEYS:
+        raise ValueError("symbol graph artifact has no exact graph receipt")
+    if receipt.get("relative_path") != _GRAPH_FILENAME:
+        raise ValueError("symbol graph receipt has an invalid relative path")
+    size = receipt.get("size")
+    digest = receipt.get("sha256")
+    if (
+        isinstance(size, bool)
+        or not isinstance(size, int)
+        or size < 0
+        or size > _MAX_GRAPH_ARTIFACT_BYTES
+    ):
+        raise ValueError("symbol graph receipt has an invalid artifact size")
+    if not isinstance(digest, str) or _SHA256_RE.fullmatch(digest) is None:
+        raise ValueError("symbol graph receipt has an invalid SHA-256 digest")
+    return size, digest
+
+
+def _lsp_occurrence_receipt(receipt: Mapping[str, Any]) -> tuple[int, str]:
+    if type(receipt) is not dict or set(receipt) != _GRAPH_RECEIPT_KEYS:
+        raise ValueError("LSP occurrence artifact has no exact receipt")
+    if receipt.get("relative_path") != _LSP_OCCURRENCE_FILENAME:
+        raise ValueError("LSP occurrence receipt has an invalid relative path")
+    size = receipt.get("size")
+    digest = receipt.get("sha256")
+    if (
+        isinstance(size, bool)
+        or not isinstance(size, int)
+        or size < 0
+        or size > _MAX_LSP_OCCURRENCE_ARTIFACT_BYTES
+    ):
+        raise ValueError("LSP occurrence receipt has an invalid artifact size")
+    if not isinstance(digest, str) or _SHA256_RE.fullmatch(digest) is None:
+        raise ValueError("LSP occurrence receipt has an invalid SHA-256 digest")
+    return size, digest
+
+
+def _require_receipted_record(
+    records: Mapping[str, Any],
+    filename: str,
+    *,
+    expected_size: int,
+    expected_digest: str,
+    label: str,
+) -> None:
+    observed = records.get(filename)
+    if (
+        observed is None
+        or observed.size != expected_size
+        or observed.sha256 != expected_digest
+    ):
+        raise ValueError(f"{label} differs from its manifest receipt")
+
+
+def _copy_authenticated_artifact(
+    reader: PublicationDirectoryReader,
+    copied: BinaryIO,
+    *,
+    filename: str,
+    expected_size: int,
+    expected_digest: str,
+    label: str,
+) -> None:
+    with reader.open_authenticated_file(
+        filename,
+        max_bytes=expected_size,
+    ) as authenticated:
+        for chunk in authenticated.iter_bytes():
+            copied.write(chunk)
+    if (
+        authenticated.record.size != expected_size
+        or authenticated.record.sha256 != expected_digest
+    ):
+        raise ValueError(f"{label} changed before authenticated loading")
+
+
+def load_authenticated_graph_generation(
+    root_value: str | Path,
+    receipt: Mapping[str, Any],
+    *,
+    lsp_occurrence_receipt: Mapping[str, Any] | None = None,
+) -> CodeGraph:
+    """Load exactly one graph generation through its persisted receipts.
+
+    The directory is captured without following links, its canonical file
+    records are matched to the persisted receipts, and the same generation is
+    copied through authenticated descriptors/HANDLEs.  Every receipted stream
+    is copied and verified before either pickle is loaded.  An unreceipted
+    occurrence sidecar is deliberately ignored.
+    """
+
+    expected_size, expected_digest = _graph_receipt(receipt)
+    expected_occurrence = (
+        None
+        if lsp_occurrence_receipt is None
+        else _lsp_occurrence_receipt(lsp_occurrence_receipt)
+    )
+    if not isinstance(root_value, (str, Path)) or not str(root_value):
+        raise ValueError("symbol graph artifact has no directory")
+    root = Path(root_value)
+    ownership = capture_directory_ownership(
+        root,
+        required_root_file=_GRAPH_FILENAME,
+    )
+    records = {
+        record.path: record for record in directory_ownership_file_records(ownership)
+    }
+    _require_receipted_record(
+        records,
+        _GRAPH_FILENAME,
+        expected_size=expected_size,
+        expected_digest=expected_digest,
+        label="symbol graph artifact",
+    )
+    if expected_occurrence is not None:
+        occurrence_size, occurrence_digest = expected_occurrence
+        _require_receipted_record(
+            records,
+            _LSP_OCCURRENCE_FILENAME,
+            expected_size=occurrence_size,
+            expected_digest=occurrence_digest,
+            label="LSP occurrence artifact",
+        )
+
+    def load(reader: PublicationDirectoryReader) -> CodeGraph:
+        with ExitStack() as stack:
+            graph_copy = stack.enter_context(
+                tempfile.SpooledTemporaryFile(
+                    max_size=_ARTIFACT_COPY_MEMORY_BYTES,
+                    mode="w+b",
+                )
+            )
+            occurrence_copy = None
+            if expected_occurrence is not None:
+                occurrence_copy = stack.enter_context(
+                    tempfile.SpooledTemporaryFile(
+                        max_size=_ARTIFACT_COPY_MEMORY_BYTES,
+                        mode="w+b",
+                    )
+                )
+
+            _copy_authenticated_artifact(
+                reader,
+                graph_copy,
+                filename=_GRAPH_FILENAME,
+                expected_size=expected_size,
+                expected_digest=expected_digest,
+                label="symbol graph artifact",
+            )
+            if occurrence_copy is not None and expected_occurrence is not None:
+                occurrence_size, occurrence_digest = expected_occurrence
+                _copy_authenticated_artifact(
+                    reader,
+                    occurrence_copy,
+                    filename=_LSP_OCCURRENCE_FILENAME,
+                    expected_size=occurrence_size,
+                    expected_digest=occurrence_digest,
+                    label="LSP occurrence artifact",
+                )
+
+            graph_copy.seek(0)
+            graph = CodeGraph.load_graph_stream(
+                graph_copy,
+                input_label=str(root / _GRAPH_FILENAME),
+            )
+            if occurrence_copy is not None:
+                from ..scip_interface.lsp_occurrence_index import SCIPOccurrenceIndex
+
+                occurrence_copy.seek(0)
+                graph.lsp_occurrence_index = SCIPOccurrenceIndex.load_stream(
+                    occurrence_copy,
+                    input_label=str(root / _LSP_OCCURRENCE_FILENAME),
+                )
+            return graph
+
+    return reopen_authenticated_directory(root, ownership, load)
+
+
+def load_authenticated_graph_artifact(entry: Any) -> CodeGraph:
+    """Load exactly the graph generation named by one manifest entry."""
+
+    root_value = getattr(entry, "path", None)
+    if type(root_value) is not str or not root_value:
+        raise ValueError("symbol graph manifest entry has no artifact directory")
+    return load_authenticated_graph_generation(
+        root_value,
+        _entry_graph_receipt(entry),
+        lsp_occurrence_receipt=_entry_lsp_occurrence_receipt(entry),
+    )
+
+
+__all__ = [
+    "load_authenticated_graph_artifact",
+    "load_authenticated_graph_generation",
+]

--- a/codenib/compiler/graph_artifact.py
+++ b/codenib/compiler/graph_artifact.py
@@ -56,6 +56,18 @@ def _entry_lsp_occurrence_receipt(entry: Any) -> dict[str, Any] | None:
     return receipt
 
 
+def _entry_graph_root(entry: Any) -> Path:
+    root_value = getattr(entry, "path", None)
+    if type(root_value) is not str or not root_value:
+        raise ValueError("symbol graph manifest entry has no artifact directory")
+    declared = Path(root_value)
+    if declared.name == _GRAPH_FILENAME:
+        return declared.parent
+    if declared.suffix == ".pkl":
+        raise ValueError("symbol graph manifest entry names an unsupported pickle")
+    return declared
+
+
 def _graph_receipt(receipt: Mapping[str, Any]) -> tuple[int, str]:
     if type(receipt) is not dict or set(receipt) != _GRAPH_RECEIPT_KEYS:
         raise ValueError("symbol graph artifact has no exact graph receipt")
@@ -238,17 +250,56 @@ def load_authenticated_graph_generation(
 def load_authenticated_graph_artifact(entry: Any) -> CodeGraph:
     """Load exactly the graph generation named by one manifest entry."""
 
-    root_value = getattr(entry, "path", None)
-    if type(root_value) is not str or not root_value:
-        raise ValueError("symbol graph manifest entry has no artifact directory")
     return load_authenticated_graph_generation(
-        root_value,
+        _entry_graph_root(entry),
         _entry_graph_receipt(entry),
         lsp_occurrence_receipt=_entry_lsp_occurrence_receipt(entry),
     )
 
 
+def authenticated_graph_artifact_matches(entry: Any) -> bool:
+    """Return whether every receipted file still matches one graph generation."""
+
+    try:
+        root = _entry_graph_root(entry)
+        graph_size, graph_digest = _graph_receipt(_entry_graph_receipt(entry))
+        occurrence_receipt = _entry_lsp_occurrence_receipt(entry)
+        expected_occurrence = (
+            None
+            if occurrence_receipt is None
+            else _lsp_occurrence_receipt(occurrence_receipt)
+        )
+        ownership = capture_directory_ownership(
+            root,
+            required_root_file=_GRAPH_FILENAME,
+        )
+        records = {
+            record.path: record
+            for record in directory_ownership_file_records(ownership)
+        }
+        _require_receipted_record(
+            records,
+            _GRAPH_FILENAME,
+            expected_size=graph_size,
+            expected_digest=graph_digest,
+            label="symbol graph artifact",
+        )
+        if expected_occurrence is not None:
+            occurrence_size, occurrence_digest = expected_occurrence
+            _require_receipted_record(
+                records,
+                _LSP_OCCURRENCE_FILENAME,
+                expected_size=occurrence_size,
+                expected_digest=occurrence_digest,
+                label="LSP occurrence artifact",
+            )
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return False
+    return True
+
+
 __all__ = [
+    "authenticated_graph_artifact_matches",
     "load_authenticated_graph_artifact",
     "load_authenticated_graph_generation",
 ]

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -16,9 +16,12 @@ Concrete builders wrap existing index infrastructure:
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import os
 import shutil
+import stat
 import subprocess
 import time
 from dataclasses import dataclass, field
@@ -40,6 +43,12 @@ from ..provider_routes import (
 from ..repository_filters import (
     REPOSITORY_FILTER_POLICY_VERSION,
     default_exclude_patterns,
+    repository_path_is_visible,
+)
+from ..repository_source_selection import (
+    DEFAULT_REPOSITORY_SOURCE_SELECTION,
+    RepositorySourceSelection,
+    repository_relative_source_path,
 )
 from .resources import IndexState, IndexStatus
 from .verification import NullVerifier, UpdateVerifier, VerificationResult
@@ -49,6 +58,167 @@ logger = logging.getLogger(__name__)
 
 class _AtomicIncrementalRebuildRequired(RuntimeError):
     """Signal that vector deltas must use the complete-generation builder."""
+
+
+def _snapshot_source_selection(
+    source_selection: RepositorySourceSelection,
+) -> RepositorySourceSelection:
+    """Return a detached, exact-type snapshot for one build operation."""
+
+    if type(source_selection) is not RepositorySourceSelection:
+        raise TypeError("source_selection must be a RepositorySourceSelection")
+    return RepositorySourceSelection(source_selection.exclude_subtrees)
+
+
+def _source_selection_for_build(
+    configured: RepositorySourceSelection,
+    requested: object = None,
+) -> RepositorySourceSelection:
+    """Snapshot one builder selection and reject a mismatched runtime request."""
+
+    selected = _snapshot_source_selection(configured)
+    if requested is None:
+        return selected
+    runtime = _snapshot_source_selection(requested)
+    if runtime != selected:
+        raise RuntimeError(
+            "builder source selection does not match the requested selection"
+        )
+    return selected
+
+
+def _selection_exclude_hints(
+    patterns: List[str],
+    source_selection: RepositorySourceSelection,
+) -> List[str]:
+    """Add backend performance hints for exact excluded subtrees."""
+
+    hints = list(patterns)
+    for subtree in source_selection.exclude_subtrees:
+        # Hints are not the correctness boundary. Avoid handing glob
+        # metacharacters to backends that would broaden an exact literal path.
+        if any(character in subtree for character in "*?["):
+            continue
+        for pattern in (subtree, f"{subtree}/**"):
+            if pattern not in hints:
+                hints.append(pattern)
+    return hints
+
+
+def _constrain_and_save_selected_graph(
+    graph: Any,
+    output_dir: str,
+    source_selection: RepositorySourceSelection,
+) -> tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+    """Apply the central graph gate, then publish graph and occurrence views."""
+
+    from .artifact_fingerprints import regular_file_fingerprint
+    from .artifact_quality import constrain_graph_to_source_selection
+
+    occurrence_path = os.path.join(output_dir, "lsp_index.pkl")
+    report = constrain_graph_to_source_selection(graph, source_selection)
+    if report["excluded_paths_after"] or report["invalid_paths_after"]:
+        raise RuntimeError(
+            "source-selection graph gate could not prove a clean artifact"
+        )
+
+    graph.save_graph(os.path.join(output_dir, "graph.pkl"))
+    occurrence_index = getattr(graph, "lsp_occurrence_index", None)
+    lsp_occurrence_artifact = None
+    if occurrence_index is not None:
+        occurrence_index.save(occurrence_path)
+        lsp_occurrence_artifact = {
+            "relative_path": "lsp_index.pkl",
+            **regular_file_fingerprint(occurrence_path),
+        }
+    elif os.path.lexists(occurrence_path):
+        # A full rebuild must never adopt an occurrence sidecar left by an
+        # earlier generation.  Backends that produced occurrences attach the
+        # exact current object to ``graph``; absence therefore means this
+        # generation has no publishable occurrence view.
+        os.unlink(occurrence_path)
+    return (
+        {
+            "source_selection_digest": report["source_selection_digest"],
+            "nodes_before": report["nodes_before"],
+            "nodes_after": report["nodes_after"],
+            "edges_before": report["edges_before"],
+            "edges_after": report["edges_after"],
+            "removed_excluded_path_count": len(report["removed_excluded_paths"]),
+            "excluded_path_count_after": len(report["excluded_paths_after"]),
+            "invalid_path_count_before": len(report["invalid_paths_before"]),
+            "invalid_path_count_after": len(report["invalid_paths_after"]),
+        },
+        lsp_occurrence_artifact,
+    )
+
+
+def _require_selected_paths(
+    source_selection: RepositorySourceSelection,
+    paths: Any,
+    *,
+    repository_root: str,
+    subject: str,
+) -> None:
+    """Reject non-canonical or excluded repository-relative result paths."""
+
+    for source_path in paths:
+        try:
+            relative_path = repository_relative_source_path(
+                repository_root,
+                source_path,
+            )
+            allowed = repository_path_is_visible(
+                relative_path,
+                selection=source_selection,
+            )
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"{subject} has a non-canonical repository path: {source_path!r}"
+            ) from exc
+        if not allowed:
+            raise RuntimeError(
+                f"{subject} leaked excluded repository path: {relative_path}"
+            )
+
+
+def _require_selected_vector_documents(
+    vector_store: Any,
+    source_selection: RepositorySourceSelection,
+    *,
+    repository_root: str,
+) -> None:
+    """Validate every materialized vector document against source selection."""
+
+    for level in ("l0", "l2"):
+        documents = getattr(vector_store, f"{level}_documents", ()) or ()
+        _require_selected_documents(
+            source_selection,
+            documents,
+            repository_root=repository_root,
+            subject=f"vector {level} documents",
+        )
+
+
+def _require_selected_documents(
+    source_selection: RepositorySourceSelection,
+    documents: Any,
+    *,
+    repository_root: str,
+    subject: str,
+) -> None:
+    """Validate the repository file metadata on materialized documents."""
+
+    paths = []
+    for document in documents:
+        metadata = getattr(document, "metadata", None)
+        paths.append(metadata.get("file") if isinstance(metadata, dict) else None)
+    _require_selected_paths(
+        source_selection,
+        paths,
+        repository_root=repository_root,
+        subject=subject,
+    )
 
 
 def _git_output(repo_path: str, *args: str) -> str:
@@ -103,8 +273,21 @@ class BM25IndexBuilder:
     max_k: int = 128
     max_lines_per_chunk: int = 300
     additional_ignore_dirs: List[str] = field(default_factory=list)
+    source_selection: RepositorySourceSelection = field(
+        default_factory=RepositorySourceSelection
+    )
+
+    def __post_init__(self) -> None:
+        self.source_selection = _snapshot_source_selection(self.source_selection)
 
     def artifact_identity(self) -> Dict[str, Any]:
+        source_selection = _snapshot_source_selection(self.source_selection)
+        return self._artifact_identity_for_selection(source_selection)
+
+    def _artifact_identity_for_selection(
+        self,
+        source_selection: RepositorySourceSelection,
+    ) -> Dict[str, Any]:
         identity = {
             # v8 refuses skipped files and retains non-symbol source context.
             "builder_schema": 8,
@@ -114,6 +297,7 @@ class BM25IndexBuilder:
             "chunking_failure_policy": "fail",
             "include_header_epilogue": True,
             "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
+            "source_selection_digest": source_selection.digest,
         }
         if self.additional_ignore_dirs:
             identity["additional_ignore_dirs"] = sorted(
@@ -124,12 +308,20 @@ class BM25IndexBuilder:
     def build(self, scope: str, **kwargs: Any) -> IndexStatus:
         repo_path: str = kwargs["repo_path"]
         output_dir: str = kwargs["output_dir"]
+        source_selection = _source_selection_for_build(
+            self.source_selection,
+            kwargs.get("source_selection"),
+        )
+        artifact_identity = self._artifact_identity_for_selection(source_selection)
 
         from ..code_chunker import CodeChunker, RepoChunkingConfig
         from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 
         primary = self.languages[0] if self.languages else "python"
-        repo_config = RepoChunkingConfig(languages=self.languages)
+        repo_config = RepoChunkingConfig(
+            languages=self.languages,
+            source_selection=source_selection,
+        )
         repo_config.ignore_dirs.update(self.additional_ignore_dirs)
         chunker = CodeChunker(
             language=primary,
@@ -138,11 +330,23 @@ class BM25IndexBuilder:
             include_header_epilogue=True,
         )
         chunks = chunker.chunk_repository(repo_path=repo_path, strict=True)
+        _require_selected_paths(
+            source_selection,
+            (getattr(chunk, "file", None) for chunk in chunks),
+            repository_root=repo_path,
+            subject="BM25 chunks",
+        )
 
         indexer = BM25CodeIndexer(
             chunks=chunks,
             max_k=self.max_k,
             project_root=repo_path,
+        )
+        _require_selected_documents(
+            source_selection,
+            getattr(indexer, "documents", ()),
+            repository_root=repo_path,
+            subject="BM25 documents",
         )
         os.makedirs(output_dir, exist_ok=True)
         indexer.save_index(output_dir)
@@ -158,7 +362,7 @@ class BM25IndexBuilder:
             scope=scope,
             path=output_dir,
             metadata={
-                **self.artifact_identity(),
+                **artifact_identity,
                 "artifact_file_fingerprints": artifact_files,
                 "chunk_count": len(chunks),
                 "source_file_count": len(
@@ -194,10 +398,23 @@ class VectorIndexBuilder:
     index_metric: str = "ip"
     embedding_document_max_chars: int = REMOTE_EMBEDDING_DOCUMENT_MAX_CHARS
     additional_ignore_dirs: List[str] = field(default_factory=list)
+    source_selection: RepositorySourceSelection = field(
+        default_factory=RepositorySourceSelection
+    )
+
+    def __post_init__(self) -> None:
+        self.source_selection = _snapshot_source_selection(self.source_selection)
 
     def artifact_identity(self) -> Dict[str, Any]:
         """Return the embedding contract required to reopen this artifact."""
 
+        source_selection = _snapshot_source_selection(self.source_selection)
+        return self._artifact_identity_for_selection(source_selection)
+
+    def _artifact_identity_for_selection(
+        self,
+        source_selection: RepositorySourceSelection,
+    ) -> Dict[str, Any]:
         route = self._embedding_route()
         identity = {
             # v7 deterministically bounds remote document inputs in addition
@@ -217,6 +434,7 @@ class VectorIndexBuilder:
             "max_lines_per_chunk": self.max_lines_per_chunk,
             "chunking_failure_policy": "fail",
             "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
+            "source_selection_digest": source_selection.digest,
         }
         if route.provider == "openai":
             identity["embedding_document_max_chars"] = self.embedding_document_max_chars
@@ -308,6 +526,10 @@ class VectorIndexBuilder:
         )
         from ..index.embedding.builders import _PrivateBuildDirectory
 
+        source_selection = _source_selection_for_build(
+            self.source_selection,
+            kwargs.get("source_selection"),
+        )
         output_path = Path(kwargs["output_dir"])
         publication_stage = OwnedDirectoryStage.prepare(
             output_path,
@@ -338,6 +560,7 @@ class VectorIndexBuilder:
                 with build_root.path_operation("vector update marker begin"):
                     begin_vector_view_update(writer_path)
                 build_kwargs = dict(kwargs)
+                build_kwargs["source_selection"] = source_selection
                 build_kwargs["output_dir"] = str(writer_path)
                 build_kwargs["_published_output_dir"] = str(output_path)
                 build_kwargs["_build_root_guard"] = build_root
@@ -386,7 +609,11 @@ class VectorIndexBuilder:
             raise RuntimeError("full vector build requires its private root owner")
         build_root_guard.require_writer_path(Path(output_dir))
         build_root_guard.verify("full vector build entry")
-        artifact_identity = self.artifact_identity()
+        source_selection = _source_selection_for_build(
+            self.source_selection,
+            kwargs.get("source_selection"),
+        )
+        artifact_identity = self._artifact_identity_for_selection(source_selection)
         with build_root_guard.path_operation("hierarchical vector build"):
             vs = build_hierarchical_vector_store(
                 repo_path=repo_path,
@@ -407,11 +634,17 @@ class VectorIndexBuilder:
                 force_rebuild=True,
                 strict_chunking=True,
                 additional_ignore_dirs=self.additional_ignore_dirs,
+                source_selection=source_selection,
                 # ``build`` owns the complete private generation tree.  Its
                 # outer OwnedDirectoryStage is the publication boundary.
                 _atomic_publish=False,
                 _build_root_guard=build_root_guard,
             )
+        _require_selected_vector_documents(
+            vs,
+            source_selection,
+            repository_root=repo_path,
+        )
         self._validate_vector_dimension(vs)
 
         doc_count = {}
@@ -517,6 +750,13 @@ class VectorIndexBuilder:
 
     def incremental_update(self, scope: str, **kwargs: Any) -> IndexStatus:
         """Update the vector view, rebuilding on recoverable path failures."""
+
+        source_selection = _source_selection_for_build(
+            self.source_selection,
+            kwargs.get("source_selection"),
+        )
+        kwargs = dict(kwargs)
+        kwargs["source_selection"] = source_selection
 
         from ..native_index_authorization import (
             MissingNativeIndexAuthorizationError,
@@ -654,6 +894,596 @@ class VectorIndexBuilder:
         )
 
 
+_ZOEKT_SHARD_TREE_RECEIPT_SCHEMA = "codenib.zoekt-shard-tree.v1"
+_ZOEKT_MAX_SOURCE_ENTRIES = 500_000
+_ZOEKT_MAX_SOURCE_METADATA_BYTES = 128 * 1024 * 1024
+_ZOEKT_MAX_SOURCE_PATH_BYTES = 4_096
+_ZOEKT_MAX_SOURCE_PATH_COMPONENTS = 256
+_ZOEKT_BLOB_COPY_BYTES = 1024 * 1024
+_ZOEKT_PROTECTED_FLAGS = frozenset({"branches", "index", "prefix", "submodules"})
+
+
+@dataclass(frozen=True, slots=True)
+class _ZoektGitTreeEntry:
+    mode: str
+    object_id: str
+    path: str
+
+
+def _zoekt_hash_field(digest: Any, value: bytes) -> None:
+    digest.update(len(value).to_bytes(8, "big"))
+    digest.update(value)
+
+
+def _zoekt_git_env() -> dict[str, str]:
+    environment = dict(os.environ)
+    environment["GIT_NO_REPLACE_OBJECTS"] = "1"
+    return environment
+
+
+def _zoekt_extra_args(extra_args: object) -> list[str]:
+    if type(extra_args) is not list:
+        raise TypeError("Zoekt extra_args must be a list of single-token flags")
+    selected: list[str] = []
+    for argument in extra_args:
+        if (
+            type(argument) is not str
+            or not argument.startswith("-")
+            or argument in {"-", "--"}
+            or "=" not in argument
+            or "\x00" in argument
+            or any(character.isspace() for character in argument)
+        ):
+            raise ValueError(
+                "Zoekt extra_args must use single-token flags with = values"
+            )
+        flag = argument.lstrip("-").partition("=")[0]
+        if not flag or flag in _ZOEKT_PROTECTED_FLAGS:
+            raise ValueError("Zoekt extra_args cannot override a protected flag")
+        selected.append(argument)
+    return selected
+
+
+def _zoekt_source_commit(repo_path: str, requested: object) -> str:
+    if requested is None:
+        revision = "HEAD^{commit}"
+        expected = None
+    elif (
+        type(requested) is str
+        and len(requested) == 40
+        and all(character in "0123456789abcdef" for character in requested)
+    ):
+        revision = f"{requested}^{{commit}}"
+        expected = requested
+    else:
+        raise RuntimeError(
+            "Zoekt could not bind an immutable Git source commit; "
+            "no Zoekt output was created"
+        )
+
+    resolved = subprocess.run(
+        ["git", "-C", repo_path, "rev-parse", "--verify", revision],
+        check=False,
+        capture_output=True,
+        env=_zoekt_git_env(),
+    )
+    try:
+        source_commit = resolved.stdout.strip().decode("ascii", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise RuntimeError(
+            "Zoekt could not bind an immutable Git source commit; "
+            "no Zoekt output was created"
+        ) from exc
+    if (
+        resolved.returncode != 0
+        or len(source_commit) != 40
+        or any(character not in "0123456789abcdef" for character in source_commit)
+        or (expected is not None and source_commit != expected)
+    ):
+        raise RuntimeError(
+            "Zoekt could not bind an immutable Git source commit; "
+            "no Zoekt output was created"
+        )
+    return source_commit
+
+
+def _zoekt_commit_tree(
+    repo_path: str,
+    source_commit: str,
+    source_selection: RepositorySourceSelection,
+) -> tuple[list[_ZoektGitTreeEntry], str]:
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            repo_path,
+            "ls-tree",
+            "-rz",
+            "--full-tree",
+            source_commit,
+        ],
+        check=False,
+        capture_output=True,
+        env=_zoekt_git_env(),
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Zoekt could not prove the selected tracked-file surface; "
+            "no Zoekt output was created"
+        )
+
+    entries: list[_ZoektGitTreeEntry] = []
+    paths: set[str] = set()
+    excluded_paths: list[str] = []
+    metadata_bytes = 0
+    tree_digest = hashlib.sha256()
+    tree_digest.update(b"codenib.zoekt-commit-tree.v2\0")
+    raw_entry_count = 0
+    for raw_entry in result.stdout.split(b"\0"):
+        if not raw_entry:
+            continue
+        raw_entry_count += 1
+        if raw_entry_count > _ZOEKT_MAX_SOURCE_ENTRIES:
+            raise RuntimeError("Zoekt commit tree exceeds its entry limit")
+        raw_header, separator, raw_path = raw_entry.partition(b"\t")
+        fields = raw_header.split(b" ")
+        if not separator or not raw_path or len(fields) != 3:
+            raise RuntimeError("Zoekt commit tree has a malformed entry")
+        try:
+            mode, object_type, object_id = (
+                field.decode("ascii", errors="strict") for field in fields
+            )
+        except UnicodeDecodeError as exc:
+            raise RuntimeError("Zoekt commit tree has a malformed entry") from exc
+        if len(object_id) != 40 or any(
+            character not in "0123456789abcdef" for character in object_id
+        ):
+            raise RuntimeError("Zoekt commit tree has a malformed object id")
+        try:
+            relative = repository_relative_source_path(
+                repo_path,
+                os.fsdecode(raw_path),
+            )
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                "Zoekt tracked-file surface contains a non-canonical path"
+            ) from exc
+        encoded_path = os.fsencode(relative)
+        if (
+            len(encoded_path) > _ZOEKT_MAX_SOURCE_PATH_BYTES
+            or len(relative.split("/")) > _ZOEKT_MAX_SOURCE_PATH_COMPONENTS
+        ):
+            raise RuntimeError("Zoekt commit tree path exceeds its supported limits")
+        metadata_bytes += len(encoded_path) + 96
+        if metadata_bytes > _ZOEKT_MAX_SOURCE_METADATA_BYTES:
+            raise RuntimeError("Zoekt commit tree exceeds its metadata limit")
+        if relative in paths:
+            raise RuntimeError("Zoekt commit tree contains a duplicate path")
+        paths.add(relative)
+
+        visible = repository_path_is_visible(
+            relative,
+            selection=source_selection,
+        )
+        if not visible:
+            excluded_paths.append(relative)
+        elif mode == "160000" and object_type == "commit":
+            raise RuntimeError(
+                "Zoekt cannot publish a visible gitlink/submodule: " + relative
+            )
+        elif (mode, object_type) not in {
+            ("100644", "blob"),
+            ("100755", "blob"),
+            ("120000", "blob"),
+        }:
+            raise RuntimeError(
+                "Zoekt commit tree contains an unsupported visible entry: " + relative
+            )
+
+        for value in (mode.encode("ascii"), object_id.encode("ascii"), encoded_path):
+            _zoekt_hash_field(tree_digest, value)
+        if visible:
+            entries.append(
+                _ZoektGitTreeEntry(
+                    mode=mode,
+                    object_id=object_id,
+                    path=relative,
+                )
+            )
+
+    if excluded_paths:
+        raise RuntimeError(
+            "Zoekt cannot prove the repository source selection because "
+            "tracked files are excluded: " + ", ".join(excluded_paths[:5])
+        )
+    return entries, tree_digest.hexdigest()
+
+
+def _zoekt_index_surface(
+    repo_path: str,
+    entries: list[_ZoektGitTreeEntry],
+    source_selection: RepositorySourceSelection,
+) -> None:
+    result = subprocess.run(
+        ["git", "-C", repo_path, "ls-files", "--stage", "-z"],
+        check=False,
+        capture_output=True,
+        env=_zoekt_git_env(),
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Zoekt could not prove the selected Git index surface; "
+            "no Zoekt output was created"
+        )
+    expected = {entry.path: (entry.mode, entry.object_id) for entry in entries}
+    observed: dict[str, tuple[str, str]] = {}
+    for raw_entry in result.stdout.split(b"\0"):
+        if not raw_entry:
+            continue
+        raw_header, separator, raw_path = raw_entry.partition(b"\t")
+        fields = raw_header.split(b" ")
+        if not separator or not raw_path or len(fields) != 3:
+            raise RuntimeError("Zoekt Git index has a malformed entry")
+        try:
+            mode, object_id, stage = (
+                field.decode("ascii", errors="strict") for field in fields
+            )
+            relative = repository_relative_source_path(
+                repo_path,
+                os.fsdecode(raw_path),
+            )
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError("Zoekt Git index has a malformed entry") from exc
+        if not repository_path_is_visible(relative, selection=source_selection):
+            continue
+        if stage != "0" or relative in observed:
+            raise RuntimeError(
+                "Zoekt cannot publish because the selected Git index is unmerged"
+            )
+        observed[relative] = (mode, object_id)
+    if observed != expected:
+        raise RuntimeError(
+            "Zoekt cannot publish because the selected Git index differs "
+            "from the immutable commit"
+        )
+
+
+def _zoekt_selected_untracked(
+    repo_path: str,
+    source_selection: RepositorySourceSelection,
+) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", repo_path, "ls-files", "--others", "-z"],
+        check=False,
+        capture_output=True,
+        env=_zoekt_git_env(),
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Zoekt could not prove the selected untracked-file surface; "
+            "no Zoekt output was created"
+        )
+    selected: list[str] = []
+    for raw_path in result.stdout.split(b"\0"):
+        if not raw_path:
+            continue
+        try:
+            relative = repository_relative_source_path(
+                repo_path,
+                os.fsdecode(raw_path),
+            )
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                "Zoekt untracked-file surface contains a non-canonical path"
+            ) from exc
+        if repository_path_is_visible(relative, selection=source_selection):
+            selected.append(relative)
+    return selected
+
+
+def _zoekt_read_exact(stream: Any, byte_count: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = byte_count
+    while remaining:
+        chunk = stream.read(remaining)
+        if not isinstance(chunk, bytes) or not chunk:
+            raise RuntimeError("Zoekt could not read an immutable Git blob")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _zoekt_read_fd_exact(descriptor: int, byte_count: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = byte_count
+    while remaining:
+        chunk = os.read(descriptor, remaining)
+        if not chunk:
+            raise RuntimeError("Zoekt selected worktree file was truncated")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _zoekt_file_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+    )
+
+
+def _zoekt_open_parent(repo_path: str, relative: str) -> tuple[int, str]:
+    if (
+        not hasattr(os, "O_DIRECTORY")
+        or not hasattr(os, "O_NOFOLLOW")
+        or os.open not in os.supports_dir_fd
+        or os.stat not in os.supports_dir_fd
+        or os.stat not in os.supports_follow_symlinks
+        or os.readlink not in os.supports_dir_fd
+    ):
+        raise RuntimeError(
+            "Zoekt cannot prove lexical worktree containment on this host"
+        )
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+    descriptor = -1
+    try:
+        descriptor = os.open(
+            os.path.abspath(os.path.expanduser(repo_path)),
+            flags,
+        )
+        parts = relative.split("/")
+        for part in parts[:-1]:
+            child = os.open(part, flags, dir_fd=descriptor)
+            opened = os.fstat(child)
+            if not stat.S_ISDIR(opened.st_mode):
+                os.close(child)
+                raise RuntimeError(
+                    "Zoekt selected worktree path has a non-directory ancestor: "
+                    + relative
+                )
+            os.close(descriptor)
+            descriptor = child
+        return descriptor, parts[-1]
+    except BaseException:
+        if descriptor >= 0:
+            os.close(descriptor)
+        raise
+
+
+def _zoekt_verify_regular_blob(
+    git_stream: Any,
+    blob_size: int,
+    parent: int,
+    name: str,
+    entry: _ZoektGitTreeEntry,
+    metadata: os.stat_result,
+) -> None:
+    expected_executable = entry.mode == "100755"
+    if not stat.S_ISREG(metadata.st_mode) or bool(metadata.st_mode & 0o111) != (
+        expected_executable
+    ):
+        raise RuntimeError(
+            "Zoekt selected worktree mode differs from the immutable commit: "
+            + entry.path
+        )
+    flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    descriptor = os.open(name, flags, dir_fd=parent)
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode) or (opened.st_dev, opened.st_ino) != (
+            metadata.st_dev,
+            metadata.st_ino,
+        ):
+            raise RuntimeError(
+                "Zoekt selected worktree file differs from the immutable commit: "
+                + entry.path
+            )
+        if opened.st_size != blob_size:
+            raise RuntimeError(
+                "Zoekt selected worktree bytes differ from the immutable commit: "
+                + entry.path
+            )
+        remaining = blob_size
+        while remaining:
+            chunk_size = min(remaining, _ZOEKT_BLOB_COPY_BYTES)
+            expected = _zoekt_read_exact(git_stream, chunk_size)
+            actual = _zoekt_read_fd_exact(descriptor, chunk_size)
+            if actual != expected:
+                raise RuntimeError(
+                    "Zoekt selected worktree bytes differ from the immutable "
+                    "commit: " + entry.path
+                )
+            remaining -= chunk_size
+        if os.read(descriptor, 1):
+            raise RuntimeError(
+                "Zoekt selected worktree file grew while it was verified: " + entry.path
+            )
+        after = os.fstat(descriptor)
+        path_after = os.stat(name, dir_fd=parent, follow_symlinks=False)
+        if _zoekt_file_identity(after) != _zoekt_file_identity(opened) or (
+            path_after.st_dev,
+            path_after.st_ino,
+        ) != (opened.st_dev, opened.st_ino):
+            raise RuntimeError(
+                "Zoekt selected worktree file changed while it was verified: "
+                + entry.path
+            )
+    finally:
+        os.close(descriptor)
+
+
+def _zoekt_verify_worktree_blobs(
+    repo_path: str,
+    entries: list[_ZoektGitTreeEntry],
+) -> None:
+    if not entries:
+        return
+    try:
+        process = subprocess.Popen(
+            ["git", "-C", repo_path, "cat-file", "--batch"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            bufsize=0,
+            env=_zoekt_git_env(),
+        )
+    except OSError as exc:
+        raise RuntimeError(
+            "Zoekt could not open the immutable Git blob surface"
+        ) from exc
+    succeeded = False
+    try:
+        if process.stdin is None or process.stdout is None:
+            raise RuntimeError("Zoekt could not open the immutable Git blob surface")
+        for entry in entries:
+            process.stdin.write(entry.object_id.encode("ascii") + b"\n")
+            process.stdin.flush()
+            header = process.stdout.readline()
+            fields = header.rstrip(b"\n").split(b" ")
+            if len(fields) != 3:
+                raise RuntimeError("Zoekt received a malformed Git blob header")
+            try:
+                blob_id = fields[0].decode("ascii", errors="strict")
+                object_type = fields[1].decode("ascii", errors="strict")
+                blob_size = int(fields[2].decode("ascii", errors="strict"))
+            except ValueError as exc:
+                raise RuntimeError(
+                    "Zoekt received a malformed Git blob header"
+                ) from exc
+            if blob_id != entry.object_id or object_type != "blob" or blob_size < 0:
+                raise RuntimeError("Zoekt received the wrong immutable Git blob")
+
+            try:
+                parent, name = _zoekt_open_parent(repo_path, entry.path)
+            except (OSError, RuntimeError) as exc:
+                raise RuntimeError(
+                    "Zoekt selected worktree path is missing or not lexical: "
+                    + entry.path
+                ) from exc
+            try:
+                try:
+                    metadata = os.stat(name, dir_fd=parent, follow_symlinks=False)
+                except OSError as exc:
+                    raise RuntimeError(
+                        "Zoekt selected worktree path is missing: " + entry.path
+                    ) from exc
+                if entry.mode == "120000":
+                    if not stat.S_ISLNK(metadata.st_mode):
+                        raise RuntimeError(
+                            "Zoekt selected worktree link differs from the "
+                            "immutable commit: " + entry.path
+                        )
+                    target = os.fsencode(os.readlink(name, dir_fd=parent))
+                    expected = _zoekt_read_exact(process.stdout, blob_size)
+                    after = os.stat(name, dir_fd=parent, follow_symlinks=False)
+                    if target != expected or _zoekt_file_identity(
+                        after
+                    ) != _zoekt_file_identity(metadata):
+                        raise RuntimeError(
+                            "Zoekt selected worktree link differs from the "
+                            "immutable commit: " + entry.path
+                        )
+                else:
+                    _zoekt_verify_regular_blob(
+                        process.stdout,
+                        blob_size,
+                        parent,
+                        name,
+                        entry,
+                        metadata,
+                    )
+            finally:
+                os.close(parent)
+            if _zoekt_read_exact(process.stdout, 1) != b"\n":
+                raise RuntimeError("Zoekt received a malformed Git blob payload")
+        process.stdin.close()
+        returncode = process.wait()
+        if returncode != 0:
+            raise RuntimeError("Zoekt could not read the immutable Git blob surface")
+        succeeded = True
+    except OSError as exc:
+        raise RuntimeError(
+            "Zoekt could not verify the immutable Git blob surface"
+        ) from exc
+    finally:
+        if not succeeded:
+            if process.stdin is not None and not process.stdin.closed:
+                process.stdin.close()
+            if process.poll() is None:
+                process.terminate()
+            process.wait()
+
+
+def _zoekt_shard_tree_receipt(
+    output_dir: str,
+) -> tuple[dict[str, Any], int, Any]:
+    from pathlib import Path
+
+    from .._atomic_directory import (
+        capture_directory_ownership,
+        directory_ownership_file_records,
+        directory_ownership_inventory,
+        require_publishable_directory_ownership,
+    )
+
+    def require_flat_regular_file(
+        relative: str,
+        kind: str,
+        _mode: int,
+        _size: int,
+    ) -> None:
+        if kind != "file" or "/" in relative:
+            raise RuntimeError(
+                "Zoekt shard output must be a flat tree of regular files"
+            )
+
+    ownership = capture_directory_ownership(
+        Path(output_dir),
+        allow_empty_root=True,
+        entry_policy=require_flat_regular_file,
+    )
+    require_publishable_directory_ownership(ownership, label="Zoekt shard tree")
+    inventory = directory_ownership_inventory(ownership)
+    records = directory_ownership_file_records(ownership)
+    if len(inventory) != len(records):
+        raise RuntimeError("Zoekt shard output contains a non-file entry")
+    files = [
+        {
+            "path": record.path,
+            "size": record.size,
+            "sha256": record.sha256,
+        }
+        for record in records
+    ]
+    shard_count = sum(record.path.endswith(".zoekt") for record in records)
+    if shard_count == 0:
+        raise RuntimeError("zoekt-git-index produced no .zoekt shards")
+    canonical = json.dumps(
+        {
+            "schema": _ZOEKT_SHARD_TREE_RECEIPT_SCHEMA,
+            "files": files,
+        },
+        allow_nan=False,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("ascii")
+    receipt = {
+        "schema": _ZOEKT_SHARD_TREE_RECEIPT_SCHEMA,
+        "digest": f"sha256:{hashlib.sha256(canonical).hexdigest()}",
+        "file_count": len(files),
+        "total_bytes": sum(record.size for record in records),
+        "files": files,
+    }
+    return receipt, shard_count, ownership
+
+
 @dataclass
 class ZoektIndexBuilder:
     """Build a Zoekt trigram index by shelling out to ``zoekt-git-index``.
@@ -673,10 +1503,54 @@ class ZoektIndexBuilder:
 
     binary: str = "zoekt-git-index"
     extra_args: List[str] = field(default_factory=list)
+    source_selection: RepositorySourceSelection = field(
+        default_factory=RepositorySourceSelection
+    )
+
+    def __post_init__(self) -> None:
+        self.source_selection = _snapshot_source_selection(self.source_selection)
+
+    def artifact_identity(self) -> Dict[str, Any]:
+        selection = _snapshot_source_selection(self.source_selection)
+        return {
+            "builder_schema": 3,
+            "source_contract": "immutable-git-commit-tree-v2",
+            "worktree_contract": "selected-files-match-source-commit-v2",
+            "shard_tree_receipt_schema": _ZOEKT_SHARD_TREE_RECEIPT_SCHEMA,
+            "submodules": False,
+            "source_selection_digest": selection.digest,
+        }
 
     def build(self, scope: str, **kwargs: Any) -> IndexStatus:
+        source_selection = _source_selection_for_build(
+            self.source_selection,
+            kwargs.get("source_selection"),
+        )
+        if source_selection.exclude_subtrees:
+            raise RuntimeError(
+                "Zoekt does not support custom repository source selection; "
+                "no Zoekt output was created"
+            )
         repo_path: str = kwargs["repo_path"]
         output_dir: str = kwargs["output_dir"]
+        extra_args = _zoekt_extra_args(self.extra_args)
+        source_commit = _zoekt_source_commit(
+            repo_path,
+            kwargs.get("source_commit"),
+        )
+        tracked_entries, tracked_digest = _zoekt_commit_tree(
+            repo_path,
+            source_commit,
+            source_selection,
+        )
+        _zoekt_index_surface(repo_path, tracked_entries, source_selection)
+        selected_untracked = _zoekt_selected_untracked(repo_path, source_selection)
+        if selected_untracked:
+            raise RuntimeError(
+                "Zoekt cannot publish because selected untracked files are absent "
+                "from its immutable commit: " + ", ".join(selected_untracked[:5])
+            )
+        _zoekt_verify_worktree_blobs(repo_path, tracked_entries)
 
         binary_path = shutil.which(self.binary) or (
             self.binary if os.path.isfile(self.binary) else None
@@ -689,25 +1563,91 @@ class ZoektIndexBuilder:
                 "Skipping zoekt index build."
             )
 
-        os.makedirs(output_dir, exist_ok=True)
-        cmd = [binary_path, "-index", output_dir, *self.extra_args, repo_path]
-        logger.info("Building Zoekt index: %s", " ".join(cmd))
-        try:
-            subprocess.run(
-                cmd,
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as exc:
-            raise RuntimeError(
-                f"zoekt-git-index failed (rc={exc.returncode}): "
-                f"{(exc.stderr or '').strip()}"
-            ) from exc
+        from pathlib import Path, PurePosixPath
 
-        shard_count = sum(
-            1 for entry in os.listdir(output_dir) if entry.endswith(".zoekt")
+        from .._atomic_directory import (
+            PublicationDirectoryReader,
+            reopen_authenticated_directory,
         )
+        from .._captured_directory import OwnedDirectoryStage
+        from ..index.embedding.builders import _PrivateBuildDirectory
+
+        output_path = Path(output_dir).expanduser().absolute()
+        publication_stage = OwnedDirectoryStage.prepare(
+            output_path,
+            allow_empty_destination=True,
+        )
+
+        def copy_generation(reader: PublicationDirectoryReader) -> None:
+            for record in reader.file_records():
+                relative = PurePosixPath(record.path)
+                with reader.iter_authenticated_chunks(
+                    relative,
+                    max_bytes=record.size,
+                ) as chunks:
+                    publication_stage.write_file(
+                        relative,
+                        chunks,
+                        mode=record.mode,
+                        max_bytes=record.size,
+                    )
+
+        try:
+            with _PrivateBuildDirectory(
+                prefix=f".{output_path.name}.generation-build-",
+                parent=output_path.parent,
+            ) as build_root:
+                writer_path = build_root.writer_path
+                try:
+                    writer_descriptor = int(writer_path.name)
+                except ValueError as exc:
+                    raise RuntimeError(
+                        "Zoekt private writer path has no inherited descriptor"
+                    ) from exc
+                cmd = [
+                    binary_path,
+                    "-index",
+                    str(writer_path),
+                    *extra_args,
+                    "-submodules=false",
+                    f"-branches={source_commit}",
+                    "-prefix=",
+                    repo_path,
+                ]
+                logger.info("Building Zoekt index: %s", " ".join(cmd))
+                try:
+                    with build_root.path_operation("Zoekt shard generation"):
+                        subprocess.run(
+                            cmd,
+                            check=True,
+                            capture_output=True,
+                            text=True,
+                            env=_zoekt_git_env(),
+                            pass_fds=(writer_descriptor,),
+                        )
+                except subprocess.CalledProcessError as exc:
+                    raise RuntimeError(
+                        f"zoekt-git-index failed (rc={exc.returncode}): "
+                        f"{(exc.stderr or '').strip()}"
+                    ) from exc
+
+                (
+                    shard_tree_receipt,
+                    shard_count,
+                    generation_ownership,
+                ) = _zoekt_shard_tree_receipt(str(build_root.path))
+                reopen_authenticated_directory(
+                    build_root.path,
+                    generation_ownership,
+                    copy_generation,
+                )
+            publication_stage.publish()
+        except BaseException:  # noqa: B036 - preserve publication interruptions
+            try:
+                publication_stage.discard()
+            except BaseException:  # noqa: B036 - retain the generation failure
+                logger.exception("Could not isolate failed Zoekt generation stage")
+            raise
 
         return IndexStatus(
             index_type="zoekt",
@@ -717,8 +1657,13 @@ class ZoektIndexBuilder:
             scope=scope,
             path=output_dir,
             metadata={
+                **self.artifact_identity(),
                 "shard_count": shard_count,
+                "shard_tree_receipt": shard_tree_receipt,
                 "binary": binary_path,
+                "tracked_source_count": len(tracked_entries),
+                "tracked_source_sha256": tracked_digest,
+                "source_commit": source_commit,
             },
         )
 
@@ -740,6 +1685,9 @@ class SymbolGraphBuilder:
     languages: Optional[List[str]] = None
     graph_route: str = "active"
     exclude_patterns: List[str] = field(default_factory=default_exclude_patterns)
+    source_selection: RepositorySourceSelection = field(
+        default_factory=RepositorySourceSelection
+    )
     allow_partial_languages: bool = False
     allow_partial_index: bool = False
     source_coverage_fallback: bool = False
@@ -758,9 +1706,16 @@ class SymbolGraphBuilder:
     require_verification: bool = True
 
     def artifact_identity(self) -> Dict[str, Any]:
+        source_selection = _snapshot_source_selection(self.source_selection)
+        return self._artifact_identity_for_selection(source_selection)
+
+    def _artifact_identity_for_selection(
+        self,
+        source_selection: RepositorySourceSelection,
+    ) -> Dict[str, Any]:
         graph_languages = self.languages or [self.language]
         return {
-            "builder_schema": 5,
+            "builder_schema": 6,
             "languages": list(graph_languages),
             "graph_route": self.graph_route,
             "exclude_patterns": sorted(self.exclude_patterns),
@@ -770,9 +1725,11 @@ class SymbolGraphBuilder:
             "allow_project_preparation": self.allow_project_preparation,
             "target_dir": None,
             "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
+            "source_selection_digest": source_selection.digest,
         }
 
     def __post_init__(self) -> None:
+        self.source_selection = _snapshot_source_selection(self.source_selection)
         if self.allow_partial_index and not self.source_coverage_fallback:
             raise ValueError(
                 "allow_partial_index requires source_coverage_fallback so a "
@@ -780,6 +1737,11 @@ class SymbolGraphBuilder:
             )
 
     def build(self, scope: str, **kwargs: Any) -> IndexStatus:
+        source_selection = _source_selection_for_build(
+            self.source_selection,
+            kwargs.get("source_selection"),
+        )
+        artifact_identity = self._artifact_identity_for_selection(source_selection)
         repo_path: str = kwargs["repo_path"]
         output_dir: str = kwargs["output_dir"]
 
@@ -793,11 +1755,15 @@ class SymbolGraphBuilder:
 
         os.makedirs(output_dir, exist_ok=True)
         graph_languages = self.languages or [self.language]
+        effective_exclude_patterns = _selection_exclude_hints(
+            self.exclude_patterns,
+            source_selection,
+        )
         build_kwargs = {
             "languages": graph_languages,
             "project_name": os.path.basename(os.path.abspath(repo_path)),
             "skip_level": None,
-            "exclude_patterns": self.exclude_patterns,
+            "exclude_patterns": effective_exclude_patterns,
             "graph_route": self.graph_route,
             "capture_artifact_receipts": True,
         }
@@ -830,6 +1796,16 @@ class SymbolGraphBuilder:
 
             graph = CodeGraph(repo_path)
             graph.add_root_node(ROOT_NODE)
+        elif graph_output_receipt is not None:
+            writer_artifact = graph_output_artifact_fingerprint(
+                output_dir,
+                receipt=graph_output_receipt,
+            )
+            writer_query_surface = writer_artifact.pop("query_surface_sha256")
+            if writer_query_surface != query_surface_sha256(graph):
+                raise ValueError(
+                    "symbol graph query surface changed after its writer returned"
+                )
 
         compiler_partial_languages = sorted(
             language
@@ -872,7 +1848,8 @@ class SymbolGraphBuilder:
                 surface=surface,
                 extensions=extensions,
                 represented_paths=graph_file_paths(graph),
-                exclude_patterns=self.exclude_patterns,
+                exclude_patterns=effective_exclude_patterns,
+                source_selection=source_selection,
             )
             if coverage_report.get("coverage_after") != 1.0:
                 raise RuntimeError(
@@ -887,13 +1864,20 @@ class SymbolGraphBuilder:
                 "compiler_edges": compiler_edge_count,
                 **coverage_report,
             }
-            graph_output_path = os.path.join(output_dir, "graph.pkl")
-            graph.save_graph(graph_output_path)
-            graph_output_receipt = {
-                "path": os.path.realpath(graph_output_path),
-                **regular_file_fingerprint(graph_output_path),
-                "query_surface_sha256": query_surface_sha256(graph),
-            }
+        (
+            source_selection_report,
+            lsp_occurrence_artifact,
+        ) = _constrain_and_save_selected_graph(
+            graph,
+            output_dir,
+            source_selection,
+        )
+        graph_output_path = os.path.join(output_dir, "graph.pkl")
+        graph_output_receipt = {
+            "path": os.path.realpath(graph_output_path),
+            **regular_file_fingerprint(graph_output_path),
+            "query_surface_sha256": query_surface_sha256(graph),
+        }
 
         node_count = len(graph.graph.vs)
         edge_count = len(graph.graph.es)
@@ -930,7 +1914,7 @@ class SymbolGraphBuilder:
             scope=scope,
             path=output_dir,
             metadata={
-                **self.artifact_identity(),
+                **artifact_identity,
                 "node_count": node_count,
                 "edge_count": edge_count,
                 "language": available_languages[0],
@@ -939,6 +1923,7 @@ class SymbolGraphBuilder:
                 "index_generation_reports": result.index_generation_reports,
                 "scip_decoded_artifacts": scip_decoded_artifacts,
                 "graph_artifact": graph_artifact,
+                "lsp_occurrence_artifact": lsp_occurrence_artifact,
                 "query_surface_sha256": observed_query_surface,
                 "update_mode": "full_rebuild",
                 "partial_index": bool(compiler_partial_languages),
@@ -949,6 +1934,7 @@ class SymbolGraphBuilder:
                     if fallback_report is not None
                     else {}
                 ),
+                "source_selection_report": source_selection_report,
             },
         )
 
@@ -968,11 +1954,30 @@ class SymbolGraphBuilder:
         Falls back to :meth:`build` whenever the incremental path is
         unavailable or its result is not admitted.
         """
+        source_selection = _source_selection_for_build(
+            self.source_selection,
+            kwargs.get("source_selection"),
+        )
+        previous_artifact = kwargs.get("previous_artifact_config")
+        if previous_artifact is not None and not isinstance(previous_artifact, dict):
+            raise ValueError("previous graph artifact config must be a mapping")
+        selection_changed = (
+            previous_artifact is None and bool(source_selection.exclude_subtrees)
+        ) or (
+            previous_artifact is not None
+            and previous_artifact.get("source_selection_digest")
+            != source_selection.digest
+        )
+
         repo_path: str = kwargs["repo_path"]
         output_dir: str = kwargs["output_dir"]
         last_commit: str = kwargs.get("last_commit", "") or ""
 
-        reason = self._incremental_blocker(repo_path, output_dir, last_commit)
+        reason = (
+            "source selection changed since the previous graph generation"
+            if selection_changed
+            else self._incremental_blocker(repo_path, output_dir, last_commit)
+        )
         if reason:
             logger.info("symbol_graph: full rebuild (%s)", reason)
             return self.build(
@@ -980,7 +1985,13 @@ class SymbolGraphBuilder:
             )
 
         try:
-            status = self._patch_graph(scope, repo_path, output_dir, last_commit)
+            status = self._patch_graph(
+                scope,
+                repo_path,
+                output_dir,
+                last_commit,
+                source_selection=source_selection,
+            )
         except Exception as exc:  # noqa: BLE001 - any patch failure means rebuild
             logger.warning("symbol_graph: patch failed (%s); rebuilding", exc)
             return self.build(
@@ -1024,7 +2035,13 @@ class SymbolGraphBuilder:
         return None
 
     def _patch_graph(
-        self, scope: str, repo_path: str, output_dir: str, last_commit: str
+        self,
+        scope: str,
+        repo_path: str,
+        output_dir: str,
+        last_commit: str,
+        *,
+        source_selection: Optional[RepositorySourceSelection] = None,
     ) -> Optional[IndexStatus]:
         """Run the LSP patcher over every configured language. None = rebuild."""
         from ..graph.code_graph import CodeGraph
@@ -1033,6 +2050,21 @@ class SymbolGraphBuilder:
 
         graph_path = os.path.join(output_dir, "graph.pkl")
         graph = CodeGraph.load_graph(graph_path)
+        occurrence_path = os.path.join(output_dir, "lsp_index.pkl")
+        has_prior_occurrence_index = False
+        if os.path.isfile(occurrence_path):
+            from ..scip_interface.lsp_occurrence_index import SCIPOccurrenceIndex
+
+            # Incremental patching explicitly starts from the prior complete
+            # generation.  Keep that handoff local to this path rather than
+            # letting the full-build publication helper discover ambient
+            # sidecars in its destination directory.
+            graph.lsp_occurrence_index = SCIPOccurrenceIndex.load(occurrence_path)
+            has_prior_occurrence_index = True
+        selected = _source_selection_for_build(
+            self.source_selection,
+            source_selection,
+        )
         graph_languages = self.languages or [self.language]
         head = _git_output(repo_path, "rev-parse", "HEAD")
 
@@ -1051,6 +2083,18 @@ class SymbolGraphBuilder:
                 count = sum(len(paths) for paths in changed.values())
                 if not count:
                     continue
+                if has_prior_occurrence_index:
+                    # GraphPatcher updates graph nodes and edges but has no
+                    # occurrence-sidecar delta contract.  Admitting the graph
+                    # while republishing the previous occurrence rows would
+                    # create a mixed generation, so source changes require a
+                    # full rebuild whenever that sidecar exists.
+                    logger.info(
+                        "symbol_graph: full rebuild requested for %s "
+                        "(occurrence index has no incremental update contract)",
+                        lang,
+                    )
+                    return None
 
                 patcher = GraphPatcher(
                     project_root=repo_path, code_graph=graph, language=lang
@@ -1103,7 +2147,14 @@ class SymbolGraphBuilder:
             )
             return None
 
-        graph.save_graph(graph_path)
+        (
+            source_selection_report,
+            lsp_occurrence_artifact,
+        ) = _constrain_and_save_selected_graph(
+            graph,
+            output_dir,
+            selected,
+        )
         elapsed = time.monotonic() - start
         node_count = len(graph.graph.vs)
         return IndexStatus(
@@ -1114,7 +2165,7 @@ class SymbolGraphBuilder:
             scope=scope,
             path=output_dir,
             metadata={
-                **self.artifact_identity(),
+                **self._artifact_identity_for_selection(selected),
                 "node_count": node_count,
                 "language": graph_languages[0],
                 "update_mode": "incremental",
@@ -1123,6 +2174,8 @@ class SymbolGraphBuilder:
                 "earlier_commit": last_commit,
                 "later_commit": head,
                 "patch_stats": per_language,
+                "source_selection_report": source_selection_report,
+                "lsp_occurrence_artifact": lsp_occurrence_artifact,
                 **result.to_metadata(),
             },
         )
@@ -1149,12 +2202,14 @@ def register_default_builders(
     embedding_max_seq_length: Optional[int] = None,
     exclude_patterns: Optional[List[str]] = None,
     additional_chunk_ignore_dirs: Optional[List[str]] = None,
+    source_selection: RepositorySourceSelection = DEFAULT_REPOSITORY_SOURCE_SELECTION,
     allow_partial_graph_languages: bool = False,
     allow_partial_graph_index: bool = False,
     graph_source_coverage_fallback: bool = False,
     allow_graph_project_preparation: bool = True,
 ) -> None:
     """Register all standard index builders with sensible defaults."""
+    selected = _snapshot_source_selection(source_selection)
     langs = languages or ["python"]
     chunk_ignore_dirs = sorted(set(additional_chunk_ignore_dirs or ()))
     registry.register(
@@ -1162,6 +2217,7 @@ def register_default_builders(
         BM25IndexBuilder(
             languages=langs,
             additional_ignore_dirs=chunk_ignore_dirs,
+            source_selection=selected,
         ),
     )
 
@@ -1207,6 +2263,7 @@ def register_default_builders(
             embedding_credential_env=embedding_credential_env,
             embedding_runtime_kwargs=embedding_runtime_kwargs,
             additional_ignore_dirs=chunk_ignore_dirs,
+            source_selection=selected,
         ),
     )
     registry.register(
@@ -1224,9 +2281,10 @@ def register_default_builders(
                 if exclude_patterns is not None
                 else default_exclude_patterns()
             ),
+            source_selection=selected,
         ),
     )
     # Zoekt is registered unconditionally; build() raises a clear error at
     # invocation time if the binary is unavailable so the IndexCompiler can
     # mark the entry as failed without aborting other index builds.
-    registry.register("zoekt", ZoektIndexBuilder())
+    registry.register("zoekt", ZoektIndexBuilder(source_selection=selected))

--- a/codenib/compiler/index_compiler.py
+++ b/codenib/compiler/index_compiler.py
@@ -30,6 +30,12 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from ..paths import REPO_INDEX_DIRNAME
+from ..repository_filters import repository_path_is_visible
+from ..repository_source_selection import (
+    DEFAULT_REPOSITORY_SOURCE_SELECTION,
+    RepositorySourceSelection,
+    repository_relative_source_path,
+)
 from ..source_fingerprint import (
     SourceFingerprint,
     fingerprint_repository,
@@ -37,8 +43,8 @@ from ..source_fingerprint import (
 )
 from .cache_lock import compiler_cache_lock
 from .index_builders import IndexBuilderRegistry
-from .manifest import MANIFEST_FILENAME, IndexEntry, RepoManifest
-from .resources import IndexStatus
+from .manifest import MANIFEST_FILENAME, MANIFEST_VERSION, IndexEntry, RepoManifest
+from .resources import IndexState, IndexStatus
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +58,16 @@ class IndexCompilerConfig:
         default_factory=lambda: ["bm25", "vector", "symbol_graph"],
     )
     languages: List[str] = field(default_factory=lambda: ["python"])
+    source_selection: RepositorySourceSelection | None = None
+
+    def __post_init__(self) -> None:
+        if self.source_selection is None:
+            return
+        if type(self.source_selection) is not RepositorySourceSelection:
+            raise TypeError("source_selection must be a RepositorySourceSelection")
+        self.source_selection = RepositorySourceSelection(
+            self.source_selection.exclude_subtrees
+        )
 
 
 @dataclass(slots=True)
@@ -106,11 +122,13 @@ class IndexCompiler:
         cache = self._resolve_cache_dir(repo_path, cache_dir)
         with compiler_cache_lock(cache):
             existing = self._load_existing_manifest(cache)
+            source_selection = self._snapshot_source_selection(existing)
             return self._compile(
                 repo_path,
                 index_types=index_types,
                 cache_dir=cache,
                 existing_manifest=existing,
+                source_selection=source_selection,
                 force_rebuild=True,
             )
 
@@ -163,6 +181,7 @@ class IndexCompiler:
                 index_types=index_types,
                 cache_dir=cache,
                 existing_manifest=None,
+                source_selection=self._snapshot_source_selection(None),
                 force_rebuild=True,
             )
 
@@ -177,12 +196,27 @@ class IndexCompiler:
                 index_types=index_types,
                 cache_dir=cache,
                 existing_manifest=None,
+                source_selection=self._snapshot_source_selection(None),
                 force_rebuild=True,
             )
 
+        source_selection = self._snapshot_source_selection(existing)
+        # The manifest identity excludes the cache tree.  Do not let the
+        # update fast path accept an apparently-current manifest when a
+        # caller placed that cache inside the selected repository surface.
+        # The same guard also runs in ``_compile``; it must precede the
+        # fingerprint/incomplete check here because that check can return the
+        # existing manifest without entering ``_compile`` at all.
+        self._require_cache_outside_source(repo_path, cache, source_selection)
+
         types_to_update = index_types or self._config.index_types
         head_commit = self._get_head_commit(repo_path)
-        source = fingerprint_repository(repo_path, exclude_roots=(cache,))
+        source = fingerprint_repository(
+            repo_path,
+            exclude_roots=(cache,),
+            selection=source_selection,
+        )
+        source_selection_digest = source_selection.digest
         incomplete = [
             idx_type
             for idx_type in types_to_update
@@ -191,6 +225,7 @@ class IndexCompiler:
                 existing.indexes[idx_type],
                 commit=head_commit,
                 source_fingerprint=source.value,
+                source_selection_digest=source_selection_digest,
             )
             or not self._entry_matches_builder(
                 existing.indexes[idx_type],
@@ -219,6 +254,7 @@ class IndexCompiler:
             cache_dir=cache,
             existing_manifest=existing,
             source=source,
+            source_selection=source_selection,
             force_rebuild=False,
         )
 
@@ -248,42 +284,74 @@ class IndexCompiler:
         index_types: Optional[List[str]],
         cache_dir: Optional[str],
         existing_manifest: Optional[RepoManifest],
+        source_selection: RepositorySourceSelection,
         source: Optional[SourceFingerprint] = None,
         force_rebuild: bool,
     ) -> RepoManifest:
         """Build requested views while preserving independent manifest entries."""
         repo_path = os.path.abspath(repo_path)
         cache = cache_dir or os.path.join(repo_path, self._config.cache_dir_name)
+        self._require_cache_outside_source(repo_path, cache, source_selection)
 
         types_to_build = index_types or self._config.index_types
 
         head_commit = self._get_head_commit(repo_path)
-        source = source or fingerprint_repository(repo_path, exclude_roots=(cache,))
+        source = source or fingerprint_repository(
+            repo_path,
+            exclude_roots=(cache,),
+            selection=source_selection,
+        )
+        source_selection_digest = source_selection.digest
         existing = existing_manifest
-        languages = list(self._config.languages)
-        if existing is not None:
-            languages = list(dict.fromkeys([*existing.languages, *languages]))
+        # The caller computes languages from the current selected source
+        # surface. Carrying old values forward would resurrect languages that
+        # disappeared or were explicitly excluded by a new selection policy.
+        languages = list(dict.fromkeys(self._config.languages))
+        carried_indexes = (
+            copy.deepcopy(existing.indexes) if existing is not None else {}
+        )
+        existing_has_current_selection_identity = (
+            existing is not None
+            and existing.version == MANIFEST_VERSION
+            and existing.source_selection is not None
+        )
+        if existing is not None and not existing_has_current_selection_identity:
+            for entry in carried_indexes.values():
+                if entry.status == "fresh":
+                    entry.status = "stale"
+                    entry.metadata["stale_reason"] = (
+                        "manifest source-selection contract requires migration"
+                    )
         manifest = RepoManifest(
             repo_path=repo_path,
             commit=head_commit,
             last_indexed_commit=(
-                existing.last_indexed_commit if existing is not None else head_commit
+                existing.last_indexed_commit
+                if existing_has_current_selection_identity
+                else (head_commit if existing is None else "")
             ),
             source_fingerprint=source.value,
             last_indexed_source_fingerprint=(
                 existing.last_indexed_source_fingerprint
-                if existing is not None
-                else source.value
+                if existing_has_current_selection_identity
+                else (source.value if existing is None else "")
+            ),
+            source_selection=source_selection,
+            last_indexed_source_selection_digest=(
+                existing.last_indexed_source_selection_digest
+                if existing_has_current_selection_identity
+                else (source_selection_digest if existing is None else "")
             ),
             languages=languages,
             file_count=source.file_count,
-            indexes=(copy.deepcopy(existing.indexes) if existing is not None else {}),
+            indexes=carried_indexes,
         )
         for entry in manifest.indexes.values():
             if entry.status == "fresh" and not self._entry_matches_source(
                 entry,
                 commit=head_commit,
                 source_fingerprint=source.value,
+                source_selection_digest=source_selection_digest,
             ):
                 entry.status = "stale"
 
@@ -318,30 +386,18 @@ class IndexCompiler:
                     current_entry,
                     commit=head_commit,
                     source_fingerprint=source.value,
+                    source_selection_digest=source_selection_digest,
                 )
             ):
                 continue
 
-            previous_commit = ""
-            previous_entry_compatible = (
-                previous_entry is not None
-                and previous_entry.status in {"fresh", "stale"}
-                and existing is not None
-                and is_secure_source_fingerprint_v2(existing.source_fingerprint)
-                and is_secure_source_fingerprint_v2(previous_entry.source_fingerprint)
-                and self._entry_matches_builder(previous_entry, builder)
-            )
-            if previous_entry_compatible:
-                previous_commit = previous_entry.commit
-                if not previous_commit and existing is not None:
-                    previous_commit = existing.last_indexed_commit
             # Do not seed an incremental builder from a Git status/HEAD check
             # performed through a separately resolved path.  A repository can
             # be A for both source fingerprints, B (clean) only for that check,
             # and A again before the build.  Until Git observations share the
             # pinned source authority, a full rebuild is the only safe reuse
-            # policy.  ``previous_commit`` is still retained below so a failed
-            # rebuild can preserve the last known generation in the manifest.
+            # policy. A failed rebuild retains the complete previous entry
+            # below so the manifest never publishes mixed provenance.
             incremental_from = None
 
             output_dir = os.path.join(cache, idx_type)
@@ -356,6 +412,13 @@ class IndexCompiler:
                     if incremental_from and previous_entry is not None
                     else None
                 ),
+                source_selection=source_selection,
+                expected_source_commit=head_commit,
+            )
+            result = self._validate_build_selection(
+                result,
+                source_selection=source_selection,
+                expected_source_commit=head_commit,
             )
             if (
                 idx_type == "symbol_graph"
@@ -374,28 +437,36 @@ class IndexCompiler:
                         )
 
             now = datetime.now(timezone.utc)
-            entry = IndexEntry(
-                index_type=idx_type,
-                path=output_dir,
-                built_at=now.isoformat(),
-                built_at_epoch=now.timestamp(),
-                status="fresh" if result.success else "failed",
-                config=result.status.metadata if result.status else {},
-                metadata={
-                    **(result.status.metadata if result.status else {}),
+            if not result.success and previous_entry is not None:
+                # A failed attempt must not invent a half-new generation. Keep
+                # every field that describes the last produced artifact and
+                # overlay only attempt diagnostics/status.
+                entry = copy.deepcopy(previous_entry)
+                entry.status = "failed"
+                entry.built_at = now.isoformat()
+                entry.built_at_epoch = now.timestamp()
+                entry.metadata = {
+                    **copy.deepcopy(previous_entry.metadata),
                     "build_duration_seconds": round(result.duration_seconds, 2),
-                },
-                commit=head_commit if result.success else previous_commit,
-                source_fingerprint=(
-                    source.value
-                    if result.success
-                    else (
-                        previous_entry.source_fingerprint
-                        if previous_entry is not None
-                        else ""
-                    )
-                ),
-            )
+                }
+            else:
+                entry = IndexEntry(
+                    index_type=idx_type,
+                    path=output_dir,
+                    built_at=now.isoformat(),
+                    built_at_epoch=now.timestamp(),
+                    status="fresh" if result.success else "failed",
+                    config=result.status.metadata if result.status else {},
+                    metadata={
+                        **(result.status.metadata if result.status else {}),
+                        "build_duration_seconds": round(result.duration_seconds, 2),
+                    },
+                    commit=head_commit if result.success else "",
+                    source_fingerprint=source.value if result.success else "",
+                    source_selection_digest=(
+                        source_selection_digest if result.success else ""
+                    ),
+                )
             if not result.success and result.error:
                 entry.metadata["error"] = result.error
 
@@ -404,7 +475,11 @@ class IndexCompiler:
                 requested_succeeded = False
 
         final_head_commit = self._get_head_commit(repo_path)
-        final_source = fingerprint_repository(repo_path, exclude_roots=(cache,))
+        final_source = fingerprint_repository(
+            repo_path,
+            exclude_roots=(cache,),
+            selection=source_selection,
+        )
         source_changed_during_build = (
             final_head_commit != head_commit or final_source.value != source.value
         )
@@ -426,18 +501,29 @@ class IndexCompiler:
                 entry,
                 commit=head_commit,
                 source_fingerprint=source.value,
+                source_selection_digest=source_selection_digest,
             )
             for entry in manifest.indexes.values()
         )
         if requested_succeeded and all_views_at_head:
             manifest.last_indexed_commit = head_commit
             manifest.last_indexed_source_fingerprint = source.value
+            manifest.last_indexed_source_selection_digest = source_selection_digest
         else:
             manifest.last_indexed_commit = (
-                existing.last_indexed_commit if existing is not None else ""
+                existing.last_indexed_commit
+                if existing_has_current_selection_identity
+                else ""
             )
             manifest.last_indexed_source_fingerprint = (
-                existing.last_indexed_source_fingerprint if existing is not None else ""
+                existing.last_indexed_source_fingerprint
+                if existing_has_current_selection_identity
+                else ""
+            )
+            manifest.last_indexed_source_selection_digest = (
+                existing.last_indexed_source_selection_digest
+                if existing_has_current_selection_identity
+                else ""
             )
             logger.warning(
                 "Not all indexes reached source %s; "
@@ -455,6 +541,26 @@ class IndexCompiler:
         logger.info("Manifest written to %s", manifest_path)
 
         return manifest
+
+    @staticmethod
+    def _require_cache_outside_source(
+        repo_path: str,
+        cache: str,
+        source_selection: RepositorySourceSelection,
+    ) -> None:
+        """Reject a cache that builders would treat as selected source."""
+
+        if os.path.normcase(cache) == os.path.normcase(repo_path):
+            raise ValueError("index cache directory cannot be the repository root")
+        try:
+            relative = repository_relative_source_path(repo_path, cache)
+        except ValueError:
+            return
+        if repository_path_is_visible(relative, selection=source_selection):
+            raise ValueError(
+                "an in-repository index cache must be excluded by the effective "
+                "repository source selection"
+            )
 
     @staticmethod
     def _entry_matches_builder(entry: IndexEntry, builder: Any) -> bool:
@@ -476,17 +582,54 @@ class IndexCompiler:
         *,
         commit: str,
         source_fingerprint: str,
+        source_selection_digest: str,
     ) -> bool:
         """Whether an entry was built from the exact current repository source."""
 
         if entry.status != "fresh":
             return False
-        if commit and entry.commit != commit:
+        if entry.commit != commit:
             return False
         return (
             is_secure_source_fingerprint_v2(source_fingerprint)
             and entry.source_fingerprint == source_fingerprint
+            and entry.source_selection_digest == source_selection_digest
         )
+
+    @staticmethod
+    def _validate_build_selection(
+        result: BuildResult,
+        *,
+        source_selection: RepositorySourceSelection,
+        expected_source_commit: str,
+    ) -> BuildResult:
+        """Require positive evidence for the complete repository source policy."""
+
+        if not result.success or result.status is None:
+            return result
+        reported = result.status.metadata.get("source_selection_digest")
+        expected = source_selection.digest
+        if reported != expected:
+            return BuildResult(
+                index_type=result.index_type,
+                success=False,
+                error=(
+                    "builder did not confirm the configured repository "
+                    "source-selection identity"
+                ),
+                duration_seconds=result.duration_seconds,
+            )
+        if (
+            result.index_type == "zoekt"
+            and result.status.metadata.get("source_commit") != expected_source_commit
+        ):
+            return BuildResult(
+                index_type=result.index_type,
+                success=False,
+                error=("Zoekt builder did not confirm the compiler source commit"),
+                duration_seconds=result.duration_seconds,
+            )
+        return result
 
     @staticmethod
     def _build_one(
@@ -497,6 +640,8 @@ class IndexCompiler:
         *,
         last_commit: Optional[str] = None,
         previous_artifact_config: Optional[Dict[str, Any]] = None,
+        source_selection: RepositorySourceSelection,
+        expected_source_commit: str,
     ) -> BuildResult:
         """Build a single index, catching errors.
 
@@ -511,7 +656,10 @@ class IndexCompiler:
                     "repo_path": repo_path,
                     "output_dir": output_dir,
                     "last_commit": last_commit,
+                    "source_selection": source_selection,
                 }
+                if index_type == "zoekt":
+                    update_kwargs["source_commit"] = expected_source_commit
                 if previous_artifact_config is not None:
                     update_kwargs["previous_artifact_config"] = previous_artifact_config
                 status = builder.incremental_update(
@@ -519,11 +667,26 @@ class IndexCompiler:
                     **update_kwargs,
                 )
             else:
-                status = builder.build(
-                    scope="current_repo",
-                    repo_path=repo_path,
-                    output_dir=output_dir,
-                )
+                build_kwargs: Dict[str, Any] = {
+                    "repo_path": repo_path,
+                    "output_dir": output_dir,
+                    "source_selection": source_selection,
+                }
+                if index_type == "zoekt":
+                    build_kwargs["source_commit"] = expected_source_commit
+                status = builder.build(scope="current_repo", **build_kwargs)
+            if not isinstance(status, IndexStatus) or type(status.metadata) is not dict:
+                raise TypeError("index builder must return an IndexStatus")
+            if status.index_type != index_type:
+                raise ValueError("index builder returned the wrong index type")
+            if status.state is not IndexState.FRESH:
+                raise ValueError("index builder did not return a fresh index")
+            if status.scope != "current_repo":
+                raise ValueError("index builder returned the wrong repository scope")
+            if type(status.path) is not str or os.path.abspath(
+                os.path.expanduser(status.path)
+            ) != os.path.abspath(os.path.expanduser(output_dir)):
+                raise ValueError("index builder returned the wrong output path")
             elapsed = time.monotonic() - start
             return BuildResult(
                 index_type=index_type,
@@ -540,6 +703,24 @@ class IndexCompiler:
                 error=str(e),
                 duration_seconds=elapsed,
             )
+
+    def _snapshot_source_selection(
+        self,
+        existing_manifest: RepoManifest | None,
+    ) -> RepositorySourceSelection:
+        selection = self._config.source_selection
+        if selection is None:
+            if (
+                existing_manifest is not None
+                and type(existing_manifest.source_selection)
+                is RepositorySourceSelection
+            ):
+                selection = existing_manifest.source_selection
+            else:
+                selection = DEFAULT_REPOSITORY_SOURCE_SELECTION
+        if type(selection) is not RepositorySourceSelection:
+            raise TypeError("source_selection must be a RepositorySourceSelection")
+        return RepositorySourceSelection(selection.exclude_subtrees)
 
     @staticmethod
     def _get_head_commit(repo_path: str) -> str:

--- a/codenib/compiler/manifest.py
+++ b/codenib/compiler/manifest.py
@@ -15,18 +15,174 @@ Phase 2 (``AgentRunner`` + ``ResourceGuard``) reads the manifest via
 
 from __future__ import annotations
 
+import io
 import json
+import math
 import os
+import re
 import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
+from .._bounded_json import validate_bounded_json_stream
+from ..repository_source_selection import (
+    DEFAULT_REPOSITORY_SOURCE_SELECTION,
+    RepositorySourceSelection,
+)
+from ..source_fingerprint import is_secure_source_fingerprint_v2
 from .resources import IndexState, IndexStatus
 
 MANIFEST_FILENAME = "repo_manifest.json"
-MANIFEST_VERSION = "1.1"
+LEGACY_MANIFEST_VERSION = "1.1"
+MANIFEST_VERSION = "1.2"
+SUPPORTED_MANIFEST_VERSIONS = frozenset({LEGACY_MANIFEST_VERSION, MANIFEST_VERSION})
+
+_TOP_LEVEL_FIELDS = frozenset(
+    {
+        "version",
+        "repo",
+        "indexes",
+        "capabilities",
+        "compiled_at",
+        "compiled_at_epoch",
+    }
+)
+_REPO_V11_FIELDS = frozenset(
+    {
+        "path",
+        "commit",
+        "last_indexed_commit",
+        "source_fingerprint",
+        "last_indexed_source_fingerprint",
+        "languages",
+        "file_count",
+    }
+)
+_REPO_V12_FIELDS = _REPO_V11_FIELDS | frozenset(
+    {
+        "source_selection",
+        "last_indexed_source_selection_digest",
+    }
+)
+_INDEX_V11_FIELDS = frozenset(
+    {
+        "index_type",
+        "path",
+        "built_at",
+        "built_at_epoch",
+        "status",
+        "config",
+        "metadata",
+        "commit",
+        "source_fingerprint",
+    }
+)
+_INDEX_V12_FIELDS = _INDEX_V11_FIELDS | frozenset({"source_selection_digest"})
+_SELECTION_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_MAX_MANIFEST_BYTES = 16 * 1024 * 1024
+
+
+def _require_exact_object(
+    value: object,
+    expected_fields: frozenset[str],
+    *,
+    label: str,
+) -> Dict[str, Any]:
+    if type(value) is not dict:
+        raise ValueError(f"{label} must be a JSON object")
+    observed = set(value)
+    if observed != expected_fields:
+        missing = sorted(expected_fields - observed)
+        unknown = sorted(observed - expected_fields)
+        details = []
+        if missing:
+            details.append(f"missing fields: {', '.join(missing)}")
+        if unknown:
+            details.append(f"unknown fields: {', '.join(unknown)}")
+        raise ValueError(f"{label} has invalid fields ({'; '.join(details)})")
+    return value
+
+
+def _require_string(value: object, *, label: str) -> str:
+    if type(value) is not str:
+        raise ValueError(f"{label} must be a string")
+    return value
+
+
+def _require_epoch(value: object, *, label: str) -> float:
+    if type(value) not in {int, float} or not math.isfinite(value):
+        raise ValueError(f"{label} must be a finite number")
+    return float(value)
+
+
+def _require_string_list(value: object, *, label: str) -> List[str]:
+    if type(value) is not list or any(type(item) is not str for item in value):
+        raise ValueError(f"{label} must be an array of strings")
+    return list(value)
+
+
+def _require_json_object(value: object, *, label: str) -> Dict[str, Any]:
+    if type(value) is not dict or any(type(key) is not str for key in value):
+        raise ValueError(f"{label} must be a JSON object with string keys")
+    return dict(value)
+
+
+def _require_selection_digest(
+    value: object,
+    *,
+    label: str,
+    allow_empty: bool,
+) -> str:
+    digest = _require_string(value, label=label)
+    if (allow_empty and not digest) or _SELECTION_DIGEST_RE.fullmatch(digest):
+        return digest
+    raise ValueError(f"{label} must be a canonical source-selection digest")
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> Dict[str, Any]:
+    result: Dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"manifest JSON contains duplicate key {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_json_constant(value: str) -> None:
+    raise ValueError(f"manifest JSON contains non-finite number {value}")
+
+
+def _validate_json_tree(value: object, *, label: str) -> None:
+    """Reject non-JSON and non-finite nested values before they cross trust tiers."""
+
+    stack: list[object] = [value]
+    while stack:
+        current = stack.pop()
+        if type(current) is dict:
+            for key, child in current.items():
+                if type(key) is not str:
+                    raise ValueError(f"{label} object keys must be strings")
+                try:
+                    key.encode("utf-8", errors="strict")
+                except UnicodeError as exc:
+                    raise ValueError(f"{label} contains invalid Unicode") from exc
+                stack.append(child)
+        elif type(current) is list:
+            stack.extend(current)
+        elif type(current) is float:
+            if not math.isfinite(current):
+                raise ValueError(f"{label} numbers must be finite")
+        elif type(current) is str:
+            try:
+                current.encode("utf-8", errors="strict")
+            except UnicodeError as exc:
+                raise ValueError(f"{label} contains invalid Unicode") from exc
+        elif current is None or type(current) in {bool, int}:
+            continue
+        else:
+            raise ValueError(f"{label} contains a non-JSON value")
 
 
 @dataclass(slots=True)
@@ -42,9 +198,12 @@ class IndexEntry:
     metadata: Dict[str, Any] = field(default_factory=dict)
     commit: str = ""
     source_fingerprint: str = ""
+    source_selection_digest: str = ""
 
-    def to_dict(self) -> Dict[str, Any]:
-        return {
+    def to_dict(self, *, manifest_version: str = MANIFEST_VERSION) -> Dict[str, Any]:
+        if manifest_version not in SUPPORTED_MANIFEST_VERSIONS:
+            raise ValueError(f"unsupported manifest version: {manifest_version!r}")
+        payload = {
             "index_type": self.index_type,
             "path": self.path,
             "built_at": self.built_at,
@@ -55,19 +214,58 @@ class IndexEntry:
             "commit": self.commit,
             "source_fingerprint": self.source_fingerprint,
         }
+        if manifest_version == MANIFEST_VERSION:
+            payload["source_selection_digest"] = self.source_selection_digest
+        elif self.source_selection_digest:
+            raise ValueError(
+                "manifest v1.1 index entries cannot carry source-selection identity"
+            )
+        return payload
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> IndexEntry:
+    def from_dict(
+        cls,
+        data: Mapping[str, Any],
+        *,
+        manifest_version: str = MANIFEST_VERSION,
+    ) -> IndexEntry:
+        if manifest_version not in SUPPORTED_MANIFEST_VERSIONS:
+            raise ValueError(f"unsupported manifest version: {manifest_version!r}")
+        expected = (
+            _INDEX_V12_FIELDS
+            if manifest_version == MANIFEST_VERSION
+            else _INDEX_V11_FIELDS
+        )
+        payload = _require_exact_object(
+            data,
+            expected,
+            label=f"manifest {manifest_version} index entry",
+        )
+        status = _require_string(payload["status"], label="index status")
+        if status not in {"fresh", "stale", "failed"}:
+            raise ValueError("index status is unsupported")
+        selection_digest = ""
+        if manifest_version == MANIFEST_VERSION:
+            selection_digest = _require_selection_digest(
+                payload["source_selection_digest"],
+                label="index source_selection_digest",
+                allow_empty=True,
+            )
         return cls(
-            index_type=data["index_type"],
-            path=data["path"],
-            built_at=data["built_at"],
-            built_at_epoch=data["built_at_epoch"],
-            status=data["status"],
-            config=data.get("config", {}),
-            metadata=data.get("metadata", {}),
-            commit=data.get("commit", ""),
-            source_fingerprint=data.get("source_fingerprint", ""),
+            index_type=_require_string(payload["index_type"], label="index index_type"),
+            path=_require_string(payload["path"], label="index path"),
+            built_at=_require_string(payload["built_at"], label="index built_at"),
+            built_at_epoch=_require_epoch(
+                payload["built_at_epoch"], label="index built_at_epoch"
+            ),
+            status=status,
+            config=_require_json_object(payload["config"], label="index config"),
+            metadata=_require_json_object(payload["metadata"], label="index metadata"),
+            commit=_require_string(payload["commit"], label="index commit"),
+            source_fingerprint=_require_string(
+                payload["source_fingerprint"], label="index source_fingerprint"
+            ),
+            source_selection_digest=selection_digest,
         )
 
 
@@ -86,6 +284,10 @@ class RepoManifest:
     last_indexed_commit: str = ""
     source_fingerprint: str = ""
     last_indexed_source_fingerprint: str = ""
+    source_selection: RepositorySourceSelection | None = field(
+        default_factory=lambda: DEFAULT_REPOSITORY_SOURCE_SELECTION
+    )
+    last_indexed_source_selection_digest: str = ""
     languages: List[str] = field(default_factory=list)
     file_count: int = 0
     indexes: Dict[str, IndexEntry] = field(default_factory=dict)
@@ -93,52 +295,297 @@ class RepoManifest:
     compiled_at: str = ""
     compiled_at_epoch: float = 0.0
 
+    def __post_init__(self) -> None:
+        if type(self.source_selection) is RepositorySourceSelection:
+            self.source_selection = RepositorySourceSelection(
+                self.source_selection.exclude_subtrees
+            )
+        # Keep the source-unbound programmatic constructor convenient for
+        # existing empty-selection consumers. Strict persisted v1.2 input is
+        # validated before construction, and non-empty policies are never
+        # inferred on behalf of a builder.
+        if (
+            self.version == MANIFEST_VERSION
+            and self.source_selection == DEFAULT_REPOSITORY_SOURCE_SELECTION
+        ):
+            digest = self.source_selection.digest
+            if (
+                self.last_indexed_source_fingerprint
+                and not self.last_indexed_source_selection_digest
+            ):
+                self.last_indexed_source_selection_digest = digest
+            for entry in self.indexes.values():
+                if entry.status == "fresh":
+                    if not entry.commit:
+                        entry.commit = self.commit
+                    if not entry.source_selection_digest:
+                        entry.source_selection_digest = digest
+
+    @property
+    def source_selection_digest(self) -> str | None:
+        """Canonical current selection identity, or the v1.1 legacy sentinel."""
+
+        if self.source_selection is None:
+            return None
+        return self.source_selection.digest
+
+    def _validate_v12_source_closure(self) -> None:
+        """Require every current v1.2 view to bind the exact source identity."""
+
+        if self.version != MANIFEST_VERSION:
+            return
+        if self.source_fingerprint and not is_secure_source_fingerprint_v2(
+            self.source_fingerprint
+        ):
+            raise ValueError(
+                "manifest v1.2 source_fingerprint must be a secure v2 identity"
+            )
+        if self.last_indexed_source_fingerprint and not (
+            is_secure_source_fingerprint_v2(self.last_indexed_source_fingerprint)
+        ):
+            raise ValueError(
+                "manifest v1.2 last_indexed_source_fingerprint must be a "
+                "secure v2 identity"
+            )
+        selection_digest = self.source_selection_digest
+        if (
+            self.source_fingerprint
+            and self.last_indexed_source_fingerprint == self.source_fingerprint
+            and self.last_indexed_source_selection_digest != selection_digest
+        ):
+            raise ValueError(
+                "the current and last-indexed source identities must use the "
+                "same repository source selection"
+            )
+        for entry in self.indexes.values():
+            if entry.status != "fresh":
+                continue
+            if not is_secure_source_fingerprint_v2(self.source_fingerprint):
+                raise ValueError(
+                    f"fresh index {entry.index_type!r} requires a secure v2 "
+                    "repository source fingerprint"
+                )
+            if entry.commit != self.commit:
+                raise ValueError(
+                    f"fresh index {entry.index_type!r} commit does not match "
+                    "the manifest repository commit"
+                )
+            if entry.source_fingerprint != self.source_fingerprint:
+                raise ValueError(
+                    f"fresh index {entry.index_type!r} source fingerprint does "
+                    "not match the manifest repository source fingerprint"
+                )
+            if entry.source_selection_digest != selection_digest:
+                raise ValueError(
+                    f"fresh index {entry.index_type!r} does not match the "
+                    "manifest source selection"
+                )
+
     def to_dict(self) -> Dict[str, Any]:
+        if self.version not in SUPPORTED_MANIFEST_VERSIONS:
+            raise ValueError(f"unsupported manifest version: {self.version!r}")
+        repo = {
+            "path": self.repo_path,
+            "commit": self.commit,
+            "last_indexed_commit": self.last_indexed_commit,
+            "source_fingerprint": self.source_fingerprint,
+            "last_indexed_source_fingerprint": (self.last_indexed_source_fingerprint),
+            "languages": list(self.languages),
+            "file_count": self.file_count,
+        }
+        if self.version == MANIFEST_VERSION:
+            if type(self.source_selection) is not RepositorySourceSelection:
+                raise ValueError(
+                    "manifest v1.2 requires a canonical repository source selection"
+                )
+            digest = self.source_selection.digest
+            _require_selection_digest(
+                self.last_indexed_source_selection_digest,
+                label="last_indexed_source_selection_digest",
+                allow_empty=True,
+            )
+            if bool(self.last_indexed_source_fingerprint) != bool(
+                self.last_indexed_source_selection_digest
+            ):
+                raise ValueError(
+                    "last indexed source fingerprint and selection digest "
+                    "must be present together"
+                )
+            for entry in self.indexes.values():
+                if (
+                    entry.status == "fresh"
+                    and self.source_selection == DEFAULT_REPOSITORY_SOURCE_SELECTION
+                ):
+                    if not entry.commit:
+                        entry.commit = self.commit
+                    if not entry.source_selection_digest:
+                        entry.source_selection_digest = digest
+                _require_selection_digest(
+                    entry.source_selection_digest,
+                    label=f"index {entry.index_type!r} source_selection_digest",
+                    allow_empty=entry.status != "fresh",
+                )
+                if entry.status == "fresh" and entry.source_selection_digest != digest:
+                    raise ValueError(
+                        f"fresh index {entry.index_type!r} does not match the "
+                        "manifest source selection"
+                    )
+            self._validate_v12_source_closure()
+            repo["source_selection"] = self.source_selection.to_dict()
+            repo["last_indexed_source_selection_digest"] = (
+                self.last_indexed_source_selection_digest
+            )
+        else:
+            if self.source_selection is not None:
+                raise ValueError(
+                    "manifest v1.1 must retain the legacy source-selection sentinel"
+                )
+            if self.last_indexed_source_selection_digest or any(
+                entry.source_selection_digest for entry in self.indexes.values()
+            ):
+                raise ValueError("manifest v1.1 cannot carry source-selection identity")
+
         return {
             "version": self.version,
-            "repo": {
-                "path": self.repo_path,
-                "commit": self.commit,
-                "last_indexed_commit": self.last_indexed_commit,
-                "source_fingerprint": self.source_fingerprint,
-                "last_indexed_source_fingerprint": (
-                    self.last_indexed_source_fingerprint
-                ),
-                "languages": list(self.languages),
-                "file_count": self.file_count,
+            "repo": repo,
+            "indexes": {
+                k: v.to_dict(manifest_version=self.version)
+                for k, v in self.indexes.items()
             },
-            "indexes": {k: v.to_dict() for k, v in self.indexes.items()},
             "capabilities": dict(self.capabilities),
             "compiled_at": self.compiled_at,
             "compiled_at_epoch": self.compiled_at_epoch,
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> RepoManifest:
-        repo = data.get("repo", {})
-        indexes: Dict[str, IndexEntry] = {}
-        for k, v in data.get("indexes", {}).items():
-            entry = IndexEntry.from_dict(v)
-            if not entry.commit and entry.status == "fresh":
-                entry.commit = repo.get("commit", "")
-            indexes[k] = entry
-        return cls(
-            version=data.get("version", MANIFEST_VERSION),
-            repo_path=repo.get("path", ""),
-            commit=repo.get("commit", ""),
-            last_indexed_commit=repo.get("last_indexed_commit", repo.get("commit", "")),
-            source_fingerprint=repo.get("source_fingerprint", ""),
-            last_indexed_source_fingerprint=repo.get(
-                "last_indexed_source_fingerprint",
-                repo.get("source_fingerprint", ""),
-            ),
-            languages=repo.get("languages", []),
-            file_count=repo.get("file_count", 0),
-            indexes=indexes,
-            capabilities=data.get("capabilities", {}),
-            compiled_at=data.get("compiled_at", ""),
-            compiled_at_epoch=data.get("compiled_at_epoch", 0.0),
+    def from_dict(cls, data: Mapping[str, Any]) -> RepoManifest:
+        _validate_json_tree(data, label="repository manifest")
+        payload = _require_exact_object(
+            data,
+            _TOP_LEVEL_FIELDS,
+            label="repository manifest",
         )
+        version = _require_string(payload["version"], label="manifest version")
+        if version not in SUPPORTED_MANIFEST_VERSIONS:
+            raise ValueError(f"unsupported manifest version: {version!r}")
+        repo = _require_exact_object(
+            payload["repo"],
+            _REPO_V12_FIELDS if version == MANIFEST_VERSION else _REPO_V11_FIELDS,
+            label=f"manifest {version} repo",
+        )
+        raw_indexes = _require_json_object(payload["indexes"], label="manifest indexes")
+        indexes: Dict[str, IndexEntry] = {}
+        for k, v in raw_indexes.items():
+            entry = IndexEntry.from_dict(v, manifest_version=version)
+            if entry.index_type != k:
+                raise ValueError(
+                    f"manifest index key {k!r} does not match entry index_type"
+                )
+            indexes[k] = entry
+        source_selection: RepositorySourceSelection | None = None
+        last_selection_digest = ""
+        repo_commit = _require_string(repo["commit"], label="manifest repo commit")
+        repo_source = _require_string(
+            repo["source_fingerprint"], label="source_fingerprint"
+        )
+        if version == MANIFEST_VERSION:
+            try:
+                source_selection = RepositorySourceSelection.from_dict(
+                    repo["source_selection"]
+                )
+            except (TypeError, ValueError) as exc:
+                raise ValueError("manifest v1.2 source_selection is invalid") from exc
+            last_selection_digest = _require_selection_digest(
+                repo["last_indexed_source_selection_digest"],
+                label="last_indexed_source_selection_digest",
+                allow_empty=True,
+            )
+            last_source = _require_string(
+                repo["last_indexed_source_fingerprint"],
+                label="last_indexed_source_fingerprint",
+            )
+            if bool(last_source) != bool(last_selection_digest):
+                raise ValueError(
+                    "last indexed source fingerprint and selection digest "
+                    "must be present together"
+                )
+            if repo_source and not is_secure_source_fingerprint_v2(repo_source):
+                raise ValueError(
+                    "manifest v1.2 source_fingerprint must be a secure v2 identity"
+                )
+            if last_source and not is_secure_source_fingerprint_v2(last_source):
+                raise ValueError(
+                    "manifest v1.2 last_indexed_source_fingerprint must be a "
+                    "secure v2 identity"
+                )
+            current_digest = source_selection.digest
+            for entry in indexes.values():
+                if entry.status == "fresh" and (
+                    not entry.source_selection_digest
+                    or entry.source_selection_digest != current_digest
+                ):
+                    raise ValueError(
+                        f"fresh index {entry.index_type!r} does not match the "
+                        "manifest source selection"
+                    )
+                if entry.status == "fresh":
+                    if not is_secure_source_fingerprint_v2(repo_source):
+                        raise ValueError(
+                            f"fresh index {entry.index_type!r} requires a secure "
+                            "v2 repository source fingerprint"
+                        )
+                    if entry.commit != repo_commit:
+                        raise ValueError(
+                            f"fresh index {entry.index_type!r} commit does not "
+                            "match the manifest repository commit"
+                        )
+                    if entry.source_fingerprint != repo_source:
+                        raise ValueError(
+                            f"fresh index {entry.index_type!r} source fingerprint "
+                            "does not match the manifest repository source "
+                            "fingerprint"
+                        )
+        else:
+            last_source = _require_string(
+                repo["last_indexed_source_fingerprint"],
+                label="last_indexed_source_fingerprint",
+            )
+
+        file_count = repo["file_count"]
+        if type(file_count) is not int or file_count < 0:
+            raise ValueError("manifest repo file_count must be a non-negative integer")
+        capabilities = _require_json_object(
+            payload["capabilities"], label="manifest capabilities"
+        )
+        if any(type(value) is not bool for value in capabilities.values()):
+            raise ValueError("manifest capabilities values must be booleans")
+
+        manifest = cls(
+            version=version,
+            repo_path=_require_string(repo["path"], label="manifest repo path"),
+            commit=repo_commit,
+            last_indexed_commit=_require_string(
+                repo["last_indexed_commit"], label="last_indexed_commit"
+            ),
+            source_fingerprint=repo_source,
+            last_indexed_source_fingerprint=last_source,
+            source_selection=source_selection,
+            last_indexed_source_selection_digest=last_selection_digest,
+            languages=_require_string_list(
+                repo["languages"], label="manifest repo languages"
+            ),
+            file_count=file_count,
+            indexes=indexes,
+            capabilities=capabilities,
+            compiled_at=_require_string(
+                payload["compiled_at"], label="manifest compiled_at"
+            ),
+            compiled_at_epoch=_require_epoch(
+                payload["compiled_at_epoch"], label="manifest compiled_at_epoch"
+            ),
+        )
+        manifest._validate_v12_source_closure()
+        return manifest
 
     def save(self, path: str | Path) -> None:
         """Atomically replace the manifest after flushing the JSON payload."""
@@ -160,7 +607,7 @@ class RepoManifest:
                 fchmod = getattr(os, "fchmod", None)
                 if fchmod is not None and mode is not None:
                     fchmod(handle.fileno(), mode)
-                json.dump(self.to_dict(), handle, indent=2)
+                json.dump(self.to_dict(), handle, indent=2, allow_nan=False)
                 handle.flush()
                 os.fsync(handle.fileno())
             os.replace(temporary_path, p)
@@ -170,8 +617,34 @@ class RepoManifest:
     @classmethod
     def load(cls, path: str | Path) -> RepoManifest:
         """Load a manifest from a JSON file."""
-        with open(path, encoding="utf-8") as f:
-            data = json.load(f)
+        with open(path, "rb") as source:
+            payload = source.read(_MAX_MANIFEST_BYTES + 1)
+        if len(payload) > _MAX_MANIFEST_BYTES:
+            raise ValueError(f"repository manifest exceeds {_MAX_MANIFEST_BYTES} bytes")
+        if payload.startswith(
+            (
+                b"\xef\xbb\xbf",
+                b"\xff\xfe",
+                b"\xfe\xff",
+                b"\x00\x00\xfe\xff",
+                b"\xff\xfe\x00\x00",
+            )
+        ):
+            raise ValueError("repository manifest must use BOM-free UTF-8")
+        validate_bounded_json_stream(
+            io.BytesIO(payload),
+            label="repository manifest",
+            max_bytes=_MAX_MANIFEST_BYTES,
+        )
+        try:
+            text = payload.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise ValueError("repository manifest must use UTF-8") from exc
+        data = json.loads(
+            text,
+            object_pairs_hook=_reject_duplicate_json_keys,
+            parse_constant=_reject_nonfinite_json_constant,
+        )
         return cls.from_dict(data)
 
     def derive_capabilities(self) -> None:
@@ -193,10 +666,36 @@ class RepoManifest:
         entry = self.indexes.get(index_type)
         if entry is None or entry.status != "fresh":
             return False
-        if self.commit and entry.commit and entry.commit != self.commit:
+        if self.version == MANIFEST_VERSION:
+            if not is_secure_source_fingerprint_v2(self.source_fingerprint):
+                return False
+            if entry.commit != self.commit and not (
+                not entry.commit
+                and not self.source_fingerprint
+                and self.source_selection == DEFAULT_REPOSITORY_SOURCE_SELECTION
+            ):
+                return False
+            if entry.source_fingerprint != self.source_fingerprint:
+                return False
+        elif self.commit and entry.commit and entry.commit != self.commit:
             return False
-        if self.source_fingerprint:
-            return entry.source_fingerprint == self.source_fingerprint
+        if (
+            self.version != MANIFEST_VERSION
+            and self.source_fingerprint
+            and (entry.source_fingerprint != self.source_fingerprint)
+        ):
+            return False
+        if self.version == MANIFEST_VERSION:
+            selection_digest = self.source_selection_digest
+            if selection_digest is None or (
+                entry.source_selection_digest != selection_digest
+                and not (
+                    not entry.source_selection_digest
+                    and not self.source_fingerprint
+                    and self.source_selection == DEFAULT_REPOSITORY_SOURCE_SELECTION
+                )
+            ):
+                return False
         return True
 
 

--- a/codenib/compiler/manifest_export.py
+++ b/codenib/compiler/manifest_export.py
@@ -66,12 +66,11 @@ from ..storage.view_bundle import (
     consume_verified_view_bundle_stream,
     validate_view_bundle_physical_size,
 )
-from .manifest import MANIFEST_VERSION, RepoManifest
+from .manifest import MANIFEST_VERSION, SUPPORTED_MANIFEST_VERSIONS, RepoManifest
 from .manifest_import import DEFAULT_MAX_PROJECTION_BYTES
 from .manifest_storage import (
     DEFAULT_MAX_MANIFEST_BYTES,
     PORTABLE_STORAGE_VIEWS,
-    REPO_MANIFEST_IMPORT_PLAN_SCHEMA,
     RepoManifestImportPlan,
     ViewImportIntent,
     plan_repo_manifest_import_bytes,
@@ -1159,11 +1158,15 @@ def _require_bundle_semantics(
             label="snapshot vector root config",
         )
         try:
-            suffix, dimension, revision, metric, index_type = (
-                validate_portable_vector_persistence_semantics(
-                    root,
-                    view_config,
-                )
+            (
+                suffix,
+                dimension,
+                revision,
+                metric,
+                index_type,
+            ) = validate_portable_vector_persistence_semantics(
+                root,
+                view_config,
             )
             provider = resolve_embedding_artifact_route(
                 view_config,
@@ -1332,6 +1335,14 @@ def _portable_export_manifest_bytes(
     return manifest_bytes
 
 
+def _intent_generation_metadata(intent: ViewImportIntent) -> dict[str, Any]:
+    """Keep retained generation identity bound to the embedded manifest."""
+
+    metadata = repo_manifest_generation_metadata(intent)
+    metadata["manifest_version"] = intent.profile.config["manifest_version"]
+    return metadata
+
+
 def _validate_projection(
     projection: dict[str, Any],
     *,
@@ -1356,8 +1367,16 @@ def _validate_projection(
         raise StorageIntegrityError("repository manifest projection shape is invalid")
     if projection["repository_id"] != retained.repository.repository_id:
         raise StorageIntegrityError("repository manifest projection identity conflicts")
+    manifest_value = projection["manifest"]
+    if (
+        type(manifest_value) is not dict
+        or type(manifest_value.get("version")) is not str
+        or manifest_value["version"] not in SUPPORTED_MANIFEST_VERSIONS
+    ):
+        raise StorageIntegrityError("projected repository manifest is invalid")
+    embedded_version = manifest_value["version"]
     projected_source = projection["source"]
-    if type(projected_source) is not dict or set(projected_source) != {
+    expected_source_fields = {
         "source_revision_id",
         "kind",
         "source_fingerprint",
@@ -1367,7 +1386,16 @@ def _validate_projection(
         "source_verified",
         "commit_verified",
         "checkout_state",
-    }:
+    }
+    if embedded_version == MANIFEST_VERSION:
+        expected_source_fields |= {
+            "source_selection",
+            "source_selection_digest",
+        }
+    if (
+        type(projected_source) is not dict
+        or set(projected_source) != expected_source_fields
+    ):
         raise StorageIntegrityError("projected source shape is invalid")
     source = retained.source
     if (
@@ -1415,9 +1443,6 @@ def _validate_projection(
             raise StorageIntegrityError(f"projected {field} is invalid")
     if type(selection["skipped_views"]) is not dict:
         raise StorageIntegrityError("projected skipped views are invalid")
-    manifest_value = projection["manifest"]
-    if type(manifest_value) is not dict:
-        raise StorageIntegrityError("projected repository manifest is invalid")
     full_manifest_bytes = canonical_json(manifest_value).encode("ascii")
     if len(full_manifest_bytes) > max_manifest_bytes:
         raise StorageIntegrityError(
@@ -1438,7 +1463,6 @@ def _validate_projection(
     if (
         not same_exact_json(projection["plan"], expected_plan)
         or not same_exact_json(selection, plan.selection.to_dict())
-        or plan.schema != REPO_MANIFEST_IMPORT_PLAN_SCHEMA
         or plan.source.fingerprint != source.source_fingerprint
         or plan.source.file_count != projected_source["file_count"]
         or plan.source.display_commit != projected_source["display_commit"]
@@ -1446,6 +1470,19 @@ def _validate_projection(
         or plan.manifest.repo_path != "source"
     ):
         raise StorageIntegrityError("projected import plan identity conflicts")
+    source_selection = plan.source.source_selection
+    if embedded_version == MANIFEST_VERSION:
+        if (
+            source_selection is None
+            or not same_exact_json(
+                projected_source["source_selection"],
+                source_selection.to_dict(),
+            )
+            or projected_source["source_selection_digest"] != source_selection.digest
+        ):
+            raise StorageIntegrityError("projected source selection identity conflicts")
+    elif source_selection is not None:  # pragma: no cover - planner invariant
+        raise StorageIntegrityError("legacy projected source has a selection")
     selected = plan.selection.selected_views
     projected_views = projection["views"]
     if type(projected_views) is not dict or set(projected_views) != set(selected):
@@ -1494,7 +1531,7 @@ def _validate_projection(
             )
         metadata = json.loads(catalog_view.generation.metadata_json)
         metadata.pop(VIEW_GENERATION_MEMBERS_METADATA_KEY, None)
-        if not same_exact_json(metadata, repo_manifest_generation_metadata(intent)):
+        if not same_exact_json(metadata, _intent_generation_metadata(intent)):
             raise StorageIntegrityError(
                 f"projected {view_type!r} generation metadata conflicts"
             )
@@ -1614,7 +1651,7 @@ def _read_and_validate_projection(
     metadata.pop(VIEW_GENERATION_MEMBERS_METADATA_KEY, None)
     expected_metadata = {
         "contract": REPO_MANIFEST_PROJECTION_SCHEMA,
-        "manifest_version": MANIFEST_VERSION,
+        "manifest_version": validated.plan.manifest.version,
         "manifest_digest": plan_identity["digest"],
         "plan_digest": validated.plan.plan_digest,
         "projected_views": list(validated.plan.selection.selected_views),

--- a/codenib/compiler/manifest_import.py
+++ b/codenib/compiler/manifest_import.py
@@ -76,7 +76,6 @@ from ..storage.view_bundle import (
     consume_planned_view_bundle,
     plan_view_bundle_reader,
 )
-from .manifest import MANIFEST_VERSION
 from .manifest_storage import (
     RepoManifestImportPlan,
     SourceIntent,
@@ -365,6 +364,13 @@ def _snapshot_plan(plan: RepoManifestImportPlan) -> RepoManifestImportPlan:
             fingerprint_version=plan.source.fingerprint_version,
             file_count=plan.source.file_count,
             display_commit=plan.source.display_commit,
+            source_selection=(
+                None
+                if plan.source.source_selection is None
+                else type(plan.source.source_selection)(
+                    plan.source.source_selection.exclude_subtrees
+                )
+            ),
         )
         selection = ViewSelection(
             required_views=tuple(plan.selection.required_views),
@@ -563,6 +569,14 @@ def _portable_projection_manifest(
     return manifest
 
 
+def _intent_generation_metadata(intent: ViewImportIntent) -> dict[str, Any]:
+    """Keep retained generation identity bound to the embedded manifest."""
+
+    metadata = _generation_metadata(intent)
+    metadata["manifest_version"] = intent.profile.config["manifest_version"]
+    return metadata
+
+
 def _projection_value(
     plan: RepoManifestImportPlan,
     *,
@@ -571,20 +585,28 @@ def _projection_value(
     source: SourceRevision,
     views: Sequence[_PreparedView],
 ) -> dict[str, Any]:
+    projected_source: dict[str, Any] = {
+        "source_revision_id": source.source_revision_id,
+        "kind": source.source_kind,
+        "source_fingerprint": source.source_fingerprint,
+        "file_count": plan.source.file_count,
+        "display_commit": plan.source.display_commit,
+        "verification_scope": "content-bytes",
+        "source_verified": True,
+        "commit_verified": False,
+        "checkout_state": "not-attested",
+    }
+    if plan.source.source_selection is not None:
+        projected_source.update(
+            {
+                "source_selection": plan.source.source_selection.to_dict(),
+                "source_selection_digest": plan.source.source_selection.digest,
+            }
+        )
     return {
         "schema": REPO_MANIFEST_PROJECTION_SCHEMA,
         "repository_id": repository_id,
-        "source": {
-            "source_revision_id": source.source_revision_id,
-            "kind": source.source_kind,
-            "source_fingerprint": source.source_fingerprint,
-            "file_count": plan.source.file_count,
-            "display_commit": plan.source.display_commit,
-            "verification_scope": "content-bytes",
-            "source_verified": True,
-            "commit_verified": False,
-            "checkout_state": "not-attested",
-        },
+        "source": projected_source,
         "artifact": {
             "workspace_plan_digest": artifact_plan_digest,
             "postflight": "completed-before-catalog",
@@ -717,6 +739,7 @@ def _prepare_import_inside_authority(
         publication,
         expected_repository=repository_key,
         expected_commit=plan.source.display_commit,
+        expected_manifest_version=plan.manifest.version,
         max_files=max_context_files,
         max_bytes=max_context_bytes,
     )
@@ -819,7 +842,7 @@ def _prepare_import_inside_authority(
             intent.profile,
             bundle_object.record,
             schema_version=VIEW_BUNDLE_SCHEMA,
-            metadata=_generation_metadata(intent),
+            metadata=_intent_generation_metadata(intent),
             member_object_digests=member_digests,
         )
         prepared_views.append(
@@ -869,7 +892,7 @@ def _prepare_import_inside_authority(
     )
     projection_metadata = {
         "contract": REPO_MANIFEST_PROJECTION_SCHEMA,
-        "manifest_version": MANIFEST_VERSION,
+        "manifest_version": plan.manifest.version,
         "manifest_digest": plan.manifest_digest,
         "plan_digest": plan.plan_digest,
         "projected_views": [view.intent.view_type for view in prepared_views],
@@ -1422,6 +1445,7 @@ def import_retained_repo_manifest(
     if (
         plan.source.fingerprint != source_snapshot.fingerprint
         or plan.source.file_count != source_snapshot.file_count
+        or plan.source.source_selection != source_snapshot.source_selection
     ):
         raise StorageIntegrityError(
             "manifest import plan differs from the retained repository source"

--- a/codenib/compiler/manifest_materialization.py
+++ b/codenib/compiler/manifest_materialization.py
@@ -56,6 +56,7 @@ from ..artifacts.context import (
 )
 from ..artifacts.runtime import verify_context_artifact_reader
 from ..artifacts.security import assert_publishable_tree_reader
+from ..repository_source_selection import RepositorySourceSelection
 from ..source_fingerprint import is_secure_source_fingerprint_v2
 from ..storage.cas import BlobInfo
 from ..storage.models import (
@@ -83,7 +84,7 @@ from ..storage.view_bundle import (
     consume_verified_view_bundle_stream,
     validate_view_bundle_physical_size,
 )
-from .manifest import MANIFEST_FILENAME, MANIFEST_VERSION
+from .manifest import MANIFEST_FILENAME, MANIFEST_VERSION, SUPPORTED_MANIFEST_VERSIONS
 from .manifest_export import (
     RepoManifestExportReceipt,
     RepoManifestExportResult,
@@ -107,7 +108,6 @@ from .manifest_import import (
 from .manifest_storage import (
     DEFAULT_MAX_MANIFEST_BYTES,
     PORTABLE_STORAGE_VIEWS,
-    REPO_MANIFEST_IMPORT_PLAN_SCHEMA,
     RepoManifestImportPlan,
     ViewImportIntent,
     plan_repo_manifest_import_bytes,
@@ -205,6 +205,7 @@ class _RetainedContextPlan:
     workspace: WorkspacePlan
     repository: str
     commit: str
+    manifest_version: str
     source_fingerprint: str
     views: tuple[str, ...]
     view_plans: tuple[_RetainedViewPlan, ...]
@@ -830,6 +831,14 @@ def _retained_generation(
         ) from exc
 
 
+def _intent_generation_metadata(intent: ViewImportIntent) -> dict[str, Any]:
+    """Keep retained generation identity bound to the embedded manifest."""
+
+    metadata = repo_manifest_generation_metadata(intent)
+    metadata["manifest_version"] = intent.profile.config["manifest_version"]
+    return metadata
+
+
 def _authenticate_projection(
     object_store: ReceiptRetainingObjectStore,
     exported: RepoManifestExportResult,
@@ -873,8 +882,17 @@ def _authenticate_projection(
     ):
         raise StorageIntegrityError("repository manifest projection identity conflicts")
 
+    manifest_value = projection["manifest"]
+    if (
+        type(manifest_value) is not dict
+        or type(manifest_value.get("version")) is not str
+        or manifest_value["version"] not in SUPPORTED_MANIFEST_VERSIONS
+    ):
+        raise StorageIntegrityError("projected repository manifest is invalid")
+    embedded_version = manifest_value["version"]
+
     projected_source = projection["source"]
-    if type(projected_source) is not dict or set(projected_source) != {
+    expected_source_fields = {
         "source_revision_id",
         "kind",
         "source_fingerprint",
@@ -884,7 +902,16 @@ def _authenticate_projection(
         "source_verified",
         "commit_verified",
         "checkout_state",
-    }:
+    }
+    if embedded_version == MANIFEST_VERSION:
+        expected_source_fields |= {
+            "source_selection",
+            "source_selection_digest",
+        }
+    if (
+        type(projected_source) is not dict
+        or set(projected_source) != expected_source_fields
+    ):
         raise StorageIntegrityError("projected source shape is invalid")
     source_fingerprint = projected_source["source_fingerprint"]
     if (
@@ -940,9 +967,6 @@ def _authenticate_projection(
     if type(selection["skipped_views"]) is not dict:
         raise StorageIntegrityError("projected skipped views are invalid")
 
-    manifest_value = projection["manifest"]
-    if type(manifest_value) is not dict:
-        raise StorageIntegrityError("projected repository manifest is invalid")
     try:
         projected_manifest = canonical_json(manifest_value).encode("ascii")
     except StorageValidationError as exc:
@@ -966,7 +990,6 @@ def _authenticate_projection(
     if (
         not same_exact_json(projection["plan"], expected_plan)
         or not same_exact_json(selection, plan.selection.to_dict())
-        or plan.schema != REPO_MANIFEST_IMPORT_PLAN_SCHEMA
         or plan.source.fingerprint != source.source_fingerprint
         or plan.source.file_count != projected_source["file_count"]
         or plan.source.display_commit != projected_source["display_commit"]
@@ -974,6 +997,19 @@ def _authenticate_projection(
         or plan.manifest.repo_path != "source"
     ):
         raise StorageIntegrityError("projected import plan identity conflicts")
+    source_selection = plan.source.source_selection
+    if embedded_version == MANIFEST_VERSION:
+        if (
+            source_selection is None
+            or not same_exact_json(
+                projected_source["source_selection"],
+                source_selection.to_dict(),
+            )
+            or projected_source["source_selection_digest"] != source_selection.digest
+        ):
+            raise StorageIntegrityError("projected source selection identity conflicts")
+    elif source_selection is not None:  # pragma: no cover - planner invariant
+        raise StorageIntegrityError("legacy projected source has a selection")
     selected = plan.selection.selected_views
     if (
         selected != receipt.views
@@ -1048,7 +1084,7 @@ def _authenticate_projection(
             media_type=VIEW_BUNDLE_MEDIA_TYPE,
             profile=intent.profile,
             schema_version=VIEW_BUNDLE_SCHEMA,
-            metadata=repo_manifest_generation_metadata(intent),
+            metadata=_intent_generation_metadata(intent),
             member_digests=member_digests,
         )
         generation_value = value["generation"]
@@ -1091,7 +1127,7 @@ def _authenticate_projection(
 
     projection_metadata = {
         "contract": REPO_MANIFEST_PROJECTION_SCHEMA,
-        "manifest_version": MANIFEST_VERSION,
+        "manifest_version": plan.manifest.version,
         "manifest_digest": plan.manifest_digest,
         "plan_digest": plan.plan_digest,
         "projected_views": list(selected),
@@ -1276,6 +1312,7 @@ def _workspace_subject(
     repository: str,
     commit: str,
     source_fingerprint: str,
+    source_selection: RepositorySourceSelection | None,
     view_plans: tuple[_RetainedViewPlan, ...],
     output_records: tuple[TreeFileRecord, ...],
 ) -> str:
@@ -1318,6 +1355,9 @@ def _workspace_subject(
         ],
         "output_records": [_record_payload(record) for record in output_records],
     }
+    if source_selection is not None:
+        identity["source_selection"] = source_selection.to_dict()
+        identity["source_selection_digest"] = source_selection.digest
     try:
         payload = canonical_json(identity).encode("ascii")
     except (RecursionError, TypeError, ValueError) as exc:
@@ -1451,6 +1491,7 @@ def _build_context_plan(
             repository=repository,
             commit=manifest.commit,
             source_fingerprint=manifest.source_fingerprint,
+            source_selection=manifest.source_selection,
             view_plans=frozen_view_plans,
             output_records=output_records,
         ),
@@ -1477,6 +1518,7 @@ def _build_context_plan(
         workspace=workspace,
         repository=repository,
         commit=manifest.commit,
+        manifest_version=manifest.version,
         source_fingerprint=manifest.source_fingerprint,
         views=exported.receipt.views,
         view_plans=frozen_view_plans,
@@ -1526,6 +1568,7 @@ def _validate_candidate(
         candidate,
         expected_repository=planned.repository,
         expected_commit=planned.commit,
+        expected_manifest_version=planned.manifest_version,
         max_files=max_context_files,
         max_bytes=max_context_bytes,
     )

--- a/codenib/compiler/manifest_source.py
+++ b/codenib/compiler/manifest_source.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bind live repository reads to a manifest's exact source-selection era."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Iterable
+
+from .. import source_fingerprint as source_fingerprint_module
+from ..repository_filters import REPOSITORY_FILTER_POLICY_VERSION
+from ..repository_source_selection import RepositorySourceSelection
+from ..source_fingerprint import (
+    RepositorySourceBinding,
+    RepositorySourceIdentitySnapshot,
+    SourceFingerprint,
+)
+from .manifest import (
+    LEGACY_MANIFEST_VERSION,
+    MANIFEST_FILENAME,
+    MANIFEST_VERSION,
+    RepoManifest,
+)
+
+_LEGACY_MANIFEST_REPOSITORY_FILTER_POLICY_VERSION = 3
+
+
+def repository_source_selection_for_manifest(
+    manifest: RepoManifest,
+) -> RepositorySourceSelection | None:
+    selection = manifest.source_selection
+    if manifest.version == LEGACY_MANIFEST_VERSION:
+        if selection is not None:
+            raise ValueError(
+                "manifest v1.1 must use its legacy source-selection identity"
+            )
+        return None
+    if manifest.version != MANIFEST_VERSION:
+        raise ValueError(f"unsupported manifest version: {manifest.version!r}")
+    if type(selection) is not RepositorySourceSelection:
+        raise ValueError("manifest v1.2 has no canonical repository source selection")
+    return RepositorySourceSelection(selection.exclude_subtrees)
+
+
+def repository_filter_policy_for_manifest(manifest: RepoManifest) -> int:
+    """Return the repository-filter policy embedded by one manifest era."""
+
+    selection = repository_source_selection_for_manifest(manifest)
+    if selection is None:
+        return _LEGACY_MANIFEST_REPOSITORY_FILTER_POLICY_VERSION
+    return REPOSITORY_FILTER_POLICY_VERSION
+
+
+def resolve_compiler_source_selection(
+    cache_dir: str | Path,
+    explicit: RepositorySourceSelection | None = None,
+) -> RepositorySourceSelection:
+    """Resolve an explicit policy or reuse the current persisted manifest policy.
+
+    Public compiler wrappers use ``None`` to mean "reuse". Passing an exact
+    empty selection remains the explicit way to clear custom exclusions.
+    Legacy manifests migrate to the current empty policy instead of being
+    relabeled as if policy v3 and v4 had identical identities.
+    """
+
+    if explicit is not None:
+        if type(explicit) is not RepositorySourceSelection:
+            raise TypeError("source_selection must be a RepositorySourceSelection")
+        return RepositorySourceSelection(explicit.exclude_subtrees)
+    manifest_path = Path(cache_dir) / MANIFEST_FILENAME
+    if not manifest_path.is_file():
+        return RepositorySourceSelection()
+    manifest = RepoManifest.load(manifest_path)
+    selected = repository_source_selection_for_manifest(manifest)
+    return (
+        RepositorySourceSelection()
+        if selected is None
+        else RepositorySourceSelection(selected.exclude_subtrees)
+    )
+
+
+def fingerprint_repository_for_manifest(
+    root: str | Path,
+    manifest: RepoManifest,
+    *,
+    exclude_roots: Iterable[str | Path] = (),
+) -> SourceFingerprint:
+    """Recompute the source identity using the manifest's persisted policy."""
+
+    selection = repository_source_selection_for_manifest(manifest)
+    if selection is None:
+        return source_fingerprint_module._fingerprint_repository_legacy_manifest_v11(
+            root,
+            exclude_roots=exclude_roots,
+        )
+    return source_fingerprint_module.fingerprint_repository(
+        root,
+        exclude_roots=exclude_roots,
+        selection=selection,
+    )
+
+
+def capture_repository_source_for_manifest(
+    root: str | Path,
+    manifest: RepoManifest,
+    *,
+    exclude_roots: Iterable[str | Path] = (),
+    _source_owner: Callable[[object], None] | None = None,
+) -> RepositorySourceBinding:
+    """Capture retained reads using the manifest's persisted policy."""
+
+    selection = repository_source_selection_for_manifest(manifest)
+    if selection is None:
+        return source_fingerprint_module._capture_repository_source_legacy_manifest_v11(
+            root,
+            exclude_roots=exclude_roots,
+            _source_owner=_source_owner,
+        )
+    return source_fingerprint_module.capture_repository_source(
+        root,
+        exclude_roots=exclude_roots,
+        selection=selection,
+        _source_owner=_source_owner,
+    )
+
+
+def require_manifest_source_identity(
+    identity: RepositorySourceIdentitySnapshot,
+    manifest: RepoManifest,
+    *,
+    label: str,
+    mismatch_message: str | None = None,
+) -> None:
+    """Require one retained identity to match every manifest source axis."""
+
+    expected_selection = repository_source_selection_for_manifest(manifest)
+
+    def reject(axis: str) -> None:
+        if mismatch_message is not None:
+            raise ValueError(mismatch_message)
+        raise ValueError(f"{label} {axis} does not match the manifest")
+
+    if identity.fingerprint != manifest.source_fingerprint:
+        reject("source fingerprint")
+    if identity.file_count != manifest.file_count:
+        reject("source file count")
+    if identity.source_selection != expected_selection:
+        reject("source selection")
+
+
+__all__ = [
+    "capture_repository_source_for_manifest",
+    "fingerprint_repository_for_manifest",
+    "repository_filter_policy_for_manifest",
+    "repository_source_selection_for_manifest",
+    "resolve_compiler_source_selection",
+    "require_manifest_source_identity",
+]

--- a/codenib/compiler/manifest_storage.py
+++ b/codenib/compiler/manifest_storage.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Pure retained-import planning for :class:`RepoManifest` v1.1 documents.
+"""Pure retained-import planning for supported :class:`RepoManifest` documents.
 
 This module deliberately stops before filesystem or storage authority begins.
 It parses one manifest with bounded, unambiguous JSON rules and turns it into
@@ -34,11 +34,19 @@ from ..index.embedding.model_policy import (
     resolve_embedding_artifact_load_policy_from_options,
 )
 from ..provider_routes import resolve_embedding_artifact_route
+from ..repository_source_selection import RepositorySourceSelection
 from ..source_fingerprint import source_fingerprint_version
 from ..storage.models import StorageValidationError, ViewProfile, canonical_json
-from .manifest import MANIFEST_VERSION, IndexEntry, RepoManifest
+from .manifest import (
+    LEGACY_MANIFEST_VERSION,
+    MANIFEST_VERSION,
+    SUPPORTED_MANIFEST_VERSIONS,
+    IndexEntry,
+    RepoManifest,
+)
 
-REPO_MANIFEST_IMPORT_PLAN_SCHEMA = "codenib.repo-manifest-import-plan.v1"
+REPO_MANIFEST_IMPORT_PLAN_SCHEMA_V1 = "codenib.repo-manifest-import-plan.v1"
+REPO_MANIFEST_IMPORT_PLAN_SCHEMA = "codenib.repo-manifest-import-plan.v2"
 REPO_MANIFEST_PROFILE_CONTRACT = "codenib.repo-manifest-profile.v1"
 REPO_MANIFEST_PROFILE_NAME = "repo-manifest-explicit"
 REPO_MANIFEST_BM25_GENERATION_CONTRACT = "codenib.repo-manifest-bm25-generation.v1"
@@ -63,6 +71,7 @@ _MAX_CONFIG_BYTES = 16 * 1024 * 1024
 _MAX_DOCUMENTS_BYTES = 256 * 1024 * 1024
 _INT64_MAX = 9_223_372_036_854_775_807
 _DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
+_SOURCE_SELECTION_DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}\Z", re.ASCII)
 _DIAGNOSTIC_FIELD_NAMES = frozenset(
     {"error", "errormessage", "stalereason", "traceback", "exception"}
 )
@@ -153,6 +162,7 @@ BM25_PROFILE_AXES = (
     "chunking_failure_policy",
     "include_header_epilogue",
     "repository_filter_policy",
+    "source_selection_digest",
 )
 VECTOR_PROFILE_AXES = (
     "builder_schema",
@@ -170,6 +180,7 @@ VECTOR_PROFILE_AXES = (
     "max_lines_per_chunk",
     "chunking_failure_policy",
     "repository_filter_policy",
+    "source_selection_digest",
 )
 _BM25_OPTIONAL_PROFILE_AXES = ("additional_ignore_dirs",)
 _VECTOR_OPTIONAL_PROFILE_AXES = (
@@ -215,7 +226,7 @@ _NON_PROFILE_METADATA_FIELDS = frozenset({"build_duration_seconds"})
 _TOP_LEVEL_FIELDS = frozenset(
     {"version", "repo", "indexes", "capabilities", "compiled_at", "compiled_at_epoch"}
 )
-_REPO_FIELDS = frozenset(
+_REPO_V11_FIELDS = frozenset(
     {
         "path",
         "commit",
@@ -226,7 +237,13 @@ _REPO_FIELDS = frozenset(
         "file_count",
     }
 )
-_ENTRY_FIELDS = frozenset(
+_REPO_V12_FIELDS = _REPO_V11_FIELDS | frozenset(
+    {
+        "source_selection",
+        "last_indexed_source_selection_digest",
+    }
+)
+_ENTRY_V11_FIELDS = frozenset(
     {
         "index_type",
         "path",
@@ -239,6 +256,7 @@ _ENTRY_FIELDS = frozenset(
         "source_fingerprint",
     }
 )
+_ENTRY_V12_FIELDS = _ENTRY_V11_FIELDS | frozenset({"source_selection_digest"})
 
 
 class _AmbiguousJSONError(ValueError):
@@ -269,6 +287,7 @@ class SourceIntent:
     fingerprint_version: int
     file_count: int
     display_commit: str
+    source_selection: RepositorySourceSelection | None = None
 
     def __post_init__(self) -> None:
         if type(self) is not SourceIntent:
@@ -298,6 +317,21 @@ class SourceIntent:
                 raise StorageValidationError("source intent file count must be exact")
             _nonnegative_int(self.file_count, "source intent file count")
             _bounded_text(self.display_commit, "source intent display commit")
+            if self.source_selection is not None:
+                if type(self.source_selection) is not RepositorySourceSelection:
+                    raise StorageValidationError(
+                        "source intent selection must use the exact selection type"
+                    )
+                # Reconstruct the immutable value so a forged internal index cannot
+                # become part of an authority-bearing plan later.
+                canonical_selection = RepositorySourceSelection(
+                    self.source_selection.exclude_subtrees
+                )
+                if canonical_selection != self.source_selection:
+                    raise StorageValidationError(
+                        "source intent selection is not canonical"
+                    )
+                object.__setattr__(self, "source_selection", canonical_selection)
         except StorageValidationError:
             raise
         except Exception as exc:
@@ -321,19 +355,24 @@ class SourceIntent:
     def identity_digest(self) -> str:
         """Digest only the content-bearing intent, excluding display commit."""
 
-        return _sha256(
-            _canonical_bytes(
+        identity: dict[str, Any] = {
+            "contract": "codenib.repo-manifest-source-intent.v1",
+            "source_fingerprint": self.fingerprint,
+            "fingerprint_version": self.fingerprint_version,
+            "file_count": self.file_count,
+        }
+        if self.source_selection is not None:
+            identity.update(
                 {
-                    "contract": "codenib.repo-manifest-source-intent.v1",
-                    "source_fingerprint": self.fingerprint,
-                    "fingerprint_version": self.fingerprint_version,
-                    "file_count": self.file_count,
+                    "contract": "codenib.repo-manifest-source-intent.v2",
+                    "source_selection": self.source_selection.to_dict(),
+                    "source_selection_digest": self.source_selection.digest,
                 }
             )
-        )
+        return _sha256(_canonical_bytes(identity))
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        value: dict[str, Any] = {
             "contract": "codenib.repo-manifest-source-intent.v1",
             "disposition": self.disposition,
             "eligible_for_verification": self.eligible_for_verification,
@@ -343,6 +382,15 @@ class SourceIntent:
             "display_commit": self.display_commit,
             "identity_digest": self.identity_digest,
         }
+        if self.source_selection is not None:
+            value.update(
+                {
+                    "contract": "codenib.repo-manifest-source-intent.v2",
+                    "source_selection": self.source_selection.to_dict(),
+                    "source_selection_digest": self.source_selection.digest,
+                }
+            )
+        return value
 
 
 @dataclass(frozen=True, slots=True)
@@ -461,7 +509,11 @@ class RepoManifestImportPlan:
 
     @property
     def schema(self) -> str:
-        return REPO_MANIFEST_IMPORT_PLAN_SCHEMA
+        return (
+            REPO_MANIFEST_IMPORT_PLAN_SCHEMA_V1
+            if self.source.source_selection is None
+            else REPO_MANIFEST_IMPORT_PLAN_SCHEMA
+        )
 
     @property
     def canonical_manifest_bytes(self) -> bytes:
@@ -475,7 +527,7 @@ class RepoManifestImportPlan:
     def manifest(self) -> RepoManifest:
         value = json.loads(self.manifest_json)
         assert isinstance(value, dict)
-        return _repo_manifest_v11_from_data(value)
+        return _repo_manifest_from_data(value)
 
     @property
     def view_map(self) -> Mapping[str, ViewImportIntent]:
@@ -491,7 +543,7 @@ class RepoManifestImportPlan:
         return {
             "schema": self.schema,
             "manifest": {
-                "version": MANIFEST_VERSION,
+                "version": self.manifest.version,
                 "digest": self.manifest_digest,
                 "byte_size": len(self.canonical_manifest_bytes),
             },
@@ -706,6 +758,7 @@ def _snapshot_json_value(
             )
         state["seen"][identity] = value
         try:
+            version = value.version
             languages = value.languages
             indexes = value.indexes
             capabilities = value.capabilities
@@ -724,19 +777,45 @@ def _snapshot_json_value(
                 raise StorageValidationError(
                     "repository manifest capabilities must be a bounded exact object"
                 )
+            projected_repo: dict[str, Any] = {
+                "path": value.repo_path,
+                "commit": value.commit,
+                "last_indexed_commit": value.last_indexed_commit,
+                "source_fingerprint": value.source_fingerprint,
+                "last_indexed_source_fingerprint": (
+                    value.last_indexed_source_fingerprint
+                ),
+                "languages": languages,
+                "file_count": value.file_count,
+            }
+            if version == MANIFEST_VERSION:
+                source_selection = value.source_selection
+                if type(source_selection) is not RepositorySourceSelection:
+                    raise StorageValidationError(
+                        "manifest v1.2 source selection must use the exact type"
+                    )
+                detached_selection = RepositorySourceSelection(
+                    source_selection.exclude_subtrees
+                )
+                projected_repo.update(
+                    {
+                        "source_selection": detached_selection.to_dict(),
+                        "last_indexed_source_selection_digest": (
+                            value.last_indexed_source_selection_digest
+                        ),
+                    }
+                )
+            elif version == LEGACY_MANIFEST_VERSION:
+                if (
+                    value.source_selection is not None
+                    or value.last_indexed_source_selection_digest
+                ):
+                    raise StorageValidationError(
+                        "manifest v1.1 cannot carry source-selection identity"
+                    )
             projected = {
-                "version": value.version,
-                "repo": {
-                    "path": value.repo_path,
-                    "commit": value.commit,
-                    "last_indexed_commit": value.last_indexed_commit,
-                    "source_fingerprint": value.source_fingerprint,
-                    "last_indexed_source_fingerprint": (
-                        value.last_indexed_source_fingerprint
-                    ),
-                    "languages": languages,
-                    "file_count": value.file_count,
-                },
+                "version": version,
+                "repo": projected_repo,
                 "indexes": indexes,
                 "capabilities": capabilities,
                 "compiled_at": value.compiled_at,
@@ -748,6 +827,7 @@ def _snapshot_json_value(
             raise StorageValidationError(
                 f"{label} is missing or failed to expose manifest fields"
             ) from exc
+        state["manifest_version"] = version
         return _snapshot_json_value(
             projected,
             label=label,
@@ -770,6 +850,7 @@ def _snapshot_json_value(
                 raise StorageValidationError(
                     "repository manifest index config and metadata must be exact objects"
                 )
+            manifest_version = state.get("manifest_version", MANIFEST_VERSION)
             projected = {
                 "index_type": value.index_type,
                 "path": value.path,
@@ -781,6 +862,13 @@ def _snapshot_json_value(
                 "commit": value.commit,
                 "source_fingerprint": value.source_fingerprint,
             }
+            if manifest_version == MANIFEST_VERSION:
+                projected["source_selection_digest"] = value.source_selection_digest
+            elif value.source_selection_digest:
+                raise StorageValidationError(
+                    "manifest v1.1 index entries cannot carry source-selection "
+                    "identity"
+                )
         except StorageValidationError:
             raise
         except Exception as exc:
@@ -1107,14 +1195,16 @@ def _validate_publishable_entry(entry: IndexEntry, *, view_type: str) -> None:
         _assert_no_diagnostic_fields(value, source=source)
 
 
-def _repo_manifest_v11_from_data(data: dict[str, Any]) -> RepoManifest:
-    """Validate and detach one exact RepoManifest v1.1 object."""
+def _repo_manifest_from_data(data: dict[str, Any]) -> RepoManifest:
+    """Validate and detach one exact supported RepoManifest object."""
 
     _validate_json_budget(data, label="repository manifest")
     _require_exact_fields(data, _TOP_LEVEL_FIELDS, label="repository manifest")
-    if data.get("version") != MANIFEST_VERSION:
+    version = data.get("version")
+    if type(version) is not str or version not in SUPPORTED_MANIFEST_VERSIONS:
         raise StorageValidationError(
-            f"repository manifest version must be {MANIFEST_VERSION}"
+            "repository manifest version must be one of "
+            + ", ".join(sorted(SUPPORTED_MANIFEST_VERSIONS))
         )
 
     repo = data.get("repo")
@@ -1128,7 +1218,11 @@ def _repo_manifest_v11_from_data(data: dict[str, Any]) -> RepoManifest:
         raise StorageValidationError(
             "repository manifest capabilities must be an object"
         )
-    _require_exact_fields(repo, _REPO_FIELDS, label="repository manifest repo")
+    repo_fields = _REPO_V12_FIELDS if version == MANIFEST_VERSION else _REPO_V11_FIELDS
+    entry_fields = (
+        _ENTRY_V12_FIELDS if version == MANIFEST_VERSION else _ENTRY_V11_FIELDS
+    )
+    _require_exact_fields(repo, repo_fields, label="repository manifest repo")
     if len(indexes) > _MAX_INDEXES:
         raise StorageValidationError("repository manifest has too many indexes")
     if len(capabilities) > _MAX_CAPABILITIES:
@@ -1179,6 +1273,33 @@ def _repo_manifest_v11_from_data(data: dict[str, Any]) -> RepoManifest:
     file_count = _nonnegative_int(
         repo.get("file_count"), "repository manifest file count"
     )
+    source_selection: RepositorySourceSelection | None = None
+    last_selection_digest = ""
+    if version == MANIFEST_VERSION:
+        try:
+            source_selection = RepositorySourceSelection.from_dict(
+                repo.get("source_selection")
+            )
+        except (TypeError, ValueError) as exc:
+            raise StorageValidationError(
+                "repository manifest source selection is invalid"
+            ) from exc
+        last_selection_digest = _bounded_text(
+            repo.get("last_indexed_source_selection_digest"),
+            "repository manifest last indexed source selection digest",
+        )
+        if last_selection_digest and not _SOURCE_SELECTION_DIGEST_RE.fullmatch(
+            last_selection_digest
+        ):
+            raise StorageValidationError(
+                "repository manifest last indexed source selection digest "
+                "is unsupported"
+            )
+        if bool(last_source) != bool(last_selection_digest):
+            raise StorageValidationError(
+                "repository manifest last indexed source identities must be "
+                "present together"
+            )
 
     entries: dict[str, IndexEntry] = {}
     for name, raw_entry in indexes.items():
@@ -1194,7 +1315,7 @@ def _repo_manifest_v11_from_data(data: dict[str, Any]) -> RepoManifest:
             )
         _require_exact_fields(
             raw_entry,
-            _ENTRY_FIELDS,
+            entry_fields,
             label=f"repository manifest view {view_name!r}",
         )
         config = raw_entry.get("config")
@@ -1228,6 +1349,26 @@ def _repo_manifest_v11_from_data(data: dict[str, Any]) -> RepoManifest:
             raise StorageValidationError(
                 f"repository manifest view {view_name!r} index type does not match"
             )
+        entry_selection_digest = ""
+        if version == MANIFEST_VERSION:
+            entry_selection_digest = _bounded_text(
+                raw_entry.get("source_selection_digest"),
+                f"view {view_name!r} source selection digest",
+            )
+            if entry_selection_digest and not _SOURCE_SELECTION_DIGEST_RE.fullmatch(
+                entry_selection_digest
+            ):
+                raise StorageValidationError(
+                    f"view {view_name!r} source selection digest is unsupported"
+                )
+            if status == "fresh" and (
+                not entry_selection_digest
+                or source_selection is None
+                or entry_selection_digest != source_selection.digest
+            ):
+                raise StorageValidationError(
+                    f"fresh view {view_name!r} source selection does not match"
+                )
         entries[view_name] = IndexEntry(
             index_type=index_type,
             path=_bounded_text(
@@ -1247,6 +1388,7 @@ def _repo_manifest_v11_from_data(data: dict[str, Any]) -> RepoManifest:
             metadata=metadata,
             commit=_bounded_text(raw_entry.get("commit"), f"view {view_name!r} commit"),
             source_fingerprint=entry_source,
+            source_selection_digest=entry_selection_digest,
         )
 
     normalized_capabilities: dict[str, bool] = {}
@@ -1264,12 +1406,14 @@ def _repo_manifest_v11_from_data(data: dict[str, Any]) -> RepoManifest:
         normalized_capabilities[capability] = enabled
 
     manifest = RepoManifest(
-        version=MANIFEST_VERSION,
+        version=version,
         repo_path=repo_path,
         commit=commit,
         last_indexed_commit=last_commit,
         source_fingerprint=source,
         last_indexed_source_fingerprint=last_source,
+        source_selection=source_selection,
+        last_indexed_source_selection_digest=last_selection_digest,
         languages=languages,
         file_count=file_count,
         indexes=entries,
@@ -1351,6 +1495,11 @@ def _entry_is_current(manifest: RepoManifest, view_type: str) -> tuple[bool, str
         entry.source_fingerprint != manifest.source_fingerprint
     ):
         return False, "source_mismatch"
+    if manifest.version == MANIFEST_VERSION and (
+        manifest.source_selection_digest is None
+        or entry.source_selection_digest != manifest.source_selection_digest
+    ):
+        return False, "source_selection_mismatch"
     return True, ""
 
 
@@ -1460,7 +1609,12 @@ def _require_profile_axes(
         )
 
 
-def _profile_config(entry: IndexEntry, *, view_type: str) -> dict[str, Any]:
+def _profile_config(
+    entry: IndexEntry,
+    *,
+    view_type: str,
+    manifest_version: str,
+) -> dict[str, Any]:
     config = entry.config
     axes: tuple[str, ...]
     optional_axes: tuple[str, ...]
@@ -1476,6 +1630,8 @@ def _profile_config(entry: IndexEntry, *, view_type: str) -> dict[str, Any]:
         non_profile = _VECTOR_NON_PROFILE_CONFIG_FIELDS
     else:  # pragma: no cover - selection excludes unsupported views
         raise _IncompleteProfile(f"unsupported view profile: {view_type}")
+    if manifest_version == LEGACY_MANIFEST_VERSION:
+        axes = tuple(axis for axis in axes if axis != "source_selection_digest")
     _require_profile_axes(config, view_type=view_type, axes=axes)
     _reject_unknown_config_fields(
         config,
@@ -1534,6 +1690,16 @@ def _profile_config(entry: IndexEntry, *, view_type: str) -> dict[str, Any]:
         config["repository_filter_policy"],
         f"view {view_type!r} repository_filter_policy",
     )
+    if manifest_version == MANIFEST_VERSION:
+        source_selection_digest = config["source_selection_digest"]
+        if (
+            type(source_selection_digest) is not str
+            or _SOURCE_SELECTION_DIGEST_RE.fullmatch(source_selection_digest) is None
+            or source_selection_digest != entry.source_selection_digest
+        ):
+            raise _IncompleteProfile(
+                f"view {view_type!r} source selection identity is inconsistent"
+            )
     if "additional_ignore_dirs" in config:
         _text_list(
             config["additional_ignore_dirs"],
@@ -1617,7 +1783,7 @@ def _profile_config(entry: IndexEntry, *, view_type: str) -> dict[str, Any]:
         compatibility["embedding_load_policy"] = embedding_load_policy
     return {
         "contract": REPO_MANIFEST_PROFILE_CONTRACT,
-        "manifest_version": MANIFEST_VERSION,
+        "manifest_version": manifest_version,
         "builder_schema": config["builder_schema"],
         "compatibility": compatibility,
     }
@@ -1938,10 +2104,18 @@ def _generation_record(entry: IndexEntry, *, view_type: str) -> dict[str, Any]:
 
 
 def _view_import_intent(
-    entry: IndexEntry, *, view_type: str, required: bool
+    entry: IndexEntry,
+    *,
+    view_type: str,
+    required: bool,
+    manifest_version: str,
 ) -> ViewImportIntent:
     _validate_publishable_entry(entry, view_type=view_type)
-    profile_config = _profile_config(entry, view_type=view_type)
+    profile_config = _profile_config(
+        entry,
+        view_type=view_type,
+        manifest_version=manifest_version,
+    )
     try:
         profile = ViewProfile.create(
             view_type,
@@ -1957,7 +2131,9 @@ def _view_import_intent(
     return ViewImportIntent(
         view_type=view_type,
         required=required,
-        manifest_entry_json=canonical_json(entry.to_dict()),
+        manifest_entry_json=canonical_json(
+            entry.to_dict(manifest_version=manifest_version)
+        ),
         profile=profile,
         generation_record_json=canonical_json(generation),
     )
@@ -1985,17 +2161,29 @@ def _canonical_object_json(payload: object, *, label: str) -> dict[str, Any]:
     return value
 
 
-def _intent_entry_from_data(data: dict[str, Any], *, view_type: str) -> IndexEntry:
-    _require_exact_fields(data, _ENTRY_FIELDS, label="view import manifest entry")
+def _intent_entry_from_data(
+    data: dict[str, Any],
+    *,
+    view_type: str,
+    manifest_version: str,
+) -> IndexEntry:
+    expected_fields = (
+        _ENTRY_V12_FIELDS if manifest_version == MANIFEST_VERSION else _ENTRY_V11_FIELDS
+    )
+    _require_exact_fields(
+        data,
+        expected_fields,
+        label="view import manifest entry",
+    )
     if not isinstance(data.get("config"), dict) or not isinstance(
         data.get("metadata"), dict
     ):
         raise StorageValidationError("view import entry metadata must be objects")
     try:
-        entry = IndexEntry.from_dict(data)
+        entry = IndexEntry.from_dict(data, manifest_version=manifest_version)
     except (KeyError, TypeError, ValueError) as exc:
         raise StorageValidationError("view import entry is invalid") from exc
-    if entry.to_dict() != data:
+    if entry.to_dict(manifest_version=manifest_version) != data:
         raise StorageValidationError("view import entry shape is not canonical")
     if entry.index_type != view_type or entry.status != "fresh":
         raise StorageValidationError(
@@ -2056,17 +2244,34 @@ def _validate_view_import_intent(intent: ViewImportIntent) -> None:
         intent.profile.config_json,
         label="view import profile config",
     )
+    profile_config = intent.profile.config
+    manifest_version = profile_config.get("manifest_version")
+    if (
+        type(manifest_version) is not str
+        or manifest_version not in SUPPORTED_MANIFEST_VERSIONS
+    ):
+        raise StorageValidationError(
+            "view import intent profile does not match a supported manifest version"
+        )
 
     entry_data = _canonical_object_json(
         intent.manifest_entry_json,
         label="view import manifest entry",
     )
     _validate_manifest_publication_policy({"entry": entry_data})
-    entry = _intent_entry_from_data(entry_data, view_type=intent.view_type)
+    entry = _intent_entry_from_data(
+        entry_data,
+        view_type=intent.view_type,
+        manifest_version=manifest_version,
+    )
     try:
         expected_profile = ViewProfile.create(
             intent.view_type,
-            _profile_config(entry, view_type=intent.view_type),
+            _profile_config(
+                entry,
+                view_type=intent.view_type,
+                manifest_version=manifest_version,
+            ),
             name=REPO_MANIFEST_PROFILE_NAME,
         )
         _validate_non_profile_config(entry, view_type=intent.view_type)
@@ -2159,9 +2364,18 @@ def _validate_view_selection(selection: ViewSelection) -> None:
         )
 
 
-def _incomplete_view_reason(entry: IndexEntry, *, view_type: str) -> str | None:
+def _incomplete_view_reason(
+    entry: IndexEntry,
+    *,
+    view_type: str,
+    manifest_version: str,
+) -> str | None:
     try:
-        _profile_config(entry, view_type=view_type)
+        _profile_config(
+            entry,
+            view_type=view_type,
+            manifest_version=manifest_version,
+        )
     except _IncompleteProfile:
         return "incomplete_profile"
     try:
@@ -2177,7 +2391,7 @@ def _validate_import_plan(plan: RepoManifestImportPlan) -> None:
         plan.manifest_json,
         label="import plan manifest",
     )
-    manifest = _repo_manifest_v11_from_data(manifest_data)
+    manifest = _repo_manifest_from_data(manifest_data)
     _validate_manifest_publication_policy(manifest_data)
     if not isinstance(plan.source, SourceIntent):
         raise StorageValidationError("import plan source intent is invalid")
@@ -2192,17 +2406,20 @@ def _validate_import_plan(plan: RepoManifestImportPlan) -> None:
         fingerprint_version=fingerprint_version,
         file_count=manifest.file_count,
         display_commit=manifest.commit,
+        source_selection=manifest.source_selection,
     )
     if (
         plan.source.fingerprint,
         plan.source.fingerprint_version,
         plan.source.file_count,
         plan.source.display_commit,
+        plan.source.source_selection,
     ) != (
         expected_source.fingerprint,
         expected_source.fingerprint_version,
         expected_source.file_count,
         expected_source.display_commit,
+        expected_source.source_selection,
     ):
         raise StorageValidationError(
             "import plan source intent does not match its manifest"
@@ -2242,6 +2459,7 @@ def _validate_import_plan(plan: RepoManifestImportPlan) -> None:
         observed_reason = _incomplete_view_reason(
             manifest.indexes[view_type],
             view_type=view_type,
+            manifest_version=manifest.version,
         )
         if observed_reason != reason:
             raise StorageValidationError(
@@ -2258,7 +2476,9 @@ def _validate_import_plan(plan: RepoManifestImportPlan) -> None:
             raise StorageValidationError(
                 "import plan view requirement does not match its selection"
             )
-        expected_entry = canonical_json(manifest.indexes[view.view_type].to_dict())
+        expected_entry = canonical_json(
+            manifest.indexes[view.view_type].to_dict(manifest_version=manifest.version)
+        )
         if view.manifest_entry_json != expected_entry:
             raise StorageValidationError(
                 "import plan view entry does not match its manifest"
@@ -2314,7 +2534,7 @@ def plan_repo_manifest_import(
 
     limit = _manifest_limit(max_manifest_bytes)
     data = _validated_manifest_data(manifest, max_bytes=limit)
-    parsed = _repo_manifest_v11_from_data(data)
+    parsed = _repo_manifest_from_data(data)
     normalized_manifest = parsed.to_dict()
     _validate_manifest_publication_policy(normalized_manifest)
     manifest_json = canonical_json(normalized_manifest)
@@ -2337,6 +2557,7 @@ def plan_repo_manifest_import(
                 parsed.indexes[view_type],
                 view_type=view_type,
                 required=is_required,
+                manifest_version=parsed.version,
             )
         except _IncompleteProfile as exc:
             if is_required:
@@ -2373,6 +2594,7 @@ def plan_repo_manifest_import(
         fingerprint_version=fingerprint_version,
         file_count=parsed.file_count,
         display_commit=parsed.commit,
+        source_selection=parsed.source_selection,
     )
     return RepoManifestImportPlan(
         manifest_json=manifest_json,
@@ -2492,6 +2714,7 @@ __all__ = [
     "PORTABLE_STORAGE_VIEWS",
     "REPO_MANIFEST_BM25_GENERATION_CONTRACT",
     "REPO_MANIFEST_IMPORT_PLAN_SCHEMA",
+    "REPO_MANIFEST_IMPORT_PLAN_SCHEMA_V1",
     "REPO_MANIFEST_PROFILE_CONTRACT",
     "REPO_MANIFEST_PROFILE_NAME",
     "REPO_MANIFEST_VECTOR_GENERATION_CONTRACT",

--- a/codenib/compiler/skill_context.py
+++ b/codenib/compiler/skill_context.py
@@ -54,10 +54,15 @@ from ..index.embedding.model_policy import (
 )
 from ..paths import REPO_INDEX_DIRNAME
 from ..provider_routes import resolve_embedding_artifact_route
+from ..repository_source_selection import (
+    DEFAULT_REPOSITORY_SOURCE_SELECTION,
+    RepositorySourceSelection,
+)
 from .artifact_fingerprints import require_bm25_manifest_artifact
 from .index_builders import IndexBuilderRegistry, register_default_builders
 from .index_compiler import IndexCompiler, IndexCompilerConfig
 from .manifest import MANIFEST_FILENAME, IndexEntry, RepoManifest
+from .manifest_source import resolve_compiler_source_selection
 
 if TYPE_CHECKING:
     from ..native_index_authorization import NativeIndexAuthorization
@@ -298,6 +303,45 @@ def _looks_built(cache_dir: str, index_type: str) -> bool:
     return any(p.iterdir())
 
 
+def _current_skill_manifest(
+    repo_path: str,
+    cache_dir: str,
+    source_selection: RepositorySourceSelection,
+) -> RepoManifest | None:
+    """Return a manifest whose checkout and selection are safe to reuse."""
+
+    manifest_path = Path(cache_dir) / MANIFEST_FILENAME
+    if not manifest_path.is_file():
+        return None
+    try:
+        manifest = RepoManifest.load(manifest_path)
+        if manifest.source_selection != source_selection:
+            return None
+        from .checkout_identity import validate_checkout_identity
+
+        validate_checkout_identity(
+            Path(repo_path),
+            manifest,
+            artifact_root=Path(cache_dir),
+        )
+    except Exception as exc:  # noqa: BLE001 - an uncertain cache must rebuild
+        logger.warning("Ignoring stale or incompatible cache manifest: %s", exc)
+        return None
+    return manifest
+
+
+def _current_skill_view_path(
+    manifest: RepoManifest | None,
+    index_type: str,
+) -> str | None:
+    if manifest is None or not manifest.index_is_current(index_type):
+        return None
+    entry = manifest.indexes.get(index_type)
+    if entry is None or type(entry.path) is not str or not entry.path:
+        return None
+    return entry.path
+
+
 def _current_cached_vector_entry(
     cache_dir: str,
     vector_path: str,
@@ -409,12 +453,12 @@ def _load_vector(
         raise
 
 
-def _load_symbol_graph(index_path: str):
-    """Load a symbol graph from ``<index_path>/graph.pkl``."""
-    from ..graph.code_graph import CodeGraph
+def _load_symbol_graph(entry: IndexEntry):
+    """Load the exact symbol-graph generation named by ``entry``."""
 
-    graph_path = os.path.join(index_path, "graph.pkl")
-    return CodeGraph.load_graph(graph_path)
+    from .graph_artifact import load_authenticated_graph_artifact
+
+    return load_authenticated_graph_artifact(entry)
 
 
 def _run_compiler(
@@ -424,6 +468,7 @@ def _run_compiler(
     *,
     languages: Sequence[str],
     builder_registry: IndexBuilderRegistry,
+    source_selection: RepositorySourceSelection,
 ) -> RepoManifest | None:
     if not index_types:
         return None
@@ -431,6 +476,7 @@ def _run_compiler(
         cache_dir_name=Path(cache_dir).name,
         index_types=list(index_types),
         languages=list(languages),
+        source_selection=source_selection,
     )
     compiler = IndexCompiler(builder_registry, cfg)
     return compiler.compile_repo(
@@ -460,6 +506,7 @@ def build_skill_contexts(
     embedding_max_seq_length: Optional[int] = None,
     native_index_authorization: NativeIndexAuthorization | None = None,
     native_index_authorization_resolver: NativeIndexAuthorizationResolver | None = None,
+    source_selection: RepositorySourceSelection | None = None,
 ) -> Dict[str, Any]:
     """Build the union of indexes required by *skill_ids* and package them.
 
@@ -507,6 +554,7 @@ def build_skill_contexts(
         os.path.abspath(repo_path), _DEFAULT_CACHE_DIR_NAME
     )
     os.makedirs(cache_dir, exist_ok=True)
+    selected_source = resolve_compiler_source_selection(cache_dir, source_selection)
 
     needed = required_index_types(
         skill_ids, skills_dir=skills_dir, skill_registry=skill_registry
@@ -525,8 +573,21 @@ def build_skill_contexts(
 
     compiled_manifest: RepoManifest | None = None
     compiled_types: Set[str] = set()
+    current_manifest = _current_skill_manifest(
+        repo_path,
+        cache_dir,
+        selected_source,
+    )
     if needed:
-        missing = _missing_index_types(needed, cache_dir, rebuild=rebuild)
+        missing = sorted(
+            needed
+            if rebuild or current_manifest is None
+            else {
+                index_type
+                for index_type in needed
+                if _current_skill_view_path(current_manifest, index_type) is None
+            }
+        )
         # An existing native vector cache is not self-authorizing. Without a
         # caller-issued capability, rebuild it from the repository source so
         # this compiler invocation owns the bytes it will authorize below.
@@ -549,6 +610,7 @@ def build_skill_contexts(
                     trust_remote_code=load_policy.trust_remote_code,
                     embedding_batch_size=embedding_batch_size,
                     embedding_max_seq_length=embedding_max_seq_length,
+                    source_selection=selected_source,
                 )
             logger.info("Building missing indexes %s under %s", missing, cache_dir)
             compiled_manifest = _run_compiler(
@@ -557,14 +619,17 @@ def build_skill_contexts(
                 cache_dir,
                 languages=languages,
                 builder_registry=registry,
+                source_selection=selected_source,
             )
             compiled_types.update(missing)
+
+    active_manifest = compiled_manifest or current_manifest
 
     # Load required types plus any optional type already present on disk
     # (optional types are never built here — used-if-present only).
     loadable: Set[str] = set(needed)
     for t in optional:
-        if _looks_built(cache_dir, t):
+        if _current_skill_view_path(active_manifest, t) is not None:
             if (
                 t == "vector"
                 and native_index_authorization is None
@@ -579,9 +644,14 @@ def build_skill_contexts(
 
     loaded: Dict[str, Any] = {}
     if "bm25" in loadable:
-        loaded["bm25"] = _load_bm25(_index_dir(cache_dir, "bm25"))
+        bm25_path = _current_skill_view_path(active_manifest, "bm25")
+        if bm25_path is None:
+            raise ValueError("required BM25 view is not current for this source")
+        loaded["bm25"] = _load_bm25(bm25_path)
     if "vector" in loadable:
-        vector_path = _index_dir(cache_dir, "vector")
+        vector_path = _current_skill_view_path(active_manifest, "vector")
+        if vector_path is None:
+            raise ValueError("required vector view is not current for this source")
         vector_artifact_metadata: Dict[str, Any] | None = None
         vector_authorization = native_index_authorization
         if "vector" in compiled_types and compiled_manifest is not None:
@@ -617,11 +687,19 @@ def build_skill_contexts(
                             ),
                         )
         elif vector_authorization is not None:
-            cached_entry = _current_cached_vector_entry(cache_dir, vector_path)
+            cached_entry = (
+                active_manifest.indexes.get("vector")
+                if active_manifest is not None
+                else None
+            )
             if cached_entry is not None:
                 vector_artifact_metadata = dict(cached_entry.config)
         elif native_index_authorization_resolver is not None:
-            cached_entry = _current_cached_vector_entry(cache_dir, vector_path)
+            cached_entry = (
+                active_manifest.indexes.get("vector")
+                if active_manifest is not None
+                else None
+            )
             if cached_entry is None:
                 raise ValueError(
                     "cannot resolve native-index authorization without a current "
@@ -653,10 +731,16 @@ def build_skill_contexts(
                 native_index_authorization=vector_authorization,
             )
     if "symbol_graph" in loadable:
+        graph_path = _current_skill_view_path(active_manifest, "symbol_graph")
+        graph_entry = (
+            active_manifest.indexes.get("symbol_graph")
+            if active_manifest is not None
+            else None
+        )
+        if graph_path is None or graph_entry is None:
+            raise ValueError("required symbol graph is not current for this source")
         try:
-            loaded["symbol_graph"] = _load_symbol_graph(
-                _index_dir(cache_dir, "symbol_graph")
-            )
+            loaded["symbol_graph"] = _load_symbol_graph(graph_entry)
         except Exception as exc:  # noqa: BLE001
             # A REQUIRED graph must surface its load error; an OPTIONAL one
             # (``required: false``, e.g. bm25_search's relabel graph) must
@@ -676,6 +760,7 @@ def build_skill_contexts(
             repo_path=repo_path,
             languages=languages,
             symbol_graph=loaded.get("symbol_graph"),
+            source_selection=selected_source,
         )
     return _package_contexts(
         loaded,
@@ -793,9 +878,7 @@ def load_contexts_from_manifest(
             native_index_authorization=vector_authorization,
         )
     if "symbol_graph" in needed:
-        loaded["symbol_graph"] = _load_symbol_graph(
-            manifest.indexes["symbol_graph"].path
-        )
+        loaded["symbol_graph"] = _load_symbol_graph(manifest.indexes["symbol_graph"])
 
     lsp_provider = None
     if SkillType.EXPAND in skill_types or "symbol_graph" in loaded:
@@ -803,6 +886,9 @@ def load_contexts_from_manifest(
             repo_path=manifest.repo_path,
             languages=manifest.languages,
             symbol_graph=loaded.get("symbol_graph"),
+            source_selection=(
+                manifest.source_selection or DEFAULT_REPOSITORY_SOURCE_SELECTION
+            ),
         )
     return _package_contexts(
         loaded,
@@ -814,7 +900,11 @@ def load_contexts_from_manifest(
 
 
 def _select_cpp_lsp_provider(
-    *, repo_path: str, languages: Sequence[str], symbol_graph: Any
+    *,
+    repo_path: str,
+    languages: Sequence[str],
+    symbol_graph: Any,
+    source_selection: RepositorySourceSelection | None,
 ) -> Any:
     """Bind the native provider only for an unambiguous local C/C++ context."""
 
@@ -830,6 +920,7 @@ def _select_cpp_lsp_provider(
         project_root=repo_path,
         languages=languages,
         symbol_graph=symbol_graph,
+        source_selection=source_selection,
     )
     return provider
 

--- a/codenib/compiler/zoekt_artifact.py
+++ b/codenib/compiler/zoekt_artifact.py
@@ -1,0 +1,436 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authenticate Zoekt shards before handing them to an external process."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import stat
+import sys
+import tempfile
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Any, Callable
+
+from .._atomic_directory import (
+    PublicationDirectoryReader,
+    capture_directory_ownership,
+    directory_ownership_file_records,
+    directory_ownership_inventory,
+    directory_ownership_root_identity,
+    reopen_authenticated_directory,
+    require_publishable_directory_ownership,
+)
+from .._captured_directory import OwnedDirectoryStage
+
+if TYPE_CHECKING:
+    from .manifest import IndexEntry
+
+
+ZOEKT_SHARD_TREE_RECEIPT_SCHEMA = "codenib.zoekt-shard-tree.v1"
+ZOEKT_BUILDER_SCHEMA = 3
+
+_MAX_FILES = 100_000
+_MAX_TOTAL_BYTES = 64 << 30
+_MAX_METADATA_BYTES = 16 << 20
+_MAX_PATH_BYTES = 4_096
+_MAX_COMPONENT_BYTES = 255
+_SHA256_HEX_LENGTH = 64
+
+
+def _is_nonnegative_int(value: object) -> bool:
+    return type(value) is int and value >= 0
+
+
+def _require_digest(value: object, *, label: str, prefix: bool = False) -> str:
+    if type(value) is not str:
+        raise ValueError(f"{label} must be a string")
+    expected_length = _SHA256_HEX_LENGTH + (7 if prefix else 0)
+    if len(value) != expected_length:
+        raise ValueError(f"{label} must be a canonical SHA-256 digest")
+    payload = value
+    if prefix:
+        if not value.startswith("sha256:"):
+            raise ValueError(f"{label} must be a canonical SHA-256 digest")
+        payload = value[7:]
+    if payload != payload.lower() or any(
+        character not in "0123456789abcdef" for character in payload
+    ):
+        raise ValueError(f"{label} must be a canonical SHA-256 digest")
+    return value
+
+
+def _require_flat_path(value: object) -> str:
+    if type(value) is not str or not value or value in {".", ".."}:
+        raise ValueError("Zoekt shard receipt path must be a flat relative path")
+    if "/" in value or "\\" in value or "\x00" in value:
+        raise ValueError("Zoekt shard receipt path must be a flat relative path")
+    try:
+        encoded = value.encode("utf-8", errors="strict")
+    except UnicodeError as exc:
+        raise ValueError("Zoekt shard receipt path must be valid UTF-8") from exc
+    if len(encoded) > _MAX_PATH_BYTES or len(encoded) > _MAX_COMPONENT_BYTES:
+        raise ValueError("Zoekt shard receipt path exceeds its bounded length")
+    return value
+
+
+def _canonical_digest(files: list[dict[str, Any]]) -> tuple[str, bytes]:
+    canonical = json.dumps(
+        {
+            "schema": ZOEKT_SHARD_TREE_RECEIPT_SCHEMA,
+            "files": files,
+        },
+        allow_nan=False,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("ascii")
+    return f"sha256:{hashlib.sha256(canonical).hexdigest()}", canonical
+
+
+def _require_receipt(value: object) -> dict[str, Any]:
+    if type(value) is not dict or set(value) != {
+        "schema",
+        "digest",
+        "file_count",
+        "total_bytes",
+        "files",
+    }:
+        raise ValueError("Zoekt shard tree receipt has an invalid shape")
+    if value["schema"] != ZOEKT_SHARD_TREE_RECEIPT_SCHEMA:
+        raise ValueError("Zoekt shard tree receipt schema is unsupported")
+    _require_digest(value["digest"], label="Zoekt shard receipt digest", prefix=True)
+    if not _is_nonnegative_int(value["file_count"]):
+        raise ValueError("Zoekt shard receipt file_count must be nonnegative")
+    if not _is_nonnegative_int(value["total_bytes"]):
+        raise ValueError("Zoekt shard receipt total_bytes must be nonnegative")
+    raw_files = value["files"]
+    if type(raw_files) is not list:
+        raise ValueError("Zoekt shard receipt files must be an array")
+    if not 0 < len(raw_files) <= _MAX_FILES:
+        raise ValueError("Zoekt shard receipt file count is out of bounds")
+
+    files: list[dict[str, Any]] = []
+    previous_path: bytes | None = None
+    total_bytes = 0
+    shard_count = 0
+    for raw_file in raw_files:
+        if type(raw_file) is not dict or set(raw_file) != {
+            "path",
+            "size",
+            "sha256",
+        }:
+            raise ValueError("Zoekt shard receipt file has an invalid shape")
+        path = _require_flat_path(raw_file["path"])
+        path_bytes = path.encode("utf-8")
+        if previous_path is not None and previous_path >= path_bytes:
+            raise ValueError("Zoekt shard receipt files are not canonically sorted")
+        previous_path = path_bytes
+        size = raw_file["size"]
+        if not _is_nonnegative_int(size):
+            raise ValueError("Zoekt shard receipt file size must be nonnegative")
+        total_bytes += size
+        if total_bytes > _MAX_TOTAL_BYTES:
+            raise ValueError("Zoekt shard receipt total size is out of bounds")
+        digest = _require_digest(
+            raw_file["sha256"],
+            label="Zoekt shard receipt file digest",
+        )
+        files.append({"path": path, "size": size, "sha256": digest})
+        shard_count += path.endswith(".zoekt")
+
+    if shard_count == 0:
+        raise ValueError("Zoekt shard receipt contains no .zoekt shard")
+    if value["file_count"] != len(files) or value["total_bytes"] != total_bytes:
+        raise ValueError("Zoekt shard receipt accounting is inconsistent")
+    digest, canonical = _canonical_digest(files)
+    if len(canonical) > _MAX_METADATA_BYTES:
+        raise ValueError("Zoekt shard receipt metadata exceeds its size limit")
+    if value["digest"] != digest:
+        raise ValueError("Zoekt shard receipt digest does not match its files")
+    return {
+        "schema": ZOEKT_SHARD_TREE_RECEIPT_SCHEMA,
+        "digest": digest,
+        "file_count": len(files),
+        "total_bytes": total_bytes,
+        "files": files,
+    }
+
+
+def require_zoekt_manifest_receipt(entry: IndexEntry) -> dict[str, Any]:
+    """Return one detached exact receipt from a current builder entry."""
+
+    config = entry.config
+    metadata = entry.metadata
+    for label, values in (("config", config), ("metadata", metadata)):
+        if type(values) is not dict:
+            raise ValueError(f"Zoekt manifest {label} must be a JSON object")
+        if (
+            values.get("builder_schema") != ZOEKT_BUILDER_SCHEMA
+            or type(values.get("builder_schema")) is not int
+        ):
+            raise ValueError("Zoekt runtime requires current builder schema 3")
+        if values.get("shard_tree_receipt_schema") != ZOEKT_SHARD_TREE_RECEIPT_SCHEMA:
+            raise ValueError("Zoekt runtime requires the current shard receipt schema")
+    config_receipt = _require_receipt(config.get("shard_tree_receipt"))
+    metadata_receipt = _require_receipt(metadata.get("shard_tree_receipt"))
+    if config_receipt != metadata_receipt:
+        raise ValueError("Zoekt manifest receipt copies do not match")
+    return config_receipt
+
+
+def _flat_file_policy(relative: str, kind: str, _mode: int, _size: int) -> None:
+    if kind != "file" or "/" in relative:
+        raise RuntimeError("Zoekt shard tree must contain only flat regular files")
+    _require_flat_path(relative)
+
+
+def _files_from_ownership(ownership: object) -> list[dict[str, Any]]:
+    inventory = directory_ownership_inventory(ownership)  # type: ignore[arg-type]
+    records = directory_ownership_file_records(ownership)  # type: ignore[arg-type]
+    if len(inventory) != len(records):
+        raise RuntimeError("Zoekt shard tree contains a non-file entry")
+    return [
+        {"path": record.path, "size": record.size, "sha256": record.sha256}
+        for record in records
+    ]
+
+
+def _require_ownership_receipt(ownership: object, receipt: dict[str, Any]) -> None:
+    files = _files_from_ownership(ownership)
+    observed_digest, canonical = _canonical_digest(files)
+    if len(canonical) > _MAX_METADATA_BYTES:
+        raise RuntimeError("Zoekt shard tree metadata exceeds its size limit")
+    observed = {
+        "schema": ZOEKT_SHARD_TREE_RECEIPT_SCHEMA,
+        "digest": observed_digest,
+        "file_count": len(files),
+        "total_bytes": sum(file["size"] for file in files),
+        "files": files,
+    }
+    if observed != receipt:
+        raise RuntimeError("Zoekt shard tree differs from its manifest receipt")
+
+
+def _annotate_cleanup(primary: BaseException, cleanup: BaseException) -> None:
+    try:
+        primary.add_note(f"Zoekt shard snapshot cleanup also failed: {cleanup!r}")
+    except (AttributeError, TypeError):  # pragma: no cover - Python < 3.11
+        pass
+
+
+class ZoektShardSnapshot:
+    """Private authenticated shard generation retained for one webserver."""
+
+    __slots__ = (
+        "_stage",
+        "_ownership",
+        "_root_descriptor",
+        "_search_path",
+        "_closed",
+    )
+
+    def __init__(self, stage: OwnedDirectoryStage, ownership: object) -> None:
+        self._stage: OwnedDirectoryStage | None = stage
+        self._ownership = ownership
+        self._root_descriptor = -1
+        self._search_path: Path | None = None
+        self._closed = False
+        try:
+            # OwnedDirectoryStage acquired and installed this descriptor in its
+            # owner during construction. Borrow it instead of opening another
+            # cancellation-sensitive handle at a Python call boundary.
+            descriptor = stage._descriptor  # type: ignore[attr-defined]
+            if descriptor < 0:
+                raise RuntimeError("private Zoekt shard snapshot owner is closed")
+            opened = os.fstat(descriptor)
+            expected = directory_ownership_root_identity(ownership)  # type: ignore[arg-type]
+            observed = (
+                opened.st_dev,
+                opened.st_ino,
+                stat.S_IFMT(opened.st_mode),
+                getattr(opened, "st_file_attributes", 0),
+            )
+            if observed != expected:
+                raise RuntimeError("private Zoekt shard snapshot root changed")
+            self._root_descriptor = descriptor
+            if sys.platform.startswith("linux"):
+                search_path = Path("/proc") / str(os.getpid()) / "fd" / str(descriptor)
+                if not search_path.is_dir():
+                    raise RuntimeError(
+                        "descriptor-anchored Zoekt runtime paths are unavailable"
+                    )
+                self._search_path = search_path
+            else:
+                raise RuntimeError(
+                    "authenticated Zoekt runtime snapshots require Linux /proc"
+                )
+        except BaseException:
+            self._root_descriptor = -1
+            raise
+
+    @property
+    def search_path(self) -> str:
+        """Return a descriptor-anchored path after rechecking the snapshot."""
+
+        self.verify()
+        assert self._search_path is not None
+        return str(self._search_path)
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def verify(self) -> None:
+        if self._closed or self._stage is None or self._root_descriptor < 0:
+            raise RuntimeError("Zoekt shard snapshot is closed")
+        opened = os.fstat(self._root_descriptor)
+        expected = directory_ownership_root_identity(self._ownership)  # type: ignore[arg-type]
+        observed = (
+            opened.st_dev,
+            opened.st_ino,
+            stat.S_IFMT(opened.st_mode),
+            getattr(opened, "st_file_attributes", 0),
+        )
+        if observed != expected:
+            raise RuntimeError("private Zoekt shard snapshot root changed")
+        current = capture_directory_ownership(
+            self._stage.path,
+            entry_policy=_flat_file_policy,
+        )
+        require_publishable_directory_ownership(
+            current,
+            label="private Zoekt shard snapshot",
+        )
+        if current != self._ownership:
+            raise RuntimeError("private Zoekt shard snapshot changed")
+        assert self._search_path is not None
+        anchored = os.stat(self._search_path)
+        anchored_identity = (
+            anchored.st_dev,
+            anchored.st_ino,
+            stat.S_IFMT(anchored.st_mode),
+            getattr(anchored, "st_file_attributes", 0),
+        )
+        if anchored_identity != expected:
+            raise RuntimeError("descriptor-anchored Zoekt snapshot path changed")
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        failure: BaseException | None = None
+        if self._stage is not None:
+            try:
+                self._stage.discard()
+            except BaseException as exc:  # noqa: B036 - retain stage for retry
+                failure = exc
+                self._root_descriptor = self._stage._descriptor  # type: ignore[attr-defined]
+            else:
+                self._stage = None
+                self._root_descriptor = -1
+        if self._stage is None:
+            self._closed = True
+        if failure is not None:
+            raise failure
+
+
+class _ZoektStageOwner:
+    """Retain a stage before its cancellation-sensitive constructor runs."""
+
+    __slots__ = ("stage",)
+
+    def __init__(self) -> None:
+        self.stage: OwnedDirectoryStage | None = None
+
+    def retain(self, stage: OwnedDirectoryStage) -> None:
+        if self.stage is not None and self.stage is not stage:
+            raise RuntimeError("private Zoekt stage ownership changed")
+        self.stage = stage
+
+
+class _OwnedZoektStage(OwnedDirectoryStage):
+    """Install stage ownership before delegating resource acquisition."""
+
+    def __init__(self, owner: _ZoektStageOwner, destination: Path) -> None:
+        owner.retain(self)
+        super().__init__(destination)
+
+
+def capture_authenticated_zoekt_snapshot(
+    entry: IndexEntry,
+    *,
+    install: Callable[[ZoektShardSnapshot], None] | None = None,
+) -> ZoektShardSnapshot:
+    """Copy exact receipt-bound shards into a retained private generation."""
+
+    receipt = require_zoekt_manifest_receipt(entry)
+    source_path = Path(entry.path)
+    ownership = capture_directory_ownership(
+        source_path,
+        entry_policy=_flat_file_policy,
+    )
+    require_publishable_directory_ownership(ownership, label="Zoekt shard tree")
+    _require_ownership_receipt(ownership, receipt)
+
+    destination = Path(tempfile.gettempdir()) / (
+        f"codenib-zoekt-runtime-{os.getpid()}-{secrets.token_hex(12)}"
+    )
+    stage_owner = _ZoektStageOwner()
+    stage: OwnedDirectoryStage | None = None
+    snapshot: ZoektShardSnapshot | None = None
+    try:
+        _OwnedZoektStage(stage_owner, destination)
+        stage = stage_owner.stage
+        if stage is None:
+            raise RuntimeError("private Zoekt stage constructor lost ownership")
+
+        def copy_shards(reader: PublicationDirectoryReader) -> None:
+            for record in reader.file_records():
+                relative = PurePosixPath(record.path)
+                with reader.iter_authenticated_chunks(
+                    relative,
+                    max_bytes=record.size,
+                ) as chunks:
+                    stage.write_file(
+                        relative,
+                        chunks,
+                        mode=record.mode,
+                        max_bytes=record.size,
+                    )
+
+        reopen_authenticated_directory(source_path, ownership, copy_shards)
+        snapshot_ownership = stage.capture_ownership()
+        require_publishable_directory_ownership(
+            snapshot_ownership,
+            label="private Zoekt shard snapshot",
+        )
+        _require_ownership_receipt(snapshot_ownership, receipt)
+        snapshot = ZoektShardSnapshot(stage, snapshot_ownership)
+        snapshot.verify()
+        if install is not None:
+            install(snapshot)
+        return snapshot
+    except BaseException as primary:  # noqa: B036 - clean cancellation too
+        try:
+            if snapshot is None:
+                owned_stage = stage_owner.stage
+                if owned_stage is not None:
+                    owned_stage.discard()
+            else:
+                snapshot.close()
+        except BaseException as cleanup:  # noqa: B036 - keep primary failure
+            _annotate_cleanup(primary, cleanup)
+        raise
+
+
+__all__ = [
+    "ZOEKT_BUILDER_SCHEMA",
+    "ZOEKT_SHARD_TREE_RECEIPT_SCHEMA",
+    "ZoektShardSnapshot",
+    "capture_authenticated_zoekt_snapshot",
+    "require_zoekt_manifest_receipt",
+]

--- a/codenib/graph/code_graph.py
+++ b/codenib/graph/code_graph.py
@@ -840,12 +840,23 @@ class CodeGraph:
             CodeGraph: Loaded graph instance
         """
         with open(input_path, "rb") as f:
-            data = compat_pickle.load(f)
+            return cls.load_graph_stream(f, input_label=str(input_path))
+
+    @classmethod
+    def load_graph_stream(cls, handle, *, input_label="<authenticated stream>"):
+        """Load a graph from a caller-authenticated binary stream.
+
+        The serialized schema is unchanged.  Runtime loaders use this entry
+        point after binding the bytes to the manifest receipt, so they never
+        need to reopen an already-verified pathname before unpickling it.
+        """
+
+        data = compat_pickle.load(handle)
 
         on_disk = data.get("schema_version")
         if on_disk != _SCHEMA_VERSION:
             raise ValueError(
-                f"graph.pkl at {input_path} has schema_version={on_disk!r}, "
+                f"graph.pkl at {input_label} has schema_version={on_disk!r}, "
                 f"expected {_SCHEMA_VERSION}. Rebuild the repository graph "
                 "with `codenib index <repo> --preset graph --rebuild`."
             )

--- a/codenib/graph/source_coverage.py
+++ b/codenib/graph/source_coverage.py
@@ -14,6 +14,10 @@ from ..code_chunking import create_chunker
 from ..git_snapshot import GitSourceSurface, normalize_repository_path
 from ..languages import extension_to_language_map
 from ..repository_filters import repository_path_is_visible
+from ..repository_source_selection import (
+    DEFAULT_REPOSITORY_SOURCE_SELECTION,
+    RepositorySourceSelection,
+)
 from ..types import (
     NODE_TYPE_CLASS,
     NODE_TYPE_FIELD,
@@ -128,6 +132,7 @@ def supplement_graph_source_coverage(
     extensions: Iterable[str],
     represented_paths: Iterable[str],
     exclude_patterns: Sequence[str] = (),
+    source_selection: RepositorySourceSelection = DEFAULT_REPOSITORY_SOURCE_SELECTION,
 ) -> dict[str, Any]:
     """Add syntax definitions for tracked source files absent from *graph*.
 
@@ -137,6 +142,9 @@ def supplement_graph_source_coverage(
     authoritative when available.
     """
 
+    if type(source_selection) is not RepositorySourceSelection:
+        raise TypeError("source_selection must be a RepositorySourceSelection")
+    selection = RepositorySourceSelection(source_selection.exclude_subtrees)
     root = Path(repo_root).expanduser().resolve()
     accepted = frozenset(extensions)
     represented = {normalize_repository_path(path) for path in represented_paths}
@@ -145,6 +153,7 @@ def supplement_graph_source_coverage(
         for path in sorted(surface.tracked_files)
         if Path(path).suffix in accepted
         and repository_path_is_visible(path)
+        and selection.allows(path)
         and not _matches_any(path, exclude_patterns)
     ]
     missing = [path for path in expected_files if path not in represented]
@@ -233,6 +242,7 @@ def supplement_graph_source_coverage(
         "files": supplemented_files,
         "unreadable_files": unreadable_files,
         "unreadable_errors": unreadable_errors,
+        "source_selection_digest": selection.digest,
     }
 
 

--- a/codenib/index/embedding/builders.py
+++ b/codenib/index/embedding/builders.py
@@ -27,6 +27,11 @@ from ..._captured_directory import OwnedDirectoryStage
 from ...code_chunker import CodeChunker, RepoChunkingConfig
 from ...log_utils import get_logger
 from ...profiler import Profiler
+from ...repository_filters import repository_path_is_visible
+from ...repository_source_selection import (
+    RepositorySourceSelection,
+    repository_relative_source_path,
+)
 from ._lifecycle import close_vector_after_failure
 from .artifact_integrity import VECTOR_VIEW_UPDATE_MARKER
 from .vector_store import CodeVectorStore
@@ -316,6 +321,69 @@ def _profiler_section(profiler, label, metadata=None):
     return profiler.section(label, metadata)
 
 
+def _snapshot_source_selection(
+    source_selection: RepositorySourceSelection | None,
+) -> RepositorySourceSelection:
+    """Capture one detached exact-type source-selection policy."""
+
+    if source_selection is None:
+        return RepositorySourceSelection()
+    if type(source_selection) is not RepositorySourceSelection:
+        raise TypeError("source_selection must be a RepositorySourceSelection")
+    return RepositorySourceSelection(source_selection.exclude_subtrees)
+
+
+def _require_selected_paths(
+    source_selection: RepositorySourceSelection,
+    paths: Any,
+    *,
+    repository_root: str,
+    subject: str,
+) -> None:
+    """Reject non-canonical or excluded repository-relative paths."""
+
+    for source_path in paths:
+        try:
+            relative_path = repository_relative_source_path(
+                repository_root,
+                source_path,
+            )
+            allowed = repository_path_is_visible(
+                relative_path,
+                selection=source_selection,
+            )
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"{subject} has a non-canonical repository path: {source_path!r}"
+            ) from exc
+        if not allowed:
+            raise RuntimeError(
+                f"{subject} leaked excluded repository path: {relative_path}"
+            )
+
+
+def _require_selected_documents(
+    vector_store: CodeVectorStore,
+    source_selection: RepositorySourceSelection,
+    *,
+    repository_root: str,
+) -> None:
+    """Validate every vector document path against source selection."""
+
+    for level in ("l0", "l2"):
+        documents = getattr(vector_store, f"{level}_documents", ()) or ()
+        paths = []
+        for document in documents:
+            metadata = getattr(document, "metadata", None)
+            paths.append(metadata.get("file") if isinstance(metadata, dict) else None)
+        _require_selected_paths(
+            source_selection,
+            paths,
+            repository_root=repository_root,
+            subject=f"vector {level} documents",
+        )
+
+
 def build_hierarchical_vector_store(
     *,
     repo_path: str,
@@ -337,6 +405,7 @@ def build_hierarchical_vector_store(
     force_rebuild: bool = False,
     strict_chunking: bool = False,
     additional_ignore_dirs: Optional[List[str]] = None,
+    source_selection: RepositorySourceSelection | None = None,
     artifact_metadata: Optional[Dict[str, Any]] = None,
     native_index_authorization: NativeIndexAuthorization | None = None,
     _atomic_publish: bool = True,
@@ -351,6 +420,7 @@ def build_hierarchical_vector_store(
     complete private tree and atomically switch the directory only after save
     and ownership verification succeed.
     """
+    selected = _snapshot_source_selection(source_selection)
     store_path = Path(index_path)
     if plan_name:
         store_path = store_path / plan_name
@@ -403,6 +473,11 @@ def build_hierarchical_vector_store(
                     str(store_path),
                     native_index_authorization=native_index_authorization,
                 )
+                _require_selected_documents(
+                    vector_store,
+                    selected,
+                    repository_root=repo_path,
+                )
                 return vector_store
             except BaseException as primary:  # noqa: B036 - close partial state
                 close_vector_after_failure(vector_store, primary)
@@ -421,7 +496,10 @@ def build_hierarchical_vector_store(
         )
     languages = languages or ["python"]
     build_levels = normalized_levels
-    repo_cfg = RepoChunkingConfig(languages=languages)
+    repo_cfg = RepoChunkingConfig(
+        languages=languages,
+        source_selection=selected,
+    )
     repo_cfg.ignore_dirs.update(additional_ignore_dirs or ())
 
     chunks_by_level = {}
@@ -461,6 +539,12 @@ def build_hierarchical_vector_store(
                 repo_path=repo_path,
                 strict=strict_chunking,
             )
+        _require_selected_paths(
+            selected,
+            (getattr(chunk, "file", None) for chunk in chunks_by_level[level]),
+            repository_root=repo_path,
+            subject=f"vector {level} chunks",
+        )
         logger.info(
             f"Chunked {len(chunks_by_level[level])} {level} chunks "
             f"(lang={languages[0]})"
@@ -523,6 +607,11 @@ def build_hierarchical_vector_store(
                 vector_store.add_code_chunks(
                     [chunk._asdict() for chunk in l2_chunks], level="l2"
                 )
+        _require_selected_documents(
+            vector_store,
+            selected,
+            repository_root=repo_path,
+        )
         with build_root.path_operation("vector store save"):
             vector_store.save(str(build_path))
         return vector_store
@@ -582,6 +671,11 @@ def build_hierarchical_vector_store(
 
     vector_store.store_path = store_path
     vector_store.chunk_stats = chunk_stats
+    _require_selected_documents(
+        vector_store,
+        selected,
+        repository_root=repo_path,
+    )
     return vector_store
 
 

--- a/codenib/integrations/reponavigator.py
+++ b/codenib/integrations/reponavigator.py
@@ -231,7 +231,8 @@ class RepoNavigatorRepositoryProvider:
                 or isinstance(context.lsp_provider, StaticLSPProvider)
             )
         ):
-            occurrence_index = _load_manifest_occurrence_index(context)
+            graph = getattr(context, "symbol_graph", None)
+            occurrence_index = getattr(graph, "lsp_occurrence_index", None)
             if occurrence_index is not None:
                 kwargs["occurrence_index"] = occurrence_index
         return cls(context, **kwargs)
@@ -393,29 +394,6 @@ class RepoNavigatorRepositoryProvider:
             end_line=start_line,
         )
         return content, normalized_path
-
-
-def _load_manifest_occurrence_index(context: Any) -> Any | None:
-    entry = getattr(context.manifest, "indexes", {}).get("symbol_graph")
-    if entry is None or not getattr(entry, "path", None):
-        return None
-
-    graph_path = Path(entry.path)
-    index_path = (
-        graph_path / "lsp_index.pkl"
-        if graph_path.is_dir()
-        else graph_path.with_name("lsp_index.pkl")
-    )
-    if not index_path.is_file():
-        return None
-    try:
-        from ..scip_interface.lsp_occurrence_index import SCIPOccurrenceIndex
-
-        return SCIPOccurrenceIndex.load(index_path)
-    except Exception as exc:  # noqa: BLE001 - persisted integration boundary
-        raise IntegrationCapabilityError(
-            f"failed to load RepoNavigator definition signal from {index_path}: {exc}"
-        ) from exc
 
 
 def _inspect_definition_signal(provider: Any) -> RepoNavigatorDefinitionSignal:

--- a/codenib/mcp/context.py
+++ b/codenib/mcp/context.py
@@ -32,9 +32,11 @@ from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
 from ..compiler.manifest import RepoManifest
 from ..index.embedding.artifact_integrity import require_authorized_vector_view
 from ..provider_routes import resolve_embedding_artifact_route
+from ..repository_source_selection import DEFAULT_REPOSITORY_SOURCE_SELECTION
 
 if TYPE_CHECKING:
     from ..artifacts.runtime import ContextArtifactBinding
+    from ..compiler.zoekt_artifact import ZoektShardSnapshot
     from ..graph.code_graph import CodeGraph
     from ..index.embedding.vector_store import CodeVectorStore
     from ..index.regex_idx import RegexNodeIndex
@@ -188,6 +190,31 @@ def _stop_zoekt_after_failure(
     context.zoekt = None
 
 
+def _close_zoekt_snapshot_after_failure(
+    context: ServerContext,
+    primary: BaseException,
+) -> None:
+    """Release a private shard generation or retain its retryable owner."""
+
+    snapshot = context._zoekt_snapshot
+    if snapshot is None:
+        return
+    try:
+        snapshot.close()
+    except BaseException as cleanup_error:  # noqa: B036 - preserve priority
+        actual = _retain_context_cleanup_failure(
+            primary,
+            "Zoekt shard snapshot cleanup also failed",
+            cleanup_error,
+        )
+        _attach_context_cleanup_owner(actual, context)
+        if actual is cleanup_error:
+            raise cleanup_error from primary
+        raise primary from cleanup_error
+    if snapshot.closed:
+        context._zoekt_snapshot = None
+
+
 def _retain_context_cleanup_failure(
     deferred: BaseException | None,
     label: str,
@@ -301,6 +328,18 @@ class ServerContext:
         default=None,
         repr=False,
     )
+    _zoekt_snapshot: Optional[ZoektShardSnapshot] = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
+
+    def _install_zoekt_snapshot(self, snapshot: ZoektShardSnapshot) -> None:
+        """Publish snapshot ownership before a cancellation can escape."""
+
+        if self._zoekt_snapshot is not None and self._zoekt_snapshot is not snapshot:
+            raise RuntimeError("Zoekt shard snapshot ownership changed")
+        self._zoekt_snapshot = snapshot
 
     @property
     def source_verified(self) -> bool:
@@ -422,6 +461,7 @@ class ServerContext:
             owned_source = ctx._source_binding
 
             if owned_source is not None:
+                from ..compiler.manifest_source import require_manifest_source_identity
                 from ..source_fingerprint import (
                     is_secure_source_fingerprint_v2,
                     lexical_repository_path,
@@ -431,14 +471,20 @@ class ServerContext:
                 if (
                     not owned_source.usable
                     or not is_secure_source_fingerprint_v2(manifest.source_fingerprint)
-                    or source_identity.fingerprint != manifest.source_fingerprint
-                    or source_identity.file_count != manifest.file_count
                     or source_identity.root
                     != lexical_repository_path(manifest.repo_path)
                 ):
                     raise ValueError(
                         "repository source authority does not match the manifest"
                     )
+                require_manifest_source_identity(
+                    source_identity,
+                    manifest,
+                    label="repository source authority",
+                    mismatch_message=(
+                        "repository source authority does not match the manifest"
+                    ),
+                )
 
             ctx.source_error = (
                 None
@@ -601,6 +647,17 @@ class ServerContext:
                     )
                 else:
                     self.zoekt = None
+            if self.zoekt is None and self._zoekt_snapshot is not None:
+                try:
+                    self._zoekt_snapshot.close()
+                except BaseException as exc:  # noqa: B036 - continue cleanup
+                    deferred = _retain_context_cleanup_failure(
+                        deferred,
+                        "Zoekt shard snapshot cleanup also failed",
+                        exc,
+                    )
+                if self._zoekt_snapshot.closed:
+                    self._zoekt_snapshot = None
             if self.vector is not None:
                 try:
                     _close_vector(self.vector)
@@ -694,6 +751,9 @@ class ServerContext:
             project_root=self.manifest.repo_path,
             languages=self.manifest.languages,
             symbol_graph=self.symbol_graph,
+            source_selection=(
+                self.manifest.source_selection or DEFAULT_REPOSITORY_SOURCE_SELECTION
+            ),
             allow_native=allow_native,
             native_disabled_reason=native_disabled_reason,
         )
@@ -769,12 +829,10 @@ class ServerContext:
         if not entry or not self.manifest.index_is_current("symbol_graph"):
             return
         try:
-            from ..graph.code_graph import CodeGraph
+            from ..compiler.graph_artifact import load_authenticated_graph_artifact
 
-            graph_path = Path(entry.path)
-            pkl = graph_path / "graph.pkl" if graph_path.is_dir() else graph_path
-            self.symbol_graph = CodeGraph.load_graph(str(pkl))
-            logger.info("Loaded symbol_graph from %s", pkl)
+            self.symbol_graph = load_authenticated_graph_artifact(entry)
+            logger.info("Loaded symbol_graph from %s", entry.path)
         except Exception as exc:
             self.errors["symbol_graph"] = str(exc)
             logger.warning("Failed to load symbol_graph: %s", exc)
@@ -861,35 +919,55 @@ class ServerContext:
         if not entry or not self.manifest.index_is_current("zoekt"):
             return
         try:
+            from ..compiler.zoekt_artifact import capture_authenticated_zoekt_snapshot
+
+            snapshot = capture_authenticated_zoekt_snapshot(
+                entry,
+                install=self._install_zoekt_snapshot,
+            )
+        except Exception as exc:
+            self.errors["zoekt"] = str(exc)
+            logger.warning("Failed to authenticate Zoekt shards: %s", exc)
+            return
+        except BaseException:
+            raise
+
+        try:
             from ..index.trigram import ZoektSearcher, ZoektUnavailableError
         except Exception as exc:
+            _close_zoekt_snapshot_after_failure(self, exc)
             self.errors["zoekt"] = str(exc)
             logger.warning("Failed to load Zoekt runtime: %s", exc)
             return
 
         searcher = None
         try:
-            searcher = ZoektSearcher(index_dir=entry.path)
+            searcher = ZoektSearcher(index_dir=snapshot.search_path)
             searcher.start()
+            snapshot.verify()
+            port = searcher.port
             logger.info(
                 "Started zoekt-webserver  shards=%s  port=%d",
                 entry.path,
-                searcher.port,
+                port,
             )
             self.zoekt = searcher
         except ZoektUnavailableError as exc:
             if searcher is not None:
                 _stop_zoekt_after_failure(self, searcher, exc)
+            _close_zoekt_snapshot_after_failure(self, exc)
             self.errors["zoekt"] = str(exc)
             logger.warning("Zoekt unavailable: %s", exc)
         except Exception as exc:
             if searcher is not None:
                 _stop_zoekt_after_failure(self, searcher, exc)
+            _close_zoekt_snapshot_after_failure(self, exc)
             self.errors["zoekt"] = str(exc)
             logger.warning("Failed to start zoekt-webserver: %s", exc)
         except BaseException as exc:  # noqa: B036 - cleanup then propagate
             if searcher is not None:
                 _stop_zoekt_after_failure(self, searcher, exc)
+            _close_zoekt_snapshot_after_failure(self, exc)
             raise
 
     def _load_vector(self, *, probe: bool = False) -> None:

--- a/codenib/mcp/server.py
+++ b/codenib/mcp/server.py
@@ -797,10 +797,11 @@ def init_server(
             if resolved_manifest_path is not None:
                 manifest = RepoManifest.load(resolved_manifest_path)
 
-            from ..source_fingerprint import (
-                capture_repository_source,
-                is_secure_source_fingerprint_v2,
+            from ..compiler.manifest_source import (
+                capture_repository_source_for_manifest,
+                require_manifest_source_identity,
             )
+            from ..source_fingerprint import is_secure_source_fingerprint_v2
 
             source_error: str | None = "source binding has not been verified"
             retained_source = (
@@ -813,13 +814,14 @@ def init_server(
                 manifest.source_fingerprint
             ):
                 retained_identity = retained_source.authenticated_identity_snapshot()
-                if (
-                    retained_identity.fingerprint != manifest.source_fingerprint
-                    or retained_identity.file_count != manifest.file_count
-                ):
-                    raise ValueError(
+                require_manifest_source_identity(
+                    retained_identity,
+                    manifest,
+                    label="MCP repository",
+                    mismatch_message=(
                         "repository source bytes do not match the indexed content"
-                    )
+                    ),
+                )
                 verified = True
             native_authorization = None
             if verified:
@@ -835,22 +837,23 @@ def init_server(
                 else:
                     capture_cleanup_owner = SourceBindingCleanupOwner()
                     try:
-                        retained_source = capture_repository_source(
+                        retained_source = capture_repository_source_for_manifest(
                             repo_path,
+                            manifest,
                             exclude_roots=(resolved_manifest_path.parent,),
                             _source_owner=capture_cleanup_owner.retain,
                         )
                         retained_identity = (
                             retained_source.authenticated_identity_snapshot()
                         )
-                        if (
-                            retained_identity.fingerprint != manifest.source_fingerprint
-                            or retained_identity.file_count != manifest.file_count
-                        ):
-                            raise ValueError(
-                                "repository source bytes do not match the indexed "
-                                "content"
-                            )
+                        require_manifest_source_identity(
+                            retained_identity,
+                            manifest,
+                            label="MCP repository",
+                            mismatch_message=(
+                                "repository source bytes do not match the indexed content"
+                            ),
+                        )
                     except BaseException as exc:  # noqa: B036 - preserve primary
                         cleanup_failure, pending_owner = close_capture_owner(exc)
                         retained_source = None

--- a/codenib/repository_filters.py
+++ b/codenib/repository_filters.py
@@ -7,10 +7,16 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Iterable, Iterator
 
-REPOSITORY_FILTER_POLICY_VERSION = 3
+from .repository_source_selection import (
+    DEFAULT_REPOSITORY_SOURCE_SELECTION,
+    REPOSITORY_SOURCE_SELECTION_POLICY_VERSION,
+    RepositorySourceSelection,
+)
+
+REPOSITORY_FILTER_POLICY_VERSION = REPOSITORY_SOURCE_SELECTION_POLICY_VERSION
 
 DEFAULT_IGNORED_DIRS = frozenset(
     {
@@ -50,11 +56,31 @@ def default_exclude_patterns() -> list[str]:
     ]
 
 
-def repository_path_is_visible(path: str | Path) -> bool:
+def _validated_selection(
+    selection: RepositorySourceSelection,
+) -> RepositorySourceSelection:
+    if type(selection) is not RepositorySourceSelection:
+        raise TypeError("selection must be a RepositorySourceSelection")
+    return selection
+
+
+def repository_path_is_visible(
+    path: str | Path,
+    *,
+    selection: RepositorySourceSelection = DEFAULT_REPOSITORY_SOURCE_SELECTION,
+) -> bool:
     """Whether a repository-relative path survives the shared directory policy."""
 
-    parts = Path(path).parts
-    return not any(
+    selected = _validated_selection(selection)
+    relative = path.as_posix() if isinstance(path, Path) else path
+    if type(relative) is not str:
+        return False
+    try:
+        allowed = selected.allows(relative)
+    except (TypeError, ValueError):
+        return False
+    parts = PurePosixPath(relative).parts
+    return allowed and not any(
         part in DEFAULT_IGNORED_DIRS or part.startswith(".codenib") for part in parts
     )
 
@@ -67,31 +93,44 @@ def walk_repository_files(
     root: str | Path,
     *,
     exclude_roots: Iterable[str | Path] = (),
+    selection: RepositorySourceSelection = DEFAULT_REPOSITORY_SOURCE_SELECTION,
 ) -> Iterator[Path]:
     """Yield files under *root* after applying the shared directory policy."""
 
+    selected = RepositorySourceSelection(
+        _validated_selection(selection).exclude_subtrees
+    )
     root_path = Path(root).expanduser().resolve()
     excluded = tuple(Path(path).expanduser().resolve() for path in exclude_roots)
     for current_root, dirs, files in os.walk(root_path):
+        current = Path(current_root)
         dirs[:] = sorted(
             directory
             for directory in dirs
-            if directory not in DEFAULT_IGNORED_DIRS
-            and not directory.startswith(".codenib")
-            and not _is_within(Path(current_root) / directory, excluded)
+            if repository_path_is_visible(
+                (current / directory).relative_to(root_path),
+                selection=selected,
+            )
+            and not _is_within(current / directory, excluded)
         )
-        current = Path(current_root)
         for filename in sorted(files):
             path = current / filename
             relative = path.relative_to(root_path)
-            if repository_path_is_visible(relative) and not _is_within(path, excluded):
+            if repository_path_is_visible(
+                relative,
+                selection=selected,
+            ) and not _is_within(path, excluded):
                 yield path
 
 
-def count_repository_files(root: str | Path) -> int:
+def count_repository_files(
+    root: str | Path,
+    *,
+    selection: RepositorySourceSelection = DEFAULT_REPOSITORY_SOURCE_SELECTION,
+) -> int:
     """Count files visible to the default repository traversal policy."""
 
-    return sum(1 for _ in walk_repository_files(root))
+    return sum(1 for _ in walk_repository_files(root, selection=selection))
 
 
 __all__ = [

--- a/codenib/repository_source_selection.py
+++ b/codenib/repository_source_selection.py
@@ -1,0 +1,235 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical, backend-neutral repository source-selection policy."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Mapping
+
+REPOSITORY_SOURCE_SELECTION_SCHEMA = "codenib.repository-source-selection.v1"
+REPOSITORY_SOURCE_SELECTION_POLICY_VERSION = 4
+
+_PAYLOAD_FIELDS = frozenset(
+    {
+        "schema",
+        "repository_filter_policy",
+        "exclude_subtrees",
+    }
+)
+_MAX_SELECTION_PATH_BYTES = 4096
+_MAX_SELECTION_PATH_COMPONENTS = 256
+_MAX_SELECTION_EXCLUSIONS = 4096
+_MAX_SELECTION_TOTAL_BYTES = 1024 * 1024
+
+
+def _canonical_observed_relative_path(value: object) -> str:
+    if type(value) is not str:
+        raise TypeError("repository source-selection paths must be strings")
+    if not value or "\x00" in value:
+        raise ValueError(
+            "repository source-selection paths must be non-empty, NUL-free "
+            "repository-relative POSIX paths"
+        )
+    path = PurePosixPath(value)
+    if (
+        path.is_absolute()
+        or value in {".", ".."}
+        or ".." in path.parts
+        or path.as_posix() != value
+    ):
+        raise ValueError(
+            "repository source-selection paths must be canonical "
+            "repository-relative POSIX paths"
+        )
+    return value
+
+
+def _canonical_relative_path(value: object) -> str:
+    value = _canonical_observed_relative_path(value)
+    if "\\" in value:
+        raise ValueError("repository source-selection paths must use POSIX separators")
+    try:
+        encoded = value.encode("utf-8", errors="strict")
+    except UnicodeEncodeError as exc:
+        raise ValueError(
+            "repository source-selection paths must contain valid Unicode"
+        ) from exc
+    if (
+        len(encoded) > _MAX_SELECTION_PATH_BYTES
+        or len(PurePosixPath(value).parts) > _MAX_SELECTION_PATH_COMPONENTS
+    ):
+        raise ValueError(
+            "repository source-selection paths exceed the supported limits"
+        )
+    return value
+
+
+def _canonical_exclude_subtrees(values: Iterable[str]) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)):
+        raise TypeError("exclude_subtrees must be an iterable of paths")
+    try:
+        iterator = iter(values)
+    except TypeError as exc:
+        raise TypeError("exclude_subtrees must be an iterable of paths") from exc
+    canonical: set[str] = set()
+    total_bytes = 0
+    for count, value in enumerate(iterator, start=1):
+        if count > _MAX_SELECTION_EXCLUSIONS:
+            raise ValueError("repository source selection has too many exclusions")
+        normalized_value = _canonical_relative_path(value)
+        total_bytes += len(normalized_value.encode("utf-8"))
+        if total_bytes > _MAX_SELECTION_TOTAL_BYTES:
+            raise ValueError("repository source selection is too large")
+        canonical.add(normalized_value)
+    normalized = sorted(canonical)
+
+    selected: list[str] = []
+    selected_set: set[str] = set()
+    for value in normalized:
+        parts = PurePosixPath(value).parts
+        if any(
+            "/".join(parts[:component_count]) in selected_set
+            for component_count in range(1, len(parts))
+        ):
+            continue
+        selected.append(value)
+        selected_set.add(value)
+    return tuple(selected)
+
+
+def repository_relative_source_path(
+    repository_root: str | Path,
+    source_path: object,
+) -> str:
+    """Return one canonical lexical source path relative to *repository_root*.
+
+    Builder outputs historically carry either absolute checkout paths or
+    repository-relative POSIX paths. This adapter never resolves the source
+    path: absolute values must already be component-contained in the supplied
+    lexical root, and the resulting relative value must satisfy the persisted
+    source-selection grammar.
+    """
+
+    if type(source_path) is not str:
+        raise TypeError("repository source paths must be strings")
+    root = Path(repository_root).expanduser().absolute()
+    candidate = Path(source_path)
+    if candidate.is_absolute():
+        try:
+            candidate = candidate.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(
+                "repository source path is outside the repository root"
+            ) from exc
+    return _canonical_observed_relative_path(candidate.as_posix())
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class RepositorySourceSelection:
+    """Immutable exact-subtree exclusions for one repository source view.
+
+    Paths are canonical root-relative POSIX paths. An exclusion matches its
+    exact path and descendants separated by ``/``; similarly named siblings do
+    not match.
+    """
+
+    exclude_subtrees: tuple[str, ...] = ()
+    _exclude_index: frozenset[str] = field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __init__(self, exclude_subtrees: Iterable[str] = ()) -> None:
+        normalized = _canonical_exclude_subtrees(exclude_subtrees)
+        object.__setattr__(self, "exclude_subtrees", normalized)
+        object.__setattr__(self, "_exclude_index", frozenset(normalized))
+
+    def excludes(self, relative_path: str) -> bool:
+        """Return whether *relative_path* is an excluded subtree member."""
+
+        value = _canonical_observed_relative_path(relative_path)
+        parts = PurePosixPath(value).parts
+        return any(
+            "/".join(parts[:component_count]) in self._exclude_index
+            for component_count in range(1, len(parts) + 1)
+        )
+
+    def allows(self, relative_path: str) -> bool:
+        """Return whether *relative_path* survives the exact-subtree policy."""
+
+        return not self.excludes(relative_path)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-compatible selection payload."""
+
+        return {
+            "schema": REPOSITORY_SOURCE_SELECTION_SCHEMA,
+            "repository_filter_policy": (REPOSITORY_SOURCE_SELECTION_POLICY_VERSION),
+            "exclude_subtrees": list(self.exclude_subtrees),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> RepositorySourceSelection:
+        """Load a canonical persisted selection payload without coercion."""
+
+        if type(payload) is not dict or set(payload) != _PAYLOAD_FIELDS:
+            raise ValueError("repository source selection must use canonical fields")
+        if payload["schema"] != REPOSITORY_SOURCE_SELECTION_SCHEMA:
+            raise ValueError("repository source selection schema is unsupported")
+        if (
+            type(payload["repository_filter_policy"]) is not int
+            or payload["repository_filter_policy"]
+            != REPOSITORY_SOURCE_SELECTION_POLICY_VERSION
+        ):
+            raise ValueError("repository source selection policy is unsupported")
+        values = payload["exclude_subtrees"]
+        if type(values) is not list:
+            raise ValueError("repository source exclusions must be a JSON array")
+        try:
+            selection = cls(values)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("repository source exclusions are invalid") from exc
+        if list(selection.exclude_subtrees) != values:
+            raise ValueError("repository source exclusions are not canonical")
+        return selection
+
+    def canonical_json(self) -> str:
+        """Return stable, whitespace-free ASCII JSON for this selection."""
+
+        return json.dumps(
+            self.to_dict(),
+            allow_nan=False,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    def canonical_bytes(self) -> bytes:
+        """Return the canonical serialized selection bytes."""
+
+        return self.canonical_json().encode("ascii")
+
+    @property
+    def digest(self) -> str:
+        """Return the canonical SHA-256 identity of this selection."""
+
+        return f"sha256:{hashlib.sha256(self.canonical_bytes()).hexdigest()}"
+
+
+DEFAULT_REPOSITORY_SOURCE_SELECTION = RepositorySourceSelection()
+
+
+__all__ = [
+    "DEFAULT_REPOSITORY_SOURCE_SELECTION",
+    "REPOSITORY_SOURCE_SELECTION_POLICY_VERSION",
+    "REPOSITORY_SOURCE_SELECTION_SCHEMA",
+    "RepositorySourceSelection",
+    "repository_relative_source_path",
+]

--- a/codenib/sandbox/docker.py
+++ b/codenib/sandbox/docker.py
@@ -34,7 +34,6 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Collection, Dict, Mapping, Sequence, TypedDict
 
 from ..repository_filters import DEFAULT_IGNORED_DIRS, REPOSITORY_FILTER_POLICY_VERSION
-from ..repository_source_selection import DEFAULT_REPOSITORY_SOURCE_SELECTION
 from ..source_fingerprint import SOURCE_FINGERPRINT_VERSION
 from .protocol import (
     SandboxClosedError,
@@ -1135,8 +1134,8 @@ class DockerSandboxProvider:
                 str(SOURCE_FINGERPRINT_VERSION),
                 str(REPOSITORY_FILTER_POLICY_VERSION),
                 os.path.abspath(os.path.expanduser(os.fspath(spec.source_dir))),
-                DEFAULT_REPOSITORY_SOURCE_SELECTION.canonical_json(),
-                DEFAULT_REPOSITORY_SOURCE_SELECTION.digest,
+                spec.source_selection.canonical_json(),
+                spec.source_selection.digest,
             ]
         )
         completed = self._run_control_container(name, args)

--- a/codenib/sandbox/docker.py
+++ b/codenib/sandbox/docker.py
@@ -34,6 +34,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Collection, Dict, Mapping, Sequence, TypedDict
 
 from ..repository_filters import DEFAULT_IGNORED_DIRS, REPOSITORY_FILTER_POLICY_VERSION
+from ..repository_source_selection import DEFAULT_REPOSITORY_SOURCE_SELECTION
 from ..source_fingerprint import SOURCE_FINGERPRINT_VERSION
 from .protocol import (
     SandboxClosedError,
@@ -109,8 +110,67 @@ ignored = set(json.loads(sys.argv[1]))
 fingerprint_version = int(sys.argv[2])
 filter_version = int(sys.argv[3])
 source_root = pathlib.Path(sys.argv[4])
+selection_payload = json.loads(sys.argv[5])
+selection_digest = sys.argv[6]
 if fingerprint_version != 2:
     raise SystemExit('unsupported source fingerprint version')
+if (
+    type(selection_payload) is not dict
+    or set(selection_payload) != {
+        'schema', 'repository_filter_policy', 'exclude_subtrees'
+    }
+    or selection_payload['schema'] != 'codenib.repository-source-selection.v1'
+    or selection_payload['repository_filter_policy'] != filter_version
+    or type(selection_payload['exclude_subtrees']) is not list
+):
+    raise SystemExit('source selection is invalid')
+exclude_subtrees = selection_payload['exclude_subtrees']
+canonical_excludes = []
+canonical_set = set()
+for value in exclude_subtrees:
+    if (
+        type(value) is not str
+        or not value
+        or '\0' in value
+        or '\\' in value
+    ):
+        raise SystemExit('source selection is invalid')
+    path = pathlib.PurePosixPath(value)
+    if (
+        path.is_absolute()
+        or value in {'.', '..'}
+        or '..' in path.parts
+        or path.as_posix() != value
+    ):
+        raise SystemExit('source selection is invalid')
+    try:
+        value.encode('utf-8', errors='strict')
+    except UnicodeEncodeError:
+        raise SystemExit('source selection is invalid')
+    if value in canonical_set:
+        raise SystemExit('source selection is not canonical')
+    canonical_excludes.append(value)
+    canonical_set.add(value)
+if canonical_excludes != sorted(canonical_excludes):
+    raise SystemExit('source selection is not canonical')
+for index, value in enumerate(canonical_excludes):
+    parts = pathlib.PurePosixPath(value).parts
+    if any(
+        '/'.join(parts[:count]) in canonical_set
+        for count in range(1, len(parts))
+    ):
+        raise SystemExit('source selection is not canonical')
+selection_bytes = json.dumps(
+    selection_payload,
+    allow_nan=False,
+    ensure_ascii=True,
+    sort_keys=True,
+    separators=(',', ':'),
+).encode('ascii')
+computed_selection_digest = 'sha256:' + hashlib.sha256(selection_bytes).hexdigest()
+if selection_digest != computed_selection_digest:
+    raise SystemExit('source selection digest is invalid')
+excluded_parts = tuple(tuple(value.split('/')) for value in canonical_excludes)
 hasher = hashlib.sha256()
 hasher.update(b'codenib-source-fingerprint\0\x02')
 def frame_header(domain, payload_size):
@@ -138,10 +198,16 @@ def normalize_target(prefix, target):
     if not target or '\0' in target or len(os.fsencode(target)) > 4096:
         raise SystemExit('source symlink target is invalid')
     if os.path.isabs(target):
-        raise SystemExit('source symlink target must be relative')
+        root_parts = source_root.parts
+        absolute_parts = pathlib.Path(target).parts
+        if absolute_parts[:len(root_parts)] != root_parts:
+            raise SystemExit('source symlink resolves outside the repository')
+        target_parts = absolute_parts[len(root_parts):]
+        resolved = []
     else:
         resolved = list(prefix)
-    for part in target.split('/'):
+        target_parts = target.split('/')
+    for part in target_parts:
         if part in {'', '.'}:
             continue
         if part == '..':
@@ -192,7 +258,13 @@ def resolve_link(relative_parts):
         raise SystemExit('source root is not a directory')
     return 'directory', root, root_metadata
 frame(b'filter-policy-version', str(filter_version).encode('ascii'))
+frame(b'source-selection-digest', selection_digest.encode('ascii'))
 file_count = 0
+def source_selected(relative_parts):
+    return not any(
+        relative_parts[:len(excluded)] == excluded
+        for excluded in excluded_parts
+    )
 def scan_directory(current, prefix):
     global file_count
     with os.scandir(current) as iterator:
@@ -202,6 +274,8 @@ def scan_directory(current, prefix):
         if name in ignored or name.startswith('.codenib'):
             continue
         relative_parts = (*prefix, name)
+        if not source_selected(relative_parts):
+            continue
         path = current / name
         metadata = path.lstat()
         mode = metadata.st_mode
@@ -1061,6 +1135,8 @@ class DockerSandboxProvider:
                 str(SOURCE_FINGERPRINT_VERSION),
                 str(REPOSITORY_FILTER_POLICY_VERSION),
                 os.path.abspath(os.path.expanduser(os.fspath(spec.source_dir))),
+                DEFAULT_REPOSITORY_SOURCE_SELECTION.canonical_json(),
+                DEFAULT_REPOSITORY_SOURCE_SELECTION.digest,
             ]
         )
         completed = self._run_control_container(name, args)

--- a/codenib/sandbox/types.py
+++ b/codenib/sandbox/types.py
@@ -14,6 +14,8 @@ from pathlib import Path, PurePosixPath
 from types import MappingProxyType
 from typing import Dict, Mapping, Sequence, Tuple
 
+from ..repository_source_selection import RepositorySourceSelection
+
 _IMAGE_DIGEST_RE = re.compile(r"@sha256:[0-9a-f]{64}$")
 _IMAGE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/:@-]*$")
 _PLATFORM_RE = re.compile(r"^[a-z0-9]+/[a-z0-9_]+(?:/[a-z0-9_]+)?$")
@@ -175,10 +177,20 @@ class SandboxSpec:
     source_revision: str | None = None
     task_id: str | None = None
     policy: SandboxPolicy = field(default_factory=SandboxPolicy)
+    source_selection: RepositorySourceSelection = field(
+        default_factory=RepositorySourceSelection
+    )
 
     def __post_init__(self) -> None:
         source_dir = Path(self.source_dir).expanduser()
         object.__setattr__(self, "source_dir", source_dir)
+        if type(self.source_selection) is not RepositorySourceSelection:
+            raise TypeError("source_selection must be a RepositorySourceSelection")
+        object.__setattr__(
+            self,
+            "source_selection",
+            RepositorySourceSelection(self.source_selection.exclude_subtrees),
+        )
         if not self.image or not _IMAGE_REF_RE.fullmatch(self.image):
             raise ValueError("image must be a non-empty Docker image reference")
         if not self.policy.allow_unpinned_image and not _IMAGE_DIGEST_RE.search(

--- a/codenib/scip_interface/lsp_occurrence_index.py
+++ b/codenib/scip_interface/lsp_occurrence_index.py
@@ -12,7 +12,7 @@ import re
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Iterable, Mapping, Optional, Sequence
+from typing import Any, BinaryIO, Callable, Iterable, Mapping, Optional, Sequence
 
 from .scip_indexer_base import extract_scip_blocks, extract_symbol
 
@@ -135,13 +135,25 @@ class SCIPOccurrenceIndex:
     @classmethod
     def load(cls, path: str | Path) -> SCIPOccurrenceIndex:
         with Path(path).open("rb") as handle:
-            payload = pickle.load(handle)
+            return cls.load_stream(handle, input_label=str(path))
+
+    @classmethod
+    def load_stream(
+        cls,
+        handle: BinaryIO,
+        *,
+        input_label: str = "<authenticated stream>",
+    ) -> SCIPOccurrenceIndex:
+        """Load an occurrence index from a caller-owned binary stream."""
+
+        payload = pickle.load(handle)
         if not isinstance(payload, Mapping):
-            raise ValueError(f"invalid LSP occurrence index at {path}")
+            raise ValueError(f"invalid LSP occurrence index at {input_label}")
         version = payload.get("schema_version")
         if version != LSP_OCCURRENCE_INDEX_SCHEMA_VERSION:
             raise ValueError(
-                f"LSP occurrence index at {path} has schema_version={version!r}, "
+                f"LSP occurrence index at {input_label} "
+                f"has schema_version={version!r}, "
                 f"expected {LSP_OCCURRENCE_INDEX_SCHEMA_VERSION}"
             )
         rows = payload.get("occurrences") or ()

--- a/codenib/scip_interface/scip_query.py
+++ b/codenib/scip_interface/scip_query.py
@@ -31,10 +31,26 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
     import tomli as tomllib
 
 from ..compiler.artifact_fingerprints import regular_file_fingerprint
-from ..compiler.manifest import MANIFEST_VERSION, IndexEntry, RepoManifest
+from ..compiler.manifest import (
+    LEGACY_MANIFEST_VERSION,
+    MANIFEST_VERSION,
+    SUPPORTED_MANIFEST_VERSIONS,
+    IndexEntry,
+    RepoManifest,
+)
+from ..compiler.manifest_source import (
+    fingerprint_repository_for_manifest,
+    repository_filter_policy_for_manifest,
+    repository_source_selection_for_manifest,
+)
 from ..languages import graph_indexer_path, normalize_language
-from ..repository_filters import REPOSITORY_FILTER_POLICY_VERSION, walk_repository_files
-from ..source_fingerprint import SourceFingerprint, fingerprint_repository
+from ..repository_filters import walk_repository_files
+from ..repository_source_selection import DEFAULT_REPOSITORY_SOURCE_SELECTION
+from ..source_fingerprint import (
+    SourceFingerprint,
+    fingerprint_repository,
+    is_secure_source_fingerprint_v2,
+)
 from .scip_filter import scip_path_is_allowed
 
 FACT_QUERY_ABI_VERSION = 1
@@ -53,7 +69,8 @@ _ACTIVE_SCIP_INDEXERS = {
 FACT_QUERY_RECEIPT_SCHEMA_VERSION = 1
 SCIP_INPUT_RECEIPT_SCHEMA_VERSION = 1
 FACT_QUERY_FILTER_PROOF_SCHEMA_VERSION = 1
-SYMBOL_GRAPH_BUILDER_SCHEMA_VERSION = 4
+LEGACY_SYMBOL_GRAPH_BUILDER_SCHEMA_VERSION = 4
+SYMBOL_GRAPH_BUILDER_SCHEMA_VERSION = 6
 
 _HEX_DIGEST = re.compile(r"[0-9a-f]{64}")
 _SOURCE_FINGERPRINT = re.compile(r"(?:sha256|sha256-v2):[0-9a-f]{64}")
@@ -62,7 +79,7 @@ _INPUT_RECEIPT_KEYS = frozenset({"schema_version", "index", "metadata"})
 _INPUT_INDEX_KEYS = frozenset({"path", "size_bytes", "sha256"})
 _INPUT_METADATA_KEYS = frozenset({"kind", "complete", "inputs", "internal_crates"})
 _INPUT_FILE_KEYS = frozenset({"path", "size_bytes", "sha256"})
-_INDEX_ENTRY_KEYS = frozenset(
+_INDEX_ENTRY_V11_KEYS = frozenset(
     {
         "index_type",
         "path",
@@ -75,6 +92,7 @@ _INDEX_ENTRY_KEYS = frozenset(
         "source_fingerprint",
     }
 )
+_INDEX_ENTRY_V12_KEYS = _INDEX_ENTRY_V11_KEYS | frozenset({"source_selection_digest"})
 _GRAPH_ARTIFACT_KEYS = frozenset({"relative_path", "size", "sha256"})
 _FILTER_PROOF_KEYS = frozenset(
     {
@@ -104,7 +122,7 @@ _NATIVE_PAYLOAD_KEYS = frozenset(
         "input_receipt",
     }
 )
-_SYMBOL_GRAPH_CONFIG_KEYS = frozenset(
+_LEGACY_SYMBOL_GRAPH_CONFIG_KEYS = frozenset(
     {
         "builder_schema",
         "languages",
@@ -128,6 +146,25 @@ _SYMBOL_GRAPH_CONFIG_KEYS = frozenset(
         "partial_index",
         "failed_languages",
         "partial",
+    }
+)
+_SYMBOL_GRAPH_CONFIG_KEYS = _LEGACY_SYMBOL_GRAPH_CONFIG_KEYS | {
+    "allow_project_preparation",
+    "lsp_occurrence_artifact",
+    "source_selection_digest",
+    "source_selection_report",
+}
+_SOURCE_SELECTION_REPORT_KEYS = frozenset(
+    {
+        "source_selection_digest",
+        "nodes_before",
+        "nodes_after",
+        "edges_before",
+        "edges_after",
+        "removed_excluded_path_count",
+        "excluded_path_count_after",
+        "invalid_path_count_before",
+        "invalid_path_count_after",
     }
 )
 
@@ -691,8 +728,12 @@ def _validate_builder_entry(
     language, languages = _manifest_language(manifest, entry, requested_language)
     config = _mapping(entry.config, label="symbol graph config")
     metadata = _mapping(entry.metadata, label="symbol graph metadata")
-    if set(config) != _SYMBOL_GRAPH_CONFIG_KEYS:
-        raise _reject("symbol graph config fields do not match builder schema v4")
+    is_legacy = manifest.version == LEGACY_MANIFEST_VERSION
+    expected_config_keys = (
+        _LEGACY_SYMBOL_GRAPH_CONFIG_KEYS if is_legacy else _SYMBOL_GRAPH_CONFIG_KEYS
+    )
+    if set(config) != expected_config_keys:
+        raise _reject("symbol graph config fields do not match its builder schema")
     if set(metadata) != set(config) | {"build_duration_seconds"}:
         raise _reject(
             "symbol graph config/metadata fields are not an exact build record"
@@ -713,14 +754,18 @@ def _validate_builder_entry(
             raise _reject(f"symbol graph config/metadata disagree for field {key!r}")
 
     required_config = {
-        "builder_schema": SYMBOL_GRAPH_BUILDER_SCHEMA_VERSION,
+        "builder_schema": (
+            LEGACY_SYMBOL_GRAPH_BUILDER_SCHEMA_VERSION
+            if is_legacy
+            else SYMBOL_GRAPH_BUILDER_SCHEMA_VERSION
+        ),
         "languages": languages,
         "graph_route": "active",
         "allow_partial_languages": False,
         "allow_partial_index": False,
         "source_coverage_fallback": False,
         "target_dir": None,
-        "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
+        "repository_filter_policy": repository_filter_policy_for_manifest(manifest),
     }
     for key, expected in required_config.items():
         if (
@@ -729,6 +774,73 @@ def _validate_builder_entry(
             or type(config[key]) is not type(expected)
         ):
             raise _reject(f"symbol graph config {key!r} is not candidate-safe")
+
+    if not is_legacy:
+        if type(config.get("allow_project_preparation")) is not bool:
+            raise _reject(
+                "symbol graph config 'allow_project_preparation' is malformed"
+            )
+        occurrence_artifact = config.get("lsp_occurrence_artifact")
+        if occurrence_artifact is not None:
+            occurrence_record = _mapping(
+                occurrence_artifact,
+                label="symbol graph LSP occurrence artifact",
+            )
+            _require_exact_keys(
+                occurrence_record,
+                _GRAPH_ARTIFACT_KEYS,
+                label="symbol graph LSP occurrence artifact",
+            )
+            relative = _canonical_relative_path(
+                occurrence_record.get("relative_path"),
+                label="symbol graph LSP occurrence artifact relative_path",
+            )
+            if relative != "lsp_index.pkl":
+                raise _reject(
+                    "symbol graph LSP occurrence artifact must be lsp_index.pkl"
+                )
+            _nonnegative_int(
+                occurrence_record.get("size"),
+                label="symbol graph LSP occurrence artifact size",
+            )
+            _sha256(
+                occurrence_record.get("sha256"),
+                label="symbol graph LSP occurrence artifact sha256",
+            )
+        source_selection = repository_source_selection_for_manifest(manifest)
+        if source_selection is None:
+            raise _reject("current symbol graph manifest has no source selection")
+        if config.get("source_selection_digest") != source_selection.digest:
+            raise _reject("symbol graph source-selection identity is inconsistent")
+        selection_report = _mapping(
+            config.get("source_selection_report"),
+            label="symbol graph source-selection report",
+        )
+        if set(selection_report) != _SOURCE_SELECTION_REPORT_KEYS:
+            raise _reject("symbol graph source-selection report fields are malformed")
+        if selection_report.get("source_selection_digest") != source_selection.digest:
+            raise _reject(
+                "symbol graph source-selection report identity is inconsistent"
+            )
+        report_counts = {
+            key: _nonnegative_int(
+                selection_report.get(key),
+                label=f"symbol graph source-selection report {key}",
+            )
+            for key in _SOURCE_SELECTION_REPORT_KEYS
+            if key != "source_selection_digest"
+        }
+        if (
+            report_counts["nodes_after"] != config.get("node_count")
+            or report_counts["edges_after"] != config.get("edge_count")
+            or report_counts["nodes_before"] < report_counts["nodes_after"]
+            or report_counts["edges_before"] < report_counts["edges_after"]
+            or report_counts["excluded_path_count_after"] != 0
+            or report_counts["invalid_path_count_after"] != 0
+        ):
+            raise _reject(
+                "symbol graph manifest source-selection report is inconsistent"
+            )
 
     patterns = config.get("exclude_patterns")
     if type(patterns) is not list or not all(type(item) is str for item in patterns):
@@ -906,11 +1018,26 @@ def _source_and_allowed_files(
     cache_root: Path,
     exclude_patterns: Iterable[str],
     target_dir: str | None,
+    manifest: RepoManifest | None = None,
 ) -> tuple[SourceFingerprint, list[str]]:
-    source = fingerprint_repository(project_root, exclude_roots=(cache_root,))
+    if manifest is None:
+        selection = DEFAULT_REPOSITORY_SOURCE_SELECTION
+        source = fingerprint_repository(project_root, exclude_roots=(cache_root,))
+    else:
+        persisted_selection = repository_source_selection_for_manifest(manifest)
+        selection = persisted_selection or DEFAULT_REPOSITORY_SOURCE_SELECTION
+        source = fingerprint_repository_for_manifest(
+            project_root,
+            manifest,
+            exclude_roots=(cache_root,),
+        )
     allowed: list[str] = []
     seen: set[str] = set()
-    for path in walk_repository_files(project_root, exclude_roots=(cache_root,)):
+    for path in walk_repository_files(
+        project_root,
+        exclude_roots=(cache_root,),
+        selection=selection,
+    ):
         try:
             mode = path.lstat().st_mode
         except OSError as exc:
@@ -943,6 +1070,8 @@ def _validate_filter_proof(
     expected_record_count: int,
     expected_edge_count: int,
     expected_query_surface_sha256: str,
+    repository_filter_policy: int,
+    source_selection_digest: str | None,
 ) -> dict[str, Any]:
     proof = _mapping(value, label="native filter identity proof")
     _require_exact_keys(proof, _FILTER_PROOF_KEYS, label="native filter proof")
@@ -1008,6 +1137,8 @@ def _validate_filter_proof(
     return {
         "schema_version": FACT_QUERY_FILTER_PROOF_SCHEMA_VERSION,
         "identity": True,
+        "repository_filter_policy": repository_filter_policy,
+        "source_selection_digest": source_selection_digest,
         "allowed_files_sha256": expected_digest,
         "query_surface_sha256": proof_query_surface,
         **counts,
@@ -1050,11 +1181,9 @@ def load_fact_query_candidate(
     except (UnicodeError, json.JSONDecodeError) as exc:
         raise _reject("RepoManifest is not readable canonical JSON") from exc
     raw_manifest = _mapping(raw_manifest, label="RepoManifest")
-    if (
-        type(raw_manifest.get("version")) is not str
-        or raw_manifest.get("version") != MANIFEST_VERSION
-    ):
-        raise _reject("RepoManifest must explicitly record version 1.1")
+    raw_version = raw_manifest.get("version")
+    if type(raw_version) is not str or raw_version not in SUPPORTED_MANIFEST_VERSIONS:
+        raise _reject("RepoManifest must explicitly record a supported version")
     raw_repo = _mapping(raw_manifest.get("repo"), label="RepoManifest.repo")
     for required in ("path", "commit", "source_fingerprint", "file_count"):
         if required not in raw_repo:
@@ -1077,7 +1206,13 @@ def load_fact_query_candidate(
         raw_indexes.get("symbol_graph"), label="RepoManifest symbol_graph entry"
     )
     _require_exact_keys(
-        raw_entry, _INDEX_ENTRY_KEYS, label="RepoManifest symbol_graph entry"
+        raw_entry,
+        (
+            _INDEX_ENTRY_V12_KEYS
+            if raw_version == MANIFEST_VERSION
+            else _INDEX_ENTRY_V11_KEYS
+        ),
+        label="RepoManifest symbol_graph entry",
     )
     if raw_entry.get("index_type") != "symbol_graph":
         raise _reject("RepoManifest symbol_graph index_type is malformed")
@@ -1117,14 +1252,14 @@ def load_fact_query_candidate(
         manifest = RepoManifest.from_dict(dict(raw_manifest))
     except (KeyError, TypeError, ValueError) as exc:
         raise _reject("RepoManifest fields are malformed") from exc
-    if manifest.version != MANIFEST_VERSION:
-        raise _reject(
-            f"RepoManifest version must be {MANIFEST_VERSION!r} for FactQueryIndex"
-        )
     if type(manifest.file_count) is not int or manifest.file_count < 0:
         raise _reject("RepoManifest file_count is malformed")
     if type(manifest.source_fingerprint) is not str or not manifest.source_fingerprint:
         raise _reject("RepoManifest source fingerprint is missing")
+    if manifest.version == MANIFEST_VERSION and not is_secure_source_fingerprint_v2(
+        manifest.source_fingerprint
+    ):
+        raise _reject("RepoManifest v1.2 requires source fingerprint v2")
 
     try:
         manifest_root = Path(manifest.repo_path).expanduser().resolve(strict=True)
@@ -1151,6 +1286,17 @@ def load_fact_query_candidate(
         document_count,
         query_surface_digest,
     ) = _validate_builder_entry(manifest, entry, requested_language=language)
+    source_selection = repository_source_selection_for_manifest(manifest)
+    source_selection_payload = (
+        None if source_selection is None else source_selection.to_dict()
+    )
+    source_selection_digest = (
+        None if source_selection is None else source_selection.digest
+    )
+    repository_filter_policy = repository_filter_policy_for_manifest(manifest)
+    entry_source_selection_digest = (
+        None if source_selection is None else entry.source_selection_digest
+    )
     artifact_root = resolved_manifest.parent / "symbol_graph"
     index_path, index_relative, expected_index = _resolve_artifact(
         entry,
@@ -1170,6 +1316,7 @@ def load_fact_query_candidate(
         cache_root=cache_root,
         exclude_patterns=exclude_patterns,
         target_dir=None,
+        manifest=manifest,
     )
     if (
         source_before.value != manifest.source_fingerprint
@@ -1178,8 +1325,10 @@ def load_fact_query_candidate(
         or entry.commit != manifest.commit
     ):
         raise _reject("repository source does not match the symbol graph manifest")
-    source_before_decode = fingerprint_repository(
-        manifest_root, exclude_roots=(cache_root,)
+    source_before_decode = fingerprint_repository_for_manifest(
+        manifest_root,
+        manifest,
+        exclude_roots=(cache_root,),
     )
     if source_before_decode != source_before:
         raise _reject("repository source changed while computing allowed files")
@@ -1221,9 +1370,15 @@ def load_fact_query_candidate(
         expected_record_count=node_count,
         expected_edge_count=edge_count,
         expected_query_surface_sha256=query_surface_digest,
+        repository_filter_policy=repository_filter_policy,
+        source_selection_digest=source_selection_digest,
     )
 
-    source_after = fingerprint_repository(manifest_root, exclude_roots=(cache_root,))
+    source_after = fingerprint_repository_for_manifest(
+        manifest_root,
+        manifest,
+        exclude_roots=(cache_root,),
+    )
     try:
         index_after = regular_file_fingerprint(index_path)
         graph_after = regular_file_fingerprint(graph_path)
@@ -1266,16 +1421,19 @@ def load_fact_query_candidate(
             "size_bytes": manifest_file_fingerprint["size"],
             "sha256": manifest_file_fingerprint["sha256"],
             "commit": manifest.commit,
-            "builder_schema": SYMBOL_GRAPH_BUILDER_SCHEMA_VERSION,
+            "builder_schema": entry.config["builder_schema"],
             "node_count": node_count,
             "edge_count": edge_count,
             "document_count": document_count,
             "query_surface_sha256": query_surface_digest,
             "source_fingerprint": manifest.source_fingerprint,
             "file_count": manifest.file_count,
+            "source_selection": source_selection_payload,
+            "source_selection_digest": source_selection_digest,
             "entry_path": str(index_path.parent),
             "entry_commit": entry.commit,
             "entry_source_fingerprint": entry.source_fingerprint,
+            "entry_source_selection_digest": entry_source_selection_digest,
         },
         "index": {
             "relative_path": index_relative,
@@ -1296,12 +1454,16 @@ def load_fact_query_candidate(
         "source": {
             "fingerprint": source_before.value,
             "file_count": source_before.file_count,
-            "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
+            "repository_filter_policy": repository_filter_policy,
+            "source_selection": source_selection_payload,
+            "source_selection_digest": source_selection_digest,
         },
         "filters": {
             "graph_route": "active",
             "update_mode": "full_rebuild",
-            "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
+            "repository_filter_policy": repository_filter_policy,
+            "source_selection": source_selection_payload,
+            "source_selection_digest": source_selection_digest,
             "exclude_patterns": list(exclude_patterns),
             "target_dir": None,
             "allow_partial_languages": False,
@@ -1388,11 +1550,58 @@ def observe_fact_query_snapshot(value: Mapping[str, Any]) -> dict[str, Any]:
     )
     manifest_digest = _sha256(manifest.get("sha256"), label="FactQuery manifest sha256")
     try:
-        observed_manifest = regular_file_fingerprint(manifest_path)
+        manifest_bytes, _manifest_stat_identity = _read_stable_file(
+            manifest_path,
+            label="FactQuery manifest",
+        )
+        observed_manifest = {
+            "size": len(manifest_bytes),
+            "sha256": hashlib.sha256(manifest_bytes).hexdigest(),
+        }
     except (OSError, ValueError) as exc:
         raise _reject("FactQuery manifest changed after candidate admission") from exc
     if observed_manifest != {"size": manifest_size, "sha256": manifest_digest}:
         raise _reject("FactQuery manifest changed after candidate admission")
+    try:
+        embedded_manifest = RepoManifest.from_dict(
+            json.loads(manifest_bytes.decode("utf-8"))
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise _reject("FactQuery embedded RepoManifest is malformed") from exc
+    embedded_selection = repository_source_selection_for_manifest(embedded_manifest)
+    selection_payload = (
+        None if embedded_selection is None else embedded_selection.to_dict()
+    )
+    selection_digest = None if embedded_selection is None else embedded_selection.digest
+    repository_filter_policy = repository_filter_policy_for_manifest(embedded_manifest)
+    embedded_entry = embedded_manifest.indexes.get("symbol_graph")
+    if embedded_entry is None or not embedded_manifest.index_is_current("symbol_graph"):
+        raise _reject("FactQuery embedded symbol graph entry is not current")
+    entry_selection_digest = (
+        None if embedded_selection is None else embedded_entry.source_selection_digest
+    )
+    if (
+        embedded_manifest.version == MANIFEST_VERSION
+        and not is_secure_source_fingerprint_v2(embedded_manifest.source_fingerprint)
+    ):
+        raise _reject("FactQuery embedded RepoManifest requires source fingerprint v2")
+    if (
+        manifest.get("version") != embedded_manifest.version
+        or manifest.get("source_fingerprint") != embedded_manifest.source_fingerprint
+        or manifest.get("file_count") != embedded_manifest.file_count
+        or manifest.get("source_selection") != selection_payload
+        or manifest.get("source_selection_digest") != selection_digest
+        or manifest.get("entry_commit") != embedded_entry.commit
+        or manifest.get("entry_source_fingerprint") != embedded_entry.source_fingerprint
+        or manifest.get("entry_source_selection_digest") != entry_selection_digest
+    ):
+        raise _reject("FactQuery manifest receipt differs from its embedded manifest")
+    try:
+        embedded_root = Path(embedded_manifest.repo_path).resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise _reject("FactQuery embedded repository root is unavailable") from exc
+    if embedded_root != project_root:
+        raise _reject("FactQuery embedded repository root differs from its receipt")
 
     commit = manifest.get("commit")
     if type(commit) is not str or (commit and _GIT_COMMIT.fullmatch(commit) is None):
@@ -1400,6 +1609,8 @@ def observe_fact_query_snapshot(value: Mapping[str, Any]) -> dict[str, Any]:
     checkout_head = _checkout_head(project_root)
     if checkout_head != commit:
         raise _reject("live repository commit changed after candidate admission")
+    if commit != embedded_manifest.commit:
+        raise _reject("FactQuery manifest commit differs from its embedded manifest")
 
     entry_path_value = manifest.get("entry_path")
     if type(entry_path_value) is not str or not entry_path_value:
@@ -1413,6 +1624,8 @@ def observe_fact_query_snapshot(value: Mapping[str, Any]) -> dict[str, Any]:
         raise _reject("FactQuery symbol graph view is unavailable") from exc
     if not entry_path.is_dir() or entry_path != expected_entry_path:
         raise _reject("FactQuery symbol graph view is not canonical")
+    if Path(embedded_entry.path) != entry_path:
+        raise _reject("FactQuery symbol graph path differs from its embedded manifest")
 
     index = _mapping(receipt.get("index"), label="FactQuery decoded index receipt")
     index_relative = _canonical_relative_path(
@@ -1474,15 +1687,30 @@ def observe_fact_query_snapshot(value: Mapping[str, Any]) -> dict[str, Any]:
     source_file_count = _nonnegative_int(
         source.get("file_count"), label="FactQuery source file_count"
     )
+    if (
+        source.get("repository_filter_policy") != repository_filter_policy
+        or type(source.get("repository_filter_policy")) is not int
+        or source.get("source_selection") != selection_payload
+        or source.get("source_selection_digest") != selection_digest
+    ):
+        raise _reject("FactQuery source selection receipt is inconsistent")
     filters = _mapping(receipt.get("filters"), label="FactQuery filter receipt")
     patterns = filters.get("exclude_patterns")
     if type(patterns) is not list or not all(type(item) is str for item in patterns):
         raise _reject("FactQuery exclude patterns are malformed")
+    if (
+        filters.get("repository_filter_policy") != repository_filter_policy
+        or type(filters.get("repository_filter_policy")) is not int
+        or filters.get("source_selection") != selection_payload
+        or filters.get("source_selection_digest") != selection_digest
+    ):
+        raise _reject("FactQuery filter selection receipt is inconsistent")
     observed_source, allowed_files = _source_and_allowed_files(
         project_root,
         cache_root=manifest_path.parent,
         exclude_patterns=patterns,
         target_dir=None,
+        manifest=embedded_manifest,
     )
     if (
         observed_source.value != source_fingerprint
@@ -1507,6 +1735,19 @@ def observe_fact_query_snapshot(value: Mapping[str, Any]) -> dict[str, Any]:
         raise _reject("FactQuery manifest/source receipt fields disagree")
     if manifest.get("query_surface_sha256") != graph_query_digest:
         raise _reject("FactQuery graph query surface receipt fields disagree")
+    filter_identity = _mapping(
+        receipt.get("filter_identity"),
+        label="FactQuery filter identity receipt",
+    )
+    if (
+        filter_identity.get("identity") is not True
+        or filter_identity.get("repository_filter_policy") != repository_filter_policy
+        or type(filter_identity.get("repository_filter_policy")) is not int
+        or filter_identity.get("source_selection_digest") != selection_digest
+        or filter_identity.get("allowed_file_count") != len(allowed_files)
+        or filter_identity.get("allowed_files_sha256") != allowed_digest
+    ):
+        raise _reject("FactQuery filter identity selection proof is inconsistent")
 
     try:
         final_manifest = regular_file_fingerprint(manifest_path)
@@ -1514,8 +1755,9 @@ def observe_fact_query_snapshot(value: Mapping[str, Any]) -> dict[str, Any]:
         final_graph = regular_file_fingerprint(graph_path)
     except (OSError, ValueError) as exc:
         raise _reject("FactQuery inputs changed during snapshot observation") from exc
-    final_source = fingerprint_repository(
+    final_source = fingerprint_repository_for_manifest(
         project_root,
+        embedded_manifest,
         exclude_roots=(manifest_path.parent,),
     )
     final_checkout_head = _checkout_head(project_root)
@@ -1555,6 +1797,9 @@ def observe_fact_query_snapshot(value: Mapping[str, Any]) -> dict[str, Any]:
             "file_count": observed_source.file_count,
             "allowed_file_count": len(allowed_files),
             "allowed_files_sha256": allowed_digest,
+            "repository_filter_policy": repository_filter_policy,
+            "source_selection": selection_payload,
+            "source_selection_digest": selection_digest,
         },
         "native_metadata": copy.deepcopy(native_input["metadata"]),
     }

--- a/codenib/scip_interface/scip_query_provider.py
+++ b/codenib/scip_interface/scip_query_provider.py
@@ -80,11 +80,11 @@ def scip_consumer_query_mode(
     return _normalize_mode(source.get(SCIP_CONSUMER_QUERY_ENV, "off"))
 
 
-def _default_graph_loader(path: Path) -> Any:
+def _default_graph_loader(path: Path, receipt: Mapping[str, Any]) -> Any:
     # Keep CodeGraph and igraph absent until an admitted request needs them.
-    from ..graph.code_graph import CodeGraph
+    from ..compiler.graph_artifact import load_authenticated_graph_generation
 
-    return CodeGraph.load_graph(str(path))
+    return load_authenticated_graph_generation(path.parent, receipt)
 
 
 def _manifest_language(
@@ -114,7 +114,6 @@ class SCIPHybridQueryProvider:
     ) -> None:
         self.query_index = candidate.index
         self._candidate_receipt = copy.deepcopy(candidate.receipt)
-        self._graph_loader = graph_loader or _default_graph_loader
         self._snapshot_observer = snapshot_observer or observe_fact_query_snapshot
         self._public_fallback_reason = public_fallback_reason
 
@@ -135,6 +134,31 @@ class SCIPHybridQueryProvider:
         query_digest = graph.get("query_surface_sha256")
         if type(query_digest) is not str or len(query_digest) != 64:
             raise ValueError("FactQuery candidate receipt has no graph query digest")
+        if graph_loader is None:
+            graph_size = graph.get("size_bytes")
+            graph_digest = graph.get("sha256")
+            if (
+                isinstance(graph_size, bool)
+                or not isinstance(graph_size, int)
+                or graph_size < 0
+                or not isinstance(graph_digest, str)
+                or len(graph_digest) != 64
+            ):
+                raise ValueError(
+                    "FactQuery candidate receipt has no authenticated graph artifact"
+                )
+            graph_receipt = {
+                "relative_path": "graph.pkl",
+                "size": graph_size,
+                "sha256": graph_digest,
+            }
+
+            def authenticated_graph_loader(path: Path) -> Any:
+                return _default_graph_loader(path, graph_receipt)
+
+            self._graph_loader = authenticated_graph_loader
+        else:
+            self._graph_loader = graph_loader
 
         entry_path = manifest.get("entry_path")
         relative_graph = graph.get("relative_path")

--- a/codenib/source_fingerprint.py
+++ b/codenib/source_fingerprint.py
@@ -50,13 +50,22 @@ from ._windows_fs_authority import (
 from ._windows_fs_authority import WindowsDirectoryEntry as _WindowsDirectoryEntry
 from ._windows_fs_authority import WindowsHandleMetadata as _WindowsHandleMetadata
 from ._windows_fs_authority import WindowsKernelApi as _WindowsKernelApi
+from ._windows_fs_authority import WindowsReparsePoint as _WindowsReparsePoint
 from ._windows_fs_authority import _WindowsHandleCleanup
 from .repository_filters import (
     REPOSITORY_FILTER_POLICY_VERSION,
     repository_path_is_visible,
 )
+from .repository_source_selection import (
+    DEFAULT_REPOSITORY_SOURCE_SELECTION,
+    RepositorySourceSelection,
+)
 
 SOURCE_FINGERPRINT_VERSION = 2
+
+_CURRENT_SOURCE_IDENTITY_POLICY = object()
+_LEGACY_MANIFEST_V11_SOURCE_IDENTITY_POLICY = object()
+_LEGACY_MANIFEST_V11_FILTER_POLICY_VERSION = 3
 
 _SOURCE_FINGERPRINT_V1_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 _SOURCE_FINGERPRINT_V2_RE = re.compile(r"^sha256-v2:[0-9a-f]{64}$")
@@ -72,6 +81,14 @@ _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 
 class RepositoryChangedError(RuntimeError):
     """Raised when repository contents change while they are being inspected."""
+
+
+def _snapshot_repository_source_selection(
+    selection: RepositorySourceSelection,
+) -> RepositorySourceSelection:
+    if type(selection) is not RepositorySourceSelection:
+        raise TypeError("selection must be a RepositorySourceSelection")
+    return RepositorySourceSelection(selection.exclude_subtrees)
 
 
 def _remember_interruption(
@@ -305,6 +322,7 @@ class _RepositoryEntry:
     relative: str
     metadata: os.stat_result | _WindowsHandleMetadata
     link_target: str | None = None
+    windows_reparse_point: _WindowsReparsePoint | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -339,6 +357,7 @@ class _RepositorySourceLinkRecord:
     lexical_identity: tuple[object, ...]
     link_target: str
     target_state: str
+    windows_reparse_point: _WindowsReparsePoint | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -349,6 +368,7 @@ class RepositorySourceIdentitySnapshot:
     fingerprint: str
     file_count: int
     file_records: tuple[RepositorySourceFileRecord, ...]
+    source_selection: RepositorySourceSelection | None
 
 
 class _HashFanout:
@@ -510,6 +530,50 @@ def _same_source_file_record(
     )
 
 
+def _same_windows_reparse_point(
+    left: _WindowsReparsePoint | None,
+    right: _WindowsReparsePoint | None,
+) -> bool:
+    if left is None or right is None:
+        return left is right
+    return (
+        type(left) is _WindowsReparsePoint
+        and type(right) is _WindowsReparsePoint
+        and type(left.tag) is type(right.tag) is int
+        and left.tag == right.tag
+        and type(left.flags) is type(right.flags) is int
+        and left.flags == right.flags
+        and type(left.substitute_name) is type(right.substitute_name)
+        and left.substitute_name == right.substitute_name
+        and type(left.print_name) is type(right.print_name)
+        and left.print_name == right.print_name
+    )
+
+
+def _same_source_link_record(
+    left: _RepositorySourceLinkRecord,
+    right: _RepositorySourceLinkRecord,
+) -> bool:
+    return (
+        type(left) is _RepositorySourceLinkRecord
+        and type(right) is _RepositorySourceLinkRecord
+        and type(left.path) is type(right.path) is str
+        and left.path == right.path
+        and _same_source_identity_value(
+            left.lexical_identity,
+            right.lexical_identity,
+        )
+        and type(left.link_target) is type(right.link_target) is str
+        and left.link_target == right.link_target
+        and type(left.target_state) is type(right.target_state) is str
+        and left.target_state == right.target_state
+        and _same_windows_reparse_point(
+            left.windows_reparse_point,
+            right.windows_reparse_point,
+        )
+    )
+
+
 def _snapshot_source_file_record(record: object) -> RepositorySourceFileRecord:
     if type(record) is not RepositorySourceFileRecord:
         raise TypeError("repository source records must use the exact record type")
@@ -609,6 +673,7 @@ def _verify_windows_repository_links(
             expected_root_identity=root_identity,
             expected_final_identity=link.lexical_identity,
             expected_final_link_target=link.link_target,
+            expected_final_reparse_point=link.windows_reparse_point,
             api=api,
         ) as source:
             _verify_resolved_repository_link(source, link, records)
@@ -628,9 +693,12 @@ class RepositorySourceBinding:
         "_authenticated_file_records",
         "_authenticated_link_records",
         "_records",
+        "_links",
         "_inventory_digest",
         "_inventory_entries",
         "_excluded",
+        "_selection",
+        "_source_selection_identity",
         "_root_descriptor",
         "_posix_authority",
         "_root_identity",
@@ -655,6 +723,8 @@ class RepositorySourceBinding:
         inventory_digest: str,
         inventory_entries: int,
         excluded: tuple[tuple[str, ...], ...],
+        selection: RepositorySourceSelection,
+        source_selection_identity: RepositorySourceSelection | None,
         root_identity: tuple[object, ...],
         root_descriptor: int = -1,
         posix_authority: object | None = None,
@@ -691,10 +761,40 @@ class RepositorySourceBinding:
                 or type(record.lexical_identity) is not tuple
                 or type(record.link_target) is not str
                 or record.target_state not in {"regular", "directory", "unresolved"}
+                or (
+                    record.windows_reparse_point is not None
+                    and type(record.windows_reparse_point) is not _WindowsReparsePoint
+                )
             ):
                 raise ValueError(
                     "repository source binding contains invalid link records"
                 )
+            reparse = record.windows_reparse_point
+            if reparse is not None and (
+                type(reparse.tag) is not int
+                or type(reparse.flags) is not int
+                or (
+                    reparse.substitute_name is not None
+                    and type(reparse.substitute_name) is not str
+                )
+                or (
+                    reparse.print_name is not None
+                    and type(reparse.print_name) is not str
+                )
+            ):
+                raise ValueError(
+                    "repository source binding contains invalid link records"
+                )
+            authenticated_reparse = (
+                None
+                if reparse is None
+                else _WindowsReparsePoint(
+                    tag=reparse.tag,
+                    substitute_name=reparse.substitute_name,
+                    print_name=reparse.print_name,
+                    flags=reparse.flags,
+                )
+            )
             authenticated_links.append(
                 _RepositorySourceLinkRecord(
                     path=record.path,
@@ -703,15 +803,34 @@ class RepositorySourceBinding:
                     ),  # type: ignore[arg-type]
                     link_target=record.link_target,
                     target_state=record.target_state,
+                    windows_reparse_point=authenticated_reparse,
                 )
             )
         self._authenticated_link_records = tuple(authenticated_links)
         self._records = {record.path: record for record in authenticated_records}
+        self._links = {record.path: record for record in authenticated_links}
         if len(self._records) != len(authenticated_records):
             raise ValueError("repository source binding contains duplicate records")
+        if len(self._links) != len(authenticated_links):
+            raise ValueError(
+                "repository source binding contains duplicate link records"
+            )
         self._inventory_digest = inventory_digest
         self._inventory_entries = inventory_entries
         self._excluded = excluded
+        self._selection = _snapshot_repository_source_selection(selection)
+        self._source_selection_identity = (
+            None
+            if source_selection_identity is None
+            else _snapshot_repository_source_selection(source_selection_identity)
+        )
+        if (
+            self._source_selection_identity is not None
+            and self._source_selection_identity != self._selection
+        ):
+            raise ValueError(
+                "repository source selection identity differs from scan policy"
+            )
         self._root_descriptor = root_descriptor
         self._posix_authority = posix_authority
         self._root_identity = root_identity
@@ -822,6 +941,7 @@ class RepositorySourceBinding:
                 api,
                 authority.handle,
                 excluded=self._excluded,
+                selection=self._selection,
                 collect_entries=False,
             )
             if (
@@ -839,6 +959,7 @@ class RepositorySourceBinding:
         scan = _scan_pinned_repository(
             self._root_descriptor,
             excluded=self._excluded,
+            selection=self._selection,
             collect_entries=False,
         )
         if (
@@ -894,6 +1015,17 @@ class RepositorySourceBinding:
         ):
             raise RepositoryChangedError(
                 "repository source retained records changed after authentication"
+            )
+        if len(self._links) != len(self._authenticated_link_records) or any(
+            (
+                not _same_source_link_record(self._links[expected.path], expected)
+                if expected.path in self._links
+                else True
+            )
+            for expected in self._authenticated_link_records
+        ):
+            raise RepositoryChangedError(
+                "repository source retained link records changed after authentication"
             )
 
     def _verify_retained_link_targets(self) -> None:
@@ -960,6 +1092,13 @@ class RepositorySourceBinding:
                 file_records=tuple(
                     _snapshot_source_file_record(record)
                     for record in self._authenticated_file_records
+                ),
+                source_selection=(
+                    None
+                    if self._source_selection_identity is None
+                    else _snapshot_repository_source_selection(
+                        self._source_selection_identity
+                    )
                 ),
             )
 
@@ -1029,6 +1168,7 @@ class RepositorySourceBinding:
             api = self._windows_api
             if api is None:  # pragma: no cover - constructor invariant
                 raise AssertionError("Windows repository binding has no API")
+            link = self._links.get(relative)
             resolver = _resolved_windows_repository_file_at(
                 self._authenticated_root,
                 self._windows_authority,
@@ -1036,6 +1176,9 @@ class RepositorySourceBinding:
                 expected_root_identity=self._root_identity,
                 expected_final_identity=record.lexical_identity,
                 expected_final_link_target=record.link_target,
+                expected_final_reparse_point=(
+                    None if link is None else link.windows_reparse_point
+                ),
                 api=api,
             )
         else:
@@ -1071,21 +1214,27 @@ class RepositorySourceBinding:
             api = self._windows_api
             if api is None:  # pragma: no cover - constructor invariant
                 raise AssertionError("Windows repository binding has no API")
+            link = self._links.get(relative)
             resolver = _resolved_windows_repository_file_at(
-                self.root,
+                self._authenticated_root,
                 self._windows_authority,
                 relative,
                 expected_root_identity=self._root_identity,
                 expected_final_identity=record.lexical_identity,
+                expected_final_link_target=record.link_target,
+                expected_final_reparse_point=(
+                    None if link is None else link.windows_reparse_point
+                ),
                 api=api,
             )
         else:
             resolver = _resolved_repository_file_at(
-                self.root,
+                self._authenticated_root,
                 self._root_descriptor,
                 relative,
                 expected_root_identity=self._root_identity,  # type: ignore[arg-type]
                 expected_final_identity=record.lexical_identity,  # type: ignore[arg-type]
+                expected_final_link_target=record.link_target,
             )
         authenticated = _AuthenticatedPrefix(max_bytes)
         with resolver as source:
@@ -1114,21 +1263,27 @@ class RepositorySourceBinding:
             api = self._windows_api
             if api is None:  # pragma: no cover - constructor invariant
                 raise AssertionError("Windows repository binding has no API")
+            link = self._links.get(relative)
             resolver = _resolved_windows_repository_file_at(
-                self.root,
+                self._authenticated_root,
                 self._windows_authority,
                 relative,
                 expected_root_identity=self._root_identity,
                 expected_final_identity=record.lexical_identity,
+                expected_final_link_target=record.link_target,
+                expected_final_reparse_point=(
+                    None if link is None else link.windows_reparse_point
+                ),
                 api=api,
             )
         else:
             resolver = _resolved_repository_file_at(
-                self.root,
+                self._authenticated_root,
                 self._root_descriptor,
                 relative,
                 expected_root_identity=self._root_identity,  # type: ignore[arg-type]
                 expected_final_identity=record.lexical_identity,  # type: ignore[arg-type]
+                expected_final_link_target=record.link_target,
             )
         authenticated = _AuthenticatedLineRange(start_line, end_line, max_bytes)
         with resolver as source:
@@ -1510,6 +1665,46 @@ def _update_frame(hasher: object, domain: bytes, payload: bytes) -> None:
     hasher.update(payload)
 
 
+def _new_source_fingerprint_hasher(
+    version: int,
+    selection: RepositorySourceSelection,
+    *,
+    identity_policy: object,
+) -> Any:
+    hasher = hashlib.sha256()
+    if identity_policy is _LEGACY_MANIFEST_V11_SOURCE_IDENTITY_POLICY:
+        if selection != DEFAULT_REPOSITORY_SOURCE_SELECTION:
+            raise ValueError(
+                "legacy manifest v1.1 source identity requires empty selection"
+            )
+        policy_version = _LEGACY_MANIFEST_V11_FILTER_POLICY_VERSION
+        include_selection = False
+    elif identity_policy is _CURRENT_SOURCE_IDENTITY_POLICY:
+        policy_version = REPOSITORY_FILTER_POLICY_VERSION
+        include_selection = True
+    else:  # pragma: no cover - private call invariant
+        raise ValueError("unsupported repository source identity policy")
+    selection_digest = selection.digest.encode("ascii")
+    if version == 1:
+        hasher.update(
+            ("codenib-source-fingerprint:1:" f"{policy_version}\0").encode("ascii")
+        )
+        if include_selection:
+            hasher.update(b"source-selection-digest\0")
+            hasher.update(selection_digest)
+            hasher.update(b"\0")
+        return hasher
+    hasher.update(_V2_MAGIC)
+    _update_frame(
+        hasher,
+        b"filter-policy-version",
+        str(policy_version).encode("ascii"),
+    )
+    if include_selection:
+        _update_frame(hasher, b"source-selection-digest", selection_digest)
+    return hasher
+
+
 def _directory_flags() -> int:
     return (
         os.O_RDONLY
@@ -1606,6 +1801,7 @@ def _update_inventory_record(
     kind: bytes,
     metadata: os.stat_result | _WindowsHandleMetadata,
     link_target: str | None,
+    windows_reparse_point: _WindowsReparsePoint | None = None,
 ) -> None:
     _update_frame(hasher, b"inventory-kind", kind)
     _update_frame(hasher, b"inventory-path", os.fsencode(relative))
@@ -1615,16 +1811,41 @@ def _update_inventory_record(
     _update_frame(hasher, b"inventory-identity", identity)
     if link_target is not None:
         _update_frame(hasher, b"inventory-link-target", os.fsencode(link_target))
+    if windows_reparse_point is not None:
+        _update_frame(
+            hasher,
+            b"inventory-windows-reparse-tag",
+            str(windows_reparse_point.tag).encode("ascii"),
+        )
+        _update_frame(
+            hasher,
+            b"inventory-windows-reparse-flags",
+            str(windows_reparse_point.flags).encode("ascii"),
+        )
+        for domain, value in (
+            (
+                b"inventory-windows-reparse-substitute",
+                windows_reparse_point.substitute_name,
+            ),
+            (
+                b"inventory-windows-reparse-print",
+                windows_reparse_point.print_name,
+            ),
+        ):
+            payload = b"\x00" if value is None else b"\x01" + os.fsencode(value)
+            _update_frame(hasher, domain, payload)
 
 
 def _scan_pinned_repository(
     root_descriptor: int,
     *,
     excluded: tuple[tuple[str, ...], ...],
+    selection: RepositorySourceSelection = DEFAULT_REPOSITORY_SOURCE_SELECTION,
     collect_entries: bool,
 ) -> _RepositoryScan:
     """Enumerate one stable view through an already-open repository root."""
 
+    selected = _snapshot_repository_source_selection(selection)
     inventory = hashlib.sha256()
     entries: list[_RepositoryEntry] = []
     budget = _RepositoryScanBudget()
@@ -1652,7 +1873,7 @@ def _scan_pinned_repository(
                     child_parts = (*parts, child.name)
                     relative = "/".join(child_parts)
                     if _relative_is_excluded(child_parts, excluded) or not (
-                        repository_path_is_visible(relative)
+                        repository_path_is_visible(relative, selection=selected)
                     ):
                         continue
                     # Charge the name before retaining it. A hostile wide
@@ -1792,10 +2013,12 @@ def _scan_pinned_windows_repository(
     root_handle: int,
     *,
     excluded: tuple[tuple[str, ...], ...],
+    selection: RepositorySourceSelection = DEFAULT_REPOSITORY_SOURCE_SELECTION,
     collect_entries: bool,
 ) -> _RepositoryScan:
     """Enumerate through one retained Windows root without following reparses."""
 
+    selected = _snapshot_repository_source_selection(selection)
     inventory = hashlib.sha256()
     entries: list[_RepositoryEntry] = []
     budget = _RepositoryScanBudget()
@@ -1815,7 +2038,7 @@ def _scan_pinned_windows_repository(
             child_parts = (*parts, child.name)
             relative = "/".join(child_parts)
             if _windows_relative_is_excluded(child_parts, excluded) or not (
-                repository_path_is_visible(relative)
+                repository_path_is_visible(relative, selection=selected)
             ):
                 continue
             _reserve_scan_entry(budget, relative)
@@ -1840,18 +2063,25 @@ def _scan_pinned_windows_repository(
                 if metadata.st_dev != before.st_dev:
                     raise ValueError("Windows repository scan crosses a volume")
                 link_target: str | None = None
+                reparse_point: _WindowsReparsePoint | None = None
                 if _windows_entry_is_reparse(child):
                     if metadata.reparse_tag != _WINDOWS_IO_REPARSE_TAG_SYMLINK:
                         raise ValueError(
                             f"Windows repository contains unsupported reparse: {relative}"
                         )
-                    point = api.query_reparse_point(child_handle)
-                    if point.tag != _WINDOWS_IO_REPARSE_TAG_SYMLINK:
+                    reparse_point = api.query_reparse_point(child_handle)
+                    if reparse_point.tag != _WINDOWS_IO_REPARSE_TAG_SYMLINK:
                         raise ValueError(
                             f"Windows repository reparse tag changed: {relative}"
                         )
-                    link_target = _windows_link_target_text(point)
+                    link_target = _windows_link_target_text(reparse_point)
                     _reserve_link_target(budget, link_target)
+                    for value in (
+                        reparse_point.substitute_name,
+                        reparse_point.print_name,
+                    ):
+                        if value is not None and value != link_target:
+                            _reserve_link_target(budget, value)
                     kind = b"link"
                 elif stat.S_ISDIR(metadata.st_mode):
                     kind = b"directory"
@@ -1878,6 +2108,7 @@ def _scan_pinned_windows_repository(
                     kind=kind,
                     metadata=metadata,
                     link_target=link_target,
+                    windows_reparse_point=reparse_point,
                 )
                 if kind == b"directory":
                     directories.append(
@@ -1889,6 +2120,7 @@ def _scan_pinned_windows_repository(
                             relative=relative,
                             metadata=metadata,
                             link_target=link_target,
+                            windows_reparse_point=reparse_point,
                         )
                     )
 
@@ -2430,11 +2662,13 @@ def _fingerprint_windows_repository(
     root: str | Path,
     *,
     exclude_roots: Iterable[str | Path],
+    selection: RepositorySourceSelection = DEFAULT_REPOSITORY_SOURCE_SELECTION,
     version: int,
     api: _WindowsKernelApi | None = None,
     retain_binding: bool = False,
     source_owner: Callable[[object], None] | None = None,
     cleanup_slot: _SourceCleanupSlot | None = None,
+    identity_policy: object = _CURRENT_SOURCE_IDENTITY_POLICY,
 ) -> SourceFingerprint | RepositorySourceBinding:
     """Hash a Windows repository through one retained HANDLE authority."""
 
@@ -2442,21 +2676,13 @@ def _fingerprint_windows_repository(
         cleanup_slot = _SourceCleanupSlot()
         if source_owner is not None:
             source_owner(cleanup_slot)
+    selected_source = _snapshot_repository_source_selection(selection)
     root_path = _lexical_windows_repository_path(root)
-    hasher = hashlib.sha256()
-    if version == 1:
-        hasher.update(
-            (
-                "codenib-source-fingerprint:1:" f"{REPOSITORY_FILTER_POLICY_VERSION}\0"
-            ).encode("ascii")
-        )
-    else:
-        hasher.update(_V2_MAGIC)
-        _update_frame(
-            hasher,
-            b"filter-policy-version",
-            str(REPOSITORY_FILTER_POLICY_VERSION).encode("ascii"),
-        )
+    hasher = _new_source_fingerprint_hasher(
+        version,
+        selected_source,
+        identity_policy=identity_policy,
+    )
     excluded = _excluded_windows_relative_roots(root_path, exclude_roots)
     file_count = 0
     file_records: list[RepositorySourceFileRecord] = []
@@ -2474,6 +2700,7 @@ def _fingerprint_windows_repository(
             selected,
             root_authority.handle,
             excluded=excluded,
+            selection=selected_source,
             collect_entries=True,
         )
         for entry in initial_scan.entries:
@@ -2497,6 +2724,7 @@ def _fingerprint_windows_repository(
                         expected_root_identity=root_identity,
                         expected_final_identity=_windows_version_identity(metadata),
                         expected_final_link_target=raw_target,
+                        expected_final_reparse_point=entry.windows_reparse_point,
                         api=selected,
                     ) as binding:
                         target_state = (
@@ -2510,6 +2738,7 @@ def _fingerprint_windows_repository(
                                 lexical_identity=_windows_version_identity(metadata),
                                 link_target=raw_target,
                                 target_state=target_state,
+                                windows_reparse_point=entry.windows_reparse_point,
                             )
                         )
                         if binding.is_directory:
@@ -2615,6 +2844,7 @@ def _fingerprint_windows_repository(
             selected,
             root_authority.handle,
             excluded=excluded,
+            selection=selected_source,
             collect_entries=False,
         )
         if (
@@ -2687,6 +2917,12 @@ def _fingerprint_windows_repository(
                 inventory_digest=initial_scan.inventory_digest,
                 inventory_entries=initial_scan.inventory_entries,
                 excluded=excluded,
+                selection=selected_source,
+                source_selection_identity=(
+                    selected_source
+                    if identity_policy is _CURRENT_SOURCE_IDENTITY_POLICY
+                    else None
+                ),
                 root_identity=root_identity,
                 windows_api=selected,
                 windows_authority=retained,
@@ -2713,14 +2949,17 @@ def _fingerprint_repository(
     root: str | Path,
     *,
     exclude_roots: Iterable[str | Path],
+    selection: RepositorySourceSelection,
     version: int,
     retain_binding: bool = False,
     source_owner: Callable[[object], None] | None = None,
+    identity_policy: object = _CURRENT_SOURCE_IDENTITY_POLICY,
 ) -> SourceFingerprint | RepositorySourceBinding:
     """Hash visible repository contents with v2 or the diagnostic v1 format."""
 
     if version not in {1, SOURCE_FINGERPRINT_VERSION}:
         raise ValueError(f"unsupported source fingerprint version: {version}")
+    selected_source = _snapshot_repository_source_selection(selection)
     cleanup_slot: _SourceCleanupSlot | None = None
     if retain_binding:
         cleanup_slot = _SourceCleanupSlot()
@@ -2730,9 +2969,11 @@ def _fingerprint_repository(
         return _fingerprint_windows_repository(
             root,
             exclude_roots=exclude_roots,
+            selection=selected_source,
             version=version,
             retain_binding=retain_binding,
             cleanup_slot=cleanup_slot,
+            identity_policy=identity_policy,
         )
 
     # Do not call Path.resolve() here. A reversible root-to-symlink swap during
@@ -2741,20 +2982,11 @@ def _fingerprint_repository(
     # no-follow descriptor throughout the operation.
     root_path = lexical_repository_path(root)
 
-    hasher = hashlib.sha256()
-    if version == 1:
-        hasher.update(
-            (
-                "codenib-source-fingerprint:1:" f"{REPOSITORY_FILTER_POLICY_VERSION}\0"
-            ).encode("ascii")
-        )
-    else:
-        hasher.update(_V2_MAGIC)
-        _update_frame(
-            hasher,
-            b"filter-policy-version",
-            str(REPOSITORY_FILTER_POLICY_VERSION).encode("ascii"),
-        )
+    hasher = _new_source_fingerprint_hasher(
+        version,
+        selected_source,
+        identity_policy=identity_policy,
+    )
     file_count = 0
     file_records: list[RepositorySourceFileRecord] = []
     link_records: list[_RepositorySourceLinkRecord] = []
@@ -2772,6 +3004,7 @@ def _fingerprint_repository(
         initial_scan = _scan_pinned_repository(
             root_descriptor,
             excluded=excluded,
+            selection=selected_source,
             collect_entries=True,
         )
 
@@ -2915,6 +3148,7 @@ def _fingerprint_repository(
         final_scan = _scan_pinned_repository(
             root_descriptor,
             excluded=excluded,
+            selection=selected_source,
             collect_entries=False,
         )
         if (
@@ -2987,6 +3221,12 @@ def _fingerprint_repository(
                 inventory_digest=initial_scan.inventory_digest,
                 inventory_entries=initial_scan.inventory_entries,
                 excluded=excluded,
+                selection=selected_source,
+                source_selection_identity=(
+                    selected_source
+                    if identity_policy is _CURRENT_SOURCE_IDENTITY_POLICY
+                    else None
+                ),
                 root_identity=root_identity,
                 root_descriptor=retained_descriptor,
                 posix_authority=retained_authority,
@@ -3014,12 +3254,14 @@ def fingerprint_repository(
     root: str | Path,
     *,
     exclude_roots: Iterable[str | Path] = (),
+    selection: RepositorySourceSelection = DEFAULT_REPOSITORY_SOURCE_SELECTION,
 ) -> SourceFingerprint:
-    """Hash visible paths and contents with the canonical v2 framing."""
+    """Hash the selected visible paths and contents with canonical v2 framing."""
 
     result = _fingerprint_repository(
         root,
         exclude_roots=exclude_roots,
+        selection=selection,
         version=SOURCE_FINGERPRINT_VERSION,
     )
     if not isinstance(result, SourceFingerprint):  # pragma: no cover - invariant
@@ -3028,10 +3270,59 @@ def fingerprint_repository(
     return result
 
 
+def _fingerprint_repository_legacy_manifest_v11(
+    root: str | Path,
+    *,
+    exclude_roots: Iterable[str | Path] = (),
+) -> SourceFingerprint:
+    """Recompute the exact policy-3 identity persisted by manifest v1.1.
+
+    This compatibility path intentionally has no selection argument: v1.1
+    encoded the default traversal policy without a source-selection frame.
+    Missing persisted selection must not be interpreted as current policy 4's
+    canonical empty selection.
+    """
+
+    result = _fingerprint_repository(
+        root,
+        exclude_roots=exclude_roots,
+        selection=DEFAULT_REPOSITORY_SOURCE_SELECTION,
+        version=SOURCE_FINGERPRINT_VERSION,
+        identity_policy=_LEGACY_MANIFEST_V11_SOURCE_IDENTITY_POLICY,
+    )
+    if not isinstance(result, SourceFingerprint):  # pragma: no cover - invariant
+        result.close()
+        raise AssertionError("legacy fingerprint retained source authority")
+    return result
+
+
+def _capture_repository_source_legacy_manifest_v11(
+    root: str | Path,
+    *,
+    exclude_roots: Iterable[str | Path] = (),
+    _source_owner: Callable[[object], None] | None = None,
+) -> RepositorySourceBinding:
+    """Retain reads for an exact policy-3 manifest-v1.1 source identity."""
+
+    result = _fingerprint_repository(
+        root,
+        exclude_roots=exclude_roots,
+        selection=DEFAULT_REPOSITORY_SOURCE_SELECTION,
+        version=SOURCE_FINGERPRINT_VERSION,
+        retain_binding=True,
+        source_owner=_source_owner,
+        identity_policy=_LEGACY_MANIFEST_V11_SOURCE_IDENTITY_POLICY,
+    )
+    if not isinstance(result, RepositorySourceBinding):  # pragma: no cover
+        raise AssertionError("legacy source capture did not retain read authority")
+    return result
+
+
 def capture_repository_source(
     root: str | Path,
     *,
     exclude_roots: Iterable[str | Path] = (),
+    selection: RepositorySourceSelection = DEFAULT_REPOSITORY_SOURCE_SELECTION,
     _source_owner: Callable[[object], None] | None = None,
 ) -> RepositorySourceBinding:
     """Capture source fingerprint v2 and retain its exact read authority.
@@ -3044,6 +3335,7 @@ def capture_repository_source(
     result = _fingerprint_repository(
         root,
         exclude_roots=exclude_roots,
+        selection=selection,
         version=SOURCE_FINGERPRINT_VERSION,
         retain_binding=True,
         source_owner=_source_owner,
@@ -3057,6 +3349,7 @@ def fingerprint_repository_v1_for_diagnostics(
     root: str | Path,
     *,
     exclude_roots: Iterable[str | Path] = (),
+    selection: RepositorySourceSelection = DEFAULT_REPOSITORY_SOURCE_SELECTION,
 ) -> SourceFingerprint:
     """Reproduce legacy v1 solely for migration diagnostics.
 
@@ -3064,7 +3357,12 @@ def fingerprint_repository_v1_for_diagnostics(
     must never authorize source reads, native indexes, or artifact reuse.
     """
 
-    result = _fingerprint_repository(root, exclude_roots=exclude_roots, version=1)
+    result = _fingerprint_repository(
+        root,
+        exclude_roots=exclude_roots,
+        selection=selection,
+        version=1,
+    )
     if not isinstance(result, SourceFingerprint):  # pragma: no cover - invariant
         result.close()
         raise AssertionError("diagnostic fingerprint retained source authority")
@@ -3075,6 +3373,7 @@ def repository_source_is_dirty(
     root: str | Path,
     *,
     exclude_roots: Iterable[str | Path] = (),
+    selection: RepositorySourceSelection = DEFAULT_REPOSITORY_SOURCE_SELECTION,
 ) -> bool:
     """Return whether Git reports source-visible worktree changes.
 
@@ -3087,6 +3386,7 @@ def repository_source_is_dirty(
     # query and incorrectly authorize an incremental update for another tree.
     root_path = lexical_repository_path(root)
     excluded = tuple(lexical_repository_path(path) for path in exclude_roots)
+    selected = _snapshot_repository_source_selection(selection)
     try:
         result = subprocess.run(
             [
@@ -3127,7 +3427,7 @@ def repository_source_is_dirty(
             absolute = root_path / relative
             if any(absolute == path or path in absolute.parents for path in excluded):
                 continue
-            if repository_path_is_visible(relative):
+            if repository_path_is_visible(relative, selection=selected):
                 return True
     return False
 

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -34,6 +34,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response
 
 from ..log_utils import get_logger
+from ..repository_filters import repository_path_is_visible
+from ..repository_source_selection import RepositorySourceSelection
 from ..wiki import WikiBuilder
 from ..wiki.media_generation import (
     image_generator_from_config,
@@ -45,7 +47,7 @@ from .config import load_config
 from .native_authority import authorize_local_manifest_vector
 from .ports import argparse_tcp_port
 from .repo_registry import RepoRegistry
-from .repository_files import live_source_slice
+from .repository_files import bound_source_slice
 from .request_limits import RequestBodyLimitMiddleware
 from .schemas import (
     ChatRequest,
@@ -62,6 +64,35 @@ _WIKI_MEDIA_TYPES = {
 }
 
 logger = get_logger(__name__)
+
+
+def _manifest_source_selection(bundle) -> RepositorySourceSelection:
+    """Return the current persisted selection, defaulting legacy manifests."""
+
+    selection = getattr(getattr(bundle, "manifest", None), "source_selection", None)
+    return (
+        selection
+        if type(selection) is RepositorySourceSelection
+        else RepositorySourceSelection()
+    )
+
+
+def _historical_source_slice(
+    bundle,
+    source_fn,
+    commit: str,
+    file: str,
+    start: int | None,
+    end: int | None,
+):
+    """Gate a Git-backed historical read with the active manifest policy."""
+
+    if not repository_path_is_visible(
+        file,
+        selection=_manifest_source_selection(bundle),
+    ):
+        return None
+    return source_fn(commit, file, start, end)
 
 
 def _wiki_llm(config, *, model=None, max_tokens=4096):
@@ -93,10 +124,10 @@ def _wiki_narrator(config):
 async def lifespan(app: FastAPI):
     config = load_config()
     # The production service is the local administrator boundary: it verifies
-    # source fingerprint v2 and the exact captured vector tree through this
-    # injected resolver. RepoRegistry itself remains unable to mint authority.
-    # Sparse mode never invokes the resolver and therefore performs no extra
-    # source capture.
+    # source fingerprint v2 and the exact captured vector tree through the
+    # injected native-index resolver. RepoRegistry separately retains the
+    # manifest-selected repository source authority used by every current-tree
+    # Web and Wiki read.
     registry = RepoRegistry(
         config,
         native_index_authorization_resolver=authorize_local_manifest_vector,
@@ -106,23 +137,26 @@ async def lifespan(app: FastAPI):
         # source-bound capability is present.
         allow_missing_native_index_authorization=True,
     )
-    logger.info("Loading QA repos from %s ...", config.registry_path)
-    registry.load_all()
-    app.state.registry = registry
-    app.state.wiki_builders = {}
-    app.state.edge_labelers = {}
-    app.state.commit_windows = {}
-    # Shared LLM narrator for DeepWiki-style prose; cached on disk, fails soft
-    # to templated text when no model/creds are available.
-    app.state.narrator = _wiki_narrator(config)
-    logger.info(
-        "Wiki narrator: model=%s enabled=%s cache=%s",
-        app.state.narrator.model,
-        app.state.narrator.enabled,
-        app.state.narrator.cache_dir,
-    )
-    logger.info("Ready: %d repo(s) available", len(registry.list_infos()))
-    yield
+    try:
+        logger.info("Loading QA repos from %s ...", config.registry_path)
+        registry.load_all()
+        app.state.registry = registry
+        app.state.wiki_builders = {}
+        app.state.edge_labelers = {}
+        app.state.commit_windows = {}
+        # Shared LLM narrator for DeepWiki-style prose; cached on disk, fails soft
+        # to templated text when no model/creds are available.
+        app.state.narrator = _wiki_narrator(config)
+        logger.info(
+            "Wiki narrator: model=%s enabled=%s cache=%s",
+            app.state.narrator.model,
+            app.state.narrator.enabled,
+            app.state.narrator.cache_dir,
+        )
+        logger.info("Ready: %d repo(s) available", len(registry.list_infos()))
+        yield
+    finally:
+        registry.close()
 
 
 app = FastAPI(title="CodeNib Code QA", lifespan=lifespan)
@@ -280,14 +314,24 @@ def _edge_labeler(repo_id: str, commit: str | None = None):
         entry = window.resolve(commit) if window.available else None
         if entry is not None:
             source_commit = str(entry.get("sha") or "")
-            source_fn = partial(window.source_for, source_commit)
+            source_fn = partial(
+                _historical_source_slice,
+                bundle,
+                window.source_for,
+                source_commit,
+            )
         elif commit.strip().lower() not in {
             base_commit.lower(),
             base_commit[:8].lower(),
         }:
             raise ValueError(f"unknown commit for repository: {commit}")
     if source_fn is None:
-        source_fn = partial(live_source_slice, bundle.entry.repo_dir)
+        source_reader = getattr(bundle, "source_reader", None)
+        source_fn = (
+            partial(bound_source_slice, source_reader)
+            if source_reader is not None
+            else lambda *_args, **_kwargs: None
+        )
 
     cache_key = f"{repo_id}@{source_commit}"
     if cache_key not in cache:
@@ -474,6 +518,7 @@ async def wiki_page_graph(repo_id: str, page_id: str) -> dict:
         citations,
         repo_dir=bundle.entry.repo_dir,
         hierarchy_graph=hierarchy_graph,
+        source_reader=bundle.source_reader,
     )
 
 
@@ -493,7 +538,13 @@ async def source(
         entry = window.resolve(commit) if window.available else None
         if entry is not None:
             result = await asyncio.to_thread(
-                window.source_for, commit, file, start, end
+                _historical_source_slice,
+                bundle,
+                window.source_for,
+                commit,
+                file,
+                start,
+                end,
             )
         else:
             base = str(bundle.entry.base_commit or "")
@@ -503,13 +554,17 @@ async def source(
                     status_code=404,
                     detail=f"Unknown commit for this repo: {commit!r}",
                 )
-            result = await asyncio.to_thread(
-                live_source_slice, bundle.entry.repo_dir, file, start, end
-            )
+            source_reader = getattr(bundle, "source_reader", None)
+            if source_reader is not None:
+                result = await asyncio.to_thread(
+                    bound_source_slice, source_reader, file, start, end
+                )
     else:
-        result = await asyncio.to_thread(
-            live_source_slice, bundle.entry.repo_dir, file, start, end
-        )
+        source_reader = getattr(bundle, "source_reader", None)
+        if source_reader is not None:
+            result = await asyncio.to_thread(
+                bound_source_slice, source_reader, file, start, end
+            )
     if result is None:
         raise HTTPException(status_code=404, detail=f"File not found: {file!r}")
     return result
@@ -595,6 +650,12 @@ async def codemap(
         repo_dir=bundle.entry.repo_dir,
         repo_commit=selected_commit if loaded_from_window else None,
         hierarchy_graph=hierarchy_graph,
+        source_reader=(
+            None if loaded_from_window else getattr(bundle, "source_reader", None)
+        ),
+        source_selection=(
+            _manifest_source_selection(bundle) if loaded_from_window else None
+        ),
     )
     # Let the client confirm which snapshot it is looking at. ``fell_back``
     # marks the case where a window exists but its snapshot could not be served,
@@ -667,6 +728,12 @@ async def modulemap(
         repo_dir=bundle.entry.repo_dir,
         include_tests=include_tests,
         repo_commit=selected_commit if loaded_from_window else None,
+        source_reader=(
+            None if loaded_from_window else getattr(bundle, "source_reader", None)
+        ),
+        source_selection=(
+            _manifest_source_selection(bundle) if loaded_from_window else None
+        ),
     )
     if isinstance(result, dict):
         result["commit"] = selected_commit
@@ -735,11 +802,17 @@ async def chat(req: ChatRequest) -> ChatResponse:
         logger.error("agent run failed for %r: %s", req.repo_id, exc, exc_info=True)
         raise HTTPException(status_code=500, detail="agent run failed") from exc
 
+    source_reader = getattr(bundle, "source_reader", None)
+    if source_reader is None:
+        raise HTTPException(
+            status_code=503,
+            detail="authenticated repository source is unavailable",
+        )
     return await asyncio.to_thread(
         agent_result_to_response,
         result,
         repo_path=getattr(bundle.entry, "repo_dir", ""),
-        repo_commit=getattr(bundle.entry, "base_commit", ""),
+        source_reader=source_reader,
     )
 
 

--- a/codenib/web/codemap.py
+++ b/codenib/web/codemap.py
@@ -21,7 +21,17 @@ import os
 import re
 from collections import deque
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Set, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+)
 
 from ..graph.code_graph import CodeGraph
 from ..graph.hierarchy import (
@@ -32,6 +42,7 @@ from ..graph.hierarchy import (
     hierarchy_from_view_nodes,
 )
 from ..graph.traverse_graph import RepoDependencySearcher
+from ..repository_filters import repository_path_is_visible
 from ..types import NODE_TYPE_FILE
 from ..utils import (
     file_has_generated_marker,
@@ -50,6 +61,7 @@ from .repository_files import (
 )
 
 if TYPE_CHECKING:
+    from ..repository_source_selection import RepositorySourceSelection
     from ..source_fingerprint import RepositorySourceReader
 
 # Node types eligible as a focus / default seed (skip file/dir/import nodes).
@@ -406,6 +418,7 @@ def _default_seed(
     graph: CodeGraph,
     derived: Optional[_DerivedFiles] = None,
     entry_paths: Optional[Sequence[str]] = None,
+    source_allowed: Optional[Callable[[Dict[str, Any]], bool]] = None,
 ) -> Optional[str]:
     """The symbol a reader should land on, best-first.
 
@@ -442,6 +455,8 @@ def _default_seed(
     for vertex in g.vs:
         a = vertex.attributes()
         if not a.get("unified_name") or a.get("type") not in _SYMBOL_TYPES:
+            continue
+        if source_allowed is not None and not source_allowed(a):
             continue
         name = a["name"]
         path = a.get("file") or name
@@ -671,6 +686,9 @@ def build_codemap(
     repo_dir: Optional[str] = None,
     repo_commit: Optional[str] = None,
     hierarchy_graph: Optional[HierarchicalCodeGraph] = None,
+    *,
+    source_reader: Optional[RepositorySourceReader] = None,
+    source_selection: Optional[RepositorySourceSelection] = None,
 ) -> Dict[str, Any]:
     """Return a dependency subgraph + Mermaid rendering around *symbol*.
 
@@ -687,23 +705,78 @@ def build_codemap(
     max_nodes = max(2, min(int(max_nodes), 120))
     note = ""
 
-    derived = _DerivedFiles(repo_dir, repo_commit)
+    def selected_source_path(value: object) -> Optional[str]:
+        if not isinstance(value, str) or not value:
+            return None
+        if source_reader is not None:
+            return source_reader.captured_relative_path(value)
+        if source_selection is None:
+            return value
+        relative = (
+            safe_repo_relative_path(repo_dir, value)
+            if repo_dir
+            else value.replace("\\", "/")
+        )
+        if relative is None or not repository_path_is_visible(
+            relative,
+            selection=source_selection,
+        ):
+            return None
+        return relative
+
+    policy_bound = source_reader is not None or source_selection is not None
+
+    def source_allowed(attrs: Dict[str, Any]) -> bool:
+        value = attrs.get("file")
+        return (
+            not isinstance(value, str)
+            or not value
+            or selected_source_path(value) is not None
+        )
+
+    def selected_edge_metadata(meta: Any) -> Any:
+        if not policy_bound or not isinstance(meta, dict):
+            return meta
+        anchor_file = meta.get("anchor_file")
+        if not anchor_file:
+            return meta
+        relative = selected_source_path(anchor_file)
+        if relative is None:
+            return None
+        selected = dict(meta)
+        selected["anchor_file"] = relative
+        return selected
+
+    derived = _DerivedFiles(
+        repo_dir,
+        repo_commit,
+        source_reader=source_reader,
+    )
     # Resolve a historical tree once for this request. The tiny process cache
     # is only a cross-request optimization and may be evicted by concurrent
     # maps; per-node classification must not depend on it staying hot.
     repo_paths: object = _GIT_PATHS_UNSET
-    if repo_dir and valid_commit(repo_commit):
+    if source_reader is None and repo_dir and valid_commit(repo_commit):
         repo_paths = git_tree_paths(os.path.realpath(repo_dir), str(repo_commit))
     # Entry-point discovery currently reads manifests from a checkout. Historical
     # graph requests must not borrow declarations from a different commit.
     entry_paths = (
-        [] if repo_commit else [entry.path for entry in discover_entry_points(repo_dir)]
+        []
+        if repo_commit or source_reader is not None
+        else [entry.path for entry in discover_entry_points(repo_dir)]
     )
     root = _resolve(graph, symbol) if symbol else None
+    if root is not None and not source_allowed(_attrs(graph, root)):
+        root = None
     if symbol and root is None:
         note = f"Symbol {symbol!r} not found — showing the repo's entry point."
     if root is None:
-        root = _default_seed(graph, derived, entry_paths)
+        root = _default_seed(
+            graph,
+            derived,
+            entry_paths,
+            source_allowed=source_allowed if policy_bound else None,
+        )
     if root is None:
         return {
             "available": False,
@@ -744,9 +817,19 @@ def build_codemap(
         # batch from the first scan only; CodeGraph already makes those anchors
         # distinct at insertion time.
         new_edge_keys: Set[Tuple[str, str]] = set()
+        admitted_neighbors: Set[str] = set()
         for src, tgt, _w, meta in n_edges:
             if src == tgt:
                 continue  # drop self-loops (recursion) — visual noise
+            if policy_bound and (
+                not source_allowed(_attrs(graph, src))
+                or not source_allowed(_attrs(graph, tgt))
+            ):
+                continue
+            meta = selected_edge_metadata(meta)
+            if meta is None:
+                continue
+            admitted_neighbors.update((src, tgt))
             key = (src, tgt)
             if key not in edge_seen:
                 edge_seen.add(key)
@@ -756,6 +839,10 @@ def build_codemap(
                 edge_anchors.add(key, meta)
         for nb in neighbors:
             if nb in seen:
+                continue
+            if policy_bound and (
+                nb not in admitted_neighbors or not source_allowed(_attrs(graph, nb))
+            ):
                 continue
             if len(seen) >= max_nodes:
                 truncated = True
@@ -778,7 +865,11 @@ def build_codemap(
                 "name": name,
                 "label": label,
                 "short": _short(label),
-                "file": a.get("file"),
+                "file": (
+                    selected_source_path(a.get("file"))
+                    if policy_bound
+                    else a.get("file")
+                ),
                 "line": (start + 1) if isinstance(start, int) else None,
                 "end_line": (
                     (a.get("end_line") + 1)
@@ -793,6 +884,7 @@ def build_codemap(
                     repo_dir,
                     repo_commit,
                     repo_paths=repo_paths,
+                    source_reader=source_reader,
                 ),
             }
         )
@@ -935,6 +1027,36 @@ def build_page_subgraph(
     max_nodes = max(2, min(int(max_nodes), 40))
     g = graph.get_graph()
 
+    def selected_source_path(value: object) -> Optional[str]:
+        if not isinstance(value, str) or not value:
+            return None
+        if source_reader is None:
+            return value
+        return source_reader.captured_relative_path(value)
+
+    def source_allowed(name: str) -> bool:
+        if source_reader is None:
+            return True
+        value = _attrs(graph, name).get("file")
+        return (
+            not isinstance(value, str)
+            or not value
+            or selected_source_path(value) is not None
+        )
+
+    def selected_edge_metadata(meta: Any) -> Any:
+        if source_reader is None or not isinstance(meta, dict):
+            return meta
+        anchor_file = meta.get("anchor_file")
+        if not anchor_file:
+            return meta
+        relative = selected_source_path(anchor_file)
+        if relative is None:
+            return None
+        selected = dict(meta)
+        selected["anchor_file"] = relative
+        return selected
+
     # Location + name index for resolving citations precisely (built once).
     by_loc: Dict[Tuple[str, int], str] = {}
     by_file: Dict[str, List[Tuple[int, str]]] = {}
@@ -944,8 +1066,10 @@ def build_page_subgraph(
         s = a.get("start_line")
         if not f or not isinstance(s, int) or not a.get("unified_name"):
             continue
-        normalized_file = f
-        if repo_dir and os.path.isabs(f):
+        normalized_file = selected_source_path(f)
+        if normalized_file is None:
+            continue
+        if source_reader is None and repo_dir and os.path.isabs(f):
             try:
                 relative = os.path.relpath(f, repo_dir)
                 if relative != ".." and not relative.startswith("../"):
@@ -958,8 +1082,14 @@ def build_page_subgraph(
     names: List[str] = []
     chosen: Set[str] = set()
     for cit in citations:
+        if source_reader is not None:
+            citation_file = selected_source_path(cit.get("file"))
+            if citation_file is None:
+                continue
+            cit = dict(cit)
+            cit["file"] = citation_file
         nm = _resolve_citation(graph, cit, by_loc, by_file, repo_dir)
-        if nm and nm not in chosen:
+        if nm and source_allowed(nm) and nm not in chosen:
             chosen.add(nm)
             names.append(nm)
         if len(names) >= max_nodes:
@@ -1008,6 +1138,11 @@ def build_page_subgraph(
         new_anchor_keys: Set[Tuple[str, str]] = set()
         for src, tgt, _w, meta in n_edges:
             if src == tgt:
+                continue
+            if not source_allowed(src) or not source_allowed(tgt):
+                continue
+            meta = selected_edge_metadata(meta)
+            if meta is None:
                 continue
             key = (src, tgt)
             if key not in anchor_edges_seen:
@@ -1083,6 +1218,11 @@ def build_page_subgraph(
         for src, tgt, _w, meta in n_edges:
             if src == tgt or src not in nameset or tgt not in nameset:
                 continue
+            if not source_allowed(src) or not source_allowed(tgt):
+                continue
+            meta = selected_edge_metadata(meta)
+            if meta is None:
+                continue
             key = (src, tgt)
             touches_seed = src in seeds or tgt in seeds
             if not touches_seed:
@@ -1105,7 +1245,9 @@ def build_page_subgraph(
         label = _label(a, name)
         start = a.get("start_line")
         file = a.get("file")
-        if repo_dir and isinstance(file, str) and os.path.isabs(file):
+        if source_reader is not None and isinstance(file, str):
+            file = selected_source_path(file)
+        elif repo_dir and isinstance(file, str) and os.path.isabs(file):
             try:
                 relative = os.path.relpath(file, repo_dir)
                 if relative != ".." and not relative.startswith("../"):

--- a/codenib/web/local.py
+++ b/codenib/web/local.py
@@ -17,10 +17,13 @@ from typing import Any, Mapping
 import yaml
 
 from ..compiler.manifest import RepoManifest
+from ..compiler.manifest_source import (
+    capture_repository_source_for_manifest as capture_repository_source,
+)
+from ..compiler.manifest_source import require_manifest_source_identity
 from ..compiler.snapshot_store import normalize_repo
 from ..llm.options import validate_model_options
 from ..source_fingerprint import (
-    capture_repository_source,
     is_secure_source_fingerprint_v2,
     lexical_repository_path,
 )
@@ -107,14 +110,16 @@ def prepare_local_wiki(
     try:
         source_binding = capture_repository_source(
             repo_path,
+            manifest=manifest,
             exclude_roots=(manifest_path.parent,),
             _source_owner=cleanup_owner.retain,
         )
-        if (
-            source_binding.fingerprint != manifest.source_fingerprint
-            or source_binding.file_count != manifest.file_count
-        ):
-            raise ValueError("repository source content does not match the manifest")
+        require_manifest_source_identity(
+            source_binding.authenticated_identity_snapshot(),
+            manifest,
+            label="local wiki repository",
+            mismatch_message=("repository source content does not match the manifest"),
+        )
     except BaseException as primary:  # noqa: B036 - preserve validation fault
         try:
             cleanup_owner.close()

--- a/codenib/web/modulemap.py
+++ b/codenib/web/modulemap.py
@@ -30,13 +30,30 @@ frontend can reuse its renderers.
 from __future__ import annotations
 
 from collections import Counter, defaultdict, deque
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+)
 
 from ..graph.code_graph import CodeGraph
+from ..repository_filters import repository_path_is_visible
 from ..types import NODE_TYPE_FILE
 from ..utils import is_test_file
 from .codemap import EDGE_ANCHOR_SAMPLE, _DerivedFiles
 from .entrypoints import discover_entry_points
+from .repository_files import safe_repo_relative_path
+
+if TYPE_CHECKING:
+    from ..repository_source_selection import RepositorySourceSelection
+    from ..source_fingerprint import RepositorySourceReader
 
 # Symbols that can carry a file attribution (excludes file/directory/root nodes).
 _SYMBOL_TYPES = frozenset({"function", "method", "class", "field", "symbol"})
@@ -102,6 +119,7 @@ def _project(
     granularity: str,
     derived: _DerivedFiles,
     include_tests: bool,
+    selected_source_path: Callable[[object], Optional[str]],
 ) -> _Projection:
     """Aggregate symbol references into module-to-module dependencies."""
     projection = _Projection()
@@ -110,16 +128,19 @@ def _project(
     module_of_vertex: Dict[int, str] = {}
     seen_files: Dict[str, Optional[str]] = {}
     for index, file_path, is_symbol in _attributed_vertices(graph):
-        if file_path not in seen_files:
-            if not include_tests and is_test_file(file_path):
-                seen_files[file_path] = None
+        selected_path = selected_source_path(file_path)
+        if selected_path is None:
+            continue
+        if selected_path not in seen_files:
+            if not include_tests and is_test_file(selected_path):
+                seen_files[selected_path] = None
                 projection.skipped_tests += 1
-            elif derived(file_path):
-                seen_files[file_path] = None
+            elif derived(selected_path):
+                seen_files[selected_path] = None
                 projection.skipped_derived += 1
             else:
-                seen_files[file_path] = _module_of(file_path, granularity)
-        module = seen_files[file_path]
+                seen_files[selected_path] = _module_of(selected_path, granularity)
+        module = seen_files[selected_path]
         if module is None:
             continue
         module_of_vertex[index] = module
@@ -137,16 +158,19 @@ def _project(
         if source is None or target is None or source == target:
             continue
         key = (source, target)
+        anchor_file = edge.attributes().get("anchor_file")
+        selected_anchor = selected_source_path(anchor_file) if anchor_file else None
+        if anchor_file and selected_anchor is None:
+            continue
         projection.pairs[key].add(
             (g.vs[edge.source]["name"], g.vs[edge.target]["name"])
         )
         projection.anchor_total[key] += 1
-        anchor_file = edge.attributes().get("anchor_file")
-        if anchor_file and len(projection.anchors[key]) < EDGE_ANCHOR_SAMPLE:
+        if selected_anchor and len(projection.anchors[key]) < EDGE_ANCHOR_SAMPLE:
             anchor_line = edge.attributes().get("anchor_line")
             # anchor_line is 0-based (tree-sitter/LSP); expose 1-based.
             entry = {
-                "file": anchor_file,
+                "file": selected_anchor,
                 "line": (anchor_line + 1) if isinstance(anchor_line, int) else None,
             }
             if entry not in projection.anchors[key]:
@@ -177,16 +201,25 @@ def _attributed_vertices(graph: CodeGraph) -> Iterator[Tuple[int, str, bool]]:
 
 
 def _resolve_granularity(
-    graph: CodeGraph, granularity: str, derived: _DerivedFiles, include_tests: bool
+    graph: CodeGraph,
+    granularity: str,
+    derived: _DerivedFiles,
+    include_tests: bool,
+    selected_source_path: Callable[[object], Optional[str]],
 ) -> str:
     """Resolve ``auto`` by counting the repo's own source files."""
     if granularity in ("file", "directory"):
         return granularity
     files: Set[str] = set()
     for _index, file_path, _is_symbol in _attributed_vertices(graph):
-        if (not include_tests and is_test_file(file_path)) or derived(file_path):
+        selected_path = selected_source_path(file_path)
+        if selected_path is None:
             continue
-        files.add(file_path)
+        if (not include_tests and is_test_file(selected_path)) or derived(
+            selected_path
+        ):
+            continue
+        files.add(selected_path)
         if len(files) > _AUTO_FILE_LIMIT:
             return "directory"
     return "file"
@@ -471,6 +504,9 @@ def build_modulemap(
     repo_dir: Optional[str] = None,
     include_tests: bool = False,
     repo_commit: Optional[str] = None,
+    *,
+    source_reader: Optional[RepositorySourceReader] = None,
+    source_selection: Optional[RepositorySourceSelection] = None,
 ) -> Dict[str, Any]:
     """Return the repo's module dependency graph, projected from symbol references.
 
@@ -488,11 +524,53 @@ def build_modulemap(
     granularity = granularity if granularity in GRANULARITIES else "auto"
     depth = max(1, min(int(depth), 4))
     max_nodes = max(2, min(int(max_nodes), 200))
-    derived = _DerivedFiles(repo_dir, repo_commit)
-    # Historical graphs cannot use manifest data from the current checkout.
-    entries = [] if repo_commit else discover_entry_points(repo_dir)
-    resolved = _resolve_granularity(graph, granularity, derived, include_tests)
-    projection = _project(graph, resolved, derived, include_tests)
+
+    def selected_source_path(value: object) -> Optional[str]:
+        if not isinstance(value, str) or not value:
+            return None
+        if source_reader is not None:
+            return source_reader.captured_relative_path(value)
+        if source_selection is None:
+            return value
+        relative = (
+            safe_repo_relative_path(repo_dir, value)
+            if repo_dir
+            else value.replace("\\", "/")
+        )
+        if relative is None or not repository_path_is_visible(
+            relative,
+            selection=source_selection,
+        ):
+            return None
+        return relative
+
+    derived = _DerivedFiles(
+        repo_dir,
+        repo_commit,
+        source_reader=source_reader,
+    )
+    # Historical graphs cannot use manifest data from the current checkout,
+    # and a bound current view must not rediscover entry points through ambient
+    # filesystem reads outside its authenticated source inventory.
+    entries = (
+        []
+        if repo_commit or source_reader is not None
+        else discover_entry_points(repo_dir)
+    )
+    resolved = _resolve_granularity(
+        graph,
+        granularity,
+        derived,
+        include_tests,
+        selected_source_path,
+    )
+    projection = _project(
+        graph,
+        resolved,
+        derived,
+        include_tests,
+        selected_source_path,
+    )
     candidates = projection.degree()
 
     if not candidates:

--- a/codenib/web/native_authority.py
+++ b/codenib/web/native_authority.py
@@ -16,13 +16,16 @@ from ..artifacts.runtime import (
 )
 from ..compiler.cache_lock import COMPILER_CACHE_LOCK_FILENAME, compiler_cache_lock
 from ..compiler.manifest import IndexEntry, RepoManifest
+from ..compiler.manifest_source import (
+    capture_repository_source_for_manifest as capture_repository_source,
+)
+from ..compiler.manifest_source import require_manifest_source_identity
 from ..index.embedding.artifact_integrity import capture_authenticated_vector_view
 from ..native_index_authorization import (
     NativeIndexAuthorization,
     _mint_trusted_local_admin_authorization,
 )
 from ..source_fingerprint import (
-    capture_repository_source,
     is_secure_source_fingerprint_v2,
     lexical_repository_path,
 )
@@ -49,9 +52,13 @@ def _require_same_vector_manifest(
 
     observed_vector = observed.indexes.get("vector")
     if (
-        observed.repo_path != expected.repo_path
+        observed.version != expected.version
+        or observed.repo_path != expected.repo_path
         or observed.commit != expected.commit
         or observed.source_fingerprint != expected.source_fingerprint
+        or observed.source_selection != expected.source_selection
+        or observed.last_indexed_source_selection_digest
+        != expected.last_indexed_source_selection_digest
         or observed.file_count != expected.file_count
         or observed_vector != expected_vector
         or not observed.index_is_current("vector")
@@ -140,16 +147,18 @@ def authorize_local_manifest_vector(
         try:
             source_binding = capture_repository_source(
                 repo_path,
+                manifest=manifest,
                 exclude_roots=_manifest_source_exclusions(repo_path, manifest_path),
                 _source_owner=cleanup_owner.retain,
             )
-            if (
-                source_binding.fingerprint != manifest.source_fingerprint
-                or source_binding.file_count != manifest.file_count
-            ):
-                raise ValueError(
+            require_manifest_source_identity(
+                source_binding.authenticated_identity_snapshot(),
+                manifest,
+                label="native vector repository",
+                mismatch_message=(
                     "repository source content does not match the vector manifest"
-                )
+                ),
+            )
 
             with capture_authenticated_vector_view(vector_entry.path) as vector_view:
                 authorization = _mint_trusted_local_admin_authorization(

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -25,6 +25,7 @@ from ..compiler.manifest import IndexEntry, RepoManifest
 from ..index.embedding._lifecycle import close_vector_after_failure
 from ..log_utils import get_logger
 from ..provider_routes import normalize_endpoint, resolve_embedding_artifact_route
+from ..repository_source_selection import RepositorySourceSelection
 from ..repository_summary import read_bound_repository_summary, read_repository_summary
 from ..source_fingerprint import is_secure_source_fingerprint_v2
 from .config import QAConfig, RepoEntry, load_registry
@@ -37,7 +38,7 @@ if TYPE_CHECKING:
     from ..index.sparse_idx.bm25_index import BM25CodeIndexer
     from ..llm.litellm_chat import LiteLLMChat
     from ..native_index_authorization import NativeIndexAuthorization
-    from ..source_fingerprint import RepositorySourceReader
+    from ..source_fingerprint import RepositorySourceBinding, RepositorySourceReader
 
 logger = get_logger(__name__)
 
@@ -103,6 +104,46 @@ def _ask_llm_type():
     from ..llm.litellm_chat import LiteLLMChat
 
     return LiteLLMChat
+
+
+def _manifest_requires_authenticated_source(manifest: Any) -> bool:
+    """Whether a persisted current-era manifest forbids live-source fallback."""
+
+    return type(
+        getattr(manifest, "source_selection", None)
+    ) is RepositorySourceSelection and bool(getattr(manifest, "source_fingerprint", ""))
+
+
+def _require_authenticated_source_paths(
+    paths: Any,
+    source_reader: "RepositorySourceReader",
+    *,
+    subject: str,
+) -> None:
+    """Reject persisted view paths absent from the authenticated source set."""
+
+    for path in paths:
+        if (
+            not isinstance(path, str)
+            or source_reader.captured_relative_path(path) is None
+        ):
+            raise ValueError(
+                f"{subject} contains a source path outside the authenticated "
+                f"repository: {path!r}"
+            )
+
+
+def _require_authenticated_documents(
+    documents: Any,
+    source_reader: "RepositorySourceReader",
+    *,
+    subject: str,
+) -> None:
+    paths = []
+    for document in documents or ():
+        metadata = getattr(document, "metadata", None)
+        paths.append(metadata.get("file") if isinstance(metadata, dict) else None)
+    _require_authenticated_source_paths(paths, source_reader, subject=subject)
 
 
 @dataclass
@@ -320,6 +361,13 @@ class RepoBundle:
 
     def code_graph(self) -> Optional[CodeGraph]:
         """Lazily load + cache the repo's symbol graph (None if unavailable)."""
+        if self.source_reader is None and _manifest_requires_authenticated_source(
+            self.manifest
+        ):
+            self._code_graph_error = (
+                "manifest-selected repository has no authenticated source reader"
+            )
+            return None
         if getattr(self, "_code_graph_loaded", False):
             return self._code_graph
         self._code_graph_loaded = True
@@ -328,10 +376,23 @@ class RepoBundle:
         path = self._graph_path()
         if path is None:
             return None
+        graph_entry = self.manifest.indexes.get("symbol_graph")
+        if graph_entry is None or not self._view_is_current(graph_entry):
+            self._code_graph_error = (
+                "symbol graph has no current manifest-bound artifact entry"
+            )
+            return None
         try:
-            from ..graph.code_graph import CodeGraph
+            from ..compiler.artifact_quality import graph_source_paths
+            from ..compiler.graph_artifact import load_authenticated_graph_artifact
 
-            self._code_graph = CodeGraph.load_graph(path)
+            self._code_graph = load_authenticated_graph_artifact(graph_entry)
+            if self.source_reader is not None:
+                _require_authenticated_source_paths(
+                    graph_source_paths(self._code_graph),
+                    self.source_reader,
+                    subject="symbol graph",
+                )
             logger.info(
                 "codemap: loaded symbol graph for %r (%s)", self.entry.instance_id, path
             )
@@ -394,6 +455,10 @@ class RepoBundle:
 
     def hierarchical_graph(self):
         """Lazily build + cache the repo-level compound graph for CodeGraph UI."""
+        if self.source_reader is None and _manifest_requires_authenticated_source(
+            self.manifest
+        ):
+            return None
         if getattr(self, "_hierarchical_graph_loaded", False):
             return self._hierarchical_graph
         self._hierarchical_graph_loaded = True
@@ -452,11 +517,12 @@ class RepoBundle:
         cached = getattr(self, "_description_cache", None)
         if cached is not None:
             return cached
-        desc = (
-            read_bound_repository_summary(self.source_reader)
-            if self.source_reader is not None
-            else read_repository_summary(self.entry.repo_dir)
-        )
+        if self.source_reader is not None:
+            desc = read_bound_repository_summary(self.source_reader)
+        elif _manifest_requires_authenticated_source(self.manifest):
+            desc = ""
+        else:
+            desc = read_repository_summary(self.entry.repo_dir)
         self._description_cache = desc
         return desc
 
@@ -496,6 +562,8 @@ class RepoRegistry:
             allow_missing_native_index_authorization
         )
         self._bundles: Dict[str, RepoBundle] = {}
+        self._source_bindings: Dict[str, "RepositorySourceBinding"] = {}
+        self._source_cleanup_owners: Dict[str, Any] = {}
         # One embedding model per model name, shared across repos: the GPU model
         # is loaded once instead of once per CodeVectorStore (one per repo).
         self._embeddings: Dict[Tuple[str, str, int, Optional[str], str], object] = {}
@@ -503,6 +571,8 @@ class RepoRegistry:
 
     def load_all(self) -> None:
         """Load every dataset repo in the registry whose manifest exists."""
+        if self._bundles or self._source_cleanup_owners:
+            self.close()
         entries = load_registry(self._config.registry_path)
         if not entries:
             logger.warning(
@@ -510,31 +580,141 @@ class RepoRegistry:
                 self._config.registry_path,
             )
             return
-        for entry in entries:
-            if not os.path.exists(entry.manifest_path):
-                logger.warning(
-                    "Skipping %r: manifest not found at %s",
-                    entry.instance_id,
-                    entry.manifest_path,
-                )
-                continue
+        try:
+            for entry in entries:
+                if not os.path.exists(entry.manifest_path):
+                    logger.warning(
+                        "Skipping %r: manifest not found at %s",
+                        entry.instance_id,
+                        entry.manifest_path,
+                    )
+                    continue
+                try:
+                    self._bundles[entry.instance_id] = self._load_repo_metadata(entry)
+                    logger.info("Registered %r (%s)", entry.instance_id, entry.repo)
+                except Exception as exc:  # noqa: BLE001 - keep other repos alive
+                    logger.error(
+                        "Failed to load %r: %s",
+                        entry.instance_id,
+                        exc,
+                        exc_info=True,
+                    )
+        except BaseException as primary:  # noqa: B036 - cancellation cleanup
             try:
-                self._bundles[entry.instance_id] = self._load_repo_metadata(entry)
-                logger.info("Registered %r (%s)", entry.instance_id, entry.repo)
-            except Exception as exc:  # noqa: BLE001 - keep other repos alive
-                logger.error(
-                    "Failed to load %r: %s", entry.instance_id, exc, exc_info=True
-                )
+                self.close()
+            except BaseException as cleanup_failure:  # noqa: B036
+                raise primary from cleanup_failure
+            raise
 
     def _load_repo_metadata(self, entry: RepoEntry) -> RepoBundle:
-        manifest = RepoManifest.load(entry.manifest_path)
-        return RepoBundle(
-            entry=entry,
-            manifest=manifest,
-            chat_available=find_spec("litellm") is not None,
-            view_loader=self._load_repo_views,
-            runtime_loader=self._load_repo_runtime,
+        from ..artifacts.runtime import (
+            SourceBindingCleanupOwner,
+            _raise_source_cleanup_failure,
+            _source_cleanup_owner_is_pending,
         )
+        from ..compiler.manifest_source import (
+            capture_repository_source_for_manifest,
+            require_manifest_source_identity,
+        )
+
+        instance_id = entry.instance_id
+        if not isinstance(instance_id, str) or not instance_id:
+            raise ValueError("repository instance_id must be non-empty text")
+        if (
+            instance_id in self._source_bindings
+            or instance_id in self._source_cleanup_owners
+        ):
+            raise ValueError(f"duplicate repository instance_id: {instance_id!r}")
+
+        manifest = RepoManifest.load(entry.manifest_path)
+        cleanup_owner = SourceBindingCleanupOwner()
+        try:
+            source_binding = capture_repository_source_for_manifest(
+                entry.repo_dir,
+                manifest,
+                exclude_roots=(os.path.dirname(entry.manifest_path),),
+                _source_owner=cleanup_owner.retain,
+            )
+            require_manifest_source_identity(
+                source_binding.authenticated_identity_snapshot(),
+                manifest,
+                label="Web repository",
+                mismatch_message=(
+                    "repository source content does not match the manifest"
+                ),
+            )
+            bundle = RepoBundle(
+                entry=entry,
+                manifest=manifest,
+                chat_available=find_spec("litellm") is not None,
+                view_loader=self._load_repo_views,
+                runtime_loader=self._load_repo_runtime,
+                source_reader=source_binding.borrow_reader(),
+            )
+            self._source_bindings[instance_id] = source_binding
+            self._source_cleanup_owners[instance_id] = cleanup_owner
+        except BaseException as primary:  # noqa: B036 - preserve + clean owner
+            self._source_bindings.pop(instance_id, None)
+            self._source_cleanup_owners.pop(instance_id, None)
+            cleanup_failure: BaseException | None = None
+            try:
+                cleanup_owner.close()
+            except BaseException as exc:  # noqa: B036 - shared cleanup priority
+                cleanup_failure = exc
+            pending_owner = (
+                cleanup_owner
+                if _source_cleanup_owner_is_pending(cleanup_owner)
+                else None
+            )
+            if pending_owner is not None:
+                # ``load_all`` intentionally degrades ordinary per-repository
+                # failures. Retain cleanup ownership on the registry before it
+                # catches this error so a failed close is still retryable.
+                self._source_cleanup_owners[instance_id] = pending_owner
+            if cleanup_failure is not None or pending_owner is not None:
+                _raise_source_cleanup_failure(
+                    primary,
+                    cleanup_failure,
+                    pending_owner,
+                )
+            raise
+
+        return bundle
+
+    def close(self) -> None:
+        """Release retrieval views, then every retained repository authority."""
+
+        first_failure: BaseException | None = None
+        pending_vector_cleanup = False
+        for bundle in tuple(self._bundles.values()):
+            vector_store = bundle.vector_store
+            bundle.bm25 = None
+            bundle.runner = None
+            bundle.source_reader = None
+            if vector_store is not None:
+                try:
+                    vector_store.close()
+                except BaseException as exc:  # noqa: B036 - finish all cleanup
+                    pending_vector_cleanup = True
+                    if first_failure is None:
+                        first_failure = exc
+                else:
+                    bundle.vector_store = None
+
+        for instance_id, owner in tuple(self._source_cleanup_owners.items()):
+            try:
+                owner.close()
+            except BaseException as exc:  # noqa: B036 - finish all cleanup
+                if first_failure is None:
+                    first_failure = exc
+            if getattr(owner, "closed", False):
+                self._source_cleanup_owners.pop(instance_id, None)
+                self._source_bindings.pop(instance_id, None)
+
+        if not self._source_cleanup_owners and not pending_vector_cleanup:
+            self._bundles.clear()
+        if first_failure is not None:
+            raise first_failure
 
     def _load_vector_store(
         self,
@@ -675,6 +855,15 @@ class RepoRegistry:
         from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 
         manifest = bundle.manifest
+        source_reader = getattr(bundle, "source_reader", None)
+        if source_reader is None and _manifest_requires_authenticated_source(manifest):
+            raise RuntimeError(
+                "manifest-selected repository has no authenticated source reader"
+            )
+        entry = getattr(bundle, "entry", None)
+        source_binding = getattr(self, "_source_bindings", {}).get(
+            getattr(entry, "instance_id", "")
+        )
 
         bm25_index: Optional["BM25CodeIndexer"] = None
         vector_store: Optional["CodeVectorStore"] = None
@@ -696,6 +885,17 @@ class RepoRegistry:
             require_bm25_manifest_artifact(bm25_entry)
             bm25_index = BM25CodeIndexer()
             bm25_index.load_index(bm25_entry.path)
+            if source_reader is not None:
+                _require_authenticated_documents(
+                    bm25_index.documents,
+                    source_reader,
+                    subject="BM25 view",
+                )
+                if source_binding is None:
+                    raise RuntimeError(
+                        "authenticated Web repository has no retained source binding"
+                    )
+                bm25_index.bind_repository_source(source_binding)
 
         vec_entry = manifest.indexes.get("vector")
         if "vector" in index_types:
@@ -747,6 +947,18 @@ class RepoRegistry:
                     vec_entry,
                     native_index_authorization=authorization,
                 )
+
+        if source_reader is not None and vector_store is not None:
+            try:
+                for level in ("l0", "l2"):
+                    _require_authenticated_documents(
+                        getattr(vector_store, f"{level}_documents", ()) or (),
+                        source_reader,
+                        subject=f"vector {level} view",
+                    )
+            except BaseException as primary:  # noqa: B036 - close rejected view
+                close_vector_after_failure(vector_store, primary)
+                raise
 
         bundle.vector_store = vector_store
         bundle.bm25 = bm25_index

--- a/codenib/web/repository_files.py
+++ b/codenib/web/repository_files.py
@@ -10,9 +10,12 @@ import os
 import re
 import subprocess
 from functools import lru_cache
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from .._contained_source import read_repository_file
+
+if TYPE_CHECKING:
+    from ..source_fingerprint import RepositorySourceReader
 
 _COMMIT_RE = re.compile(r"[0-9a-fA-F]{7,64}\Z")
 _MAX_SOURCE_BYTES = 8 * 1024 * 1024
@@ -199,13 +202,49 @@ def _source_slice(
     end: Optional[int],
 ) -> dict:
     all_lines = content.decode("utf-8", errors="replace").splitlines(keepends=True)
-    first = max(1, int(start)) if start is not None else 1
-    if end is None:
-        requested_last = first + _DEFAULT_SOURCE_LINES - 1
-    else:
-        requested_last = max(first, int(end))
-    last = min(requested_last, first + _MAX_SOURCE_LINES - 1)
+    first, last = _source_line_bounds(start, end)
     chunk = all_lines[first - 1 : last]
+    return {
+        "file": relative,
+        "start_line": first,
+        "end_line": first + len(chunk) - 1,
+        "content": "".join(chunk),
+    }
+
+
+def _source_line_bounds(
+    start: Optional[int],
+    end: Optional[int],
+) -> tuple[int, int]:
+    first = max(1, int(start)) if start is not None else 1
+    requested_last = (
+        first + _DEFAULT_SOURCE_LINES - 1 if end is None else max(first, int(end))
+    )
+    return first, min(requested_last, first + _MAX_SOURCE_LINES - 1)
+
+
+def bound_source_slice(
+    source_reader: "RepositorySourceReader",
+    file_path: str,
+    start: Optional[int] = None,
+    end: Optional[int] = None,
+) -> Optional[dict]:
+    """Read one current source slice through a borrowed authenticated reader."""
+
+    relative = source_reader.captured_relative_path(file_path)
+    if relative is None:
+        return None
+    first, last = _source_line_bounds(start, end)
+    try:
+        content = source_reader.read_line_range(
+            relative,
+            start_line=first,
+            end_line=last,
+            max_bytes=_MAX_SOURCE_BYTES,
+        )
+    except ValueError:
+        return None
+    chunk = content.decode("utf-8", errors="replace").splitlines(keepends=True)
     return {
         "file": relative,
         "start_line": first,

--- a/codenib/web/schemas.py
+++ b/codenib/web/schemas.py
@@ -12,13 +12,23 @@ from __future__ import annotations
 
 import os
 import re
-from typing import Any, List, Literal, Optional
+from typing import TYPE_CHECKING, Any, List, Literal, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
 from codenib.agent.boundary import to_agent_repr
 
-from .repository_files import git_source_slice, has_git_metadata, live_source_slice
+from ..repository_filters import repository_path_is_visible
+from ..repository_source_selection import RepositorySourceSelection
+from .repository_files import (
+    bound_source_slice,
+    git_source_slice,
+    has_git_metadata,
+    live_source_slice,
+)
+
+if TYPE_CHECKING:
+    from ..source_fingerprint import RepositorySourceReader
 
 _MAX_REPO_ID_CHARS = 512
 _MAX_PATH_CHARS = 4096
@@ -206,7 +216,12 @@ def _repo_relative(path: Optional[str], repo_path: str = "") -> Optional[str]:
     return p.lstrip("/")
 
 
-def _node_to_citation(node: Any, repo_path: str = "") -> Optional[Citation]:
+def _node_to_citation(
+    node: Any,
+    repo_path: str = "",
+    *,
+    source_reader: "RepositorySourceReader | None" = None,
+) -> Optional[Citation]:
     """Coerce a single retrieval result (QueriedNode / dict) into a Citation."""
     if not (
         hasattr(node, "model_dump")
@@ -223,8 +238,15 @@ def _node_to_citation(node: Any, repo_path: str = "") -> Optional[Citation]:
     content = data.get("content")
     if isinstance(content, str) and len(content) > 2000:
         content = content[:2000] + "\n... (truncated)"
+    file = data.get("file")
+    if source_reader is not None and file:
+        file = source_reader.captured_relative_path(file)
+        if file is None:
+            return None
+    else:
+        file = _repo_relative(file, repo_path)
     return Citation(
-        file=_repo_relative(data.get("file"), repo_path),
+        file=file,
         start_line=data.get("start_line"),
         end_line=data.get("end_line"),
         node_name=data.get("node_name") or data.get("name") or "",
@@ -294,6 +316,8 @@ def _select_answer_citations(
     limit: int = 5,
     repo_path: str = "",
     repo_commit: str = "",
+    source_reader: "RepositorySourceReader | None" = None,
+    source_selection: RepositorySourceSelection | None = None,
 ) -> List[Citation]:
     """Keep strong answer citations that resolve to exact repository source."""
 
@@ -317,10 +341,42 @@ def _select_answer_citations(
 
     renderable: List[Citation] = []
     for citation in selected:
-        if repo_path:
+        if source_reader is not None:
+            if not citation.file or citation.start_line is None:
+                continue
+            source = bound_source_slice(
+                source_reader,
+                citation.file,
+                citation.start_line,
+                citation.end_line or citation.start_line,
+            )
+            if not source or not str(source.get("content") or "").strip():
+                continue
+            content = str(source["content"])
+            if len(content) > _MAX_CITATION_CONTENT_CHARS:
+                content = content[:_MAX_CITATION_CONTENT_CHARS] + "\n... (truncated)"
+            citation = citation.model_copy(
+                update={
+                    "file": source.get("file") or citation.file,
+                    "start_line": source.get("start_line") or citation.start_line,
+                    "end_line": source.get("end_line") or citation.end_line,
+                    "content": content,
+                }
+            )
+        elif repo_path:
             if not citation.file or citation.start_line is None:
                 continue
             if repo_commit:
+                historical_selection = (
+                    source_selection
+                    if type(source_selection) is RepositorySourceSelection
+                    else RepositorySourceSelection()
+                )
+                if not repository_path_is_visible(
+                    citation.file,
+                    selection=historical_selection,
+                ):
+                    continue
                 source = git_source_slice(
                     repo_path,
                     repo_commit,
@@ -375,6 +431,9 @@ def agent_result_to_response(
     result: Any,
     repo_path: str = "",
     repo_commit: str = "",
+    *,
+    source_reader: "RepositorySourceReader | None" = None,
+    source_selection: RepositorySourceSelection | None = None,
 ) -> ChatResponse:
     """Flatten an ``AgentResult`` into the API response.
 
@@ -398,7 +457,11 @@ def agent_result_to_response(
             )
         )
         for node in nodes:
-            cit = _node_to_citation(node, repo_path)
+            cit = _node_to_citation(
+                node,
+                repo_path,
+                source_reader=source_reader,
+            )
             if cit is None:
                 continue
             key = (cit.file, cit.start_line, cit.end_line)
@@ -414,6 +477,8 @@ def agent_result_to_response(
             citations,
             repo_path=repo_path,
             repo_commit=repo_commit,
+            source_reader=source_reader,
+            source_selection=source_selection,
         ),
         tool_calls=tool_calls,
         total_turns=result.total_turns,

--- a/codenib/web/static_export.py
+++ b/codenib/web/static_export.py
@@ -33,9 +33,12 @@ from ..artifacts.runtime import (
 from ..artifacts.security import assert_publishable_tree_reader
 from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
 from ..compiler.manifest import RepoManifest
+from ..compiler.manifest_source import (
+    capture_repository_source_for_manifest as capture_repository_source,
+)
+from ..compiler.manifest_source import require_manifest_source_identity
 from ..source_fingerprint import (
     RepositorySourceReader,
-    capture_repository_source,
     is_secure_source_fingerprint_v2,
     lexical_repository_path,
 )
@@ -909,15 +912,17 @@ def export_static_wiki(
             raise ValueError("static export source reads require source fingerprint v2")
         source_binding = capture_repository_source(
             repo_path,
+            manifest=expected_manifest,
             exclude_roots=(manifest_path.parent,),
             _source_owner=cleanup_owner.retain,
         )
         source_identity = source_binding.authenticated_identity_snapshot()
-        if (
-            source_identity.fingerprint != expected_manifest.source_fingerprint
-            or source_identity.file_count != expected_manifest.file_count
-        ):
-            raise ValueError("repository source content does not match the manifest")
+        require_manifest_source_identity(
+            source_identity,
+            expected_manifest,
+            label="static export repository",
+            mismatch_message=("repository source content does not match the manifest"),
+        )
         source_reader = source_binding.borrow_reader()
 
         with source_binding.read_session():
@@ -926,13 +931,14 @@ def export_static_wiki(
                 manifest_path,
                 source_reader=source_reader,
             )
-            if (
-                source_identity.fingerprint != bundle.manifest.source_fingerprint
-                or source_identity.file_count != bundle.manifest.file_count
-            ):
-                raise ValueError(
+            require_manifest_source_identity(
+                source_identity,
+                bundle.manifest,
+                label="static export loaded repository",
+                mismatch_message=(
                     "repository source content does not match the loaded manifest"
-                )
+                ),
+            )
             builder = WikiBuilder(bundle, source_reader=source_reader)
 
             tree = builder.page_tree()

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -3198,6 +3198,17 @@ class AgentWiki:
 
     # -- caching -----------------------------------------------------------
 
+    def _source_selection_identity(self) -> str:
+        """Return the persisted source-selection identity, when available."""
+
+        manifest = getattr(self._bundle, "manifest", None)
+        digest = getattr(manifest, "source_selection_digest", None)
+        if isinstance(digest, str) and digest:
+            return digest
+        selection = getattr(manifest, "source_selection", None)
+        digest = getattr(selection, "digest", None)
+        return digest if isinstance(digest, str) else ""
+
     def _key(self, suffix: str) -> str:
         """Return a stable cache identity for equivalent repository views."""
 
@@ -3253,6 +3264,7 @@ class AgentWiki:
             or getattr(manifest, "commit", "")
             or commit
         )
+        source_selection_identity = self._source_selection_identity()
         prompt_version = (
             _OUTLINE_PROMPT_VERSION if suffix == "outline" else _PAGE_PROMPT_VERSION
         )
@@ -3263,9 +3275,10 @@ class AgentWiki:
         # producing model is recorded in the cache entry instead — see
         # ``_write_cache`` — mirroring EdgeLabeler's namespace-only keying.
         raw = (
-            f"stable-v2/{prompt_version}/"
+            f"stable-v3/{prompt_version}/"
             f"{getattr(entry, 'instance_id', 'repo')}@{commit}/"
-            f"{source_identity}/{view_identity}/{suffix}"
+            f"{source_identity}/{source_selection_identity}/"
+            f"{view_identity}/{suffix}"
         )
         return hashlib.sha1(raw.encode()).hexdigest()[:16]
 
@@ -3325,7 +3338,12 @@ class AgentWiki:
 
         if not self._cache_dir:
             return ()
-        keys = (self._key(suffix), self._legacy_key(suffix))
+        keys = [self._key(suffix)]
+        # Pre-selection caches cannot prove which source inventory produced
+        # their prompts. Keep migration only for legacy manifests that have no
+        # persisted selection identity at all.
+        if not self._source_selection_identity():
+            keys.append(self._legacy_key(suffix))
         return tuple(
             os.path.join(self._cache_dir, f"agentwiki_{key}.json")
             for key in dict.fromkeys(keys)
@@ -4602,8 +4620,13 @@ class AgentWiki:
 
         existing = {(item.source, item.target) for item in relations}
         selected: List[RelationItem] = []
-        repo_dir = os.path.realpath(
-            str(getattr(self._bundle.entry, "repo_dir", "") or "")
+        source_reader = getattr(self._bundle, "source_reader", None)
+        repo_dir = (
+            ""
+            if source_reader is not None
+            else os.path.realpath(
+                str(getattr(self._bundle.entry, "repo_dir", "") or "")
+            )
         )
         for item in evidence:
             if item.start_line is None or item.end_line is None:
@@ -4644,6 +4667,9 @@ class AgentWiki:
                 target_file = target["file"]
                 if not target_file:
                     continue
+                target_relative = self._rel(target_file)
+                if not target_relative:
+                    continue
                 if os.path.isabs(target_file) and repo_dir:
                     try:
                         if (
@@ -4669,7 +4695,7 @@ class AgentWiki:
                 score = (
                     self._relation_action_score(target["label"]),
                     int(target["kind"].lower() == "method"),
-                    int(self._rel(target_file) == item.file),
+                    int(target_relative == item.file),
                     public,
                 )
                 candidate = candidates.setdefault(
@@ -4734,6 +4760,7 @@ class AgentWiki:
                 citations,
                 max_nodes=18,
                 repo_dir=getattr(self._bundle.entry, "repo_dir", None),
+                source_reader=getattr(self._bundle, "source_reader", None),
             )
         except Exception as exc:  # noqa: BLE001 - source evidence remains usable
             logger.debug("wiki relationship evidence unavailable: %s", exc)
@@ -5267,6 +5294,13 @@ class AgentWiki:
         alike). The resolved prefix is cached after the first lookup."""
         if not file:
             return file
+        source_reader = getattr(self._bundle, "source_reader", None)
+        if source_reader is not None:
+            # A manifest-bound Wiki must never use ``exists`` as a second,
+            # ambient source authority. The borrowed reader resolves legacy
+            # absolute builder labels against the captured inventory and
+            # returns ``None`` for excluded or unauthenticated paths.
+            return source_reader.captured_relative_path(file)
         p = file.replace("\\", "/")
         root = getattr(self, "_iroot", None)
         if root is not None:

--- a/codenib/wiki/builder.py
+++ b/codenib/wiki/builder.py
@@ -17,6 +17,7 @@ import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict, List, Optional
 
+from ..repository_source_selection import RepositorySourceSelection
 from ..repository_summary import read_bound_repository_summary, read_repository_summary
 from .multimodal import plan_media_slots
 from .narrator import Narrator
@@ -171,7 +172,21 @@ class WikiBuilder:
         self._entry = bundle.entry
         self._language = bundle.entry.language
         self._narrator = narrator or Narrator(enabled=False)
-        self._source_reader = source_reader
+        self._source_reader = (
+            source_reader
+            if source_reader is not None
+            else getattr(bundle, "source_reader", None)
+        )
+        manifest = getattr(bundle, "manifest", None)
+        if (
+            self._source_reader is None
+            and type(getattr(manifest, "source_selection", None))
+            is RepositorySourceSelection
+            and bool(getattr(manifest, "source_fingerprint", ""))
+        ):
+            raise RuntimeError(
+                "manifest-selected Wiki requires an authenticated source reader"
+            )
         self._symbols_cache: Optional[tuple] = None
         self._project_summary_cache: Optional[str] = None
 

--- a/codenib/wiki/outline.py
+++ b/codenib/wiki/outline.py
@@ -22,13 +22,15 @@ import os
 import re
 from collections import Counter, defaultdict
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List
 
 from ..log_utils import get_logger
-from ..repository_filters import walk_repository_files
 from ..types import is_symbol_node
 from .builder import Symbol, WikiBuilder
 from .evidence import promotional_phrases
+
+if TYPE_CHECKING:
+    from ..source_fingerprint import RepositorySourceReader
 
 logger = get_logger(__name__)
 
@@ -158,20 +160,26 @@ def _page_allows_supporting_files(page: Dict[str, Any]) -> bool:
     return bool(terms & _SUPPORTING_PAGE_TOKENS)
 
 
-def _read_readme(repo_dir: str, limit: int = 3500) -> str:
+def _read_readme(
+    source_reader: "RepositorySourceReader | None",
+    limit: int = 3500,
+) -> str:
+    if source_reader is None:
+        return ""
     for name in _README_NAMES:
-        path = os.path.join(repo_dir, name)
-        if os.path.isfile(path):
-            try:
-                with open(path, encoding="utf-8", errors="replace") as fh:
-                    return fh.read()[:limit]
-            except OSError:
-                return ""
+        relative = source_reader.captured_relative_path(name)
+        if relative is None:
+            continue
+        try:
+            payload = source_reader.read_prefix(relative, max_bytes=limit * 4)
+        except ValueError:
+            return ""
+        return payload.decode("utf-8", errors="replace")[:limit]
     return ""
 
 
 def _readme_entry_files(
-    repo_dir: str,
+    source_paths: Iterable[str],
     readme: str,
     *,
     limit: int = 12,
@@ -179,9 +187,10 @@ def _readme_entry_files(
     """Resolve source paths explicitly named by a repository README."""
 
     known = {
-        path.relative_to(repo_dir).as_posix()
-        for path in walk_repository_files(repo_dir)
-        if path.suffix.lower() in _DOCUMENTED_ENTRY_SUFFIXES
+        path
+        for path in source_paths
+        if isinstance(path, str)
+        and Path(path).suffix.lower() in _DOCUMENTED_ENTRY_SUFFIXES
     }
     by_basename: dict[str, List[str]] = defaultdict(list)
     for file in known:
@@ -234,11 +243,12 @@ def _top_files(symbols: List[Symbol], limit: int) -> List[str]:
     ]
 
 
-def _repository_structure(repo_dir: str, limit: int = 16) -> str:
+def _repository_structure(source_paths: Iterable[str], limit: int = 16) -> str:
     counts: Counter[str] = Counter()
-    for path in walk_repository_files(repo_dir):
-        rel = path.relative_to(repo_dir).as_posix()
-        parts = rel.split("/")
+    for relative in source_paths:
+        if not isinstance(relative, str) or not relative:
+            continue
+        parts = relative.split("/")
         area = "/".join(parts[:2]) if len(parts) > 2 else parts[0]
         counts[area] += 1
     if not counts:
@@ -545,9 +555,14 @@ def generate_outline(
     ]
     core_files = _top_files(core_symbols, limit=40)
     supporting_files = _top_files(supporting_symbols, limit=12)
-    repo_dir = getattr(bundle.entry, "repo_dir", "") or ""
-    readme = _read_readme(repo_dir)
-    documented_files = _readme_entry_files(repo_dir, readme)
+    source_reader = getattr(bundle, "source_reader", None)
+    source_paths = (
+        source_reader.file_paths
+        if source_reader is not None
+        else frozenset(symbol.file for symbol in symbols if symbol.file)
+    )
+    readme = _read_readme(source_reader)
+    documented_files = _readme_entry_files(source_paths, readme)
     files = list(dict.fromkeys([*core_files, *documented_files, *supporting_files]))
     languages = ", ".join(getattr(bundle.manifest, "languages", []) or [])
 
@@ -567,7 +582,7 @@ def generate_outline(
         ),
         top_level_pages=breadth_pages,
         children_per_page=breadth_children,
-        structure=_repository_structure(repo_dir),
+        structure=_repository_structure(source_paths),
         core_symbols=_format_symbols(_top_symbols(core_symbols, limit=60)) or "(none)",
         supporting_symbols=_format_symbols(_top_symbols(supporting_symbols, limit=10))
         or "(none)",
@@ -593,7 +608,7 @@ def generate_outline(
 
     data = _validate_outline(
         _parse_outline(text),
-        repo_dir,
+        source_paths,
         symbols=symbols,
         fallback_files=files,
         documented_files=documented_files,
@@ -635,14 +650,14 @@ def generate_outline(
             )
             repaired = _validate_outline(
                 _parse_outline(repaired_text),
-                repo_dir,
+                source_paths,
                 symbols=symbols,
                 fallback_files=files,
                 documented_files=documented_files,
             )
             merged = _validate_outline(
                 _merge_outlines(data, repaired),
-                repo_dir,
+                source_paths,
                 symbols=symbols,
                 fallback_files=files,
                 documented_files=documented_files,
@@ -1076,15 +1091,18 @@ def _parse_outline(text: str) -> Dict[str, Any]:
 
 def _validate_outline(
     data: Dict[str, Any],
-    repo_dir: str,
+    repository_files: Iterable[str],
     *,
     symbols: List[Symbol] | None = None,
     fallback_files: List[str] | None = None,
     documented_files: List[str] | None = None,
 ) -> Dict[str, Any]:
+    if isinstance(repository_files, (str, bytes)):
+        raise TypeError("repository_files must be an iterable of source paths")
     known_files = {
-        path.relative_to(repo_dir).as_posix()
-        for path in walk_repository_files(repo_dir)
+        str(path).replace("\\", "/").strip().lstrip("./")
+        for path in repository_files
+        if isinstance(path, str) and path.strip()
     }
     symbols = symbols or []
     fallback_files = fallback_files or []

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -61,13 +61,13 @@ OrcaLoca native implementations support those languages.
 ### Shared LSP navigation provider
 
 The definition, reference, and route agent skills resolve the same provider
-injected into `ExpandContext`. For a source-verified C/C++-only build, symbol
-definition and reference requests can use the native clangd fact-query postings
-without materializing igraph; position and route requests lazily build and
-reuse the compatible complete graph. Mixed-language contexts select the
-persisted symbol graph; prebuilt contexts without a usable local native
-generation do the same, and portable artifacts always do so. Provider results
-retain backend,
+injected into `ExpandContext`. In 0.2.2 manifest-bound contexts, including
+C/C++-only builds, select the verified persisted symbol graph. Native clangd
+fact-query postings remain an independently benchmarked implementation, but
+their mutable project-local `.idx` generation has no source-selection receipt
+or allowed-file proof yet and is not admitted by the agent runtime. Portable
+artifacts and mixed-language contexts use the same persisted route. Provider
+results retain backend,
 fallback, capability, and snapshot metadata so an agent trace can explain the
 route without changing the public location shape.
 
@@ -243,7 +243,7 @@ reasoning loop while replacing its repository data plane with
 localization baselines:
 
 ```bash
-python -m pip install "codenib[agent,graph]==0.2.1"
+python -m pip install "codenib[agent,graph]==0.2.2"
 codenib toolchain install /path/to/repository --scope graph
 ```
 

--- a/docs/codegraph.md
+++ b/docs/codegraph.md
@@ -14,10 +14,10 @@ bounded source reads.
 
 ## One-command setup
 
-Install CodeNib 0.2.1 with the graph runtime and official MCP SDK:
+Install CodeNib 0.2.2 with the graph runtime and official MCP SDK:
 
 ```bash
-python -m pip install "codenib[graph,mcp]==0.2.1"
+python -m pip install "codenib[graph,mcp]==0.2.2"
 codenib codegraph init /absolute/path/to/repository
 ```
 
@@ -54,6 +54,55 @@ codenib codegraph init . --agent codex --agent claude --dry-run
 Running the same initialization again reuses a current index and matching
 native registrations. CodeNib refuses to overwrite an unmanaged server with
 the same name or a managed registration whose command has drifted.
+
+## Select the repository source surface
+
+Generated or vendored subtrees can be excluded with a repeatable, exact
+repository-relative path:
+
+```bash
+codenib codegraph init . \
+  --exclude-dir ios/Pods \
+  --exclude-dir generated/api
+```
+
+An explicit set replaces the complete custom exclusion policy. With no flag,
+later `codegraph init` and `index` runs reuse the policy recorded in the
+repository manifest. Clear it explicitly when those trees should become source
+again:
+
+```bash
+codenib codegraph init . --clear-exclude-dirs
+```
+
+Paths use repository-relative POSIX spelling (`/`) on every platform and do
+not accept glob syntax. The match is lexical and component-aware:
+`ios/Pods` excludes that exact
+subtree, not `packages/mobile/ios/Pods` or a directory with a similar prefix.
+CodeNib applies the same selection to language detection, source identity,
+BM25/vector documents, graph/SCIP output, runtime verification, and status.
+Changing it therefore rebuilds affected views instead of relabeling an old
+artifact as current.
+
+CodeNib does not implicitly consume `.gitignore`, `.git/info/exclude`, or a
+global Git excludes file as its source policy. Ignored and untracked local
+source can be meaningful input, while ambient global rules would make one
+manifest mean different things on different machines.
+
+Zoekt requires its fixed commit tree to match the authenticated checkout and
+contain no tracked path rejected by the default repository policy. It cannot
+yet prove a non-empty custom selection end to end. Requests for the `zoekt`
+view, including `--preset full`, therefore fail before producing a new shard
+when either condition is unmet. The default CodeGraph path uses BM25 plus
+`symbol_graph` and remains supported.
+Serving an authenticated Zoekt shard through MCP is Linux-only in 0.2.2 because
+the child process receives a retained `/proc` descriptor path rather than the
+mutable published directory.
+
+Absolute symlinks are accepted only by the authenticated indexing path when
+their target remains inside the same pinned checkout. The target is re-walked
+from that checkout and retains the normal identity and rebind checks; links to
+another directory, device paths, and prefix lookalikes remain rejected.
 
 ## Use it from an agent
 
@@ -101,9 +150,11 @@ the complete path is ready:
 codenib codegraph status /absolute/path/to/repository --json
 ```
 
-After source changes, rerun `init`; compatible views update incrementally.
-Force a clean graph rebuild only when deliberately changing a builder or
-recovering incompatible state:
+After source changes, rerun `init`. Views whose complete identities remain
+current are reused; affected requested views rebuild atomically. File-level
+delta repair is currently disabled until it can use the same pinned source
+authority. Force a clean graph rebuild only when deliberately changing a
+builder or recovering incompatible state:
 
 ```bash
 codenib codegraph init . --rebuild
@@ -162,6 +213,9 @@ provider boundary.
   if a provider or client changes the checkout.
 - **Source identity mismatch:** rerun `codenib codegraph init .` for the current
   checkout rather than serving a stale graph.
+- **Generated subtree should be omitted:** rerun `init` with one or more exact
+  `--exclude-dir PATH` values. The values replace the persisted custom set;
+  inspect them with `codegraph status` before serving the graph.
 - **Configuration differs:** inspect the named server with `codex mcp get` or
   `claude mcp get`. CodeNib will not overwrite or remove drift implicitly.
 

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -161,12 +161,13 @@ it exactly, covering vertex and edge identity, fields, and insertion order
 rather than only aggregate counts.
 
 `codenib.scip_interface.scip_query.load_fact_query_candidate(...)` is the
-graph-free admission boundary. It requires a current builder-schema-v4,
+graph-free admission boundary. It requires a current builder-schema-v6
+(builder schema v4 is admitted only with a legacy manifest 1.1 profile),
 single-language full rebuild; verifies the manifest, source, decoded artifact,
 persisted graph-writer receipt, query-surface digest, repository filter policy,
 and Rust Cargo identity before and after decode; and returns the index only
 after the native proof succeeds. Receipt capture is enabled only by the
-compiler build that publishes schema-v4 evidence; ordinary graph pipelines do
+compiler build that publishes the matching schema evidence; ordinary graph pipelines do
 not incur the extra scans. Partial, incremental, multi-language,
 source-coverage fallback, symlinked cache artifacts, mutated inputs, or facts
 absent from the bound serial filtered query surface fail closed.
@@ -176,6 +177,12 @@ allowed source anchor. The first admitted languages are Python and Rust; other
 metadata contracts remain future work. The legacy `decode()` graph path
 remains unchanged, and this candidate is not a production MCP route until the
 separate consumer-boundary gate passes exact parity and the required speedup.
+
+Builder schema v6 also records `lsp_occurrence_artifact` on every current
+symbol-graph build: either an exact receipt for `lsp_index.pkl` or `null` when
+that generation has no occurrence sidecar. Runtime graph consumers may load a
+non-null sidecar only through the same authenticated directory generation as
+`graph.pkl`; ambient, unreceipted pickle files are not a runtime input.
 
 ### Lazy SCIP MCP consumer gate
 
@@ -288,23 +295,30 @@ make clangd-fact-query-profile \
 This result measures an already generated `.idx` directory through identical
 definition/reference/route work. It does not claim faster clangd generation.
 
+The promotion above remains an implementation and profiling result. The 0.2.2
+manifest-bound runtime gate supersedes it for production selection: mutable
+project-local `.idx` files are not consumed until they also have an
+authenticated generation receipt and allowed-file proof.
+
 ### MCP and agent runtime selection
 
 `ServerContext` and compiler skill contexts select one runtime-only LSP
-provider. A source-verified local C/C++-only checkout can reuse its existing
-clangd shards through `native-clangd-fact-query-v1`; selection does not generate
-an index. Portable artifacts, mixed-language repositories, unverified
-checkouts, and disabled or unavailable native support use
-`persisted-symbol-graph-v1` with a deterministic fallback reason.
+provider. In 0.2.2 every manifest-bound context uses
+`persisted-symbol-graph-v1` with a deterministic fallback reason, including a
+source-verified local C/C++-only checkout. The runtime does not consume existing
+clangd shards because their generation is outside the authenticated manifest
+source surface. Direct benchmark APIs may still exercise
+`native-clangd-fact-query-v1`; production re-admission requires the receipt and
+allowed-file gate above.
 
-MCP definition, reference, and route tools and all three agent LSP skills use
-the common provider resolver. Definition/reference symbol requests remain on
-the startup postings path; supported exact positions use the lazy native
-occurrence view; supported routes use compact native adjacency. None constructs
-igraph. Position and route fallbacks share one snapshot-compatible complete
-graph. MCP result rows and `get_manifest` runtime metadata identify the
-backend, capabilities, fallback, encoding, and snapshot. The profiling report
-checks raw and MCP parity together with provider routing.
+The direct `native-clangd-fact-query-v1` benchmark provider keeps definition
+and reference symbols on startup postings, exact positions on its lazy native
+occurrence view, and supported routes on compact native adjacency. That
+behavior remains covered by the raw/MCP parity profile, but 0.2.2
+manifest-bound MCP and agent skills do not select it. Their common resolver
+queries the persisted graph and reports that backend, fallback reason,
+capabilities, encoding, and snapshot through result rows and
+`get_manifest.runtime.lsp_provider`.
 
 ### Mixed workload and resource gate
 

--- a/docs/github_pages.md
+++ b/docs/github_pages.md
@@ -30,16 +30,16 @@ permissions:
 
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.1
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.2
 ```
 
-The prerelease tag keeps the compiler, frontend, Action, and artifact schema on
+The version tag keeps the compiler, frontend, Action, and artifact schema on
 one reviewed version. Production deployments may replace it with the tag's
 resolved commit SHA. In the repository's **Settings > Pages**, select
 **GitHub Actions** as the source.
 
-The workflow checks out the caller's exact commit, incrementally builds the
-`semantic` preset, exports the Wiki at the Pages-provided mount path, and
+The workflow checks out the caller's exact commit, builds or reuses the
+`semantic` preset views, exports the Wiki at the Pages-provided mount path, and
 deploys it through the `github-pages` environment. It also uploads an artifact
 named from the repository and commit. The workflow caches both repository
 views and the pinned Hugging Face model. The static Wiki serves precomputed
@@ -54,7 +54,7 @@ than natural-language retrieval quality:
 ```yaml
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.1
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.2
     with:
       preset: fast
 ```
@@ -71,7 +71,7 @@ artifact or Pages workflow:
 ```yaml
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.1
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.2
     with:
       preset: semantic
       embedding-provider: openai
@@ -141,7 +141,7 @@ The composite Action can be used directly when another static host or artifact
 store owns deployment:
 
 ```yaml
-- uses: sysevol-ai/CodeNib/.github/actions/publish@v0.2.1
+- uses: sysevol-ai/CodeNib/.github/actions/publish@v0.2.2
   id: codenib
   with:
     preset: fast

--- a/docs/incremental_graph/index.md
+++ b/docs/incremental_graph/index.md
@@ -6,18 +6,30 @@ SPDX-License-Identifier: Apache-2.0
 
 # Incremental Graph Patching
 
-Update an existing `CodeGraph` in place when code changes, avoiding a full
-re-index whenever the language backend supports a safe delta. Most languages
-use an LSP server; C/C++ refreshes clangd `.idx` data instead.
+CodeNib contains a low-level, experimental graph patcher for studying safe
+file- and symbol-level updates. Most languages use an LSP server; C/C++ can
+refresh clangd `.idx` data in a direct experimental workflow.
 
-There are two entry points:
+> **0.2.2 production gate:** `IndexCompiler.update_repo()` reuses views whose
+> source and builder identities are still current, but atomically rebuilds
+> requested views affected by a source or policy change. It does not invoke
+> builder delta paths. This remains the recommended repository-maintenance
+> entry point until Git observations and delta inputs share the same pinned
+> source authority.
 
-1. **`IndexCompiler.update_repo()`** (recommended) — the compiler drives the patcher for you, alongside every other index, under admission control. See [Compiler-Driven Updates](#compiler-driven-updates-recommended).
-2. **`LSIndexer.graph_patch()`** — the low-level primitive that patches a single graph directly. The rest of this page documents this layer.
+There are two distinct surfaces:
+
+1. **`IndexCompiler.update_repo()`** (recommended) — reuse current views and
+   rebuild changed requested views under manifest admission control.
+2. **`LSIndexer.graph_patch()` and builder `incremental_update()` methods** —
+   low-level experimental APIs. The rest of this page documents that layer;
+   the production compiler does not currently call it.
 
 ## Compiler-Driven Updates (Recommended)
 
-`IndexCompiler.update_repo()` productionizes graph patching: it advances an existing manifest (written by an initial `compile_repo()` build, see [MCP server](../mcp.md)) to the repo's current `HEAD`, routing each requested index through its builder's `incremental_update()` instead of a full `build()`:
+`IndexCompiler.update_repo()` advances an existing manifest (written by an
+initial `compile_repo()` build, see [MCP server](../mcp.md)) to the repository's
+current authenticated source identity:
 
 ```python
 from codenib.compiler import IndexCompiler
@@ -33,7 +45,7 @@ compiler = IndexCompiler(registry)
 compiler.compile_repo("/path/to/repo")   # initial full build
 
 # ... new commits land ...
-compiler.update_repo("/path/to/repo")    # incremental advance to HEAD
+compiler.update_repo("/path/to/repo")    # reuse current or atomically rebuild
 ```
 
 `update_repo()` compares the manifest's `last_indexed_commit` against `HEAD` and then:
@@ -41,7 +53,9 @@ compiler.update_repo("/path/to/repo")    # incremental advance to HEAD
 - **Nothing to do** — `HEAD` unchanged and every requested index `fresh`: returns the existing manifest untouched.
 - **Retry incomplete builds** — `HEAD` unchanged but some requested index is missing or not `fresh` (a previous run failed partway): re-runs a full `compile_repo()` so the failed indexes are retried instead of staying stale.
 - **Full rebuild fallback** — no manifest, an unreadable manifest, or an empty `last_indexed_commit` (no complete baseline was ever established): falls back to `compile_repo()`.
-- **Incremental advance** — otherwise, each builder's `incremental_update(..., last_commit=<previous>)` runs. Builders without a safely publishable delta path rebuild internally. BM25 and Zoekt rebuild, and the vector builder validates the existing generation and its native-read authority before publishing one complete private-generation rebuild; it does not mutate the live vector tree in place. The symbol-graph builder runs the LSP patcher described below — the result is always correct, only the cost differs.
+- **Changed source or policy** — each affected requested view runs its full
+  builder and publishes one complete generation. BM25, vector, symbol graph,
+  and Zoekt do not mutate the live generation in place.
 
 ### last_indexed_commit Semantics
 
@@ -49,7 +63,11 @@ The manifest claims `HEAD` as `last_indexed_commit` only when **every** requeste
 
 ### Admission Control for the Symbol Graph
 
-An incremental symbol-graph result is only *admitted* when the patched artifact can be taken as equivalent to a fresh rebuild. `SymbolGraphBuilder` delegates that decision to the `UpdateVerifier` contract (`codenib/compiler/verification.py`):
+The following contract applies only when callers invoke the experimental
+`SymbolGraphBuilder.incremental_update()` API directly. An incremental
+symbol-graph result is only *admitted* when the patched artifact can be taken
+as equivalent to a fresh rebuild. `SymbolGraphBuilder` delegates that decision
+to the `UpdateVerifier` contract (`codenib/compiler/verification.py`):
 
 | Verifier | Behavior |
 |----------|----------|
@@ -58,15 +76,20 @@ An incremental symbol-graph result is only *admitted* when the patched artifact 
 
 With the builder's default `require_verification=True`, an unadmitted patch is discarded and the graph is fully rebuilt — so out of the box the symbol-graph path behaves exactly like a full rebuild until a real verifier is configured. To accept unverified patches, construct `SymbolGraphBuilder` with `AlwaysAdmitVerifier()` (or `require_verification=False`) and register it in place of the default. Either way the outcome (`verified`, `verification_checked`, `verification_reason`) is written into the manifest entry's metadata, so admission is auditable on disk. A patch that touches no source files of the configured languages is admitted directly.
 
-Independently of verification, the builder falls back to a full rebuild whenever the incremental path cannot run safely: no previously indexed commit, no existing `graph.pkl`, an unresolvable `HEAD`, uncommitted changes to tracked files, a missing language server, or any patch failure.
+Independently of verification, the builder falls back to a full rebuild
+whenever the incremental path cannot run safely: no previously indexed commit,
+no existing `graph.pkl`, an unresolvable `HEAD`, uncommitted changes to tracked
+files, an occurrence sidecar without a matching delta contract, a missing
+language server, or any patch failure.
 
 For TypeScript and TSX, schema 5 also protects the separate file-to-file import
 layer. Before starting the language server or mutating the graph, the patcher
 compares tree-sitter fingerprints of static imports and source-bearing
 re-exports at the indexed and target commits. A changed statement or anchor,
 an added or deleted file, or a rename requests a full rebuild; a body-only edit
-may remain incremental. The compiler catches that explicit request and
-rebuilds, so an incremental update cannot silently retain stale import edges.
+may remain incremental in the direct experimental API. That API catches an
+explicit rebuild request and falls back to a full generation, so it cannot
+silently retain stale import edges.
 
 ## How It Works
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,11 +34,11 @@ core decoder parity.
 
 ## Quick Start
 
-CodeNib 0.2.1 can prepare a local, model-free CodeGraph and register it with
+CodeNib 0.2.2 can prepare a local, model-free CodeGraph and register it with
 installed Codex and Claude Code clients in one command:
 
 ```bash
-python -m pip install "codenib[graph,mcp]==0.2.1"
+python -m pip install "codenib[graph,mcp]==0.2.2"
 codenib codegraph init /path/to/repository
 ```
 
@@ -49,7 +49,7 @@ the clients' own CLIs. The target checkout remains unchanged. Read the
 tool examples.
 
 ```bash
-python -m pip install "codenib[semantic]==0.2.1"
+python -m pip install "codenib[semantic]==0.2.2"
 codenib wiki /path/to/repository
 ```
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -13,11 +13,11 @@ then reuse that manifest across agent sessions.
 
 ## Install And Index
 
-For Codex or Claude Code, the recommended 0.2.1 path prepares the graph index
+For Codex or Claude Code, the recommended 0.2.2 path prepares the graph index
 and native client configuration together:
 
 ```bash
-python -m pip install "codenib[graph,mcp]==0.2.1"
+python -m pip install "codenib[graph,mcp]==0.2.2"
 codenib codegraph init /path/to/repository
 ```
 
@@ -31,14 +31,14 @@ For a custom MCP client or a retrieval-only setup, build and launch the server
 manually. The smaller no-model fallback is:
 
 ```bash
-python -m pip install "codenib[mcp]==0.2.1"
+python -m pip install "codenib[mcp]==0.2.2"
 codenib index /path/to/repository --preset fast
 ```
 
 Add static navigation and dependency tools without an embedding download:
 
 ```bash
-python -m pip install "codenib[graph,mcp]==0.2.1"
+python -m pip install "codenib[graph,mcp]==0.2.2"
 codenib toolchain install /path/to/repository --scope graph
 codenib index /path/to/repository --preset graph
 ```
@@ -120,8 +120,8 @@ absolute path to a repository previously indexed with `codenib index`. The
 declared launch is equivalent to:
 
 ```bash
-uvx --with "codenib[mcp]==0.2.1" \
-  "codenib==0.2.1" mcp /absolute/path/to/repository
+uvx --with "codenib[mcp]==0.2.2" \
+  "codenib==0.2.2" mcp /absolute/path/to/repository
 ```
 
 The Registry path is intentionally query-only and model-free. It can always
@@ -177,15 +177,15 @@ is known. This best-effort fallback examines at most 10,000 graph nodes, retains
 at most 256 query matches and 512 expanded candidates, and stops after 100
 milliseconds.
 
-For a source-verified local C/C++-only checkout, the server can reuse an
-existing project-local clangd index for definition and reference symbol
-queries. This runtime selection never generates clangd data. Position and route
-queries lazily load the compatible complete graph once. Portable artifacts,
-mixed-language repositories, unverified checkouts, and disabled or unavailable
-native support remain on the persisted symbol graph. LSP result rows identify
-their backend, fallback reason, capabilities, and snapshot when provider
-metadata is available; `get_manifest.runtime.lsp_provider` reports the same
-selection even before a result is returned.
+In 0.2.2 every manifest-bound C/C++ checkout uses the verified persisted
+symbol graph. Project-local clangd `.idx` files often live below the
+default-excluded `build/` tree and do not yet carry an authenticated generation
+receipt plus allowed-file proof, so the server does not reuse them directly.
+This is a fail-closed query-time boundary, not a removal of C/C++ graph
+indexing. LSP result rows identify the backend, fallback reason, capabilities,
+and snapshot when provider metadata is available;
+`get_manifest.runtime.lsp_provider` reports the same persisted-graph selection
+before a result is returned.
 
 `search_context` accepts `query`, `top_k` (1-100), `budget`
 (`fast`, `balanced`, or `thorough`), dense `level` (`l0` or `l2`), and
@@ -211,10 +211,16 @@ Parameter and return schemas live in
 The `full` preset requests BM25, vectors, a symbol graph, and Zoekt:
 
 ```bash
-python -m pip install "codenib[full]==0.2.1"
+python -m pip install "codenib[full]==0.2.2"
 codenib toolchain install /path/to/repository --scope graph
 codenib index /path/to/repository --preset full
 ```
+
+This succeeds only with the default source selection, an immutable commit tree
+that exactly matches the authenticated checkout, and no tracked path rejected
+by the default policy. A non-empty custom exclusion set, or a tracked
+default-excluded path, makes the Zoekt build fail closed; see
+[the CodeGraph source-surface boundary](codegraph.md#select-the-repository-source-surface).
 
 Graph and Zoekt construction also require external backend binaries. Check the
 repository's language-specific graph provider before building:
@@ -230,6 +236,11 @@ commands independently:
 command -v zoekt-git-index
 command -v zoekt-webserver
 ```
+
+In 0.2.2 authenticated `search_zoekt` serving is Linux-only. The runtime keeps
+the verified shard generation open and gives `zoekt-webserver` a `/proc`
+descriptor path; macOS and Windows fail closed rather than reopen the mutable
+published directory.
 
 See [SCIP Indexing](scip_index.md) and
 [Language Capabilities](language_capabilities.md) for backend-specific setup

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,11 +18,11 @@ uses BM25 plus static symbol relationships and needs no model or API key.
 Install the exact release with its graph and MCP dependencies from PyPI:
 
 ```bash
-python -m pip install "codenib[graph,mcp]==0.2.1"
+python -m pip install "codenib[graph,mcp]==0.2.2"
 codenib --version
 ```
 
-The version command must report `codenib 0.2.1`. Exact version pins keep the
+The version command must report `codenib 0.2.2`. Exact version pins keep the
 environment reproducible.
 
 ## Connect A CodeGraph To Your Agent
@@ -61,6 +61,22 @@ Preview every planned action without a download or write:
 codenib codegraph init /path/to/repository --dry-run
 ```
 
+For generated or vendored trees, pass exact root-relative exclusions. They are
+recorded with the source identity and reused by later runs:
+
+```bash
+codenib codegraph init /path/to/repository --exclude-dir ios/Pods
+```
+
+Repeat the flag to replace the full custom set, or use
+`--clear-exclude-dirs`. CodeNib deliberately does not infer this policy from
+`.gitignore`; see [Select the repository source surface](codegraph.md#select-the-repository-source-surface).
+Each value is an exact repository-relative subtree written with `/`, not a
+glob. A non-empty custom set currently cannot be combined with the `zoekt`
+view or `--preset full`; CodeNib fails closed instead of broadening it. Zoekt
+also refuses a default-policy build when the fixed commit contains a tracked
+path that the authenticated source policy excludes.
+
 Verify the full path, including source freshness and native client
 configuration:
 
@@ -80,7 +96,7 @@ Install the semantic extra when the browser Wiki should use local dense
 retrieval in addition to BM25:
 
 ```bash
-python -m pip install "codenib[semantic]==0.2.1"
+python -m pip install "codenib[semantic]==0.2.2"
 ```
 
 ```bash
@@ -192,6 +208,10 @@ embedding model, and BYO endpoint configurations.
 | `graph` | `codenib[graph]` | BM25 and symbol graph |
 | `full` | `codenib[full]` | BM25, dense vectors, symbol graph, and Zoekt |
 
+Building the Zoekt view and serving it are separate boundaries. In 0.2.2,
+authenticated MCP `search_zoekt` serving requires Linux `/proc`; macOS and
+Windows fail closed instead of handing the process a mutable shard path.
+
 The recommended installation already selects `semantic` through the default
 `auto` preset. Select it explicitly in automation when the artifact contract
 must not depend on the installed environment:
@@ -210,7 +230,7 @@ To keep embeddings out of the local process, use a BYO OpenAI-compatible
 embedding service:
 
 ```bash
-python -m pip install "codenib[semantic-remote]==0.2.1"
+python -m pip install "codenib[semantic-remote]==0.2.2"
 export EMBEDDING_API_KEY=...
 codenib doctor --require semantic \
   --embedding-provider openai \
@@ -280,7 +300,7 @@ clangd, and live LSP providers are language-specific executables, so CodeNib
 plans them from the detected repository rather than installing every language:
 
 ```bash
-python -m pip install "codenib[graph]==0.2.1"
+python -m pip install "codenib[graph]==0.2.2"
 codenib toolchain status /path/to/repository --scope graph
 codenib toolchain install /path/to/repository --scope graph
 codenib doctor /path/to/repository --require graph
@@ -327,7 +347,7 @@ Static Wiki pages are the default. To generate conceptual page narratives
 through a LiteLLM-supported provider:
 
 ```bash
-python -m pip install "codenib[agent,semantic]==0.2.1"
+python -m pip install "codenib[agent,semantic]==0.2.2"
 export OPENAI_API_KEY=...
 codenib doctor --require agent \
   --model openai/gpt-4o-mini --api-key-env OPENAI_API_KEY --probe-model
@@ -358,7 +378,7 @@ codenib wiki . --generate --model anthropic/claude-sonnet-4-5
 Vertex AI additionally requires CodeNib's `vertex` extra:
 
 ```bash
-python -m pip install "codenib[agent,semantic,vertex]==0.2.1"
+python -m pip install "codenib[agent,semantic,vertex]==0.2.2"
 gcloud auth application-default login
 codenib wiki . --generate \
   --model vertex_ai/gemini-2.5-flash \
@@ -413,7 +433,7 @@ continues to work.
 ## Serve The Index Over MCP
 
 ```bash
-python -m pip install "codenib[mcp,semantic]==0.2.1"
+python -m pip install "codenib[mcp,semantic]==0.2.2"
 codenib index /path/to/repository
 codenib mcp /path/to/repository
 ```

--- a/docs/releases/0.2.2.md
+++ b/docs/releases/0.2.2.md
@@ -1,0 +1,94 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# CodeNib 0.2.2
+
+CodeNib 0.2.2 makes one authenticated repository source surface authoritative
+from indexing through agent and Web serving. It fixes the Expo/CocoaPods layout
+reported in [Issue #641](https://github.com/sysevol-ai/CodeNib/issues/641) and
+adds an explicit alternative for generated or vendored subtrees:
+
+```bash
+python -m pip install --upgrade "codenib[graph,mcp]==0.2.2"
+codenib codegraph init /absolute/path/to/repository \
+  --exclude-dir ios/Pods
+```
+
+## Contained absolute symlinks
+
+The authenticated fingerprint and source-binding paths now accept an absolute
+symlink only when its lexical target is inside the same pinned checkout. The
+target is re-walked from the repository authority instead of being opened by
+ambient absolute path. Raw link text remains part of the source identity, and
+initial/final identity checks still reject retargeting, prefix lookalikes,
+outside targets, device paths, alternate data streams, and unsupported Windows
+namespaces.
+
+This supports layouts such as an `ios/Pods` link into an in-repository pnpm
+store without making `ios`, `android`, or `Pods` globally ignored names. Those
+directories can contain user-maintained source and remain indexed by default.
+
+## Persistent source selection
+
+Use repeatable `--exclude-dir` arguments for exact root-relative subtrees:
+
+```bash
+codenib codegraph init . \
+  --exclude-dir ios/Pods \
+  --exclude-dir generated/api
+```
+
+Paths use POSIX `/` spelling on every platform, are lexical and
+component-aware, and are not globs. An explicit set replaces the complete
+custom selection. Later `codegraph init`, `index`, Wiki, publish, doctor, and
+toolchain flows reuse the manifest policy when no replacement is supplied;
+`--clear-exclude-dirs` returns to the default source surface. CodeNib does not
+silently adopt `.gitignore` or ambient global Git excludes.
+
+Manifest 1.2 records the canonical selection and digest as part of repository
+and view identity. A policy change rebuilds affected views even when the
+selected bytes otherwise happen to match. Manifest 1.1 remains readable under
+its exact legacy policy and migrates on the next successful compilation.
+
+The same selected inventory gates language detection, BM25/vector documents,
+symbol graph and SCIP output, MCP source tools, Wiki and Web reads, historical
+projections, and Ask citations. A backend or artifact that cannot confirm the
+recorded selection fails closed rather than being labeled current.
+
+Symbol-graph builder schema 6 now records `lsp_index.pkl` as an optional,
+fingerprinted occurrence artifact. When present, it is copied and verified from
+the same owned graph generation before either pickle is loaded; when absent,
+ambient sidecars are ignored instead of being discovered by path.
+
+## Backend boundaries
+
+Zoekt accepts the default repository policy through a fixed commit-tree proof,
+private generation publication, and an authenticated shard-tree receipt, but
+only when that commit tree exactly matches the authenticated checkout and has
+no tracked path rejected by the default policy. It does not yet support
+non-empty custom exclusions. Requesting the `zoekt` view, including through
+`--preset full`, therefore fails before producing a new shard when any of those
+conditions is unmet; the default CodeGraph path (`bm25` plus `symbol_graph`)
+remains supported.
+The authenticated MCP Zoekt runtime is Linux-only in 0.2.2: it passes a
+retained `/proc` descriptor path to `zoekt-webserver`. Other platforms fail
+closed rather than reopen a mutable published shard path.
+
+Manifest-bound native clangd indexes are also disabled until their generated
+`.idx` files have an authenticated allowed-file proof. C and C++ queries fall
+back to the verified persisted graph instead of consuming mutable files from a
+default-ignored build directory.
+
+## Upgrade notes
+
+- Re-run `codenib codegraph init` or `codenib index` after upgrading. Existing
+  manifest 1.1 data remains readable; selected views rebuild into manifest 1.2.
+- Existing default source behavior is preserved. No directory name is newly
+  ignored globally.
+- Use `codenib codegraph status --json` to inspect the recorded source
+  selection and digest before changing it.
+- The target checkout remains unchanged; CodeNib-owned indexes and receipts
+  stay below `CODENIB_HOME`.

--- a/docs/scip_index.md
+++ b/docs/scip_index.md
@@ -23,7 +23,7 @@ Install the graph dependencies, check the target repository, and then select
 the graph preset:
 
 ```bash
-python -m pip install "codenib[graph]==0.2.1"
+python -m pip install "codenib[graph]==0.2.2"
 codenib toolchain install /path/to/repository --scope graph
 codenib doctor /path/to/repository --require graph
 codenib index /path/to/repository --preset graph

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -34,6 +34,16 @@ through `graph_route="lsp"` for regression checks and for loose-file fallback.
 Scala has no registered LSP graph route today; its active graph support is the
 `scip-java` route only.
 
+The 0.2.2 repository-source authority gate temporarily disables manifest-bound
+query-time reuse of native clangd `.idx` files for C and C++, including the
+default/legacy source policy. Those files commonly live below the
+default-excluded `build/` tree and do not yet carry an authenticated generation
+receipt plus allowed-file proof. C/C++ graph indexing remains available, while
+queries fall back to the verified persisted symbol graph. Re-enabling the
+native route requires exact `.idx` generation ownership, source-selection
+closure, and parity tests; this is an acceleration gate change, not a language
+support removal.
+
 ## Archived Layered Goal
 
 The completed multi-language SCIP cold-start and acceleration program required:

--- a/docs/semantic_fact_batches.md
+++ b/docs/semantic_fact_batches.md
@@ -191,6 +191,12 @@ export CODENIB_NATIVE_FACT_QUERY_INDEX=auto
 export CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX=auto
 ```
 
+The clangd variable remains available to the direct experiment and profiling
+surface. CodeNib 0.2.2 does not admit mutable project-local `.idx` files in a
+manifest-bound MCP or agent runtime; those contexts use the verified persisted
+graph until clangd generations carry an authenticated receipt and allowed-file
+proof.
+
 Run the alternating-arm parity and performance gate with:
 
 ```bash

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -231,10 +231,26 @@ opens, and gives FAISS a callback over the already authenticated index
 descriptor rather than reopening an attacker-replaceable path.  The M1 JSON
 format has a fixed 16 MiB configuration limit and 256 MiB documents-file limit;
 larger repositories require a future streaming or sharded format rather than a
-manifest-controlled memory override.  Repository-relative source aliases may
-use bounded relative symlinks only when resolution remains inside the pinned
-checkout; absolute, outside, looping, raced, and reparse-point paths fail
-closed in staging, binding, BM25 reads, and MCP reads.  The shared credential
+manifest-controlled memory override.  Authenticated repository snapshots may
+use bounded relative symlinks or absolute symlinks whose raw target has the
+pinned lexical checkout root as a complete path-component prefix.  Absolute
+targets are rebased and walked again from the retained root descriptor or
+HANDLE; Windows containment uses the reparse substitute name and retains the
+full reparse payload for later verification.  Unauthenticated path-only reads
+and portable staging remain relative-only.  Outside, root-escaping, looping,
+raced, and unsupported reparse-point paths continue to fail closed, and the
+Docker source fingerprint helper applies the same host-root-to-workspace
+mapping.  Repository manifest v1.2 additionally persists one canonical
+`repository-source-selection.v1` value and digest across the repository,
+last-indexed generation, and every view entry. Exact root-relative subtree
+exclusions are part of source fingerprint v2 framing, so policy changes cannot
+reuse or relabel a view built for another source surface. Compiler builders,
+retained import/export/materialization plans, live source bindings, and
+portable runtimes all verify the same selection identity; v1.1 remains readable
+only through its exact policy-3/no-selection compatibility path and migrates on
+the next successful compilation. Graph and Zoekt artifacts require
+authenticated content receipts before deserialization or process startup.
+The shared credential
 classifier lives outside both artifacts and storage so the artifact layer does
 not depend on the catalog implementation.  These gates close the current
 portable context publication surface, and the injectable retained materializer
@@ -404,7 +420,8 @@ retention callback, receipts remain point-in-time checks rather than lifetime
 pins.
 
 A pure retained-manifest planning layer now closes the data-only side of that
-boundary for current portable `RepoManifest` v1.1 projections. It accepts only
+boundary for current portable `RepoManifest` v1.2 projections while preserving
+strict compatibility with retained v1.1 projections. It accepts only
 bounded, unambiguous, BOM-free UTF-8 JSON; rejects unknown shape, non-finite or
 over-complex values, credential data, diagnostic data, and forged storage or
 filesystem authority claims; and selects only current BM25/vector entries whose
@@ -419,12 +436,12 @@ and Git commit text remains display provenance rather than source authority.
 Planning performs no source or artifact reads, native parsing, CAS/catalog
 operation, receipt minting, or ref publication. Execution is a separate
 authority-bearing API, so inspecting or serializing a plan cannot publish it.
-The retained exporter described below now supplies equivalent canonical v1.1
-bytes, and the injectable retained materializer closes their filesystem
-publication boundary. The explicit local CLI bridge uses the concrete local
-provider only for an operator-selected retained ref or snapshot. Default
-compiler/import/runtime wiring remains outstanding, so M1 remains in progress.
-Profile adapters and fenced publication remain M2 work;
+The retained exporter described below now supplies equivalent canonical bytes
+for both supported manifest versions, and the injectable retained materializer
+closes their filesystem publication boundary. The explicit local CLI bridge
+uses the concrete local provider only for an operator-selected retained ref or
+snapshot. Default compiler/import/runtime wiring remains outstanding, so M1
+remains in progress. Profile adapters and fenced publication remain M2 work;
 production retention and garbage collection remain M5 work.
 
 The retained-import foundation now also exposes schema-v4 compound-generation
@@ -529,11 +546,13 @@ are checked source-free while native vector indexes remain inert. Unselected
 entries are omitted from the emitted manifest, unknown capability extensions
 are preserved, and the built-in sparse/dense/hybrid/symbol capabilities are
 recomputed from the retained selection. A final receipt sweep precedes return
-of canonical `RepoManifest` v1.1 bytes and a point-in-time observation receipt
-that carries the attested namespace ID, canonical repository key, and derived
-repository ID. It is neither a GC pin nor a materialization/native-load
-authority; filesystem output and runtime activation remain separate authority
-boundaries rather than implicit powers of the export receipt.
+of canonical current `RepoManifest` v1.2 bytes (or exact v1.1 compatibility
+bytes when exporting a retained legacy projection) and a point-in-time
+observation receipt that carries the attested namespace ID, canonical repository
+key, and derived repository ID. It is neither a GC pin nor a
+materialization/native-load authority; filesystem output and runtime activation
+remain separate authority boundaries rather than implicit powers of the export
+receipt.
 
 The first retained context materializer now turns that data-only export into
 one exact, query-compatible filesystem generation without treating the export
@@ -697,6 +716,10 @@ Foundation now available:
   identity, profile identity, and position encoding.
 - Compatibility adapters project the existing Python `CodeGraph` and SCIP
   occurrence index without changing the persisted graph schema or C++ decoder.
+- Symbol-graph builder schema v6 binds the optional persisted SCIP occurrence
+  index with an exact `lsp_occurrence_artifact` receipt. Graph consumers copy
+  and authenticate that sidecar from the same owned generation as `graph.pkl`
+  before deserializing it; an unreceipted ambient sidecar is never discovered.
 - Ordered resolver passes resolve only unique monikers and require framework or
   heuristic edges to retain provenance, confidence, and the synthesizing
   resolver name.

--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -10,7 +10,7 @@ For one local repository, use the packaged two-command path in the
 [Quickstart](quickstart.md):
 
 ```bash
-python -m pip install "codenib[semantic]==0.2.1"
+python -m pip install "codenib[semantic]==0.2.2"
 codenib wiki /path/to/repository
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -170,6 +170,7 @@ nav:
       - get-started/index.md
       - Quickstart: quickstart.md
       - Agent-ready CodeGraph: codegraph.md
+      - Release 0.2.2: releases/0.2.2.md
       - Release 0.2.1: releases/0.2.1.md
       - Release 0.2.0: releases/0.2.0.md
       - GitHub Pages: github_pages.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codenib"
-version = "0.2.1"
+version = "0.2.2"
 description = "A multi-view data system for serving repository context to coding agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -8,19 +8,19 @@
     "url": "https://github.com/sysevol-ai/CodeNib",
     "source": "github"
   },
-  "version": "0.2.1",
+  "version": "0.2.2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "codenib",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "runtimeHint": "uvx",
       "runtimeArguments": [
         {
           "type": "named",
           "name": "--with",
-          "value": "codenib[graph,mcp]==0.2.1",
+          "value": "codenib[graph,mcp]==0.2.2",
           "description": "Install the version-matched CodeNib CodeGraph and MCP runtime."
         }
       ],

--- a/test/agent/test_lsp_provider.py
+++ b/test/agent/test_lsp_provider.py
@@ -30,6 +30,7 @@ from codenib.agent.skills.core import (
 from codenib.agent.skills.registry import SkillRegistry
 from codenib.graph.code_graph import CodeGraph
 from codenib.llm.litellm_chat import LiteLLMChat
+from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.scip_interface.lsp_occurrence_index import (
     SCIPOccurrence,
     SCIPOccurrenceIndex,
@@ -296,6 +297,34 @@ def test_unknown_language_alongside_cpp_forces_graph_fallback():
     assert provider.graph is graph
     assert selection["backend"] == "persisted-symbol-graph-v1"
     assert selection["fallback_reason"] == ("mixed_language_requires_persisted_graph")
+
+
+@pytest.mark.parametrize(
+    "selection_policy",
+    (
+        RepositorySourceSelection(),
+        RepositorySourceSelection(("private[1]",)),
+    ),
+)
+def test_manifest_source_policy_disables_unproved_native_cpp_provider(
+    selection_policy,
+):
+    graph = _range_graph()
+
+    with patch("codenib.ls_router.LSIndexer") as indexer:
+        provider, selection = select_checkout_lsp_provider(
+            project_root="/local/repo",
+            languages=["cpp"],
+            symbol_graph=graph,
+            source_selection=selection_policy,
+        )
+
+    indexer.assert_not_called()
+    assert provider.graph is graph
+    assert selection["backend"] == "persisted-symbol-graph-v1"
+    assert selection["fallback_reason"] == (
+        "repository_source_policy_requires_persisted_graph"
+    )
 
 
 def test_runtime_native_off_switch_uses_persisted_provider(monkeypatch):

--- a/test/agent/test_query_manifest.py
+++ b/test/agent/test_query_manifest.py
@@ -27,6 +27,11 @@ from codenib.agent import CodeNibAgentOptions, query
 from codenib.agent.skills.registry import SkillRegistry
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.llm.litellm_chat import LiteLLMChat
+from codenib.repository_source_selection import RepositorySourceSelection
+
+_SOURCE_COMMIT = "d" * 40
+_SOURCE_FINGERPRINT = "sha256-v2:" + ("e" * 64)
+_SOURCE_SELECTION = RepositorySourceSelection()
 
 
 @pytest.fixture(autouse=True)
@@ -65,10 +70,18 @@ def _fake_manifest(
             built_at="2026-01-01T00:00:00Z",
             built_at_epoch=time.time(),
             status="fresh",
+            commit=_SOURCE_COMMIT,
+            source_fingerprint=_SOURCE_FINGERPRINT,
+            source_selection_digest=_SOURCE_SELECTION.digest,
         )
     manifest = RepoManifest(
         repo_path=repo_path,
-        commit="deadbeef",
+        commit=_SOURCE_COMMIT,
+        last_indexed_commit=_SOURCE_COMMIT,
+        source_fingerprint=_SOURCE_FINGERPRINT,
+        last_indexed_source_fingerprint=_SOURCE_FINGERPRINT,
+        source_selection=_SOURCE_SELECTION,
+        last_indexed_source_selection_digest=_SOURCE_SELECTION.digest,
         languages=["python"],
         file_count=1,
         indexes=indexes,

--- a/test/artifacts/test_context_artifact.py
+++ b/test/artifacts/test_context_artifact.py
@@ -27,6 +27,8 @@ from codenib.index.embedding.artifact_integrity import (
     vector_config_artifact_record,
     vector_level_artifact_records,
 )
+from codenib.repository_filters import REPOSITORY_FILTER_POLICY_VERSION
+from codenib.repository_source_selection import DEFAULT_REPOSITORY_SOURCE_SELECTION
 from codenib.source_fingerprint import fingerprint_repository
 
 
@@ -167,6 +169,8 @@ def _fixture_vector_manifest(root: Path) -> tuple[Path, Path, Path]:
         "dimension": 4,
         "embedding_kwargs": {},
         "index_metric": "ip",
+        "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
+        "source_selection_digest": DEFAULT_REPOSITORY_SOURCE_SELECTION.digest,
         "persistence_config_fingerprint": vector_config_artifact_record(
             vector,
             "test__model",

--- a/test/artifacts/test_runtime.py
+++ b/test/artifacts/test_runtime.py
@@ -47,12 +47,13 @@ from codenib.artifacts import (
     verify_context_artifact,
 )
 from codenib.cli import run
-from codenib.compiler.index_builders import VectorIndexBuilder
-from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.compiler.index_builders import BM25IndexBuilder, VectorIndexBuilder
+from codenib.compiler.manifest import LEGACY_MANIFEST_VERSION, IndexEntry, RepoManifest
 from codenib.index.embedding.artifact_integrity import vector_config_artifact_record
 from codenib.index.embedding.vector_store import CodeVectorStore
 from codenib.mcp.context import ServerContext
 from codenib.mcp.tools.source import read_source_impl
+from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.source_fingerprint import (
     RepositoryChangedError,
     capture_repository_source,
@@ -128,6 +129,7 @@ def _bm25_artifact(
         encoding="utf-8",
     )
     source_identity = fingerprint_repository(repo)
+    config = BM25IndexBuilder(languages=["python"], max_k=15).artifact_identity()
     manifest_path = index_root / "repo_manifest.json"
     RepoManifest(
         repo_path=str(repo),
@@ -144,6 +146,8 @@ def _bm25_artifact(
                 built_at="2026-08-04T00:00:00+00:00",
                 built_at_epoch=1.0,
                 status="fresh",
+                config=dict(config),
+                metadata=dict(config),
                 commit=commit,
                 source_fingerprint=source_identity.value,
             )
@@ -294,16 +298,28 @@ def _refresh_inventory_file(artifact: Path, metadata: dict, relative: str) -> No
     record["sha256"] = hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def _rewrite_artifact_source_fingerprint(artifact: Path, fingerprint: str) -> None:
+def _rewrite_artifact_as_legacy_source_fingerprint(
+    artifact: Path,
+    fingerprint: str,
+) -> None:
     metadata = _metadata(artifact)
     metadata["repository"]["source_fingerprint"] = fingerprint
+    metadata["builder"]["manifest_version"] = LEGACY_MANIFEST_VERSION
     manifest_relative = metadata["manifest"]["path"]
     manifest_path = artifact / manifest_relative
     manifest = RepoManifest.load(manifest_path)
+    manifest.version = LEGACY_MANIFEST_VERSION
     manifest.source_fingerprint = fingerprint
     manifest.last_indexed_source_fingerprint = fingerprint
+    manifest.source_selection = None
+    manifest.last_indexed_source_selection_digest = ""
     for entry in manifest.indexes.values():
         entry.source_fingerprint = fingerprint
+        entry.source_selection_digest = ""
+        for contract in (entry.config, entry.metadata):
+            contract.pop("source_selection_digest", None)
+            if "repository_filter_policy" in contract:
+                contract["repository_filter_policy"] = 3
     manifest.save(manifest_path)
     _refresh_inventory_file(artifact, metadata, manifest_relative)
     _write_metadata(artifact, metadata)
@@ -1042,7 +1058,7 @@ def test_v1_artifact_supports_inert_bm25_query_but_cannot_bind(
 ) -> None:
     repo, artifact, _commit = _bm25_artifact(tmp_path)
     legacy = f"sha256:{'a' * 64}"
-    _rewrite_artifact_source_fingerprint(artifact, legacy)
+    _rewrite_artifact_as_legacy_source_fingerprint(artifact, legacy)
 
     query_binding = query_context_artifact(artifact)
     verified = query_binding.artifact
@@ -1062,6 +1078,123 @@ def test_v1_artifact_supports_inert_bm25_query_but_cannot_bind(
 
     with pytest.raises(ValueError, match="query-only"):
         bind_context_artifact(artifact, repo)
+
+
+@pytest.mark.parametrize("excluded_path", ["sample.py", ".git/config"])
+def test_query_rejects_view_paths_excluded_by_manifest_policy(
+    tmp_path: Path,
+    excluded_path: str,
+) -> None:
+    _repo, artifact, _commit = _bm25_artifact(tmp_path)
+    metadata = _metadata(artifact)
+    manifest_relative = metadata["manifest"]["path"]
+    manifest_path = artifact / manifest_relative
+    manifest = RepoManifest.load(manifest_path)
+    selection = RepositorySourceSelection(
+        ("sample.py",) if excluded_path == "sample.py" else ()
+    )
+    manifest.source_selection = selection
+    manifest.last_indexed_source_selection_digest = selection.digest
+    for entry in manifest.indexes.values():
+        entry.source_selection_digest = selection.digest
+        for contract in (entry.config, entry.metadata):
+            if "source_selection_digest" in contract:
+                contract["source_selection_digest"] = selection.digest
+    manifest.save(manifest_path)
+    _refresh_inventory_file(artifact, metadata, manifest_relative)
+    _write_metadata(artifact, metadata)
+
+    if excluded_path != "sample.py":
+        documents_path = artifact / "views" / "bm25" / "documents.json"
+        documents = json.loads(documents_path.read_text(encoding="utf-8"))
+        documents[0]["metadata"]["file"] = excluded_path
+        documents_path.write_text(json.dumps(documents), encoding="utf-8")
+        _refresh_inventory_file(
+            artifact,
+            metadata,
+            "views/bm25/documents.json",
+        )
+        _write_metadata(artifact, metadata)
+
+    with pytest.raises(ValueError, match="source paths excluded"):
+        query_context_artifact(artifact)
+
+
+@pytest.mark.parametrize("contract_name", ["config", "metadata"])
+def test_query_rejects_view_source_selection_contract_mismatch(
+    tmp_path: Path,
+    contract_name: str,
+) -> None:
+    _repo, artifact, _commit = _bm25_artifact(tmp_path)
+    metadata = _metadata(artifact)
+    manifest_relative = metadata["manifest"]["path"]
+    manifest_path = artifact / manifest_relative
+    manifest = RepoManifest.load(manifest_path)
+    contract = getattr(manifest.indexes["bm25"], contract_name)
+    contract["source_selection_digest"] = RepositorySourceSelection(
+        ("generated",)
+    ).digest
+    manifest.save(manifest_path)
+    _refresh_inventory_file(artifact, metadata, manifest_relative)
+    _write_metadata(artifact, metadata)
+
+    with pytest.raises(ValueError, match="source-selection identity"):
+        query_context_artifact(artifact)
+
+
+@pytest.mark.parametrize("contract_name", ["config", "metadata"])
+def test_query_rejects_null_repository_filter_policy(
+    tmp_path: Path,
+    contract_name: str,
+) -> None:
+    _repo, artifact, _commit = _bm25_artifact(tmp_path)
+    metadata = _metadata(artifact)
+    manifest_relative = metadata["manifest"]["path"]
+    manifest_path = artifact / manifest_relative
+    manifest = RepoManifest.load(manifest_path)
+    getattr(manifest.indexes["bm25"], contract_name)["repository_filter_policy"] = None
+    manifest.save(manifest_path)
+    _refresh_inventory_file(artifact, metadata, manifest_relative)
+    _write_metadata(artifact, metadata)
+
+    with pytest.raises(ValueError, match="repository filter policy"):
+        query_context_artifact(artifact)
+
+
+def test_legacy_query_rejects_default_ignored_view_path(tmp_path: Path) -> None:
+    _repo, artifact, _commit = _bm25_artifact(tmp_path)
+    _rewrite_artifact_as_legacy_source_fingerprint(
+        artifact,
+        f"sha256:{'a' * 64}",
+    )
+    metadata = _metadata(artifact)
+    documents_relative = "views/bm25/documents.json"
+    documents_path = artifact / documents_relative
+    documents = json.loads(documents_path.read_text(encoding="utf-8"))
+    documents[0]["metadata"]["file"] = ".git/config"
+    documents_path.write_text(json.dumps(documents), encoding="utf-8")
+    _refresh_inventory_file(artifact, metadata, documents_relative)
+    _write_metadata(artifact, metadata)
+
+    with pytest.raises(ValueError, match="source paths excluded"):
+        query_context_artifact(artifact)
+
+
+def test_current_query_requires_every_document_to_declare_source_path(
+    tmp_path: Path,
+) -> None:
+    _repo, artifact, _commit = _bm25_artifact(tmp_path)
+    metadata = _metadata(artifact)
+    documents_relative = "views/bm25/documents.json"
+    documents_path = artifact / documents_relative
+    documents = json.loads(documents_path.read_text(encoding="utf-8"))
+    documents[0]["metadata"].pop("file")
+    documents_path.write_text(json.dumps(documents), encoding="utf-8")
+    _refresh_inventory_file(artifact, metadata, documents_relative)
+    _write_metadata(artifact, metadata)
+
+    with pytest.raises(ValueError, match="must declare a source file"):
+        query_context_artifact(artifact)
 
 
 def test_verify_rejects_unsafe_bm25_source_contract(tmp_path: Path) -> None:
@@ -2401,7 +2534,10 @@ def test_mcp_server_query_only_v1_artifact_loads_bm25_without_checkout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _repo, artifact, _commit = _bm25_artifact(tmp_path)
-    _rewrite_artifact_source_fingerprint(artifact, f"sha256:{'a' * 64}")
+    _rewrite_artifact_as_legacy_source_fingerprint(
+        artifact,
+        f"sha256:{'a' * 64}",
+    )
 
     with patch.object(server_module.mcp, "run") as run_server:
         server_module.main(
@@ -2449,7 +2585,10 @@ def test_mcp_server_query_only_v1_vector_artifact_never_parses_native_bytes(
     tmp_path: Path,
 ) -> None:
     _repo, artifact, _commit = _vector_artifact(tmp_path)
-    _rewrite_artifact_source_fingerprint(artifact, f"sha256:{'a' * 64}")
+    _rewrite_artifact_as_legacy_source_fingerprint(
+        artifact,
+        f"sha256:{'a' * 64}",
+    )
 
     with (
         patch.object(server_module.mcp, "run") as run_server,

--- a/test/artifacts/test_strict_context_publication.py
+++ b/test/artifacts/test_strict_context_publication.py
@@ -42,6 +42,8 @@ from codenib.artifacts import (
 )
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.index.embedding.artifact_integrity import VECTOR_PERSISTENCE_SCHEMA
+from codenib.repository_filters import REPOSITORY_FILTER_POLICY_VERSION
+from codenib.repository_source_selection import DEFAULT_REPOSITORY_SOURCE_SELECTION
 from codenib.source_fingerprint import (
     RepositorySourceBinding,
     RepositorySourceIdentitySnapshot,
@@ -50,7 +52,12 @@ from codenib.source_fingerprint import (
 
 _Result = TypeVar("_Result")
 _COMMIT = "a" * 40
+_SOURCE_SELECTION_CONFIG = {
+    "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
+    "source_selection_digest": DEFAULT_REPOSITORY_SOURCE_SELECTION.digest,
+}
 _VECTOR_CONFIG = {
+    **_SOURCE_SELECTION_CONFIG,
     "builder_schema": 2,
     "embedding_model": "test/model",
     "embedding_provider": "huggingface",
@@ -323,7 +330,7 @@ def _entry(
     *,
     source_fingerprint: str,
 ) -> IndexEntry:
-    config = {} if view == "bm25" else dict(_VECTOR_CONFIG)
+    config = dict(_SOURCE_SELECTION_CONFIG) if view == "bm25" else dict(_VECTOR_CONFIG)
     return IndexEntry(
         index_type=view,
         path=f"state/{view}",

--- a/test/chunker/test_repo_chunking_config.py
+++ b/test/chunker/test_repo_chunking_config.py
@@ -115,7 +115,8 @@ def test_repo_discovery_applies_exact_selection_before_file_reads(
         "src/app.py",
         "src/private_api/public.py",
     ]
-    assert inspected == discovered
+    assert sorted(inspected) == discovered
+    assert "src/private/secret.py" not in inspected
 
 
 def test_repo_language_detection_ignores_excluded_subtrees(tmp_path: Path):

--- a/test/chunker/test_repo_chunking_config.py
+++ b/test/chunker/test_repo_chunking_config.py
@@ -5,11 +5,13 @@
 """Unit tests for repository-level chunking language metadata."""
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from codenib.code_chunker import CodeChunker, RepoChunkingConfig
 from codenib.languages import extensions_for_language
+from codenib.repository_source_selection import RepositorySourceSelection
 
 
 def test_repo_chunking_config_defaults_come_from_language_registry():
@@ -26,6 +28,18 @@ def test_repo_chunking_config_defaults_come_from_language_registry():
     assert cfg.kotlin_extensions == extensions_for_language("kotlin", "chunker")
     assert cfg.javascript_extensions == extensions_for_language("javascript", "chunker")
     assert cfg.typescript_extensions == extensions_for_language("typescript", "chunker")
+
+
+def test_repo_chunking_config_retains_an_exact_detached_selection_snapshot():
+    selection = RepositorySourceSelection(["src/private"])
+    cfg = RepoChunkingConfig(source_selection=selection)
+
+    object.__setattr__(selection, "exclude_subtrees", ("src/changed",))
+
+    assert cfg.source_selection is not selection
+    assert cfg.source_selection.exclude_subtrees == ("src/private",)
+    with pytest.raises(TypeError, match="RepositorySourceSelection"):
+        RepoChunkingConfig(source_selection=object())
 
 
 def test_repo_discovery_normalizes_language_aliases(tmp_path: Path):
@@ -62,6 +76,88 @@ def test_repo_discovery_respects_custom_extension_overrides(tmp_path: Path):
 
     assert stats["total_files"] == 1
     assert stats["files_by_language"]["python"][0]["path"] == "tool.pyw"
+
+
+def test_repo_discovery_applies_exact_selection_before_file_reads(
+    tmp_path: Path,
+    monkeypatch,
+):
+    paths = (
+        "src/app.py",
+        "src/private/secret.py",
+        "src/private_api/public.py",
+        "other/private/also_public.py",
+    )
+    for relative in paths:
+        source = tmp_path / relative
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text("value = 1\n", encoding="utf-8")
+
+    cfg = RepoChunkingConfig(
+        languages=["python"],
+        filter_tests=False,
+        source_selection=RepositorySourceSelection(["src/private"]),
+    )
+    chunker = CodeChunker(language="python", repo_config=cfg)
+    inspected = []
+
+    def inspect_minification(file_path):
+        inspected.append(file_path.relative_to(tmp_path).as_posix())
+        return False
+
+    monkeypatch.setattr(chunker, "_is_minified_file", inspect_minification)
+
+    files = chunker._discover_files(tmp_path, cfg.languages)
+    discovered = [path.relative_to(tmp_path).as_posix() for path, _ in files]
+
+    assert discovered == [
+        "other/private/also_public.py",
+        "src/app.py",
+        "src/private_api/public.py",
+    ]
+    assert inspected == discovered
+
+
+def test_repo_language_detection_ignores_excluded_subtrees(tmp_path: Path):
+    excluded = tmp_path / "generated" / "main.go"
+    excluded.parent.mkdir()
+    excluded.write_text("package main\n", encoding="utf-8")
+    included = tmp_path / "lib" / "app.rb"
+    included.parent.mkdir()
+    included.write_text("class App\nend\n", encoding="utf-8")
+    cfg = RepoChunkingConfig(
+        source_selection=RepositorySourceSelection(["generated"]),
+    )
+    chunker = CodeChunker(language="python", repo_config=cfg)
+
+    assert chunker._detect_repo_language(tmp_path) == ["ruby"]
+
+
+def test_repository_chunking_rejects_an_excluded_chunk_result(
+    tmp_path: Path,
+    monkeypatch,
+):
+    source = tmp_path / "app.py"
+    source.write_text("value = 1\n", encoding="utf-8")
+    cfg = RepoChunkingConfig(
+        languages=["python"],
+        filter_tests=False,
+        source_selection=RepositorySourceSelection(["src/private"]),
+    )
+    chunker = CodeChunker(language="python", repo_config=cfg)
+    monkeypatch.setattr(
+        chunker,
+        "_discover_files",
+        lambda *_args, **_kwargs: [(source, "python")],
+    )
+    monkeypatch.setattr(
+        chunker,
+        "_chunk_file_with_language",
+        lambda *_args: [SimpleNamespace(file="src/private/secret.py")],
+    )
+
+    with pytest.raises(RuntimeError, match="leaked excluded chunk"):
+        chunker.chunk_repository(str(tmp_path), strict=True)
 
 
 def test_strict_repository_chunking_rejects_partial_results(tmp_path, monkeypatch):

--- a/test/clients/test_execution.py
+++ b/test/clients/test_execution.py
@@ -32,6 +32,7 @@ from codenib.clients.execution import (
     RunStatus,
     SandboxProcessRunner,
 )
+from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.sandbox import (
     ExecResult,
     NetworkMode,
@@ -407,6 +408,7 @@ def test_sandbox_process_runner_copies_source_and_rewrites_workspace(
         ("git", "commit", "--quiet", "-m", "source"), cwd=tmp_path, check=True
     )
     provider = FakeSandboxProvider()
+    source_selection = RepositorySourceSelection(("generated",))
     runner = SandboxProcessRunner(
         provider=provider,
         image="guardian:test",
@@ -417,6 +419,7 @@ def test_sandbox_process_runner_copies_source_and_rewrites_workspace(
             allow_unpinned_image=True,
         ),
         staged_files={".guardian-runtime/auth.json": b"secret"},
+        source_selection=source_selection,
     )
     request = ProcessRequest(
         argv=("codex", "exec", "--cd", str(tmp_path), "-"),
@@ -431,6 +434,7 @@ def test_sandbox_process_runner_copies_source_and_rewrites_workspace(
     assert result.stdout == "sandbox output"
     assert result.duration_seconds == 1.25
     assert provider.specs[0].source_dir == tmp_path.resolve()
+    assert provider.specs[0].source_selection == source_selection
     session = provider.sessions[0]
     assert session.closed
     assert session.writes == [

--- a/test/compiler/test_artifact_quality.py
+++ b/test/compiler/test_artifact_quality.py
@@ -17,12 +17,19 @@ from codenib import compat_pickle
 from codenib.compiler.artifact_quality import (
     assess_vector_artifact,
     constrain_and_assess_graph_artifact,
+    constrain_graph_to_source_selection,
     vector_artifact_files_match,
 )
 from codenib.git_snapshot import GitSourceSurface
 from codenib.graph.code_graph import CodeGraph
 from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
 from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
+from codenib.repository_source_selection import RepositorySourceSelection
+from codenib.scip_interface.lsp_occurrence_index import (
+    SCIPOccurrence,
+    SCIPOccurrenceIndex,
+)
+from codenib.types import EDGE_TYPE_REFERENCE
 
 
 def _git(repo, *args):
@@ -129,6 +136,116 @@ def test_graph_quality_reports_malformed_paths_before_constraining(tmp_path):
     assert report["surface"]["invalid_paths_before"]
     assert report["surface"]["invalid_paths_after"] == []
     assert "../generated.py" not in graph.name_to_vertex
+
+
+def test_graph_source_selection_constrains_every_record_and_rebuilds_indexes():
+    graph = CodeGraph("/repo")
+    graph.add_root_node(".")
+    for directory in ("src", "generated", "generated-copy", "empty"):
+        graph.add_directory_node(directory)
+
+    graph.add_file_node("src/main.py")
+    graph.add_symbol_node("kept", 1, 1, 3, "function")
+    graph.add_file_node("generated/private.py")
+    graph.add_symbol_node("private", 1, 1, 3, "function")
+    graph.add_file_node("generated-copy/public.py")
+    graph.add_symbol_node("prefix-safe", 1, 1, 3, "function")
+    graph._add_edge(
+        "kept",
+        "prefix-safe",
+        EDGE_TYPE_REFERENCE,
+        anchor_file="src/main.py",
+        anchor_line=2,
+    )
+    graph._add_edge(
+        "kept",
+        "prefix-safe",
+        EDGE_TYPE_REFERENCE,
+        anchor_file="generated/private.py",
+        anchor_line=2,
+    )
+    graph.lsp_occurrence_index = SCIPOccurrenceIndex(
+        [
+            SCIPOccurrence("src/main.py", 1, 0, 1, 4, "kept"),
+            SCIPOccurrence("generated/private.py", 1, 0, 1, 4, "private"),
+            SCIPOccurrence("generated-copy/public.py", 1, 0, 1, 4, "prefix-safe"),
+        ]
+    )
+    graph.build_range_indexes()
+
+    selection = RepositorySourceSelection(["generated"])
+    report = constrain_graph_to_source_selection(graph, selection)
+
+    assert report["source_selection_digest"] == selection.digest
+    assert report["excluded_paths_after"] == []
+    assert report["invalid_paths_after"] == []
+    assert "generated/private.py" in report["removed_excluded_paths"]
+    assert "private" not in graph.name_to_vertex
+    assert "generated/private.py" not in graph.name_to_vertex
+    assert "generated" not in graph.name_to_vertex
+    assert "empty" not in graph.name_to_vertex
+    assert "kept" in graph.name_to_vertex
+    assert "prefix-safe" in graph.name_to_vertex
+    assert "src" in graph.name_to_vertex
+    assert "generated-copy" in graph.name_to_vertex
+    assert set(graph.symbol_ranges) == {"kept", "prefix-safe"}
+    assert set(graph._file_nodes) == {"src/main.py", "generated-copy/public.py"}
+    assert set(graph._file_edge_anchors) == {"src/main.py"}
+    assert [
+        occurrence.file_path for occurrence in graph.lsp_occurrence_index.occurrences
+    ] == ["src/main.py", "generated-copy/public.py"]
+
+
+def test_graph_source_selection_enforces_default_ignored_paths_when_empty():
+    graph = CodeGraph("/repo")
+    graph.add_root_node(".")
+    graph.add_directory_node("src")
+    graph.add_file_node("src/main.py")
+    graph.add_symbol_node("kept", 1, 1, 3, "function")
+    graph.add_directory_node("node_modules")
+    graph.add_file_node("node_modules/dependency.js")
+    graph.add_symbol_node("dependency", 1, 1, 3, "function")
+    graph.build_range_indexes()
+
+    report = constrain_graph_to_source_selection(
+        graph,
+        RepositorySourceSelection(),
+    )
+
+    assert report["excluded_paths_after"] == []
+    assert "node_modules/dependency.js" in report["removed_excluded_paths"]
+    assert "node_modules/dependency.js" not in graph.name_to_vertex
+    assert "dependency" not in graph.name_to_vertex
+    assert "src/main.py" in graph.name_to_vertex
+
+
+def test_graph_source_selection_removes_defined_symbol_without_source_path():
+    graph = CodeGraph("/repo")
+    graph.add_root_node(".")
+    graph.add_directory_node("src")
+    graph.add_file_node("src/main.py")
+    graph.add_symbol_node("local", 1, 1, 3, "function")
+    local = graph.graph.vs.find(name="local")
+    local["file"] = None
+    local["has_definition"] = True
+    graph.add_symbol_node("external", 1, 1, 3, "function")
+    external = graph.graph.vs.find(name="external")
+    external["file"] = None
+    external["has_definition"] = False
+    graph.build_range_indexes()
+
+    report = constrain_graph_to_source_selection(
+        graph,
+        RepositorySourceSelection(),
+    )
+
+    assert "local" not in graph.name_to_vertex
+    assert "external" in graph.name_to_vertex
+    assert any(
+        "local" not in item and ".file=None" in item
+        for item in report["invalid_paths_before"]
+    )
+    assert report["invalid_paths_after"] == []
 
 
 def test_vector_quality_checks_identity_counts_paths_and_l0_coverage(

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -36,6 +36,7 @@ from codenib.artifacts import query_context_artifact
 from codenib.compiler.cache_import import (
     CompilerCacheBm25RecaptureResult,
     CompilerCacheImportResult,
+    compiler_cache_source_selection,
     import_compiler_cache_bm25,
 )
 from codenib.compiler.index_builders import BM25IndexBuilder, IndexBuilderRegistry
@@ -46,9 +47,11 @@ from codenib.compiler.manifest_materialization import (
     materialize_retained_repo_manifest_ref,
 )
 from codenib.mcp.context import ServerContext
+from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.source_fingerprint import (
     RepositorySourceBinding,
     capture_repository_source,
+    fingerprint_repository,
 )
 from codenib.storage import (
     RETAINED_IMPORT_CATALOG_CONTRACT,
@@ -453,6 +456,34 @@ def test_compiler_cache_import_is_a_lazy_public_export() -> None:
         "catalog",
         "object_store",
     ]
+
+
+def test_compiler_cache_source_selection_reads_exact_persisted_policy(
+    tmp_path: Path,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    selection = RepositorySourceSelection(("generated",))
+    identity = fingerprint_repository(
+        fixture.repository,
+        exclude_roots=(fixture.cache,),
+        selection=selection,
+    )
+    manifest_path = fixture.cache / "repo_manifest.json"
+    manifest = RepoManifest.load(manifest_path)
+    manifest.source_selection = selection
+    manifest.last_indexed_source_selection_digest = selection.digest
+    manifest.source_fingerprint = identity.value
+    manifest.last_indexed_source_fingerprint = identity.value
+    manifest.file_count = identity.file_count
+    entry = manifest.indexes["bm25"]
+    entry.source_selection_digest = selection.digest
+    entry.source_fingerprint = identity.value
+    manifest.save(manifest_path)
+
+    observed = compiler_cache_source_selection(fixture.cache)
+
+    assert observed == selection
+    assert observed is not selection
 
 
 def test_import_recaptures_inside_cache_lock_and_imports_after_release(

--- a/test/compiler/test_graph_artifact.py
+++ b/test/compiler/test_graph_artifact.py
@@ -10,7 +10,10 @@ import pytest
 
 import codenib.compiler.graph_artifact as graph_artifact_module
 from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
-from codenib.compiler.graph_artifact import load_authenticated_graph_artifact
+from codenib.compiler.graph_artifact import (
+    authenticated_graph_artifact_matches,
+    load_authenticated_graph_artifact,
+)
 from codenib.compiler.manifest import IndexEntry
 from codenib.graph.code_graph import CodeGraph
 from codenib.scip_interface.lsp_occurrence_index import (
@@ -62,6 +65,22 @@ def test_load_authenticated_graph_artifact_uses_receipted_generation(tmp_path):
     loaded = load_authenticated_graph_artifact(_entry(root, graph_path))
 
     assert "src/current.py" in loaded.graph.vs["name"]
+
+
+def test_load_authenticated_graph_artifact_accepts_legacy_direct_graph_path(
+    tmp_path,
+):
+    root = tmp_path / "symbol_graph"
+    root.mkdir()
+    graph_path = root / "graph.pkl"
+    _write_graph(graph_path, file_path="src/legacy.py")
+    entry = _entry(root, graph_path)
+    entry.path = str(graph_path)
+
+    loaded = load_authenticated_graph_artifact(entry)
+
+    assert "src/legacy.py" in loaded.graph.vs["name"]
+    assert authenticated_graph_artifact_matches(entry) is True
 
 
 def test_load_authenticated_graph_artifact_attaches_receipted_occurrence_index(
@@ -149,6 +168,7 @@ def test_load_authenticated_graph_artifact_rejects_occurrence_receipt_mismatch(
         pytest.raises(ValueError, match="LSP occurrence artifact.*manifest receipt"),
     ):
         load_authenticated_graph_artifact(entry)
+    assert authenticated_graph_artifact_matches(entry) is False
 
 
 def test_load_authenticated_graph_artifact_rejects_occurrence_generation_swap(

--- a/test/compiler/test_graph_artifact.py
+++ b/test/compiler/test_graph_artifact.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+import codenib.compiler.graph_artifact as graph_artifact_module
+from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
+from codenib.compiler.graph_artifact import load_authenticated_graph_artifact
+from codenib.compiler.manifest import IndexEntry
+from codenib.graph.code_graph import CodeGraph
+from codenib.scip_interface.lsp_occurrence_index import (
+    SCIPOccurrence,
+    SCIPOccurrenceIndex,
+)
+
+
+def _entry(root, graph_path, occurrence_path=None) -> IndexEntry:
+    config = {
+        "graph_artifact": {
+            "relative_path": "graph.pkl",
+            **regular_file_fingerprint(graph_path),
+        },
+        "lsp_occurrence_artifact": None,
+    }
+    if occurrence_path is not None:
+        config["lsp_occurrence_artifact"] = {
+            "relative_path": "lsp_index.pkl",
+            **regular_file_fingerprint(occurrence_path),
+        }
+    return IndexEntry(
+        index_type="symbol_graph",
+        path=str(root),
+        built_at="2026-08-20T00:00:00Z",
+        built_at_epoch=0.0,
+        status="fresh",
+        config=config,
+    )
+
+
+def _write_graph(path, *, file_path: str) -> None:
+    graph = CodeGraph(path.parent)
+    graph.add_root_node(".")
+    graph.add_file_node(file_path)
+    graph.save_graph(path)
+
+
+def _write_occurrence_index(path, *, file_path: str, symbol: str) -> None:
+    SCIPOccurrenceIndex([SCIPOccurrence(file_path, 1, 2, 1, 8, symbol, 1)]).save(path)
+
+
+def test_load_authenticated_graph_artifact_uses_receipted_generation(tmp_path):
+    root = tmp_path / "symbol_graph"
+    root.mkdir()
+    graph_path = root / "graph.pkl"
+    _write_graph(graph_path, file_path="src/current.py")
+
+    loaded = load_authenticated_graph_artifact(_entry(root, graph_path))
+
+    assert "src/current.py" in loaded.graph.vs["name"]
+
+
+def test_load_authenticated_graph_artifact_attaches_receipted_occurrence_index(
+    tmp_path,
+):
+    root = tmp_path / "symbol_graph"
+    root.mkdir()
+    graph_path = root / "graph.pkl"
+    occurrence_path = root / "lsp_index.pkl"
+    _write_graph(graph_path, file_path="src/current.py")
+    _write_occurrence_index(
+        occurrence_path,
+        file_path="src/current.py",
+        symbol="scip-python fixture current().",
+    )
+
+    loaded = load_authenticated_graph_artifact(
+        _entry(root, graph_path, occurrence_path)
+    )
+
+    occurrence = loaded.lsp_occurrence_index.occurrence_at(
+        "src/current.py",
+        1,
+        3,
+    )
+    assert occurrence is not None
+    assert occurrence.symbol == "scip-python fixture current()."
+
+
+def test_load_authenticated_graph_artifact_ignores_unreceipted_occurrence_index(
+    tmp_path,
+):
+    root = tmp_path / "symbol_graph"
+    root.mkdir()
+    graph_path = root / "graph.pkl"
+    occurrence_path = root / "lsp_index.pkl"
+    _write_graph(graph_path, file_path="src/current.py")
+    _write_occurrence_index(
+        occurrence_path,
+        file_path="private/ambient.py",
+        symbol="scip-python fixture ambient().",
+    )
+
+    with patch.object(
+        SCIPOccurrenceIndex,
+        "load_stream",
+        side_effect=AssertionError("unreceipted occurrence pickle must not be loaded"),
+    ):
+        loaded = load_authenticated_graph_artifact(_entry(root, graph_path))
+
+    assert not hasattr(loaded, "lsp_occurrence_index")
+
+
+def test_load_authenticated_graph_artifact_rejects_occurrence_receipt_mismatch(
+    tmp_path,
+):
+    root = tmp_path / "symbol_graph"
+    root.mkdir()
+    graph_path = root / "graph.pkl"
+    occurrence_path = root / "lsp_index.pkl"
+    _write_graph(graph_path, file_path="src/current.py")
+    _write_occurrence_index(
+        occurrence_path,
+        file_path="src/current.py",
+        symbol="scip-python fixture expected().",
+    )
+    entry = _entry(root, graph_path, occurrence_path)
+    _write_occurrence_index(
+        occurrence_path,
+        file_path="private/replacement.py",
+        symbol="scip-python fixture replacement().",
+    )
+
+    with (
+        patch.object(
+            graph_artifact_module.CodeGraph,
+            "load_graph_stream",
+            side_effect=AssertionError("graph pickle must wait for all receipts"),
+        ),
+        patch.object(
+            SCIPOccurrenceIndex,
+            "load_stream",
+            side_effect=AssertionError("mismatched occurrence pickle must not load"),
+        ),
+        pytest.raises(ValueError, match="LSP occurrence artifact.*manifest receipt"),
+    ):
+        load_authenticated_graph_artifact(entry)
+
+
+def test_load_authenticated_graph_artifact_rejects_occurrence_generation_swap(
+    tmp_path,
+    monkeypatch,
+):
+    root = tmp_path / "symbol_graph"
+    root.mkdir()
+    graph_path = root / "graph.pkl"
+    occurrence_path = root / "lsp_index.pkl"
+    _write_graph(graph_path, file_path="src/current.py")
+    _write_occurrence_index(
+        occurrence_path,
+        file_path="src/current.py",
+        symbol="scip-python fixture expected().",
+    )
+    entry = _entry(root, graph_path, occurrence_path)
+    real_reopen = graph_artifact_module.reopen_authenticated_directory
+
+    def replace_then_reopen(path, ownership, callback):
+        occurrence_path.unlink()
+        _write_occurrence_index(
+            occurrence_path,
+            file_path="private/replacement.py",
+            symbol="scip-python fixture replacement().",
+        )
+        return real_reopen(path, ownership, callback)
+
+    monkeypatch.setattr(
+        graph_artifact_module,
+        "reopen_authenticated_directory",
+        replace_then_reopen,
+    )
+    with (
+        patch.object(
+            graph_artifact_module.CodeGraph,
+            "load_graph_stream",
+            side_effect=AssertionError("graph pickle must wait for one generation"),
+        ),
+        patch.object(
+            SCIPOccurrenceIndex,
+            "load_stream",
+            side_effect=AssertionError("swapped occurrence pickle must not load"),
+        ),
+        pytest.raises((RuntimeError, ValueError)),
+    ):
+        load_authenticated_graph_artifact(entry)
+
+
+def test_load_authenticated_graph_artifact_rejects_replacement_before_unpickle(
+    tmp_path,
+):
+    root = tmp_path / "symbol_graph"
+    root.mkdir()
+    graph_path = root / "graph.pkl"
+    _write_graph(graph_path, file_path="src/expected.py")
+    entry = _entry(root, graph_path)
+    _write_graph(graph_path, file_path="private/replacement.py")
+
+    with (
+        patch.object(
+            graph_artifact_module.CodeGraph,
+            "load_graph_stream",
+            side_effect=AssertionError("unverified pickle must not be loaded"),
+        ),
+        pytest.raises(ValueError, match="manifest receipt"),
+    ):
+        load_authenticated_graph_artifact(entry)
+
+
+def test_load_authenticated_graph_artifact_rejects_capture_to_open_swap(
+    tmp_path,
+    monkeypatch,
+):
+    root = tmp_path / "symbol_graph"
+    root.mkdir()
+    graph_path = root / "graph.pkl"
+    _write_graph(graph_path, file_path="src/expected.py")
+    entry = _entry(root, graph_path)
+    real_reopen = graph_artifact_module.reopen_authenticated_directory
+
+    def replace_then_reopen(path, ownership, callback):
+        graph_path.unlink()
+        _write_graph(graph_path, file_path="private/replacement.py")
+        return real_reopen(path, ownership, callback)
+
+    monkeypatch.setattr(
+        graph_artifact_module,
+        "reopen_authenticated_directory",
+        replace_then_reopen,
+    )
+    with (
+        patch.object(
+            graph_artifact_module.CodeGraph,
+            "load_graph_stream",
+            side_effect=AssertionError("swapped pickle must not be loaded"),
+        ),
+        pytest.raises((RuntimeError, ValueError)),
+    ):
+        load_authenticated_graph_artifact(entry)
+
+
+def test_load_authenticated_graph_artifact_rejects_symlink(tmp_path):
+    root = tmp_path / "symbol_graph"
+    root.mkdir()
+    target = tmp_path / "outside.pkl"
+    _write_graph(target, file_path="private/outside.py")
+    graph_path = root / "graph.pkl"
+    graph_path.symlink_to(target)
+    entry = IndexEntry(
+        index_type="symbol_graph",
+        path=str(root),
+        built_at="2026-08-20T00:00:00Z",
+        built_at_epoch=0.0,
+        status="fresh",
+        config={
+            "graph_artifact": {
+                "relative_path": "graph.pkl",
+                **regular_file_fingerprint(target),
+            }
+        },
+    )
+
+    with pytest.raises((RuntimeError, ValueError)):
+        load_authenticated_graph_artifact(entry)

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+import copy
+import hashlib
 import json
 import os
 import shutil
@@ -36,6 +38,7 @@ from codenib.compiler.index_builders import (
 )
 from codenib.compiler.index_compiler import IndexCompiler, IndexCompilerConfig
 from codenib.compiler.manifest import (
+    LEGACY_MANIFEST_VERSION,
     MANIFEST_FILENAME,
     MANIFEST_VERSION,
     ManifestIndexStateStore,
@@ -59,6 +62,7 @@ from codenib.repository_filters import (
     REPOSITORY_FILTER_POLICY_VERSION,
     default_exclude_patterns,
 )
+from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.source_fingerprint import is_secure_source_fingerprint_v2
 
 # ---------------------------------------------------------------------------
@@ -71,6 +75,21 @@ def _write_fake_graph_artifact(output_dir: str | Path) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(b"test-symbol-graph\n")
     return path
+
+
+def _minimal_code_graph(
+    repo_path: str = "/fake/repo",
+    *,
+    file_count: int = 1,
+):
+    from codenib.graph.code_graph import CodeGraph
+
+    graph = CodeGraph(repo_path)
+    graph.add_root_node(".")
+    for index in range(file_count):
+        graph.add_file_node(f"src/file_{index}.py")
+    graph.build_range_indexes()
+    return graph
 
 
 def _fake_graph_output_receipt(output_dir: str | Path) -> dict:
@@ -89,6 +108,7 @@ def _mock_builder(index_type: str = "mock", file_count: int = 42):
         def build(self, scope: str, **kwargs) -> IndexStatus:
             output_dir = kwargs.get("output_dir", "/tmp/mock")
             os.makedirs(output_dir, exist_ok=True)
+            selection = kwargs.get("source_selection", RepositorySourceSelection())
             return IndexStatus(
                 index_type=index_type,
                 state=IndexState.FRESH,
@@ -96,7 +116,10 @@ def _mock_builder(index_type: str = "mock", file_count: int = 42):
                 age_seconds=0.0,
                 scope=scope,
                 path=output_dir,
-                metadata={"file_count": file_count},
+                metadata={
+                    "file_count": file_count,
+                    "source_selection_digest": selection.digest,
+                },
             )
 
         def incremental_update(self, scope: str, **kwargs) -> IndexStatus:
@@ -148,7 +171,12 @@ class TestBM25IndexBuilder:
         mock_indexer_instance.save_index.side_effect = save_index
         MockIndexer.return_value = mock_indexer_instance
 
-        builder = BM25IndexBuilder(languages=["python"], max_k=64)
+        selection = RepositorySourceSelection(["src/private"])
+        builder = BM25IndexBuilder(
+            languages=["python"],
+            max_k=64,
+            source_selection=selection,
+        )
         output = str(tmp_path / "bm25")
 
         status = builder.build(
@@ -166,6 +194,7 @@ class TestBM25IndexBuilder:
         assert status.metadata["chunking_failure_policy"] == "fail"
         assert status.metadata["include_header_epilogue"] is True
         assert status.metadata["max_k"] == 64
+        assert status.metadata["source_selection_digest"] == selection.digest
         assert set(status.metadata["artifact_file_fingerprints"]) == {
             "documents.json",
             "bm25_metadata.json",
@@ -177,6 +206,9 @@ class TestBM25IndexBuilder:
             max_lines_per_chunk=300,
             include_header_epilogue=True,
         )
+        repo_config = MockChunker.call_args.kwargs["repo_config"]
+        assert repo_config.source_selection == selection
+        assert repo_config.source_selection is not selection
         mock_chunker_instance.chunk_repository.assert_called_once_with(
             repo_path="/fake/repo", strict=True
         )
@@ -193,6 +225,111 @@ class TestBM25IndexBuilder:
 
     def test_artifact_identity_tracks_source_body_indexing(self):
         assert BM25IndexBuilder().artifact_identity()["builder_schema"] == 8
+
+    @patch("codenib.index.sparse_idx.bm25_index.BM25CodeIndexer")
+    @patch("codenib.code_chunker.CodeChunker")
+    def test_build_rejects_chunks_outside_source_selection(
+        self,
+        MockChunker,
+        MockIndexer,
+        tmp_path,
+    ):
+        MockChunker.return_value.chunk_repository.return_value = [
+            SimpleNamespace(file="src/private/secret.py")
+        ]
+        builder = BM25IndexBuilder(
+            source_selection=RepositorySourceSelection(["src/private"]),
+        )
+
+        with pytest.raises(RuntimeError, match="BM25 chunks leaked excluded"):
+            builder.build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(tmp_path / "bm25"),
+            )
+
+        MockIndexer.assert_not_called()
+
+    @patch("codenib.index.sparse_idx.bm25_index.BM25CodeIndexer")
+    @patch("codenib.code_chunker.CodeChunker")
+    def test_build_rejects_chunks_ignored_by_default_policy(
+        self,
+        MockChunker,
+        MockIndexer,
+        tmp_path,
+    ):
+        MockChunker.return_value.chunk_repository.return_value = [
+            SimpleNamespace(file="node_modules/dependency.js")
+        ]
+
+        with pytest.raises(RuntimeError, match="BM25 chunks leaked excluded"):
+            BM25IndexBuilder().build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(tmp_path / "bm25"),
+            )
+
+        MockIndexer.assert_not_called()
+
+    @patch("codenib.index.sparse_idx.bm25_index.BM25CodeIndexer")
+    @patch("codenib.code_chunker.CodeChunker")
+    def test_build_rejects_documents_outside_source_selection(
+        self,
+        MockChunker,
+        MockIndexer,
+        tmp_path,
+    ):
+        MockChunker.return_value.chunk_repository.return_value = [
+            SimpleNamespace(file="src/public.py")
+        ]
+        MockIndexer.return_value.documents = [
+            SimpleNamespace(metadata={"file": "src/private/secret.py"})
+        ]
+        builder = BM25IndexBuilder(
+            source_selection=RepositorySourceSelection(["src/private"]),
+        )
+
+        with pytest.raises(RuntimeError, match="BM25 documents leaked excluded"):
+            builder.build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(tmp_path / "bm25"),
+            )
+
+        MockIndexer.return_value.save_index.assert_not_called()
+
+    def test_builder_snapshots_selection_and_rejects_non_exact_types(self):
+        selection = RepositorySourceSelection(["src/private"])
+        builder = BM25IndexBuilder(source_selection=selection)
+        expected_digest = selection.digest
+
+        object.__setattr__(selection, "exclude_subtrees", ("src/changed",))
+
+        assert builder.source_selection is not selection
+        assert builder.artifact_identity()["source_selection_digest"] == expected_digest
+        with pytest.raises(TypeError, match="RepositorySourceSelection"):
+            BM25IndexBuilder(source_selection=object())
+        with pytest.raises(TypeError, match="RepositorySourceSelection"):
+            VectorIndexBuilder(source_selection=object())
+
+    @patch("codenib.code_chunker.CodeChunker")
+    def test_build_rejects_runtime_selection_mismatch_before_reading_source(
+        self,
+        MockChunker,
+        tmp_path,
+    ):
+        builder = BM25IndexBuilder()
+
+        with pytest.raises(RuntimeError, match="does not match"):
+            builder.build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(tmp_path / "bm25"),
+                source_selection=RepositorySourceSelection(("generated",)),
+            )
+
+        MockChunker.assert_not_called()
+        assert not (tmp_path / "bm25").exists()
 
     def test_build_indexes_source_without_symbol_definitions(self, tmp_path):
         from codenib.index.sparse_idx.bm25_index import BM25CodeIndexer
@@ -248,11 +385,63 @@ def _tree_file_bytes(root: Path) -> dict[str, bytes]:
 
 
 class TestVectorIndexBuilder:
+    @patch("codenib._captured_directory.OwnedDirectoryStage.prepare")
+    def test_build_rejects_runtime_selection_mismatch_before_staging_output(
+        self,
+        prepare_stage,
+        tmp_path,
+    ):
+        builder = VectorIndexBuilder()
+
+        with pytest.raises(RuntimeError, match="does not match"):
+            builder.build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(tmp_path / "vector"),
+                source_selection=RepositorySourceSelection(("generated",)),
+            )
+
+        prepare_stage.assert_not_called()
+        assert not (tmp_path / "vector").exists()
+
+    @patch(
+        "codenib.native_index_authorization."
+        "require_native_index_authorization_preflight"
+    )
+    def test_incremental_rejects_runtime_selection_mismatch_before_preflight(
+        self,
+        authorization_preflight,
+        tmp_path,
+    ):
+        builder = VectorIndexBuilder()
+
+        with pytest.raises(RuntimeError, match="does not match"):
+            builder.incremental_update(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(tmp_path / "vector"),
+                last_commit="a" * 40,
+                source_selection=RepositorySourceSelection(("generated",)),
+            )
+
+        authorization_preflight.assert_not_called()
+        assert not (tmp_path / "vector").exists()
+
     @patch("codenib.index.embedding.builders.build_hierarchical_vector_store")
     def test_build_returns_status_with_stats(self, mock_build_fn, tmp_path):
+        def document(file_path):
+            return SimpleNamespace(
+                page_content="value = 1\n",
+                metadata={"file": file_path},
+            )
+
         mock_vs = MagicMock()
-        mock_vs.l0_documents = ["d1", "d2"]
-        mock_vs.l2_documents = ["d3", "d4", "d5"]
+        mock_vs.l0_documents = [document("src/a.py"), document("src/b.py")]
+        mock_vs.l2_documents = [
+            document("src/a.py"),
+            document("src/b.py"),
+            document("src/c.py"),
+        ]
 
         def build_vector(**kwargs):
             build_path = Path(kwargs["index_path"])
@@ -261,10 +450,12 @@ class TestVectorIndexBuilder:
 
         mock_build_fn.side_effect = build_vector
 
+        selection = RepositorySourceSelection(["src/private"])
         builder = VectorIndexBuilder(
             languages=["python"],
             embedding_model="test-model",
             embedding_dimension=384,
+            source_selection=selection,
         )
         output_path = tmp_path / "vector"
         output_path.mkdir()
@@ -287,6 +478,7 @@ class TestVectorIndexBuilder:
         assert status.metadata["dimension"] == 384
         assert status.metadata["embedding_kwargs"] == {}
         assert status.metadata["index_metric"] == "ip"
+        assert status.metadata["source_selection_digest"] == selection.digest
         assert status.metadata["persistence_config_fingerprint"]["file"] == (
             "config_test-model.json"
         )
@@ -294,8 +486,82 @@ class TestVectorIndexBuilder:
         mock_build_fn.assert_called_once()
         assert mock_build_fn.call_args.kwargs["force_rebuild"] is True
         assert mock_build_fn.call_args.kwargs["strict_chunking"] is True
+        passed_selection = mock_build_fn.call_args.kwargs["source_selection"]
+        assert passed_selection == selection
+        assert passed_selection is not selection
         assert mock_build_fn.call_args.kwargs["_atomic_publish"] is False
         assert not (output_path / VECTOR_VIEW_UPDATE_MARKER).exists()
+
+    @patch("codenib.index.embedding.builders.build_hierarchical_vector_store")
+    def test_build_rejects_documents_outside_source_selection(
+        self,
+        mock_build_fn,
+        tmp_path,
+    ):
+        def build_vector(**kwargs):
+            _write_mock_vector_generation(Path(kwargs["index_path"]), "test-model")
+            return SimpleNamespace(
+                dimension=384,
+                l0_documents=[],
+                l2_documents=[
+                    SimpleNamespace(
+                        page_content="secret\n",
+                        metadata={"file": "src/private/secret.py"},
+                    )
+                ],
+            )
+
+        mock_build_fn.side_effect = build_vector
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+            source_selection=RepositorySourceSelection(["src/private"]),
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match="vector l2 documents leaked excluded",
+        ):
+            builder.build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(tmp_path / "vector"),
+            )
+
+    @patch("codenib.index.embedding.builders.build_hierarchical_vector_store")
+    def test_build_rejects_documents_ignored_by_default_policy(
+        self,
+        mock_build_fn,
+        tmp_path,
+    ):
+        def build_vector(**kwargs):
+            _write_mock_vector_generation(Path(kwargs["index_path"]), "test-model")
+            return SimpleNamespace(
+                dimension=384,
+                l0_documents=[],
+                l2_documents=[
+                    SimpleNamespace(
+                        page_content="dependency\n",
+                        metadata={"file": "node_modules/dependency.js"},
+                    )
+                ],
+            )
+
+        mock_build_fn.side_effect = build_vector
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match="vector l2 documents leaked excluded",
+        ):
+            builder.build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(tmp_path / "vector"),
+            )
 
     def test_build_publishes_one_complete_generation_without_stale_state(
         self,
@@ -639,6 +905,7 @@ class TestVectorIndexBuilder:
             "current_repo",
             repo_path=str(tmp_path),
             output_dir=str(tmp_path / "vector"),
+            source_selection=RepositorySourceSelection(),
         )
         assert result is rebuilt
         assert result.metadata["update_mode"] == "full_rebuild"
@@ -971,6 +1238,7 @@ class TestVectorIndexBuilder:
             repo_path=str(tmp_path),
             output_dir=str(output_path),
             native_index_authorization=authorization,
+            source_selection=RepositorySourceSelection(),
         )
         assert result is rebuilt
         assert result.metadata["update_mode"] == "full_rebuild"
@@ -1055,6 +1323,7 @@ class TestVectorIndexBuilder:
             "max_lines_per_chunk": 300,
             "chunking_failure_policy": "fail",
             "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
+            "source_selection_digest": RepositorySourceSelection().digest,
         }
 
     def test_runtime_options_do_not_change_identity_or_appear_in_repr(self):
@@ -1089,7 +1358,7 @@ class TestVectorIndexBuilder:
         mock_build_fn.return_value = SimpleNamespace(
             dimension=1024,
             l0_documents=[],
-            l2_documents=["doc"],
+            l2_documents=[SimpleNamespace(metadata={"file": "src/a.py"})],
         )
         builder = VectorIndexBuilder(
             embedding_model="test-model",
@@ -1107,7 +1376,10 @@ class TestVectorIndexBuilder:
 
     @patch("codenib.index.embedding.builders.build_hierarchical_vector_store")
     def test_remote_runtime_secret_is_not_persisted(self, mock_build_fn, tmp_path):
-        mock_vs = MagicMock(l0_documents=[], l2_documents=["doc"])
+        mock_vs = MagicMock(
+            l0_documents=[],
+            l2_documents=[SimpleNamespace(metadata={"file": "src/a.py"})],
+        )
 
         def build_vector(**kwargs):
             build_path = Path(kwargs["index_path"])
@@ -1167,9 +1439,12 @@ class TestSymbolGraphBuilder:
 
     def test_build_returns_status(self, monkeypatch, tmp_path):
         from codenib import ls_router
+        from codenib.graph.code_graph import CodeGraph
 
-        mock_graph = MagicMock()
-        mock_graph.graph.vs = list(range(50))  # 50 nodes
+        mock_graph = CodeGraph("/fake/repo")
+        mock_graph.add_root_node(".")
+        for index in range(49):
+            mock_graph.add_file_node(f"src/file_{index}.py")
         calls = []
 
         def fake_build_graph_for_languages(*args, **kwargs):
@@ -1207,16 +1482,17 @@ class TestSymbolGraphBuilder:
         assert status.metadata["edge_count"] == 0
         assert status.metadata["language"] == "python"
         assert status.metadata["languages"] == ["python"]
-        assert status.metadata["builder_schema"] == 5
+        assert status.metadata["builder_schema"] == 6
         assert status.metadata["allow_project_preparation"] is True
         assert status.metadata["target_dir"] is None
         assert status.metadata["update_mode"] == "full_rebuild"
         assert status.metadata["scip_decoded_artifacts"] == {}
         assert status.metadata["graph_artifact"] == {
             "relative_path": "graph.pkl",
-            "size": len(b"test-symbol-graph\n"),
+            "size": (Path(output) / "graph.pkl").stat().st_size,
             "sha256": regular_file_fingerprint(Path(output) / "graph.pkl")["sha256"],
         }
+        assert status.metadata["lsp_occurrence_artifact"] is None
         assert status.metadata["query_surface_sha256"] == "c" * 64
         assert calls == [
             (
@@ -1237,17 +1513,153 @@ class TestSymbolGraphBuilder:
         enabled = SymbolGraphBuilder(allow_project_preparation=True)
         disabled = SymbolGraphBuilder(allow_project_preparation=False)
 
-        assert enabled.artifact_identity()["builder_schema"] == 5
+        assert enabled.artifact_identity()["builder_schema"] == 6
         assert enabled.artifact_identity()["allow_project_preparation"] is True
         assert disabled.artifact_identity()["allow_project_preparation"] is False
         assert enabled.artifact_identity() != disabled.artifact_identity()
 
+    def test_full_rebuild_does_not_reuse_stale_occurrence_sidecar(
+        self, monkeypatch, tmp_path
+    ):
+        from codenib import ls_router
+        from codenib.scip_interface.lsp_occurrence_index import (
+            SCIPOccurrence,
+            SCIPOccurrenceIndex,
+        )
+
+        output = tmp_path / "graph"
+        output.mkdir()
+        SCIPOccurrenceIndex(
+            [SCIPOccurrence("src/main.py", 99, 0, 99, 5, "stale")]
+        ).save(output / "lsp_index.pkl")
+        current_graph = _minimal_code_graph("/fake/repo")
+
+        monkeypatch.setattr(
+            ls_router,
+            "build_graph_for_languages_with_report",
+            lambda *args, **kwargs: GraphBuildResult(
+                graph=current_graph,
+                requested_languages=["python"],
+                available_languages=["python"],
+                failed_languages={},
+                graph_output_receipt=_fake_graph_output_receipt(args[1]),
+            ),
+        )
+
+        status = SymbolGraphBuilder(language="python").build(
+            scope="current_repo",
+            repo_path="/fake/repo",
+            output_dir=str(output),
+        )
+
+        assert status.state is IndexState.FRESH
+        assert not (output / "lsp_index.pkl").exists()
+        assert status.metadata["lsp_occurrence_artifact"] is None
+
+    @pytest.mark.parametrize(
+        ("language", "graph_route"),
+        [("python", "active"), ("java", "lsp"), ("cpp", "active")],
+    )
+    def test_custom_selection_is_central_gate_when_backend_ignores_hint(
+        self,
+        monkeypatch,
+        tmp_path,
+        language,
+        graph_route,
+    ):
+        from codenib import ls_router
+        from codenib.graph.code_graph import CodeGraph
+        from codenib.scip_interface.lsp_occurrence_index import (
+            SCIPOccurrence,
+            SCIPOccurrenceIndex,
+        )
+
+        graph = CodeGraph("/repo")
+        graph.add_root_node(".")
+        graph.add_directory_node("src")
+        graph.add_file_node("src/main.py")
+        graph.add_symbol_node("kept", 0, 0, 1, "function")
+        graph.add_directory_node("private")
+        graph.add_file_node("private/secret.py")
+        graph.add_symbol_node("secret", 0, 0, 1, "function")
+        graph.add_directory_node("node_modules")
+        graph.add_file_node("node_modules/dependency.js")
+        graph.add_symbol_node("dependency", 0, 0, 1, "function")
+        graph.lsp_occurrence_index = SCIPOccurrenceIndex(
+            [
+                SCIPOccurrence("src/main.py", 0, 0, 0, 4, "kept"),
+                SCIPOccurrence("private/secret.py", 0, 0, 0, 4, "secret"),
+                SCIPOccurrence(
+                    "node_modules/dependency.js",
+                    0,
+                    0,
+                    0,
+                    4,
+                    "dependency",
+                ),
+            ]
+        )
+        calls = []
+
+        def backend_ignores_exclude_hints(*args, **kwargs):
+            calls.append(kwargs)
+            receipt = _fake_graph_output_receipt(args[1])
+            return GraphBuildResult(
+                graph=graph,
+                requested_languages=[language],
+                available_languages=[language],
+                failed_languages={},
+                graph_output_receipt=receipt,
+            )
+
+        monkeypatch.setattr(
+            ls_router,
+            "build_graph_for_languages_with_report",
+            backend_ignores_exclude_hints,
+        )
+        selection = RepositorySourceSelection(["private"])
+        output = tmp_path / f"graph-{language}"
+
+        status = SymbolGraphBuilder(
+            language=language,
+            graph_route=graph_route,
+            source_selection=selection,
+        ).build(
+            scope="current_repo",
+            repo_path="/fake/repo",
+            output_dir=str(output),
+            source_selection=selection,
+        )
+
+        persisted = CodeGraph.load_graph(output / "graph.pkl")
+        occurrences = SCIPOccurrenceIndex.load(output / "lsp_index.pkl")
+        assert "src/main.py" in persisted.name_to_vertex
+        assert "private/secret.py" not in persisted.name_to_vertex
+        assert "secret" not in persisted.name_to_vertex
+        assert "node_modules/dependency.js" not in persisted.name_to_vertex
+        assert "dependency" not in persisted.name_to_vertex
+        assert [item.file_path for item in occurrences.occurrences] == ["src/main.py"]
+        assert status.metadata["lsp_occurrence_artifact"] == {
+            "relative_path": "lsp_index.pkl",
+            **regular_file_fingerprint(output / "lsp_index.pkl"),
+        }
+        assert calls[0]["exclude_patterns"][-2:] == ["private", "private/**"]
+        assert status.metadata["source_selection_digest"] == selection.digest
+        report = status.metadata["source_selection_report"]
+        assert report["removed_excluded_path_count"] == 4
+        assert report["excluded_path_count_after"] == 0
+        assert report["invalid_path_count_after"] == 0
+        assert "removed_excluded_paths" not in report
+
     def test_build_records_existing_decoded_scip_artifact(self, monkeypatch, tmp_path):
         from codenib import ls_router
         from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
+        from codenib.graph.code_graph import CodeGraph
 
-        mock_graph = MagicMock()
-        mock_graph.graph.vs = [MagicMock()]
+        mock_graph = CodeGraph("/fake/repo")
+        mock_graph.add_root_node(".")
+        mock_graph.add_file_node("src/main.py")
+        mock_graph.build_range_indexes()
         output = tmp_path / "graph"
         output.mkdir()
         graph_receipt = _fake_graph_output_receipt(output)
@@ -1289,9 +1701,7 @@ class TestSymbolGraphBuilder:
     ):
         from codenib import ls_router
 
-        mock_graph = MagicMock()
-        mock_graph.graph.vs = [MagicMock()]
-        mock_graph.graph.es = []
+        mock_graph = _minimal_code_graph()
         output = tmp_path / "graph"
         graph_receipt = _fake_graph_output_receipt(output)
         (output / "graph.pkl").write_bytes(b"replacement graph\n")
@@ -1319,9 +1729,7 @@ class TestSymbolGraphBuilder:
     ):
         from codenib import ls_router
 
-        mock_graph = MagicMock()
-        mock_graph.graph.vs = [MagicMock()]
-        mock_graph.graph.es = []
+        mock_graph = _minimal_code_graph()
         output = tmp_path / "graph"
         graph_receipt = _fake_graph_output_receipt(output)
         graph_receipt["query_surface_sha256"] = "d" * 64
@@ -1473,9 +1881,7 @@ class TestSymbolGraphBuilder:
     def test_build_forwards_multiple_languages(self, monkeypatch, tmp_path):
         from codenib import ls_router
 
-        mock_graph = MagicMock()
-        mock_graph.graph.vs = [MagicMock()]
-        mock_graph.graph.es = []
+        mock_graph = _minimal_code_graph()
         calls = []
 
         def fake_build_graph_for_languages(*args, **kwargs):
@@ -1511,8 +1917,7 @@ class TestSymbolGraphBuilder:
     def test_build_forwards_graph_route(self, monkeypatch, tmp_path):
         from codenib import ls_router
 
-        mock_graph = MagicMock()
-        mock_graph.graph.vs = [MagicMock()]
+        mock_graph = _minimal_code_graph()
         calls = []
 
         def fake_build_graph_for_languages(*args, **kwargs):
@@ -1546,12 +1951,9 @@ class TestSymbolGraphBuilder:
     def test_build_records_source_coverage_fallback_report(self, monkeypatch, tmp_path):
         from codenib import ls_router
 
-        mock_graph = MagicMock()
-        mock_graph.graph.vs = [MagicMock()]
-        mock_graph.graph.es = []
-        mock_graph.save_graph.side_effect = lambda path: Path(path).write_bytes(
-            b"test-symbol-graph\n"
-        )
+        mock_graph = _minimal_code_graph()
+        save_graph = MagicMock(wraps=mock_graph.save_graph)
+        monkeypatch.setattr(mock_graph, "save_graph", save_graph)
         calls = []
         report = {
             "coverage_before": 0.5,
@@ -1615,19 +2017,18 @@ class TestSymbolGraphBuilder:
             "compiler_graph_available": True,
             "compiler_index_complete": False,
             "compiler_partial_languages": ["python"],
-            "compiler_nodes": 1,
+            "compiler_nodes": 2,
             "compiler_edges": 0,
             **report,
         }
         assert status.metadata["partial_index"] is True
-        mock_graph.save_graph.assert_called_once()
+        save_graph.assert_called_once()
 
     def test_build_records_partial_language_coverage(self, monkeypatch, tmp_path):
         from codenib import ls_router
         from codenib.ls_router import GraphBuildResult
 
-        mock_graph = MagicMock()
-        mock_graph.graph.vs = list(range(25))
+        mock_graph = _minimal_code_graph(file_count=24)
         calls = []
 
         def fake_build(*args, **kwargs):
@@ -1725,6 +2126,44 @@ class TestRegisterDefaultBuilders:
         assert symbol_graph.allow_partial_index is False
         assert symbol_graph.source_coverage_fallback is False
 
+    def test_source_selection_is_snapshotted_for_in_process_builders(self):
+        registry = IndexBuilderRegistry()
+        selection = RepositorySourceSelection(["generated/private"])
+        expected_digest = selection.digest
+
+        register_default_builders(registry, source_selection=selection)
+        object.__setattr__(selection, "exclude_subtrees", ("changed",))
+
+        bm25 = registry.get("bm25")
+        vector = registry.get("vector")
+        symbol_graph = registry.get("symbol_graph")
+        zoekt = registry.get("zoekt")
+        assert isinstance(bm25, BM25IndexBuilder)
+        assert isinstance(vector, VectorIndexBuilder)
+        assert isinstance(symbol_graph, SymbolGraphBuilder)
+        assert isinstance(zoekt, ZoektIndexBuilder)
+        assert bm25.source_selection.exclude_subtrees == ("generated/private",)
+        assert vector.source_selection.exclude_subtrees == ("generated/private",)
+        assert symbol_graph.source_selection.exclude_subtrees == ("generated/private",)
+        assert zoekt.source_selection.exclude_subtrees == ("generated/private",)
+        assert bm25.source_selection is not selection
+        assert vector.source_selection is not selection
+        assert symbol_graph.source_selection is not selection
+        assert zoekt.source_selection is not selection
+        assert bm25.artifact_identity()["source_selection_digest"] == expected_digest
+        assert vector.artifact_identity()["source_selection_digest"] == expected_digest
+        assert (
+            symbol_graph.artifact_identity()["source_selection_digest"]
+            == expected_digest
+        )
+        assert zoekt.artifact_identity()["source_selection_digest"] == expected_digest
+
+        with pytest.raises(TypeError, match="RepositorySourceSelection"):
+            register_default_builders(
+                IndexBuilderRegistry(),
+                source_selection=object(),
+            )
+
     def test_provider_alias_is_normalized_before_model_policy(self):
         registry = IndexBuilderRegistry()
         register_default_builders(
@@ -1775,13 +2214,97 @@ class TestRegisterDefaultBuilders:
 
 
 class TestZoektIndexBuilder:
+    @staticmethod
+    def _successful_runner(
+        calls,
+        *,
+        shard_bytes=b"zoekt-shard\n",
+        binary_kwargs=None,
+    ):
+        real_run = subprocess.run
+
+        def run(command, *args, **kwargs):
+            if command[0] != "/fake/zoekt-git-index":
+                return real_run(command, *args, **kwargs)
+            calls.append(command)
+            if binary_kwargs is not None:
+                binary_kwargs.append(kwargs)
+            output_dir = Path(command[command.index("-index") + 1])
+            (output_dir / "repository_v16.00000.zoekt").write_bytes(shard_bytes)
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+        return run
+
+    @staticmethod
+    def _commit_all(repo, message="fixture"):
+        subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True)
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-qm", message],
+            check=True,
+        )
+        return subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    def test_custom_selection_fails_before_any_output_side_effect(self, tmp_path):
+        output_dir = tmp_path / "shards"
+        builder = ZoektIndexBuilder(
+            source_selection=RepositorySourceSelection(["private"])
+        )
+
+        with (
+            patch(
+                "codenib.compiler.index_builders.shutil.which",
+                side_effect=AssertionError("binary lookup must not run"),
+            ),
+            patch(
+                "codenib.compiler.index_builders.subprocess.run",
+                side_effect=AssertionError("subprocess must not run"),
+            ),
+            pytest.raises(RuntimeError, match="does not support custom"),
+        ):
+            builder.build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_dir),
+            )
+
+        assert not output_dir.exists()
+
+    def test_default_excluded_tracked_source_fails_before_output(self, tmp_path):
+        _git_repo(tmp_path)
+        excluded = tmp_path / "node_modules" / "dependency.js"
+        excluded.parent.mkdir()
+        excluded.write_text("export const privateValue = 1;\n")
+        self._commit_all(tmp_path, "excluded tracked source")
+        output_dir = tmp_path / "shards"
+        builder = ZoektIndexBuilder()
+
+        with (
+            patch(
+                "codenib.compiler.index_builders.shutil.which",
+                side_effect=AssertionError("binary lookup must not run"),
+            ),
+            pytest.raises(RuntimeError, match="tracked files are excluded"),
+        ):
+            builder.build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_dir),
+            )
+
+        assert not output_dir.exists()
+
     def test_build_invokes_zoekt_git_index(self, tmp_path):
         builder = ZoektIndexBuilder()
+        source_commit = _git_repo(tmp_path)
         output_dir = tmp_path / "shards"
-
-        completed = MagicMock()
-        completed.returncode = 0
-        completed.stderr = ""
+        calls = []
+        binary_kwargs = []
+        shard_bytes = b"authenticated zoekt shard\n"
 
         with (
             patch(
@@ -1790,31 +2313,166 @@ class TestZoektIndexBuilder:
             ),
             patch(
                 "codenib.compiler.index_builders.subprocess.run",
-                return_value=completed,
-            ) as mock_run,
+                side_effect=self._successful_runner(
+                    calls,
+                    shard_bytes=shard_bytes,
+                    binary_kwargs=binary_kwargs,
+                ),
+            ),
         ):
             status = builder.build(
                 scope="current_repo",
                 repo_path=str(tmp_path),
                 output_dir=str(output_dir),
+                source_commit=source_commit,
             )
 
         assert status.index_type == "zoekt"
         assert status.state == IndexState.FRESH
         assert status.path == str(output_dir)
         assert output_dir.exists()
-        cmd = mock_run.call_args.args[0]
+        assert len(calls) == 1
+        cmd = calls[0]
         assert cmd[0] == "/fake/zoekt-git-index"
         assert "-index" in cmd
-        assert str(output_dir) in cmd
+        private_index = Path(cmd[cmd.index("-index") + 1])
+        assert private_index != output_dir
+        assert binary_kwargs[0]["pass_fds"] == (int(private_index.name),)
         assert str(tmp_path) in cmd
+        assert "-submodules=false" in cmd
+        assert f"-branches={source_commit}" in cmd
+        assert "-prefix=" in cmd
+        assert status.metadata["tracked_source_count"] == 1
+        assert status.metadata["source_commit"] == source_commit
+        assert status.metadata["builder_schema"] == 3
+        assert status.metadata["source_contract"] == ("immutable-git-commit-tree-v2")
+        assert status.metadata["worktree_contract"] == (
+            "selected-files-match-source-commit-v2"
+        )
+        assert status.metadata["shard_tree_receipt_schema"] == (
+            "codenib.zoekt-shard-tree.v1"
+        )
+        assert status.metadata["submodules"] is False
+        files = [
+            {
+                "path": "repository_v16.00000.zoekt",
+                "size": len(shard_bytes),
+                "sha256": hashlib.sha256(shard_bytes).hexdigest(),
+            }
+        ]
+        canonical = json.dumps(
+            {
+                "schema": "codenib.zoekt-shard-tree.v1",
+                "files": files,
+            },
+            allow_nan=False,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("ascii")
+        assert status.metadata["shard_tree_receipt"] == {
+            "schema": "codenib.zoekt-shard-tree.v1",
+            "digest": f"sha256:{hashlib.sha256(canonical).hexdigest()}",
+            "file_count": 1,
+            "total_bytes": len(shard_bytes),
+            "files": files,
+        }
+
+    @pytest.mark.skipif(os.name != "posix", reason="descriptor path is POSIX-only")
+    def test_live_binary_writes_through_inherited_private_descriptor(self, tmp_path):
+        source_commit = _git_repo(tmp_path)
+        tool_dir = tmp_path / ".codenib_cache" / "tools"
+        tool_dir.mkdir(parents=True)
+        binary = tool_dir / "fake-zoekt-git-index"
+        binary.write_text(
+            "#!/usr/bin/env python3\n"
+            "import pathlib, sys\n"
+            "args = sys.argv[1:]\n"
+            "root = pathlib.Path(args[args.index('-index') + 1])\n"
+            "(root / 'live_v16.00000.zoekt').write_bytes(b'live shard\\n')\n"
+        )
+        binary.chmod(0o755)
+        output_dir = tmp_path / ".codenib_cache" / "zoekt"
+
+        status = ZoektIndexBuilder(binary=str(binary)).build(
+            scope="current_repo",
+            repo_path=str(tmp_path),
+            output_dir=str(output_dir),
+            source_commit=source_commit,
+        )
+
+        assert (output_dir / "live_v16.00000.zoekt").read_bytes() == b"live shard\n"
+        assert status.metadata["shard_count"] == 1
+
+    def test_build_uses_compiler_source_commit_without_reading_head(self, tmp_path):
+        builder = ZoektIndexBuilder()
+        source_commit = _git_repo(tmp_path)
+        output_dir = tmp_path / "shards"
+        binary_calls = []
+        commands = []
+        successful = self._successful_runner(binary_calls)
+
+        def record_run(command, *args, **kwargs):
+            commands.append(command)
+            return successful(command, *args, **kwargs)
+
+        with (
+            patch(
+                "codenib.compiler.index_builders.shutil.which",
+                return_value="/fake/zoekt-git-index",
+            ),
+            patch(
+                "codenib.compiler.index_builders.subprocess.run",
+                side_effect=record_run,
+            ),
+        ):
+            status = builder.build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_dir),
+                source_commit=source_commit,
+            )
+
+        assert not any("HEAD^{commit}" in command for command in commands)
+        assert commands[0][-1] == f"{source_commit}^{{commit}}"
+        assert f"-branches={source_commit}" in binary_calls[0]
+        assert status.metadata["source_commit"] == source_commit
+
+    @pytest.mark.parametrize("change", ["tracked", "untracked"])
+    def test_build_rejects_selected_worktree_not_in_source_commit(
+        self, tmp_path, change
+    ):
+        _git_repo(tmp_path)
+        if change == "tracked":
+            (tmp_path / "a.py").write_text("def changed():\n    return 1\n")
+        else:
+            (tmp_path / "untracked.py").write_text("VALUE = 1\n")
+        output_dir = tmp_path / "shards"
+
+        with (
+            patch(
+                "codenib.compiler.index_builders.shutil.which",
+                side_effect=AssertionError("binary lookup must not run"),
+            ),
+            pytest.raises(RuntimeError, match="immutable commit"),
+        ):
+            ZoektIndexBuilder().build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_dir),
+            )
+
+        assert not output_dir.exists()
 
     def test_build_raises_when_binary_missing(self, tmp_path):
         builder = ZoektIndexBuilder(binary="this-binary-does-not-exist-12345")
+        _git_repo(tmp_path)
 
-        with patch(
-            "codenib.compiler.index_builders.shutil.which",
-            return_value=None,
+        with (
+            patch(
+                "codenib.compiler.index_builders.shutil.which",
+                return_value=None,
+            ),
         ):
             try:
                 builder.build(
@@ -1828,9 +2486,19 @@ class TestZoektIndexBuilder:
                 raise AssertionError("Expected RuntimeError when binary missing")
 
     def test_build_raises_when_subprocess_fails(self, tmp_path):
-        import subprocess
-
         builder = ZoektIndexBuilder()
+        _git_repo(tmp_path)
+        real_run = subprocess.run
+
+        def fail_binary(command, *args, **kwargs):
+            if command[0] == "/fake/zoekt-git-index":
+                raise subprocess.CalledProcessError(
+                    returncode=2,
+                    cmd=command,
+                    stderr="boom",
+                )
+            return real_run(command, *args, **kwargs)
+
         with (
             patch(
                 "codenib.compiler.index_builders.shutil.which",
@@ -1838,9 +2506,7 @@ class TestZoektIndexBuilder:
             ),
             patch(
                 "codenib.compiler.index_builders.subprocess.run",
-                side_effect=subprocess.CalledProcessError(
-                    returncode=2, cmd=["zoekt-git-index"], stderr="boom"
-                ),
+                side_effect=fail_binary,
             ),
         ):
             try:
@@ -1854,6 +2520,409 @@ class TestZoektIndexBuilder:
                 assert "boom" in str(exc)
             else:
                 raise AssertionError("Expected RuntimeError when subprocess fails")
+
+    def test_rejects_visible_gitlink_before_binary_or_output(self, tmp_path):
+        target_commit = _git_repo(tmp_path)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(tmp_path),
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                f"160000,{target_commit},dependency",
+            ],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "commit", "-qm", "gitlink"],
+            check=True,
+        )
+        output_dir = tmp_path / "shards"
+
+        with (
+            patch(
+                "codenib.compiler.index_builders.shutil.which",
+                side_effect=AssertionError("binary lookup must not run"),
+            ),
+            pytest.raises(RuntimeError, match="visible gitlink/submodule"),
+        ):
+            ZoektIndexBuilder().build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_dir),
+            )
+
+        assert not output_dir.exists()
+
+    def test_rejects_sparse_checkout_missing_visible_tree_path(self, tmp_path):
+        _git_repo(tmp_path)
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.py").write_text("VALUE = 1\n")
+        (tmp_path / "secrets").mkdir()
+        (tmp_path / "secrets" / "private.py").write_text("TOKEN = 'private'\n")
+        self._commit_all(tmp_path, "sparse fixture")
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "sparse-checkout", "init", "--cone"],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "sparse-checkout", "set", "src"],
+            check=True,
+        )
+        assert not (tmp_path / "secrets" / "private.py").exists()
+        output_dir = tmp_path / "shards"
+
+        with (
+            patch(
+                "codenib.compiler.index_builders.shutil.which",
+                side_effect=AssertionError("binary lookup must not run"),
+            ),
+            pytest.raises(RuntimeError, match="worktree path is missing"),
+        ):
+            ZoektIndexBuilder().build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_dir),
+            )
+
+        assert not output_dir.exists()
+
+    def test_rejects_skip_worktree_bytes_hidden_from_git_diff(self, tmp_path):
+        source_commit = _git_repo(tmp_path)
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "update-index", "--skip-worktree", "a.py"],
+            check=True,
+        )
+        (tmp_path / "a.py").write_text("def hidden_change():\n    return 1\n")
+        assert (
+            subprocess.run(
+                ["git", "-C", str(tmp_path), "diff", "--quiet", source_commit, "--"],
+                check=False,
+            ).returncode
+            == 0
+        )
+        output_dir = tmp_path / "shards"
+
+        with (
+            patch(
+                "codenib.compiler.index_builders.shutil.which",
+                side_effect=AssertionError("binary lookup must not run"),
+            ),
+            pytest.raises(RuntimeError, match="worktree bytes differ"),
+        ):
+            ZoektIndexBuilder().build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_dir),
+            )
+
+        assert not output_dir.exists()
+
+    def test_rejects_skip_worktree_symlink_target_mismatch(self, tmp_path):
+        _git_repo(tmp_path)
+        link = tmp_path / "current.py"
+        link.symlink_to("a.py")
+        source_commit = self._commit_all(tmp_path, "tracked symlink")
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(tmp_path),
+                "update-index",
+                "--skip-worktree",
+                "current.py",
+            ],
+            check=True,
+        )
+        link.unlink()
+        link.symlink_to("missing.py")
+        assert (
+            subprocess.run(
+                ["git", "-C", str(tmp_path), "diff", "--quiet", source_commit, "--"],
+                check=False,
+            ).returncode
+            == 0
+        )
+        output_dir = tmp_path / "shards"
+
+        with (
+            patch(
+                "codenib.compiler.index_builders.shutil.which",
+                side_effect=AssertionError("binary lookup must not run"),
+            ),
+            pytest.raises(RuntimeError, match="worktree link differs"),
+        ):
+            ZoektIndexBuilder().build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_dir),
+            )
+
+        assert not output_dir.exists()
+
+    def test_rejects_crlf_bytes_normalized_clean_by_git(self, tmp_path):
+        _git_repo(tmp_path)
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "config", "core.autocrlf", "true"],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "add", "--renormalize", "a.py"],
+            check=True,
+        )
+        (tmp_path / "a.py").unlink()
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "checkout", "--", "a.py"],
+            check=True,
+        )
+        assert b"\r\n" in (tmp_path / "a.py").read_bytes()
+        assert (
+            subprocess.run(
+                ["git", "-C", str(tmp_path), "status", "--porcelain"],
+                check=True,
+                capture_output=True,
+            ).stdout
+            == b""
+        )
+        output_dir = tmp_path / "shards"
+
+        with (
+            patch(
+                "codenib.compiler.index_builders.shutil.which",
+                side_effect=AssertionError("binary lookup must not run"),
+            ),
+            pytest.raises(RuntimeError, match="worktree bytes differ"),
+        ):
+            ZoektIndexBuilder().build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_dir),
+            )
+
+        assert not output_dir.exists()
+
+    def test_rejects_smudged_bytes_normalized_clean_by_filter(self, tmp_path):
+        _git_repo(tmp_path)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(tmp_path),
+                "config",
+                "filter.zoekt-proof.clean",
+                "sed -e 's/worktree/commit/g'",
+            ],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(tmp_path),
+                "config",
+                "filter.zoekt-proof.smudge",
+                "cat",
+            ],
+            check=True,
+        )
+        (tmp_path / ".gitattributes").write_text("*.txt filter=zoekt-proof\n")
+        (tmp_path / "filtered.txt").write_text("commit\n")
+        self._commit_all(tmp_path, "filtered fixture")
+        (tmp_path / "filtered.txt").write_text("worktree\n")
+        assert (
+            subprocess.run(
+                ["git", "-C", str(tmp_path), "diff", "--quiet", "HEAD", "--"],
+                check=False,
+            ).returncode
+            == 0
+        )
+        output_dir = tmp_path / "shards"
+
+        with (
+            patch(
+                "codenib.compiler.index_builders.shutil.which",
+                side_effect=AssertionError("binary lookup must not run"),
+            ),
+            pytest.raises(RuntimeError, match="worktree bytes differ"),
+        ):
+            ZoektIndexBuilder().build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_dir),
+            )
+
+        assert not output_dir.exists()
+
+    def test_git_replace_cannot_substitute_the_proved_commit_tree(self, tmp_path):
+        replacement_commit = _git_repo(tmp_path)
+        replacement_branch = subprocess.run(
+            ["git", "-C", str(tmp_path), "branch", "--show-current"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "switch", "-qc", "secret-tree"],
+            check=True,
+        )
+        (tmp_path / "a.py").unlink()
+        secret = tmp_path / "node_modules" / "secret.txt"
+        secret.parent.mkdir()
+        secret.write_text("must not be indexed\n")
+        original_commit = self._commit_all(tmp_path, "secret tree")
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "switch", "-q", replacement_branch],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(tmp_path),
+                "replace",
+                original_commit,
+                replacement_commit,
+            ],
+            check=True,
+        )
+        substituted = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(tmp_path),
+                "ls-tree",
+                "-r",
+                "--name-only",
+                original_commit,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.splitlines()
+        assert substituted == ["a.py"]
+        output_dir = tmp_path / "shards"
+
+        with (
+            patch(
+                "codenib.compiler.index_builders.shutil.which",
+                side_effect=AssertionError("binary lookup must not run"),
+            ),
+            pytest.raises(RuntimeError, match="tracked files are excluded"),
+        ):
+            ZoektIndexBuilder().build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_dir),
+                source_commit=original_commit,
+            )
+
+        assert not output_dir.exists()
+
+    @pytest.mark.parametrize(
+        "extra_args",
+        [
+            ["--"],
+            ["positional"],
+            ["-parallelism", "4"],
+            ["-parallelism"],
+            ["-branches=HEAD"],
+            ["--submodules=true"],
+        ],
+    )
+    def test_rejects_unsafe_extra_args_before_subprocess_or_output(
+        self,
+        tmp_path,
+        extra_args,
+    ):
+        output_dir = tmp_path / "shards"
+        builder = ZoektIndexBuilder(extra_args=extra_args)
+
+        with (
+            patch(
+                "codenib.compiler.index_builders.shutil.which",
+                side_effect=AssertionError("binary lookup must not run"),
+            ),
+            patch(
+                "codenib.compiler.index_builders.subprocess.run",
+                side_effect=AssertionError("subprocess must not run"),
+            ),
+            pytest.raises((TypeError, ValueError), match="Zoekt extra_args"),
+        ):
+            builder.build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_dir),
+            )
+
+        assert not output_dir.exists()
+
+    def test_rejects_nonregular_shard_tree_without_fresh_receipt(self, tmp_path):
+        _git_repo(tmp_path)
+        output_dir = tmp_path / "shards"
+        real_run = subprocess.run
+
+        def write_link(command, *args, **kwargs):
+            if command[0] != "/fake/zoekt-git-index":
+                return real_run(command, *args, **kwargs)
+            private_index = Path(command[command.index("-index") + 1])
+            (private_index / "target").write_bytes(b"shard")
+            (private_index / "repository_v16.00000.zoekt").symlink_to("target")
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+        with (
+            patch(
+                "codenib.compiler.index_builders.shutil.which",
+                return_value="/fake/zoekt-git-index",
+            ),
+            patch(
+                "codenib.compiler.index_builders.subprocess.run",
+                side_effect=write_link,
+            ),
+            pytest.raises(RuntimeError, match="refuses linked content"),
+        ):
+            ZoektIndexBuilder().build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_dir),
+            )
+
+    def test_private_generation_replaces_preexisting_shards(self, tmp_path):
+        source_commit = _git_repo(tmp_path)
+        output_dir = tmp_path / ".codenib_cache" / "zoekt"
+        output_dir.mkdir(parents=True)
+        (output_dir / "old_v16.00000.zoekt").write_bytes(b"stale secret shard\n")
+        calls = []
+        new_shard = b"current source shard\n"
+
+        with (
+            patch(
+                "codenib.compiler.index_builders.shutil.which",
+                return_value="/fake/zoekt-git-index",
+            ),
+            patch(
+                "codenib.compiler.index_builders.subprocess.run",
+                side_effect=self._successful_runner(
+                    calls,
+                    shard_bytes=new_shard,
+                ),
+            ),
+        ):
+            status = ZoektIndexBuilder().build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_dir),
+                source_commit=source_commit,
+            )
+
+        assert not (output_dir / "old_v16.00000.zoekt").exists()
+        published = output_dir / "repository_v16.00000.zoekt"
+        assert published.read_bytes() == new_shard
+        assert status.metadata["shard_count"] == 1
+        assert [
+            record["path"] for record in status.metadata["shard_tree_receipt"]["files"]
+        ] == ["repository_v16.00000.zoekt"]
 
 
 # ---------------------------------------------------------------------------
@@ -1873,7 +2942,7 @@ class TestIndexCompiler:
         )
         compiler = IndexCompiler(registry, config)
         manifest = compiler.compile_repo(
-            str(tmp_path), cache_dir=str(tmp_path / "cache")
+            str(tmp_path), cache_dir=str(tmp_path / ".codenib_cache")
         )
 
         assert manifest.repo_path == str(tmp_path)
@@ -1892,7 +2961,7 @@ class TestIndexCompiler:
         config = IndexCompilerConfig(index_types=["bm25"])
         compiler = IndexCompiler(registry, config)
         manifest = compiler.compile_repo(
-            str(tmp_path), cache_dir=str(tmp_path / "cache")
+            str(tmp_path), cache_dir=str(tmp_path / ".codenib_cache")
         )
 
         assert manifest.indexes["bm25"].status == "failed"
@@ -1910,11 +2979,98 @@ class TestIndexCompiler:
         config = IndexCompilerConfig(index_types=["bm25", "vector"])
         compiler = IndexCompiler(registry, config)
         manifest = compiler.compile_repo(
-            str(tmp_path), cache_dir=str(tmp_path / "cache")
+            str(tmp_path), cache_dir=str(tmp_path / ".codenib_cache")
         )
 
         assert "bm25" in manifest.indexes
         assert "vector" not in manifest.indexes
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        (
+            ("index_type", "other"),
+            ("state", IndexState.STALE),
+            ("scope", "other_repo"),
+            ("path", "/outside/compiler-output"),
+        ),
+    )
+    def test_rejects_builder_status_outside_compiler_contract(
+        self,
+        tmp_path,
+        field,
+        value,
+    ):
+        class InvalidStatusBuilder:
+            def build(self, scope: str, **kwargs) -> IndexStatus:
+                status = IndexStatus(
+                    index_type="rec",
+                    state=IndexState.FRESH,
+                    scope=scope,
+                    path=kwargs["output_dir"],
+                    metadata={},
+                )
+                setattr(status, field, value)
+                return status
+
+            def incremental_update(self, scope: str, **kwargs) -> IndexStatus:
+                return self.build(scope, **kwargs)
+
+        registry = IndexBuilderRegistry()
+        registry.register("rec", InvalidStatusBuilder())
+        manifest = IndexCompiler(
+            registry,
+            IndexCompilerConfig(index_types=["rec"]),
+        ).compile_repo(str(tmp_path), cache_dir=str(tmp_path / ".codenib_cache"))
+
+        assert manifest.indexes["rec"].status == "failed"
+        assert manifest.capabilities == {
+            "sparse_search": False,
+            "dense_search": False,
+            "hybrid_search": False,
+            "symbol_navigation": False,
+        }
+
+    def test_rejects_zoekt_receipt_for_another_source_commit(self, tmp_path):
+        expected_commit = "a" * 40
+        observed = []
+
+        class WrongCommitZoektBuilder:
+            def build(self, scope: str, **kwargs) -> IndexStatus:
+                observed.append(kwargs["source_commit"])
+                selection = kwargs["source_selection"]
+                return IndexStatus(
+                    index_type="zoekt",
+                    state=IndexState.FRESH,
+                    scope=scope,
+                    path=kwargs["output_dir"],
+                    metadata={
+                        "source_selection_digest": selection.digest,
+                        "source_commit": "b" * 40,
+                    },
+                )
+
+            def incremental_update(self, scope: str, **kwargs) -> IndexStatus:
+                return self.build(scope, **kwargs)
+
+        registry = IndexBuilderRegistry()
+        registry.register("zoekt", WrongCommitZoektBuilder())
+        compiler = IndexCompiler(
+            registry,
+            IndexCompilerConfig(index_types=["zoekt"]),
+        )
+        with patch.object(
+            IndexCompiler,
+            "_get_head_commit",
+            return_value=expected_commit,
+        ):
+            manifest = compiler.compile_repo(
+                str(tmp_path),
+                cache_dir=str(tmp_path / ".codenib_cache"),
+            )
+
+        assert observed == [expected_commit]
+        assert manifest.indexes["zoekt"].status == "failed"
+        assert "compiler source commit" in manifest.indexes["zoekt"].metadata["error"]
 
     def test_manifest_file_written(self, tmp_path):
         registry = IndexBuilderRegistry()
@@ -1922,7 +3078,7 @@ class TestIndexCompiler:
 
         config = IndexCompilerConfig(index_types=["bm25"])
         compiler = IndexCompiler(registry, config)
-        cache_dir = str(tmp_path / "cache")
+        cache_dir = str(tmp_path / ".codenib_cache")
         compiler.compile_repo(str(tmp_path), cache_dir=cache_dir)
 
         manifest_path = os.path.join(cache_dir, MANIFEST_FILENAME)
@@ -1937,18 +3093,191 @@ class TestIndexCompiler:
             data["repo"]["source_fingerprint"]
         )
 
+    def test_visible_in_repository_cache_is_rejected_before_build(self, tmp_path):
+        builder = _mock_builder("bm25")
+        registry = IndexBuilderRegistry()
+        registry.register("bm25", builder)
+
+        with pytest.raises(ValueError, match="index cache must be excluded"):
+            IndexCompiler(
+                registry,
+                IndexCompilerConfig(index_types=["bm25"]),
+            ).compile_repo(
+                str(tmp_path),
+                cache_dir=str(tmp_path / "visible-cache"),
+            )
+
+    def test_visible_in_repository_cache_is_rejected_before_update_fast_path(
+        self,
+        tmp_path,
+    ):
+        registry = IndexBuilderRegistry()
+        registry.register("bm25", _mock_builder("bm25"))
+        compiler = IndexCompiler(
+            registry,
+            IndexCompilerConfig(index_types=["bm25"]),
+        )
+        hidden_cache = tmp_path / ".codenib_cache"
+        compiler.compile_repo(str(tmp_path), cache_dir=str(hidden_cache))
+
+        visible_cache = tmp_path / "visible-cache"
+        shutil.copytree(hidden_cache, visible_cache)
+
+        with pytest.raises(ValueError, match="index cache must be excluded"):
+            compiler.update_repo(str(tmp_path), cache_dir=str(visible_cache))
+
+    def test_explicitly_excluded_in_repository_cache_is_allowed(self, tmp_path):
+        selection = RepositorySourceSelection(("visible-cache",))
+        registry = IndexBuilderRegistry()
+        registry.register("bm25", _mock_builder("bm25"))
+
+        manifest = IndexCompiler(
+            registry,
+            IndexCompilerConfig(
+                index_types=["bm25"],
+                source_selection=selection,
+            ),
+        ).compile_repo(
+            str(tmp_path),
+            cache_dir=str(tmp_path / "visible-cache"),
+        )
+
+        assert manifest.indexes["bm25"].status == "fresh"
+        assert manifest.source_selection == selection
+
     def test_manifest_can_be_loaded(self, tmp_path):
         registry = IndexBuilderRegistry()
         registry.register("bm25", _mock_builder("bm25"))
 
         config = IndexCompilerConfig(index_types=["bm25"])
         compiler = IndexCompiler(registry, config)
-        cache_dir = str(tmp_path / "cache")
+        cache_dir = str(tmp_path / ".codenib_cache")
         compiler.compile_repo(str(tmp_path), cache_dir=cache_dir)
 
         manifest_path = os.path.join(cache_dir, MANIFEST_FILENAME)
         loaded = RepoManifest.load(manifest_path)
         assert loaded.indexes["bm25"].status == "fresh"
+
+    def test_selection_is_bound_to_fingerprints_builder_and_manifest(self, tmp_path):
+        selection = RepositorySourceSelection(["generated"])
+        observed = []
+
+        class SelectionAwareBuilder:
+            def build(self, scope: str, **kwargs) -> IndexStatus:
+                selected = kwargs["source_selection"]
+                observed.append(selected)
+                return IndexStatus(
+                    index_type="bm25",
+                    state=IndexState.FRESH,
+                    scope=scope,
+                    path=kwargs["output_dir"],
+                    metadata={"source_selection_digest": selected.digest},
+                )
+
+            def incremental_update(self, scope: str, **kwargs) -> IndexStatus:
+                return self.build(scope, **kwargs)
+
+        registry = IndexBuilderRegistry()
+        registry.register("bm25", SelectionAwareBuilder())
+        compiler = IndexCompiler(
+            registry,
+            IndexCompilerConfig(
+                index_types=["bm25"],
+                source_selection=selection,
+            ),
+        )
+        real_fingerprint = index_compiler_module.fingerprint_repository
+
+        with patch.object(
+            index_compiler_module,
+            "fingerprint_repository",
+            wraps=real_fingerprint,
+        ) as fingerprint:
+            manifest = compiler.compile_repo(
+                str(tmp_path), cache_dir=str(tmp_path / ".codenib_cache")
+            )
+
+        assert observed == [selection]
+        assert fingerprint.call_count == 2
+        assert all(
+            call.kwargs["selection"] == selection for call in fingerprint.mock_calls
+        )
+        assert manifest.source_selection == selection
+        assert manifest.source_selection is not selection
+        assert manifest.source_selection_digest == selection.digest
+        assert manifest.last_indexed_source_selection_digest == selection.digest
+        assert manifest.indexes["bm25"].source_selection_digest == selection.digest
+        assert (
+            RepoManifest.load(
+                tmp_path / ".codenib_cache" / MANIFEST_FILENAME
+            ).source_selection
+            == selection
+        )
+
+    @pytest.mark.parametrize(
+        "selection",
+        [
+            RepositorySourceSelection(),
+            RepositorySourceSelection(["generated"]),
+        ],
+    )
+    def test_selection_fails_closed_without_builder_confirmation(
+        self,
+        tmp_path,
+        selection,
+    ):
+        class UnconfirmedBuilder:
+            def build(self, scope: str, **kwargs) -> IndexStatus:
+                return IndexStatus(
+                    index_type="bm25",
+                    state=IndexState.FRESH,
+                    scope=scope,
+                    path=kwargs["output_dir"],
+                    metadata={},
+                )
+
+            def incremental_update(self, scope: str, **kwargs) -> IndexStatus:
+                return self.build(scope, **kwargs)
+
+        registry = IndexBuilderRegistry()
+        registry.register("bm25", UnconfirmedBuilder())
+        compiler = IndexCompiler(
+            registry,
+            IndexCompilerConfig(
+                index_types=["bm25"],
+                source_selection=selection,
+            ),
+        )
+
+        manifest = compiler.compile_repo(
+            str(tmp_path), cache_dir=str(tmp_path / ".codenib_cache")
+        )
+
+        entry = manifest.indexes["bm25"]
+        assert entry.status == "failed"
+        assert entry.source_selection_digest == ""
+        assert "did not confirm" in entry.metadata["error"]
+        assert manifest.last_indexed_source_selection_digest == ""
+
+    def test_invalid_builder_result_is_recorded_as_failed(self, tmp_path):
+        class InvalidBuilder:
+            def build(self, scope: str, **kwargs):
+                return None
+
+            def incremental_update(self, scope: str, **kwargs):
+                return None
+
+        registry = IndexBuilderRegistry()
+        registry.register("bm25", InvalidBuilder())
+        manifest = IndexCompiler(
+            registry,
+            IndexCompilerConfig(index_types=["bm25"]),
+        ).compile_repo(str(tmp_path), cache_dir=str(tmp_path / ".codenib_cache"))
+
+        assert manifest.indexes["bm25"].status == "failed"
+        assert (
+            "must return an IndexStatus" in manifest.indexes["bm25"].metadata["error"]
+        )
 
     def test_index_types_override(self, tmp_path):
         registry = IndexBuilderRegistry()
@@ -1959,7 +3288,7 @@ class TestIndexCompiler:
         compiler = IndexCompiler(registry, config)
         manifest = compiler.compile_repo(
             str(tmp_path),
-            cache_dir=str(tmp_path / "cache"),
+            cache_dir=str(tmp_path / ".codenib_cache"),
             index_types=["bm25"],  # override: only build bm25
         )
 
@@ -1972,7 +3301,7 @@ class TestIndexCompiler:
         registry.register("vector", _mock_builder("vector"))
 
         compiler = IndexCompiler(registry)
-        cache_dir = str(tmp_path / "cache")
+        cache_dir = str(tmp_path / ".codenib_cache")
         compiler.compile_repo(str(tmp_path), cache_dir=cache_dir, index_types=["bm25"])
         manifest = compiler.compile_repo(
             str(tmp_path), cache_dir=cache_dir, index_types=["vector"]
@@ -1983,7 +3312,7 @@ class TestIndexCompiler:
     def test_rebuild_does_not_keep_requested_view_fresh_without_builder(self, tmp_path):
         initial_registry = IndexBuilderRegistry()
         initial_registry.register("bm25", _mock_builder("bm25"))
-        cache_dir = str(tmp_path / "cache")
+        cache_dir = str(tmp_path / ".codenib_cache")
         IndexCompiler(initial_registry).compile_repo(
             str(tmp_path), cache_dir=cache_dir, index_types=["bm25"]
         )
@@ -2028,7 +3357,7 @@ class TestIndexCompiler:
         registry = IndexBuilderRegistry()
         registry.register("bm25", TrackingBuilder())
         compiler = IndexCompiler(registry, IndexCompilerConfig(index_types=["bm25"]))
-        cache_dir = str(tmp_path / "cache")
+        cache_dir = str(tmp_path / ".codenib_cache")
 
         with ThreadPoolExecutor(max_workers=2) as pool:
             futures = [
@@ -2047,7 +3376,7 @@ class TestIndexCompiler:
         config = IndexCompilerConfig(index_types=["bm25"])
         compiler = IndexCompiler(registry, config)
         manifest = compiler.compile_repo(
-            str(tmp_path), cache_dir=str(tmp_path / "cache")
+            str(tmp_path), cache_dir=str(tmp_path / ".codenib_cache")
         )
 
         meta = manifest.indexes["bm25"].metadata
@@ -2069,7 +3398,7 @@ class TestTwoPhaseIntegration:
 
         config = IndexCompilerConfig(index_types=["bm25"])
         compiler = IndexCompiler(registry, config)
-        cache_dir = str(tmp_path / "cache")
+        cache_dir = str(tmp_path / ".codenib_cache")
         compiler.compile_repo(str(tmp_path), cache_dir=cache_dir)
 
         # Phase 2: load manifest, resolve resources
@@ -2095,7 +3424,7 @@ class TestTwoPhaseIntegration:
 
         config = IndexCompilerConfig(index_types=["bm25"])
         compiler = IndexCompiler(registry, config)
-        cache_dir = str(tmp_path / "cache")
+        cache_dir = str(tmp_path / ".codenib_cache")
         compiler.compile_repo(str(tmp_path), cache_dir=cache_dir)
 
         manifest_path = os.path.join(cache_dir, MANIFEST_FILENAME)
@@ -2127,6 +3456,7 @@ def _recording_builder(calls: list):
             output_dir = kwargs.get("output_dir", "/tmp/rec")
             os.makedirs(output_dir, exist_ok=True)
             calls.append(("build", kwargs.get("last_commit")))
+            selection = kwargs.get("source_selection", RepositorySourceSelection())
             return IndexStatus(
                 index_type="rec",
                 state=IndexState.FRESH,
@@ -2134,7 +3464,7 @@ def _recording_builder(calls: list):
                 age_seconds=0.0,
                 scope=scope,
                 path=output_dir,
-                metadata={},
+                metadata={"source_selection_digest": selection.digest},
             )
 
         def incremental_update(self, scope: str, **kwargs) -> IndexStatus:
@@ -2143,6 +3473,27 @@ def _recording_builder(calls: list):
             return self.build(scope, **rest)
 
     return RecordingBuilder()
+
+
+def _selection_recording_builder(calls: list, index_type: str = "rec"):
+    class SelectionRecordingBuilder:
+        def build(self, scope: str, **kwargs) -> IndexStatus:
+            selection = kwargs["source_selection"]
+            calls.append((index_type, selection.digest))
+            output_dir = kwargs["output_dir"]
+            os.makedirs(output_dir, exist_ok=True)
+            return IndexStatus(
+                index_type=index_type,
+                state=IndexState.FRESH,
+                scope=scope,
+                path=output_dir,
+                metadata={"source_selection_digest": selection.digest},
+            )
+
+        def incremental_update(self, scope: str, **kwargs) -> IndexStatus:
+            return self.build(scope, **kwargs)
+
+    return SelectionRecordingBuilder()
 
 
 def _git_repo(path) -> str:
@@ -2213,6 +3564,108 @@ class TestUpdateRepo:
         assert updated.indexes["rec"].source_fingerprint == (updated.source_fingerprint)
         assert updated.indexes["rec"].status == "fresh"
 
+    def test_selection_change_rebuilds_same_bytes_and_binds_all_observations(
+        self, tmp_path
+    ):
+        _git_repo(tmp_path)
+        calls = []
+        registry = IndexBuilderRegistry()
+        registry.register("rec", _selection_recording_builder(calls))
+        first_selection = RepositorySourceSelection()
+        second_selection = RepositorySourceSelection(["generated"])
+        first = IndexCompiler(
+            registry,
+            IndexCompilerConfig(
+                index_types=["rec"],
+                source_selection=first_selection,
+            ),
+        ).compile_repo(str(tmp_path))
+        real_fingerprint = index_compiler_module.fingerprint_repository
+
+        with patch.object(
+            index_compiler_module,
+            "fingerprint_repository",
+            wraps=real_fingerprint,
+        ) as fingerprint:
+            updated = IndexCompiler(
+                registry,
+                IndexCompilerConfig(
+                    index_types=["rec"],
+                    source_selection=second_selection,
+                ),
+            ).update_repo(str(tmp_path))
+
+        assert calls == [
+            ("rec", first_selection.digest),
+            ("rec", second_selection.digest),
+        ]
+        assert fingerprint.call_count == 2
+        assert all(
+            call.kwargs["selection"] == second_selection
+            for call in fingerprint.mock_calls
+        )
+        assert first.source_fingerprint != updated.source_fingerprint
+        assert updated.source_selection == second_selection
+        assert updated.indexes["rec"].source_selection_digest == (
+            second_selection.digest
+        )
+        assert updated.last_indexed_source_selection_digest == (second_selection.digest)
+
+    def test_omitted_selection_reuses_persisted_manifest_policy(self, tmp_path):
+        _git_repo(tmp_path)
+        selection = RepositorySourceSelection(("generated",))
+        initial_calls: list = []
+        initial_registry = IndexBuilderRegistry()
+        initial_registry.register(
+            "rec",
+            _selection_recording_builder(initial_calls),
+        )
+        IndexCompiler(
+            initial_registry,
+            IndexCompilerConfig(
+                index_types=["rec"],
+                source_selection=selection,
+            ),
+        ).compile_repo(str(tmp_path))
+        _commit(tmp_path, "b.py")
+
+        reuse_calls: list = []
+        reuse_registry = IndexBuilderRegistry()
+        reuse_registry.register("rec", _selection_recording_builder(reuse_calls))
+        updated = IndexCompiler(
+            reuse_registry,
+            IndexCompilerConfig(index_types=["rec"]),
+        ).update_repo(str(tmp_path))
+
+        assert reuse_calls == [("rec", selection.digest)]
+        assert updated.source_selection == selection
+        assert updated.indexes["rec"].source_selection_digest == selection.digest
+
+    def test_selection_change_replaces_languages_from_current_source_surface(
+        self, tmp_path
+    ):
+        _git_repo(tmp_path)
+        registry = IndexBuilderRegistry()
+        registry.register("rec", _selection_recording_builder([]))
+        IndexCompiler(
+            registry,
+            IndexCompilerConfig(
+                index_types=["rec"],
+                languages=["go", "python"],
+            ),
+        ).compile_repo(str(tmp_path))
+
+        updated = IndexCompiler(
+            registry,
+            IndexCompilerConfig(
+                index_types=["rec"],
+                languages=["python"],
+                source_selection=RepositorySourceSelection(("generated",)),
+            ),
+        ).update_repo(str(tmp_path))
+
+        assert updated.languages == ["python"]
+
     def test_dirty_new_head_uses_full_build(self, tmp_path):
         _git_repo(tmp_path)
         calls: list = []
@@ -2244,7 +3697,10 @@ class TestUpdateRepo:
                     age_seconds=0.0,
                     scope=scope,
                     path=kwargs["output_dir"],
-                    metadata=self.artifact_identity(),
+                    metadata={
+                        **self.artifact_identity(),
+                        "source_selection_digest": kwargs["source_selection"].digest,
+                    },
                 )
 
             def incremental_update(self, scope: str, **kwargs) -> IndexStatus:
@@ -2275,7 +3731,12 @@ class TestUpdateRepo:
             def artifact_identity(self):
                 return {"builder_schema": self.version}
 
-            def _status(self, scope: str, output_dir: str) -> IndexStatus:
+            def _status(
+                self,
+                scope: str,
+                output_dir: str,
+                source_selection: RepositorySourceSelection,
+            ) -> IndexStatus:
                 return IndexStatus(
                     index_type="rec",
                     state=IndexState.FRESH,
@@ -2283,18 +3744,29 @@ class TestUpdateRepo:
                     age_seconds=0.0,
                     scope=scope,
                     path=output_dir,
-                    metadata=self.artifact_identity(),
+                    metadata={
+                        **self.artifact_identity(),
+                        "source_selection_digest": source_selection.digest,
+                    },
                 )
 
             def build(self, scope: str, **kwargs) -> IndexStatus:
                 calls.append(("build", self.version, kwargs.get("last_commit")))
-                return self._status(scope, kwargs["output_dir"])
+                return self._status(
+                    scope,
+                    kwargs["output_dir"],
+                    kwargs["source_selection"],
+                )
 
             def incremental_update(self, scope: str, **kwargs) -> IndexStatus:
                 calls.append(
                     ("incremental_update", self.version, kwargs.get("last_commit"))
                 )
-                return self._status(scope, kwargs["output_dir"])
+                return self._status(
+                    scope,
+                    kwargs["output_dir"],
+                    kwargs["source_selection"],
+                )
 
         builder = VersionedBuilder()
         registry = IndexBuilderRegistry()
@@ -2364,7 +3836,7 @@ class TestUpdateRepo:
         assert status_calls == []
         assert calls == [("build", None), ("build", None)]
 
-    def test_v1_manifest_forces_full_rebuild_instead_of_incremental_update(
+    def test_v11_manifest_forces_full_rebuild_instead_of_incremental_update(
         self,
         tmp_path,
     ):
@@ -2373,9 +3845,13 @@ class TestUpdateRepo:
         compiler = self._compiler(calls)
         manifest = compiler.compile_repo(str(tmp_path))
         legacy = f"sha256:{'a' * 64}"
+        manifest.version = LEGACY_MANIFEST_VERSION
+        manifest.source_selection = None
+        manifest.last_indexed_source_selection_digest = ""
         manifest.source_fingerprint = legacy
         manifest.last_indexed_source_fingerprint = legacy
         manifest.indexes["rec"].source_fingerprint = legacy
+        manifest.indexes["rec"].source_selection_digest = ""
         manifest.save(tmp_path / ".codenib_cache" / MANIFEST_FILENAME)
         _commit(tmp_path, "b.py")
         calls.clear()
@@ -2386,6 +3862,130 @@ class TestUpdateRepo:
         assert rebuilt.source_fingerprint.startswith("sha256-v2:")
         assert rebuilt.indexes["rec"].source_fingerprint == (rebuilt.source_fingerprint)
 
+    def test_v11_manifest_migrates_without_blessing_unrequested_entries(self, tmp_path):
+        _git_repo(tmp_path)
+        calls = []
+        registry = IndexBuilderRegistry()
+        registry.register("bm25", _selection_recording_builder(calls, "bm25"))
+        registry.register(
+            "symbol_graph",
+            _selection_recording_builder(calls, "symbol_graph"),
+        )
+        config = IndexCompilerConfig(
+            index_types=["bm25", "symbol_graph"],
+            languages=["python"],
+        )
+        compiler = IndexCompiler(registry, config)
+        current = compiler.compile_repo(str(tmp_path))
+        payload = current.to_dict()
+        payload["version"] = LEGACY_MANIFEST_VERSION
+        payload["repo"].pop("source_selection")
+        payload["repo"].pop("last_indexed_source_selection_digest")
+        for entry in payload["indexes"].values():
+            entry.pop("source_selection_digest")
+        manifest_path = tmp_path / ".codenib_cache" / MANIFEST_FILENAME
+        manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+        calls.clear()
+
+        migrated = compiler.update_repo(str(tmp_path), index_types=["bm25"])
+
+        assert len(calls) == 1
+        assert migrated.version == MANIFEST_VERSION
+        assert migrated.source_selection == RepositorySourceSelection()
+        assert migrated.indexes["bm25"].status == "fresh"
+        assert migrated.indexes["bm25"].source_selection_digest == (
+            RepositorySourceSelection().digest
+        )
+        assert migrated.indexes["symbol_graph"].status == "stale"
+        assert migrated.indexes["symbol_graph"].source_selection_digest == ""
+        assert migrated.last_indexed_commit == ""
+        assert migrated.last_indexed_source_fingerprint == ""
+        assert migrated.last_indexed_source_selection_digest == ""
+
+    def test_failed_selection_rebuild_preserves_complete_previous_generation(
+        self, tmp_path
+    ):
+        _git_repo(tmp_path)
+        first_selection = RepositorySourceSelection(["generated-a"])
+        second_selection = RepositorySourceSelection(["generated-b"])
+        initial_calls = []
+        initial_registry = IndexBuilderRegistry()
+        initial_registry.register("rec", _selection_recording_builder(initial_calls))
+        initial = IndexCompiler(
+            initial_registry,
+            IndexCompilerConfig(
+                index_types=["rec"],
+                source_selection=first_selection,
+            ),
+        ).compile_repo(str(tmp_path))
+        previous_entry = copy.deepcopy(initial.indexes["rec"])
+
+        failing_registry = IndexBuilderRegistry()
+        failing_registry.register("rec", _failing_builder())
+        failed = IndexCompiler(
+            failing_registry,
+            IndexCompilerConfig(
+                index_types=["rec"],
+                source_selection=second_selection,
+            ),
+        ).update_repo(str(tmp_path))
+
+        entry = failed.indexes["rec"]
+        assert failed.source_selection == second_selection
+        assert entry.status == "failed"
+        assert entry.path == previous_entry.path
+        assert entry.config == previous_entry.config
+        assert entry.commit == previous_entry.commit
+        assert entry.source_fingerprint == previous_entry.source_fingerprint
+        assert entry.source_selection_digest == previous_entry.source_selection_digest
+        assert entry.metadata["source_selection_digest"] == first_selection.digest
+        assert "Build failed intentionally" in entry.metadata["error"]
+        assert failed.last_indexed_commit == initial.last_indexed_commit
+        assert failed.last_indexed_source_fingerprint == (
+            initial.last_indexed_source_fingerprint
+        )
+        assert failed.last_indexed_source_selection_digest == (first_selection.digest)
+
+    def test_last_indexed_triple_advances_only_when_every_view_matches(self, tmp_path):
+        _git_repo(tmp_path)
+        first_selection = RepositorySourceSelection(["generated-a"])
+        second_selection = RepositorySourceSelection(["generated-b"])
+        calls = []
+        registry = IndexBuilderRegistry()
+        registry.register("bm25", _selection_recording_builder(calls, "bm25"))
+        registry.register(
+            "symbol_graph", _selection_recording_builder(calls, "symbol_graph")
+        )
+        first = IndexCompiler(
+            registry,
+            IndexCompilerConfig(
+                index_types=["bm25", "symbol_graph"],
+                source_selection=first_selection,
+            ),
+        ).compile_repo(str(tmp_path))
+
+        partial = IndexCompiler(
+            registry,
+            IndexCompilerConfig(
+                index_types=["bm25", "symbol_graph"],
+                source_selection=second_selection,
+            ),
+        ).update_repo(str(tmp_path), index_types=["bm25"])
+
+        assert partial.indexes["bm25"].status == "fresh"
+        assert partial.indexes["bm25"].source_selection_digest == (
+            second_selection.digest
+        )
+        assert partial.indexes["symbol_graph"].status == "stale"
+        assert partial.indexes["symbol_graph"].source_selection_digest == (
+            first_selection.digest
+        )
+        assert partial.last_indexed_commit == first.last_indexed_commit
+        assert partial.last_indexed_source_fingerprint == (
+            first.last_indexed_source_fingerprint
+        )
+        assert partial.last_indexed_source_selection_digest == (first_selection.digest)
+
     def test_full_rebuild_does_not_receive_previous_manifest_config(self, tmp_path):
         _git_repo(tmp_path)
         observed = []
@@ -2394,7 +3994,7 @@ class TestUpdateRepo:
             def artifact_identity(self):
                 return {"builder_schema": 7}
 
-            def _status(self, scope, output_dir):
+            def _status(self, scope, output_dir, source_selection):
                 return IndexStatus(
                     index_type="rec",
                     state=IndexState.FRESH,
@@ -2403,15 +4003,24 @@ class TestUpdateRepo:
                     metadata={
                         **self.artifact_identity(),
                         "generation": "recorded",
+                        "source_selection_digest": source_selection.digest,
                     },
                 )
 
             def build(self, scope: str, **kwargs) -> IndexStatus:
-                return self._status(scope, kwargs["output_dir"])
+                return self._status(
+                    scope,
+                    kwargs["output_dir"],
+                    kwargs["source_selection"],
+                )
 
             def incremental_update(self, scope: str, **kwargs) -> IndexStatus:
                 observed.append(kwargs["previous_artifact_config"])
-                return self._status(scope, kwargs["output_dir"])
+                return self._status(
+                    scope,
+                    kwargs["output_dir"],
+                    kwargs["source_selection"],
+                )
 
         registry = IndexBuilderRegistry()
         registry.register("rec", ManifestAwareBuilder())
@@ -2434,7 +4043,13 @@ class TestUpdateRepo:
             def artifact_identity(self):
                 return {"builder_schema": 1, "languages": ["python", "cpp"]}
 
-            def _status(self, scope: str, output_dir: str, metadata) -> IndexStatus:
+            def _status(
+                self,
+                scope: str,
+                output_dir: str,
+                metadata,
+                source_selection: RepositorySourceSelection,
+            ) -> IndexStatus:
                 return IndexStatus(
                     index_type="symbol_graph",
                     state=IndexState.FRESH,
@@ -2442,7 +4057,11 @@ class TestUpdateRepo:
                     age_seconds=0.0,
                     scope=scope,
                     path=output_dir,
-                    metadata={**self.artifact_identity(), **metadata},
+                    metadata={
+                        **self.artifact_identity(),
+                        **metadata,
+                        "source_selection_digest": source_selection.digest,
+                    },
                 )
 
             def build(self, scope: str, **kwargs) -> IndexStatus:
@@ -2455,6 +4074,7 @@ class TestUpdateRepo:
                         "failed_languages": {"cpp": "compile database unavailable"},
                         "partial": True,
                     },
+                    kwargs["source_selection"],
                 )
 
             def incremental_update(self, scope: str, **kwargs) -> IndexStatus:
@@ -2463,6 +4083,7 @@ class TestUpdateRepo:
                     scope,
                     kwargs["output_dir"],
                     {"update_mode": "incremental"},
+                    kwargs["source_selection"],
                 )
 
         registry = IndexBuilderRegistry()
@@ -2906,6 +4527,51 @@ class TestSymbolGraphIncremental:
         }
         assert "scip_decoded_artifacts" not in status.metadata
         graph.save_graph.assert_called_once_with(str(out / "graph.pkl"))
+
+    def test_changed_source_with_occurrence_sidecar_requests_full_rebuild(
+        self, tmp_path, monkeypatch
+    ):
+        from codenib.graph.incremental.graph_patcher import GraphPatcher
+        from codenib.scip_interface.lsp_occurrence_index import (
+            SCIPOccurrence,
+            SCIPOccurrenceIndex,
+        )
+
+        first = _git_repo(tmp_path)
+        _commit(tmp_path, "b.py")
+        out = tmp_path / "out"
+        out.mkdir()
+        _minimal_code_graph(str(tmp_path)).save_graph(out / "graph.pkl")
+        SCIPOccurrenceIndex([SCIPOccurrence("a.py", 0, 0, 0, 5, "a")]).save(
+            out / "lsp_index.pkl"
+        )
+        monkeypatch.setattr(
+            GraphPatcher,
+            "detect_changed_files",
+            lambda *args, **kwargs: {
+                "added": ["b.py"],
+                "modified": [],
+                "deleted": [],
+                "renamed": [],
+            },
+        )
+        monkeypatch.setattr(
+            GraphPatcher,
+            "patch_files",
+            lambda *args, **kwargs: pytest.fail(
+                "occurrence-bearing generation must rebuild before patching"
+            ),
+        )
+
+        status = self._builder()._patch_graph(
+            "current_repo", str(tmp_path), str(out), first
+        )
+
+        assert status is None
+        occurrences = SCIPOccurrenceIndex.load(out / "lsp_index.pkl")
+        assert [
+            (item.file_path, item.start_line) for item in occurrences.occurrences
+        ] == [("a.py", 0)]
 
     def test_contract_rebuild_is_requested_before_lsp_start(
         self, tmp_path, monkeypatch

--- a/test/compiler/test_manifest.py
+++ b/test/compiler/test_manifest.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import stat
 import time
@@ -14,6 +15,7 @@ import pytest
 
 from codenib.compiler import manifest as manifest_module
 from codenib.compiler.manifest import (
+    LEGACY_MANIFEST_VERSION,
     MANIFEST_VERSION,
     IndexEntry,
     ManifestIndexStateStore,
@@ -25,7 +27,7 @@ from codenib.compiler.resources import (
     IndexStatus,
     ResourceResolver,
 )
-from codenib.source_fingerprint import is_secure_source_fingerprint_v2
+from codenib.repository_source_selection import RepositorySourceSelection
 
 _SOURCE_V2 = f"sha256-v2:{'a' * 64}"
 _OTHER_SOURCE_V2 = f"sha256-v2:{'b' * 64}"
@@ -78,7 +80,7 @@ class TestIndexEntry:
         assert restored.commit == original.commit
         assert restored.source_fingerprint == original.source_fingerprint
 
-    def test_from_dict_defaults(self):
+    def test_from_dict_rejects_missing_versioned_fields(self):
         data = {
             "index_type": "bm25",
             "path": "/tmp",
@@ -86,11 +88,8 @@ class TestIndexEntry:
             "built_at_epoch": 1704067200.0,
             "status": "fresh",
         }
-        entry = IndexEntry.from_dict(data)
-        assert entry.config == {}
-        assert entry.metadata == {}
-        assert entry.commit == ""
-        assert entry.source_fingerprint == ""
+        with pytest.raises(ValueError, match="missing fields"):
+            IndexEntry.from_dict(data)
 
 
 # ---------------------------------------------------------------------------
@@ -104,6 +103,7 @@ def _sample_manifest(epoch: float | None = None) -> RepoManifest:
     return RepoManifest(
         repo_path="/tmp/my_repo",
         commit="abc123def",
+        source_fingerprint=_SOURCE_V2,
         languages=["python", "typescript"],
         file_count=1234,
         indexes={
@@ -115,6 +115,7 @@ def _sample_manifest(epoch: float | None = None) -> RepoManifest:
                 status="fresh",
                 config={"max_k": 128},
                 metadata={"file_count": 890},
+                source_fingerprint=_SOURCE_V2,
             ),
             "vector": IndexEntry(
                 index_type="vector",
@@ -124,6 +125,7 @@ def _sample_manifest(epoch: float | None = None) -> RepoManifest:
                 status="fresh",
                 config={"embedding_model": "nomic-ai/CodeRankEmbed"},
                 metadata={"document_count": {"l0": 42, "l2": 350}},
+                source_fingerprint=_SOURCE_V2,
             ),
         },
         capabilities={"sparse_search": True, "dense_search": True},
@@ -160,6 +162,196 @@ class TestRepoManifest:
         assert restored.file_count == original.file_count
         assert set(restored.indexes.keys()) == set(original.indexes.keys())
         assert restored.indexes["bm25"].config == {"max_k": 128}
+
+    def test_v12_roundtrip_persists_canonical_source_selection(self):
+        selection = RepositorySourceSelection(["ios/Pods", "vendor/generated"])
+        manifest = RepoManifest(
+            source_fingerprint=_SOURCE_V2,
+            last_indexed_source_fingerprint=_SOURCE_V2,
+            source_selection=selection,
+            last_indexed_source_selection_digest=selection.digest,
+            indexes={
+                "bm25": IndexEntry(
+                    index_type="bm25",
+                    path="/tmp/bm25",
+                    built_at="2024-01-15T10:30:00+00:00",
+                    built_at_epoch=time.time(),
+                    status="fresh",
+                    source_fingerprint=_SOURCE_V2,
+                    source_selection_digest=selection.digest,
+                )
+            },
+        )
+
+        payload = manifest.to_dict()
+        restored = RepoManifest.from_dict(json.loads(json.dumps(payload)))
+
+        assert payload["repo"]["source_selection"] == selection.to_dict()
+        assert "source_selection_digest" not in payload["repo"]
+        assert payload["indexes"]["bm25"]["source_selection_digest"] == (
+            selection.digest
+        )
+        assert restored.source_selection == selection
+        assert restored.source_selection_digest == selection.digest
+        assert restored.last_indexed_source_selection_digest == selection.digest
+
+    def test_v11_roundtrip_retains_legacy_selection_sentinel(self):
+        payload = {
+            "version": LEGACY_MANIFEST_VERSION,
+            "repo": {
+                "path": "/tmp/repo",
+                "commit": "abc123",
+                "last_indexed_commit": "abc123",
+                "source_fingerprint": _SOURCE_V2,
+                "last_indexed_source_fingerprint": _SOURCE_V2,
+                "languages": ["python"],
+                "file_count": 1,
+            },
+            "indexes": {
+                "bm25": {
+                    "index_type": "bm25",
+                    "path": "/tmp/bm25",
+                    "built_at": "2024-01-15T10:30:00+00:00",
+                    "built_at_epoch": 1.0,
+                    "status": "fresh",
+                    "config": {},
+                    "metadata": {},
+                    "commit": "",
+                    "source_fingerprint": _SOURCE_V2,
+                }
+            },
+            "capabilities": {"sparse_search": True},
+            "compiled_at": "2024-01-15T10:40:00+00:00",
+            "compiled_at_epoch": 2.0,
+        }
+
+        restored = RepoManifest.from_dict(copy.deepcopy(payload))
+
+        assert restored.version == LEGACY_MANIFEST_VERSION
+        assert restored.source_selection is None
+        assert restored.source_selection_digest is None
+        assert restored.indexes["bm25"].source_selection_digest == ""
+        assert restored.indexes["bm25"].commit == ""
+        assert restored.index_is_current("bm25") is True
+        assert restored.to_dict() == payload
+
+    @pytest.mark.parametrize(
+        "mutation",
+        ["unknown_version", "missing_selection", "unknown_repo", "unknown_index"],
+    )
+    def test_versioned_parser_rejects_unknown_or_missing_fields(self, mutation):
+        payload = _sample_manifest().to_dict()
+        if mutation == "unknown_version":
+            payload["version"] = "1.3"
+        elif mutation == "missing_selection":
+            del payload["repo"]["source_selection"]
+        elif mutation == "unknown_repo":
+            payload["repo"]["future"] = True
+        else:
+            payload["indexes"]["bm25"]["future"] = True
+
+        with pytest.raises(ValueError):
+            RepoManifest.from_dict(payload)
+
+    def test_v12_parser_rejects_fresh_entry_for_different_selection(self):
+        payload = _sample_manifest().to_dict()
+        payload["indexes"]["bm25"]["source_selection_digest"] = (
+            RepositorySourceSelection(["ios/Pods"]).digest
+        )
+
+        with pytest.raises(ValueError, match="does not match"):
+            RepoManifest.from_dict(payload)
+
+    @pytest.mark.parametrize(
+        ("mutation", "message"),
+        [
+            ("empty_repository_source", "requires a secure v2"),
+            ("legacy_repository_source", "must be a secure v2 identity"),
+            ("different_entry_source", "source fingerprint does not match"),
+            ("different_entry_commit", "commit does not match"),
+        ],
+    )
+    def test_v12_parser_rejects_fresh_entry_without_exact_source_closure(
+        self, mutation, message
+    ):
+        payload = _sample_manifest().to_dict()
+        if mutation == "empty_repository_source":
+            payload["repo"]["source_fingerprint"] = ""
+            payload["indexes"]["bm25"]["source_fingerprint"] = ""
+        elif mutation == "legacy_repository_source":
+            payload["repo"]["source_fingerprint"] = _LEGACY_SOURCE_V1
+            payload["indexes"]["bm25"]["source_fingerprint"] = _LEGACY_SOURCE_V1
+        elif mutation == "different_entry_source":
+            payload["indexes"]["bm25"]["source_fingerprint"] = _OTHER_SOURCE_V2
+        else:
+            payload["indexes"]["bm25"]["commit"] = "different"
+
+        with pytest.raises(ValueError, match=message):
+            RepoManifest.from_dict(payload)
+
+    def test_v12_parser_allows_stale_entry_generation_digest(self):
+        payload = _sample_manifest().to_dict()
+        payload["indexes"]["bm25"]["status"] = "stale"
+        old_digest = RepositorySourceSelection(["ios/Pods"]).digest
+        payload["indexes"]["bm25"]["source_selection_digest"] = old_digest
+
+        restored = RepoManifest.from_dict(payload)
+
+        assert restored.indexes["bm25"].source_selection_digest == old_digest
+        assert restored.index_is_current("bm25") is False
+
+    def test_v12_last_indexed_fingerprint_and_selection_are_atomic(self):
+        payload = _sample_manifest().to_dict()
+        payload["repo"]["last_indexed_source_fingerprint"] = _SOURCE_V2
+
+        with pytest.raises(ValueError, match="must be present together"):
+            RepoManifest.from_dict(payload)
+
+    def test_v12_rejects_mismatched_last_selection_for_same_source_identity(self):
+        payload = _sample_manifest().to_dict()
+        payload["repo"]["last_indexed_source_fingerprint"] = _SOURCE_V2
+        payload["repo"]["last_indexed_source_selection_digest"] = (
+            RepositorySourceSelection(("generated",)).digest
+        )
+
+        with pytest.raises(ValueError, match="same repository source selection"):
+            RepoManifest.from_dict(payload)
+
+    def test_load_rejects_duplicate_json_keys(self, tmp_path):
+        payload = json.dumps(_sample_manifest().to_dict()).replace(
+            '"version": "1.2"',
+            '"version": "1.2", "version": "1.2"',
+            1,
+        )
+        path = tmp_path / "repo_manifest.json"
+        path.write_text(payload, encoding="utf-8")
+
+        with pytest.raises(ValueError, match="duplicate key"):
+            RepoManifest.load(path)
+
+    def test_load_rejects_bom_and_oversized_documents(self, tmp_path, monkeypatch):
+        path = tmp_path / "repo_manifest.json"
+        path.write_bytes(
+            b"\xef\xbb\xbf" + json.dumps(_sample_manifest().to_dict()).encode()
+        )
+        with pytest.raises(ValueError, match="BOM-free UTF-8"):
+            RepoManifest.load(path)
+
+        monkeypatch.setattr(manifest_module, "_MAX_MANIFEST_BYTES", 64)
+        path.write_bytes(b"{" + b" " * 64)
+        with pytest.raises(ValueError, match="exceeds 64 bytes"):
+            RepoManifest.load(path)
+
+    def test_nested_nonfinite_metadata_is_rejected_on_parse_and_save(self, tmp_path):
+        payload = _sample_manifest().to_dict()
+        payload["indexes"]["bm25"]["metadata"] = {"nested": [float("inf")]}
+        with pytest.raises(ValueError, match="numbers must be finite"):
+            RepoManifest.from_dict(payload)
+
+        manifest = _sample_manifest()
+        manifest.indexes["bm25"].metadata = {"nested": [float("nan")]}
+        with pytest.raises(ValueError, match="JSON compliant"):
+            manifest.save(tmp_path / "repo_manifest.json")
 
     def test_save_and_load(self, tmp_path):
         original = _sample_manifest()
@@ -205,11 +397,15 @@ class TestRepoManifest:
         manifest_path = tmp_path / "repo_manifest.json"
         previous = _sample_manifest()
         previous.commit = "previous"
+        for entry in previous.indexes.values():
+            entry.commit = previous.commit
         previous.save(manifest_path)
         previous_bytes = manifest_path.read_bytes()
 
         replacement = _sample_manifest()
         replacement.commit = "replacement"
+        for entry in replacement.indexes.values():
+            entry.commit = replacement.commit
 
         def fail_replace(_source, _destination):
             raise OSError("simulated publication failure")
@@ -231,6 +427,9 @@ class TestRepoManifest:
             built_at="2024-01-15T10:30:00+00:00",
             built_at_epoch=time.time(),
             status="fresh",
+            commit=m.commit,
+            source_fingerprint=m.source_fingerprint,
+            source_selection_digest=m.source_selection_digest or "",
         )
         m.derive_capabilities()
 
@@ -241,6 +440,7 @@ class TestRepoManifest:
 
     def test_derive_capabilities_sparse_only(self):
         m = RepoManifest(
+            source_fingerprint=_SOURCE_V2,
             indexes={
                 "bm25": IndexEntry(
                     index_type="bm25",
@@ -248,6 +448,7 @@ class TestRepoManifest:
                     built_at="2024-01-15T10:30:00+00:00",
                     built_at_epoch=time.time(),
                     status="fresh",
+                    source_fingerprint=_SOURCE_V2,
                 ),
             },
         )
@@ -290,6 +491,28 @@ class TestRepoManifest:
         m.derive_capabilities()
         assert m.capabilities["sparse_search"] is False
 
+    def test_v12_empty_head_does_not_alias_entry_with_a_git_commit(self):
+        selection = RepositorySourceSelection()
+        m = RepoManifest(
+            commit="",
+            source_fingerprint=_SOURCE_V2,
+            source_selection=selection,
+            indexes={
+                "bm25": IndexEntry(
+                    index_type="bm25",
+                    path="/tmp/bm25",
+                    built_at="2024-01-15T10:30:00+00:00",
+                    built_at_epoch=time.time(),
+                    status="fresh",
+                    commit="old-git-generation",
+                    source_fingerprint=_SOURCE_V2,
+                    source_selection_digest=selection.digest,
+                ),
+            },
+        )
+
+        assert m.index_is_current("bm25") is False
+
     def test_derive_capabilities_stale_source_excluded(self):
         m = RepoManifest(
             source_fingerprint=_SOURCE_V2,
@@ -301,6 +524,24 @@ class TestRepoManifest:
                     built_at_epoch=time.time(),
                     status="fresh",
                     source_fingerprint=_OTHER_SOURCE_V2,
+                ),
+            },
+        )
+        m.derive_capabilities()
+        assert m.capabilities["sparse_search"] is False
+
+    def test_derive_capabilities_stale_selection_excluded(self):
+        selection = RepositorySourceSelection(["ios/Pods"])
+        m = RepoManifest(
+            source_selection=selection,
+            indexes={
+                "bm25": IndexEntry(
+                    index_type="bm25",
+                    path="/tmp/bm25",
+                    built_at="2024-01-15T10:30:00+00:00",
+                    built_at_epoch=time.time(),
+                    status="fresh",
+                    source_selection_digest=RepositorySourceSelection().digest,
                 ),
             },
         )
@@ -329,30 +570,13 @@ class TestRepoManifest:
         assert restored.last_indexed_source_fingerprint == _OTHER_SOURCE_V2
         assert restored.index_is_current("bm25") is True
 
-    def test_v1_source_identity_loads_for_inert_query_compatibility(self):
-        restored = RepoManifest.from_dict(
-            RepoManifest(
-                source_fingerprint=_LEGACY_SOURCE_V1,
-                last_indexed_source_fingerprint=_LEGACY_SOURCE_V1,
-                indexes={
-                    "bm25": IndexEntry(
-                        index_type="bm25",
-                        path="/tmp/bm25",
-                        built_at="2024-01-15T10:30:00+00:00",
-                        built_at_epoch=time.time(),
-                        status="fresh",
-                        source_fingerprint=_LEGACY_SOURCE_V1,
-                    )
-                },
-            ).to_dict()
-        )
+    def test_v12_rejects_legacy_source_identity(self):
+        payload = _sample_manifest().to_dict()
+        payload["repo"]["source_fingerprint"] = _LEGACY_SOURCE_V1
+        payload["indexes"]["bm25"]["source_fingerprint"] = _LEGACY_SOURCE_V1
 
-        assert restored.source_fingerprint == _LEGACY_SOURCE_V1
-        assert restored.last_indexed_source_fingerprint == _LEGACY_SOURCE_V1
-        assert restored.index_is_current("bm25") is True
-        assert not is_secure_source_fingerprint_v2(restored.source_fingerprint)
-        restored.derive_capabilities()
-        assert restored.capabilities["sparse_search"] is True
+        with pytest.raises(ValueError, match="must be a secure v2 identity"):
+            RepoManifest.from_dict(payload)
 
     def test_empty_manifest(self):
         m = RepoManifest()
@@ -388,6 +612,7 @@ class TestManifestIndexStateStore:
 
     def test_get_failed_index_returns_none(self):
         m = RepoManifest(
+            source_fingerprint=_SOURCE_V2,
             indexes={
                 "bm25": IndexEntry(
                     index_type="bm25",
@@ -426,6 +651,7 @@ class TestManifestIndexStateStore:
         """Old index in manifest → ResourceResolver says 'incremental_update'."""
         now = time.time()
         m = RepoManifest(
+            source_fingerprint=_SOURCE_V2,
             indexes={
                 "bm25": IndexEntry(
                     index_type="bm25",
@@ -433,6 +659,7 @@ class TestManifestIndexStateStore:
                     built_at="2024-01-01T00:00:00Z",
                     built_at_epoch=now - 7200,  # 2 hours ago
                     status="fresh",
+                    source_fingerprint=_SOURCE_V2,
                 ),
             },
         )

--- a/test/compiler/test_manifest_export.py
+++ b/test/compiler/test_manifest_export.py
@@ -16,6 +16,7 @@ from typing import Any
 
 import pytest
 
+import codenib.artifacts.strict_context as strict_context_module
 import codenib.compiler.manifest_export as manifest_export_module
 from codenib._captured_directory import PublishedWorkspaceReceiptOwner
 from codenib.artifacts import stage_context_artifact_strict
@@ -24,7 +25,11 @@ from codenib.artifacts.portable_views import (
     MAX_PORTABLE_FAISS_INDEX_BYTES,
 )
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
-from codenib.compiler.manifest import RepoManifest
+from codenib.compiler.manifest import (
+    LEGACY_MANIFEST_VERSION,
+    MANIFEST_VERSION,
+    RepoManifest,
+)
 from codenib.compiler.manifest_export import (
     RepoManifestExportReceipt,
     RepoManifestExportResult,
@@ -41,6 +46,7 @@ from codenib.compiler.manifest_storage import (
     plan_repo_manifest_import_bytes,
 )
 from codenib.compiler.retained_snapshot import attest_detached_retained_snapshot
+from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.source_fingerprint import capture_repository_source
 from codenib.storage import (
     RETAINED_IMPORT_CATALOG_CONTRACT,
@@ -69,6 +75,7 @@ from .test_manifest_import import (
 )
 
 _REPOSITORY_KEY = "owner/repo"
+_DEFAULT_SOURCE_SELECTION = RepositorySourceSelection()
 
 
 def _exception_notes(error: BaseException) -> tuple[str, ...]:
@@ -268,8 +275,16 @@ def _retained_fixture(
     selected_views: tuple[str, ...] | None = None,
     source_text: str = "VALUE = 1\n",
     ref_name: str = "main",
+    source_selection: RepositorySourceSelection = _DEFAULT_SOURCE_SELECTION,
+    manifest_version: str = MANIFEST_VERSION,
 ) -> Iterator[tuple[_ContextFixture, Any, LocalCAS, SQLiteCatalog]]:
-    fixture = _context_fixture(root / "fixture", views, source_text=source_text)
+    fixture = _context_fixture(
+        root / "fixture",
+        views,
+        source_text=source_text,
+        source_selection=source_selection,
+        manifest_version=manifest_version,
+    )
     plan = fixture.plan(selected_views)
     object_store = LocalCAS(root / "cas")
     catalog = SQLiteCatalog(root / "catalog.sqlite")
@@ -290,7 +305,56 @@ def _retained_fixture(
         fixture.close()
 
 
-def test_real_import_round_trips_ref_and_snapshot_as_canonical_v11_bytes(
+@contextmanager
+def _legacy_retained_fixture(
+    root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[tuple[_ContextFixture, Any, LocalCAS, SQLiteCatalog]]:
+    """Synthesize a historical artifact, then use current retained APIs."""
+
+    with monkeypatch.context() as construction:
+        verify_context = strict_context_module.verify_context_artifact_reader
+
+        def verify_legacy_context(*args: Any, **kwargs: Any) -> Any:
+            kwargs["expected_manifest_version"] = LEGACY_MANIFEST_VERSION
+            return verify_context(*args, **kwargs)
+
+        construction.setattr(
+            strict_context_module,
+            "MANIFEST_VERSION",
+            LEGACY_MANIFEST_VERSION,
+        )
+        construction.setattr(
+            strict_context_module,
+            "verify_context_artifact_reader",
+            verify_legacy_context,
+        )
+        fixture = _context_fixture(
+            root / "fixture",
+            ("bm25", "vector"),
+            manifest_version=LEGACY_MANIFEST_VERSION,
+        )
+
+    plan = fixture.plan()
+    object_store = LocalCAS(root / "cas")
+    catalog = SQLiteCatalog(root / "catalog.sqlite")
+    try:
+        imported = import_retained_repo_manifest(
+            plan,
+            artifact_owner=fixture.context_owner,
+            repository_source=fixture.repository_source,
+            repository_key=_REPOSITORY_KEY,
+            catalog=catalog,
+            object_store=object_store,
+            environ={},
+        )
+        yield fixture, imported, object_store, catalog
+    finally:
+        catalog.close()
+        fixture.close()
+
+
+def test_real_import_round_trips_ref_and_snapshot_as_canonical_v12_bytes(
     tmp_path: Path,
 ) -> None:
     with _retained_fixture(tmp_path / "roundtrip") as (
@@ -309,6 +373,16 @@ def test_real_import_round_trips_ref_and_snapshot_as_canonical_v11_bytes(
 
         assert isinstance(ref_export, RepoManifestExportResult)
         assert ref_export.canonical_manifest_bytes == expected
+        expected_manifest = json.loads(expected)
+        assert expected_manifest["version"] == "1.2"
+        expected_selection = RepositorySourceSelection()
+        assert expected_manifest["repo"]["source_selection"] == (
+            expected_selection.to_dict()
+        )
+        assert all(
+            entry["source_selection_digest"] == expected_selection.digest
+            for entry in expected_manifest["indexes"].values()
+        )
         summary = catalog.get_manifest_summary(imported.snapshot_id)
         assert ref_export.receipt.namespace_id == summary["namespace"]["namespace_id"]
         assert ref_export.receipt.repository_id == imported.repository_id
@@ -349,12 +423,52 @@ def test_real_import_round_trips_ref_and_snapshot_as_canonical_v11_bytes(
         )
 
 
+def test_legacy_v11_snapshot_exports_without_migration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Current strict-context publication deliberately creates only current
+    # artifacts. Patch that construction gate solely to synthesize an already
+    # existing historical artifact for the retained compatibility path.
+    with _legacy_retained_fixture(
+        tmp_path / "legacy-roundtrip",
+        monkeypatch,
+    ) as (fixture, imported, object_store, catalog):
+        plan = fixture.plan()
+        original = plan.canonical_manifest_bytes
+        exported = export_retained_repo_manifest_snapshot(
+            imported.repository_id,
+            imported.snapshot_id,
+            catalog=catalog,
+            object_store=object_store,
+        )
+
+        assert exported.canonical_manifest_bytes == original
+        payload = json.loads(exported.canonical_manifest_bytes)
+        assert payload["version"] == LEGACY_MANIFEST_VERSION
+        assert "source_selection" not in payload["repo"]
+        assert all(
+            "source_selection_digest" not in entry
+            for entry in payload["indexes"].values()
+        )
+        projection = catalog.get_manifest_summary(imported.snapshot_id)["views"][
+            REPO_MANIFEST_PROJECTION_VIEW
+        ]
+        projection_payload = json.loads(
+            object_store.read_bytes(projection["object"]["digest"])
+        )
+        assert projection_payload["plan"]["schema"].endswith(".v1")
+        assert "source_selection" not in projection_payload["source"]
+
+
 def test_subset_export_removes_unretained_view_and_keeps_capability_extensions(
     tmp_path: Path,
 ) -> None:
+    source_selection = RepositorySourceSelection(("generated", "vendor/cache"))
     with _retained_fixture(
         tmp_path / "subset",
         selected_views=("bm25",),
+        source_selection=source_selection,
     ) as (_fixture, imported, object_store, catalog):
         exported = export_retained_repo_manifest_snapshot(
             imported.repository_id,
@@ -365,6 +479,14 @@ def test_subset_export_removes_unretained_view_and_keeps_capability_extensions(
 
         manifest = json.loads(exported.canonical_manifest_bytes)
         assert set(manifest["indexes"]) == {"bm25"}
+        assert manifest["repo"]["source_selection"] == source_selection.to_dict()
+        assert manifest["indexes"]["bm25"]["source_selection_digest"] == (
+            source_selection.digest
+        )
+        assert (
+            manifest["indexes"]["bm25"]["config"]["source_selection_digest"]
+            == source_selection.digest
+        )
         assert manifest["capabilities"] == {
             "dense_search": False,
             "future_query": True,
@@ -1283,6 +1405,40 @@ def test_projection_member_object_envelope_conflict_is_rejected(
         ] = "application/json"
 
         with pytest.raises(StorageIntegrityError, match="identity is inconsistent"):
+            manifest_export_module._validate_projection(
+                projection,
+                retained=retained,
+                max_manifest_bytes=manifest_export_module.DEFAULT_MAX_MANIFEST_BYTES,
+                max_bundle_files=manifest_export_module.DEFAULT_MAX_BUNDLE_FILES,
+            )
+
+
+@pytest.mark.parametrize("field", ["source_selection", "source_selection_digest"])
+def test_projection_source_selection_conflict_is_rejected(
+    tmp_path: Path,
+    field: str,
+) -> None:
+    selection = RepositorySourceSelection(("generated",))
+    with _retained_fixture(
+        tmp_path / f"selection-conflict-{field}",
+        views=("bm25",),
+        source_selection=selection,
+    ) as (_fixture, imported, object_store, catalog):
+        summary = catalog.get_manifest_summary(imported.snapshot_id)
+        retained = attest_detached_retained_snapshot(
+            summary,
+            label="test retained snapshot",
+            expected_repository_id=imported.repository_id,
+            expected_snapshot_id=imported.snapshot_id,
+        )
+        projection_record = summary["views"][REPO_MANIFEST_PROJECTION_VIEW]["object"]
+        projection = json.loads(object_store.read_bytes(projection_record["digest"]))
+        replacement = RepositorySourceSelection(("other",))
+        projection["source"][field] = (
+            replacement.to_dict() if field == "source_selection" else replacement.digest
+        )
+
+        with pytest.raises(StorageIntegrityError, match="source selection"):
             manifest_export_module._validate_projection(
                 projection,
                 retained=retained,

--- a/test/compiler/test_manifest_import.py
+++ b/test/compiler/test_manifest_import.py
@@ -33,7 +33,12 @@ from codenib._workspace_provider import (
 )
 from codenib.artifacts import stage_context_artifact_strict
 from codenib.compiler.index_builders import BM25IndexBuilder, VectorIndexBuilder
-from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.compiler.manifest import (
+    LEGACY_MANIFEST_VERSION,
+    MANIFEST_VERSION,
+    IndexEntry,
+    RepoManifest,
+)
 from codenib.compiler.manifest_import import (
     DEFAULT_MAX_CONTEXT_BYTES,
     DEFAULT_MAX_CONTEXT_FILES,
@@ -54,8 +59,10 @@ from codenib.compiler.manifest_storage import (
     plan_repo_manifest_import_bytes,
 )
 from codenib.index.embedding.artifact_integrity import VECTOR_PERSISTENCE_SCHEMA
+from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.source_fingerprint import (
     RepositorySourceBinding,
+    _capture_repository_source_legacy_manifest_v11,
     capture_repository_source,
 )
 from codenib.storage import (
@@ -79,6 +86,7 @@ from codenib.storage import (
 _Result = TypeVar("_Result")
 _COMMIT = "a" * 40
 _REPOSITORY_KEY = "owner/repo"
+_DEFAULT_SOURCE_SELECTION = RepositorySourceSelection()
 
 
 def _json_bytes(value: Any) -> bytes:
@@ -226,17 +234,31 @@ def _bm25_files(source_text: str) -> dict[str, bytes]:
     }
 
 
-def _vector_identity() -> dict[str, Any]:
-    return VectorIndexBuilder(
+def _vector_identity(
+    source_selection: RepositorySourceSelection = _DEFAULT_SOURCE_SELECTION,
+    *,
+    manifest_version: str = MANIFEST_VERSION,
+) -> dict[str, Any]:
+    identity = VectorIndexBuilder(
         languages=["python"],
         embedding_model="test/model",
         embedding_dimension=4,
         build_levels=["l2"],
         max_lines_per_chunk=300,
+        source_selection=source_selection,
     ).artifact_identity()
+    if manifest_version == LEGACY_MANIFEST_VERSION:
+        identity.pop("source_selection_digest")
+        identity["repository_filter_policy"] = 3
+    return identity
 
 
-def _vector_files(source_text: str) -> dict[str, bytes]:
+def _vector_files(
+    source_text: str,
+    source_selection: RepositorySourceSelection = _DEFAULT_SOURCE_SELECTION,
+    *,
+    manifest_version: str = MANIFEST_VERSION,
+) -> dict[str, bytes]:
     documents_name = "documents_test__model.json"
     index_name = "index_test__model.faiss"
     documents = _json_bytes(
@@ -259,7 +281,10 @@ def _vector_files(source_text: str) -> dict[str, bytes]:
             "l0_documents": 0,
             "l2_documents": 1,
             "persistence_schema": VECTOR_PERSISTENCE_SCHEMA,
-            "artifact": _vector_identity(),
+            "artifact": _vector_identity(
+                source_selection,
+                manifest_version=manifest_version,
+            ),
             "level_artifacts": {
                 "l2": {
                     "documents": _fingerprint(documents_name, documents),
@@ -275,15 +300,29 @@ def _vector_files(source_text: str) -> dict[str, bytes]:
     }
 
 
-def _entry(view: str, *, source_fingerprint: str) -> IndexEntry:
+def _entry(
+    view: str,
+    *,
+    source_fingerprint: str,
+    source_selection_digest: str = "",
+    source_selection: RepositorySourceSelection = _DEFAULT_SOURCE_SELECTION,
+    manifest_version: str = MANIFEST_VERSION,
+) -> IndexEntry:
     if view == "bm25":
         config = BM25IndexBuilder(
             languages=["python"],
             max_k=17,
             max_lines_per_chunk=300,
+            source_selection=source_selection,
         ).artifact_identity()
     else:
-        config = _vector_identity()
+        config = _vector_identity(
+            source_selection,
+            manifest_version=manifest_version,
+        )
+    if manifest_version == LEGACY_MANIFEST_VERSION:
+        config.pop("source_selection_digest", None)
+        config["repository_filter_policy"] = 3
     entry = IndexEntry(
         index_type=view,
         path=f"state/{view}",
@@ -294,6 +333,7 @@ def _entry(view: str, *, source_fingerprint: str) -> IndexEntry:
         metadata={},
         commit=_COMMIT,
         source_fingerprint=source_fingerprint,
+        source_selection_digest=source_selection_digest,
     )
     if view == "vector":
         for field, value in (
@@ -332,11 +372,24 @@ def _context_fixture(
     views: tuple[str, ...],
     *,
     source_text: str = "VALUE = 1\n",
+    source_selection: RepositorySourceSelection = _DEFAULT_SOURCE_SELECTION,
+    manifest_version: str = MANIFEST_VERSION,
 ) -> _ContextFixture:
     repository = root / "repo"
     repository.mkdir(parents=True)
     (repository / "sample.py").write_text(source_text, encoding="utf-8")
-    repository_source = capture_repository_source(repository)
+    repository_source = (
+        _capture_repository_source_legacy_manifest_v11(repository)
+        if manifest_version == LEGACY_MANIFEST_VERSION
+        else capture_repository_source(repository, selection=source_selection)
+    )
+    captured_selection = (
+        repository_source.authenticated_identity_snapshot().source_selection
+    )
+    expected_selection = (
+        None if manifest_version == LEGACY_MANIFEST_VERSION else source_selection
+    )
+    assert captured_selection == expected_selection
     owners: dict[str, PublishedWorkspaceReceiptOwner] = {}
     context_owner = PublishedWorkspaceReceiptOwner()
     try:
@@ -344,21 +397,35 @@ def _context_fixture(
             files = (
                 _bm25_files(source_text)
                 if view == "bm25"
-                else _vector_files(source_text)
+                else _vector_files(
+                    source_text,
+                    source_selection,
+                    manifest_version=manifest_version,
+                )
             )
             owners[view] = _publish_generation(root / "state" / view, files)
         manifest = RepoManifest(
+            version=manifest_version,
             repo_path=str(repository),
             commit=_COMMIT,
             last_indexed_commit=_COMMIT,
             source_fingerprint=repository_source.fingerprint,
             last_indexed_source_fingerprint=repository_source.fingerprint,
+            source_selection=expected_selection,
+            last_indexed_source_selection_digest=(
+                "" if expected_selection is None else expected_selection.digest
+            ),
             languages=["python"],
             file_count=repository_source.file_count,
             indexes={
                 view: _entry(
                     view,
                     source_fingerprint=repository_source.fingerprint,
+                    source_selection_digest=(
+                        "" if expected_selection is None else expected_selection.digest
+                    ),
+                    source_selection=source_selection,
+                    manifest_version=manifest_version,
                 )
                 for view in views
             },
@@ -765,6 +832,48 @@ def test_real_import_publishes_members_projection_subset_and_exact_retry(
         fixture.close()
 
 
+def test_v12_import_binds_nonempty_source_selection_into_projection(
+    tmp_path: Path,
+) -> None:
+    source_selection = RepositorySourceSelection(("generated", "vendor/cache"))
+    fixture = _context_fixture(
+        tmp_path / "fixture-selection",
+        ("bm25",),
+        source_selection=source_selection,
+    )
+    plan = fixture.plan()
+    cas = LocalCAS(tmp_path / "selection-cas")
+    catalog = SQLiteCatalog(tmp_path / "selection-catalog.sqlite")
+    try:
+        imported = import_retained_repo_manifest(
+            plan,
+            artifact_owner=fixture.context_owner,
+            repository_source=fixture.repository_source,
+            repository_key=_REPOSITORY_KEY,
+            catalog=catalog,
+            object_store=cas,
+            environ={},
+        )
+        summary = catalog.get_manifest_summary(imported.snapshot_id)
+        projection = summary["views"][REPO_MANIFEST_PROJECTION_VIEW]
+        payload = json.loads(cas.read_bytes(projection["object"]["digest"]))
+
+        assert plan.source.source_selection == source_selection
+        assert payload["source"]["source_selection"] == source_selection.to_dict()
+        assert payload["source"]["source_selection_digest"] == source_selection.digest
+        assert payload["plan"]["schema"].endswith(".v2")
+        assert (
+            payload["plan"]["source"]["source_selection_digest"]
+            == source_selection.digest
+        )
+        assert payload["manifest"]["repo"]["source_selection"] == (
+            source_selection.to_dict()
+        )
+    finally:
+        catalog.close()
+        fixture.close()
+
+
 def test_postcommit_interruption_converges_on_exact_retry(tmp_path: Path) -> None:
     fixture = _context_fixture(tmp_path / "fixture", ("bm25",))
     plan = fixture.plan()
@@ -908,11 +1017,19 @@ def test_inert_source_mismatch_and_mutated_plan_reject_before_backends(
     other_source = capture_repository_source(other_root)
     try:
         legacy_manifest = json.loads(plan.manifest_json)
+        legacy_manifest["version"] = LEGACY_MANIFEST_VERSION
+        legacy_manifest["repo"].pop("source_selection")
+        legacy_manifest["repo"].pop("last_indexed_source_selection_digest")
         legacy_fingerprint = "sha256:" + "e" * 64
         legacy_manifest["repo"]["source_fingerprint"] = legacy_fingerprint
         legacy_manifest["repo"]["last_indexed_source_fingerprint"] = legacy_fingerprint
         for entry in legacy_manifest["indexes"].values():
             entry["source_fingerprint"] = legacy_fingerprint
+            entry.pop("source_selection_digest")
+            for contract in (entry["config"], entry["metadata"]):
+                contract.pop("source_selection_digest", None)
+                if "repository_filter_policy" in contract:
+                    contract["repository_filter_policy"] = 3
         inert = plan_repo_manifest_import(legacy_manifest, views=["bm25"])
         assert inert.inert is True
         with pytest.raises(StorageValidationError, match="import-inert"):
@@ -938,6 +1055,26 @@ def test_inert_source_mismatch_and_mutated_plan_reject_before_backends(
                 environ={},
             )
         assert backend.calls == []
+
+        expected_selection = plan.source.source_selection
+        assert expected_selection is not None
+        fixture.repository_source._source_selection_identity = RepositorySourceSelection(  # type: ignore[attr-defined]
+            ("different-policy",)
+        )
+        with pytest.raises(StorageIntegrityError, match="retained repository source"):
+            import_retained_repo_manifest(
+                plan,
+                artifact_owner=fixture.context_owner,
+                repository_source=fixture.repository_source,
+                repository_key=_REPOSITORY_KEY,
+                catalog=backend,
+                object_store=backend,
+                environ={},
+            )
+        assert backend.calls == []
+        fixture.repository_source._source_selection_identity = (  # type: ignore[attr-defined]
+            expected_selection
+        )
 
         mutated = replace(plan)
         object.__setattr__(mutated, "manifest_json", mutated.manifest_json + " ")

--- a/test/compiler/test_manifest_materialization.py
+++ b/test/compiler/test_manifest_materialization.py
@@ -49,6 +49,7 @@ from codenib.compiler.manifest_materialization import (
 from codenib.mcp import server as mcp_server
 from codenib.mcp.context import ServerContext
 from codenib.mcp.tools.search import search_bm25_impl
+from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.storage import (
     BlobInfo,
     LocalCAS,
@@ -57,7 +58,7 @@ from codenib.storage import (
     StorageValidationError,
 )
 
-from .test_manifest_export import _retained_fixture
+from .test_manifest_export import _legacy_retained_fixture, _retained_fixture
 from .test_manifest_import import _TestWorkspaceProvider
 
 _Result = TypeVar("_Result")
@@ -804,6 +805,110 @@ def test_materializes_retained_export_as_exact_query_compatible_artifact(
             owner.close()
         assert owner.closed
         assert destination.is_dir()
+
+
+def test_v12_workspace_subject_binds_source_selection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    selection = RepositorySourceSelection(("generated", "vendor/cache"))
+    with _retained_fixture(
+        tmp_path / "selection-retained",
+        views=("bm25",),
+        source_selection=selection,
+    ) as (_fixture, imported, object_store, catalog):
+        exported = _export_snapshot(imported, object_store, catalog)
+        store = _RetainingReadStore(object_store)
+        provider = _TestWorkspaceProvider()
+        owner = PublishedWorkspaceReceiptOwner()
+        observed: dict[str, object] = {}
+        original = materialization_module._workspace_subject
+
+        def capture_subject(*args: Any, **kwargs: Any) -> str:
+            subject = original(*args, **kwargs)
+            without_selection = original(
+                *args,
+                **{**kwargs, "source_selection": None},
+            )
+            observed["selection"] = kwargs["source_selection"]
+            observed["subject"] = subject
+            observed["legacy_shaped_subject"] = without_selection
+            return subject
+
+        monkeypatch.setattr(
+            materialization_module,
+            "_workspace_subject",
+            capture_subject,
+        )
+        try:
+            materialize_retained_context_artifact(
+                exported,
+                tmp_path / "selection-artifact",
+                object_store=store,
+                workspace_provider=provider,
+                output_receipt_owner=owner,
+            )
+            assert observed["selection"] == selection
+            assert observed["subject"] != observed["legacy_shaped_subject"]
+            assert owner.receipt.plan.subject_digest == observed["subject"]
+        finally:
+            if owner.active:
+                owner.close()
+
+
+def test_materializes_legacy_v11_export_without_migration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _legacy_retained_fixture(
+        tmp_path / "legacy-retained",
+        monkeypatch,
+    ) as (_fixture, imported, object_store, catalog):
+        exported = _export_snapshot(imported, object_store, catalog)
+        store = _RetainingReadStore(object_store)
+        owner = PublishedWorkspaceReceiptOwner()
+        observed: dict[str, object] = {}
+        original = materialization_module._workspace_subject
+
+        def capture_subject(*args: Any, **kwargs: Any) -> str:
+            observed["selection"] = kwargs["source_selection"]
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(
+            materialization_module,
+            "_workspace_subject",
+            capture_subject,
+        )
+        destination = tmp_path / "legacy-artifact"
+        try:
+            result = materialize_retained_context_artifact(
+                exported,
+                destination,
+                object_store=store,
+                workspace_provider=_TestWorkspaceProvider(),
+                output_receipt_owner=owner,
+            )
+
+            assert result.manifest_path.read_bytes() == (
+                exported.canonical_manifest_bytes
+            )
+            manifest = json.loads(result.manifest_path.read_bytes())
+            metadata = json.loads(result.metadata_path.read_bytes())
+            assert manifest["version"] == "1.1"
+            assert "source_selection" not in manifest["repo"]
+            assert metadata["builder"]["manifest_version"] == "1.1"
+            assert observed["selection"] is None
+            verified = verify_context_artifact(
+                destination,
+                expected_repository="owner/repo",
+                expected_commit="a" * 40,
+                expected_manifest_version="1.1",
+            )
+            assert verified.manifest.version == "1.1"
+            assert verified.views == ("bm25", "vector")
+        finally:
+            if owner.active:
+                owner.close()
 
 
 def test_local_provider_materializes_real_retained_snapshot_for_mcp_bm25(

--- a/test/compiler/test_manifest_storage.py
+++ b/test/compiler/test_manifest_storage.py
@@ -17,12 +17,18 @@ import pytest
 import codenib.compiler as compiler_module
 import codenib.compiler.manifest_storage as manifest_storage_module
 from codenib.compiler.index_builders import BM25IndexBuilder, VectorIndexBuilder
-from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.compiler.manifest import (
+    LEGACY_MANIFEST_VERSION,
+    MANIFEST_VERSION,
+    IndexEntry,
+    RepoManifest,
+)
 from codenib.compiler.manifest_storage import (
     BM25_PROFILE_AXES,
     DEFAULT_MAX_MANIFEST_BYTES,
     REPO_MANIFEST_BM25_GENERATION_CONTRACT,
     REPO_MANIFEST_IMPORT_PLAN_SCHEMA,
+    REPO_MANIFEST_IMPORT_PLAN_SCHEMA_V1,
     REPO_MANIFEST_PROFILE_CONTRACT,
     REPO_MANIFEST_PROFILE_NAME,
     REPO_MANIFEST_VECTOR_GENERATION_CONTRACT,
@@ -39,7 +45,10 @@ from codenib.index.embedding.model_policy import (
     DEFAULT_EMBEDDING_REVISION,
 )
 from codenib.provider_routes import resolve_inference_route
+from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.storage.models import StorageValidationError, ViewProfile, canonical_json
+
+_DEFAULT_SOURCE_SELECTION = RepositorySourceSelection()
 
 
 def _file_record(seed: str, *, filename: str | None = None) -> dict[str, object]:
@@ -49,11 +58,14 @@ def _file_record(seed: str, *, filename: str | None = None) -> dict[str, object]
     return record
 
 
-def _bm25_config() -> dict[str, object]:
+def _bm25_config(
+    source_selection: RepositorySourceSelection = _DEFAULT_SOURCE_SELECTION,
+) -> dict[str, object]:
     config = BM25IndexBuilder(
         languages=["python", "typescript"],
         max_k=96,
         max_lines_per_chunk=240,
+        source_selection=source_selection,
     ).artifact_identity()
     config["artifact_file_fingerprints"] = {
         "documents.json": _file_record("a"),
@@ -65,13 +77,16 @@ def _bm25_config() -> dict[str, object]:
     return config
 
 
-def _vector_config() -> dict[str, object]:
+def _vector_config(
+    source_selection: RepositorySourceSelection = _DEFAULT_SOURCE_SELECTION,
+) -> dict[str, object]:
     config = VectorIndexBuilder(
         languages=["python", "typescript"],
         embedding_model="test/model",
         embedding_dimension=4,
         build_levels=["l0", "l2"],
         max_lines_per_chunk=240,
+        source_selection=source_selection,
     ).artifact_identity()
     config["persistence_config_fingerprint"] = _file_record(
         "c", filename="config_test__model.json"
@@ -117,6 +132,7 @@ def _entry(
     fingerprint: str,
     commit: str,
     status: str = "fresh",
+    source_selection_digest: str = "",
 ) -> IndexEntry:
     return IndexEntry(
         index_type=view_type,
@@ -128,6 +144,7 @@ def _entry(
         metadata={**copy.deepcopy(config), "build_duration_seconds": 0.25},
         commit=commit,
         source_fingerprint=fingerprint,
+        source_selection_digest=source_selection_digest,
     )
 
 
@@ -136,30 +153,50 @@ def _manifest(
     fingerprint_version: int = 2,
     include_vector: bool = True,
     commit: str = "c" * 40,
+    manifest_version: str = MANIFEST_VERSION,
+    exclude_subtrees: tuple[str, ...] = (),
 ) -> RepoManifest:
     prefix = "sha256-v2:" if fingerprint_version == 2 else "sha256:"
     fingerprint = prefix + "d" * 64
+    selection = (
+        RepositorySourceSelection(exclude_subtrees)
+        if manifest_version == MANIFEST_VERSION
+        else None
+    )
+    selection_digest = "" if selection is None else selection.digest
+    builder_selection = selection or RepositorySourceSelection()
+    bm25_config = _bm25_config(builder_selection)
+    vector_config = _vector_config(builder_selection)
+    if manifest_version == LEGACY_MANIFEST_VERSION:
+        for config in (bm25_config, vector_config):
+            config.pop("source_selection_digest")
+            config["repository_filter_policy"] = 3
     indexes = {
         "bm25": _entry(
             "bm25",
-            _bm25_config(),
+            bm25_config,
             fingerprint=fingerprint,
             commit=commit,
+            source_selection_digest=selection_digest,
         )
     }
     if include_vector:
         indexes["vector"] = _entry(
             "vector",
-            _vector_config(),
+            vector_config,
             fingerprint=fingerprint,
             commit=commit,
+            source_selection_digest=selection_digest,
         )
     return RepoManifest(
+        version=manifest_version,
         repo_path="source",
         commit=commit,
         last_indexed_commit=commit,
         source_fingerprint=fingerprint,
         last_indexed_source_fingerprint=fingerprint,
+        source_selection=selection,
+        last_indexed_source_selection_digest=selection_digest,
         languages=["python", "typescript"],
         file_count=3,
         indexes=indexes,
@@ -183,6 +220,7 @@ def _add_unselected_view(
         fingerprint=manifest.source_fingerprint,
         commit=manifest.commit,
         status=status,
+        source_selection_digest=manifest.source_selection_digest or "",
     )
     manifest.indexes["symbol_graph"] = entry
     return entry
@@ -234,7 +272,7 @@ def test_plan_accepts_current_builder_contracts_and_is_canonical() -> None:
     assert tuple(plan.view_map) == ("bm25", "vector")
     assert plan.view_map["bm25"].profile.config == {
         "contract": REPO_MANIFEST_PROFILE_CONTRACT,
-        "manifest_version": "1.1",
+        "manifest_version": MANIFEST_VERSION,
         "builder_schema": manifest.indexes["bm25"].config["builder_schema"],
         "compatibility": {
             axis: manifest.indexes["bm25"].config[axis]
@@ -262,6 +300,65 @@ def test_plan_accepts_current_builder_contracts_and_is_canonical() -> None:
     assert reparsed.manifest_digest == plan.manifest_digest
     assert reparsed.canonical_bytes == plan.canonical_bytes
     assert reparsed.plan_digest == plan.plan_digest
+
+
+def test_v12_plan_binds_canonical_source_selection_into_every_identity() -> None:
+    manifest = _manifest(exclude_subtrees=("generated", "vendor/cache"))
+    plan = plan_repo_manifest_import(manifest)
+    selection = manifest.source_selection
+
+    assert selection is not None
+    assert plan.schema == REPO_MANIFEST_IMPORT_PLAN_SCHEMA
+    assert plan.source.source_selection == selection
+    assert plan.source.to_dict()["source_selection"] == selection.to_dict()
+    assert plan.source.to_dict()["source_selection_digest"] == selection.digest
+    assert plan.manifest.source_selection == selection
+    assert all(
+        view.profile.config["compatibility"]["source_selection_digest"]
+        == selection.digest
+        for view in plan.views
+    )
+
+    same_bytes_different_policy = _manifest(exclude_subtrees=("other",))
+    other = plan_repo_manifest_import(same_bytes_different_policy)
+    assert other.source.fingerprint == plan.source.fingerprint
+    assert other.source.file_count == plan.source.file_count
+    assert other.source.identity_digest != plan.source.identity_digest
+    assert other.plan_digest != plan.plan_digest
+
+
+def test_v11_plan_round_trips_without_inventing_a_selection_identity() -> None:
+    manifest = _manifest(manifest_version=LEGACY_MANIFEST_VERSION)
+    original = canonical_json(manifest.to_dict()).encode("ascii")
+    plan = plan_repo_manifest_import_bytes(original)
+
+    assert plan.schema == REPO_MANIFEST_IMPORT_PLAN_SCHEMA_V1
+    assert plan.canonical_manifest_bytes == original
+    assert plan.manifest.version == LEGACY_MANIFEST_VERSION
+    assert plan.source.source_selection is None
+    assert "source_selection" not in plan.source.to_dict()
+    assert "source_selection_digest" not in plan.source.to_dict()
+    assert all(
+        view.profile.config["manifest_version"] == LEGACY_MANIFEST_VERSION
+        for view in plan.views
+    )
+    assert "source_selection" not in json.loads(original)["repo"]
+    assert all(
+        "source_selection_digest" not in entry
+        for entry in json.loads(original)["indexes"].values()
+    )
+
+
+def test_manifest_versions_reject_cross_version_selection_fields() -> None:
+    legacy = _manifest(manifest_version=LEGACY_MANIFEST_VERSION).to_dict()
+    legacy["repo"]["source_selection"] = RepositorySourceSelection().to_dict()
+    with pytest.raises(StorageValidationError, match="invalid shape"):
+        plan_repo_manifest_import(legacy)
+
+    current = _manifest().to_dict()
+    current["repo"].pop("source_selection")
+    with pytest.raises(StorageValidationError, match="invalid shape"):
+        plan_repo_manifest_import(current)
 
 
 def test_planner_symbols_are_lazy_compiler_exports() -> None:
@@ -456,8 +553,16 @@ def test_normal_repo_path_and_display_commit_are_not_authority_claim_keys() -> N
 
 
 def test_v1_source_is_diagnostic_and_commit_is_only_display_provenance() -> None:
-    first_manifest = _manifest(fingerprint_version=1, commit="a" * 40)
-    second_manifest = _manifest(fingerprint_version=1, commit="b" * 40)
+    first_manifest = _manifest(
+        fingerprint_version=1,
+        commit="a" * 40,
+        manifest_version=LEGACY_MANIFEST_VERSION,
+    )
+    second_manifest = _manifest(
+        fingerprint_version=1,
+        commit="b" * 40,
+        manifest_version=LEGACY_MANIFEST_VERSION,
+    )
     first = plan_repo_manifest_import(first_manifest)
     second = plan_repo_manifest_import(second_manifest)
 
@@ -837,6 +942,7 @@ def test_selection_is_canonical_and_nonportable_views_are_not_inferred() -> None
         {},
         fingerprint=manifest.source_fingerprint,
         commit=manifest.commit,
+        source_selection_digest=manifest.source_selection_digest or "",
     )
     plan = plan_repo_manifest_import(
         manifest,
@@ -892,7 +998,10 @@ def test_required_view_needs_an_exact_manifest_source_binding(drift: str) -> Non
     else:
         entry.index_type = "vector"
 
-    with pytest.raises(StorageValidationError, match="not current|does not match"):
+    with pytest.raises(
+        StorageValidationError,
+        match="not current|does not match|not canonical",
+    ):
         plan_repo_manifest_import(manifest, views=["bm25"])
 
 
@@ -904,8 +1013,10 @@ def test_strict_json_rejects_ambiguous_or_nonobject_documents(corruption: str) -
     manifest = _manifest(include_vector=False)
     payload = json.dumps(manifest.to_dict())
     if corruption == "duplicate":
+        version_literal = json.dumps(MANIFEST_VERSION)
         payload = payload.replace(
-            '"version": "1.1"', '"version": "1.1", "version": "1.1"'
+            f'"version": {version_literal}',
+            f'"version": {version_literal}, "version": {version_literal}',
         )
     elif corruption == "nan":
         payload = payload.replace(

--- a/test/compiler/test_skill_context.py
+++ b/test/compiler/test_skill_context.py
@@ -26,6 +26,7 @@ pin down:
 from __future__ import annotations
 
 from contextlib import nullcontext
+from pathlib import Path
 from types import SimpleNamespace
 from typing import List
 
@@ -45,6 +46,27 @@ from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprin
 from codenib.compiler.manifest import MANIFEST_FILENAME, IndexEntry, RepoManifest
 from codenib.index.embedding.model_policy import DEFAULT_EMBEDDING_REVISION
 from codenib.native_index_authorization import InvalidNativeIndexAuthorizationError
+from codenib.repository_source_selection import RepositorySourceSelection
+
+_TEST_COMMIT = "c" * 40
+_TEST_SOURCE_FINGERPRINT = "sha256-v2:" + ("d" * 64)
+_TEST_SOURCE_SELECTION = RepositorySourceSelection()
+
+
+def _current_manifest(indexes: dict[str, IndexEntry]) -> RepoManifest:
+    for entry in indexes.values():
+        entry.commit = _TEST_COMMIT
+        entry.source_fingerprint = _TEST_SOURCE_FINGERPRINT
+        entry.source_selection_digest = _TEST_SOURCE_SELECTION.digest
+    return RepoManifest(
+        commit=_TEST_COMMIT,
+        last_indexed_commit=_TEST_COMMIT,
+        source_fingerprint=_TEST_SOURCE_FINGERPRINT,
+        last_indexed_source_fingerprint=_TEST_SOURCE_FINGERPRINT,
+        source_selection=_TEST_SOURCE_SELECTION,
+        last_indexed_source_selection_digest=_TEST_SOURCE_SELECTION.digest,
+        indexes=indexes,
+    )
 
 
 def _make_meta(
@@ -246,11 +268,74 @@ def mocked_build(monkeypatch):
     on the build/load call pattern (e.g. "missing types triggered build,
     already-built types did not").
     """
-    calls = {"compile": [], "loaded": [], "registries": [], "vector_kwargs": []}
+    compiled_authorization = object()
+    calls = {
+        "compile": [],
+        "loaded": [],
+        "registries": [],
+        "vector_kwargs": [],
+        "manifest": None,
+        "compiled_authorization": compiled_authorization,
+    }
+
+    def manifest_for(
+        cache_dir,
+        index_types,
+        source_selection=_TEST_SOURCE_SELECTION,
+    ):
+        indexes = {
+            index_type: IndexEntry(
+                index_type=index_type,
+                path=str(Path(cache_dir) / index_type),
+                built_at="2026-08-11T00:00:00Z",
+                built_at_epoch=0.0,
+                status="fresh",
+            )
+            for index_type in index_types
+        }
+        manifest = _current_manifest(indexes)
+        manifest.source_selection = source_selection
+        manifest.last_indexed_source_selection_digest = source_selection.digest
+        for entry in manifest.indexes.values():
+            entry.source_selection_digest = source_selection.digest
+        return manifest
+
+    def fake_current_manifest(_repo_path, cache_dir, source_selection):
+        compiled = calls["manifest"]
+        if compiled is not None:
+            return compiled
+        manifest_path = Path(cache_dir) / MANIFEST_FILENAME
+        if manifest_path.is_file():
+            manifest = RepoManifest.load(manifest_path)
+            return manifest if manifest.source_selection == source_selection else None
+        existing = {
+            index_type
+            for index_type in ("bm25", "vector", "symbol_graph")
+            if skill_context._looks_built(cache_dir, index_type)
+        }
+        return manifest_for(cache_dir, existing, source_selection) if existing else None
 
     def fake_run_compiler(repo_path, index_types, cache_dir, **kwargs):
         calls["compile"].append(tuple(sorted(index_types)))
         calls["registries"].append(kwargs["builder_registry"])
+        current = fake_current_manifest(
+            repo_path,
+            cache_dir,
+            kwargs["source_selection"],
+        )
+        available = set(current.indexes) if current is not None else set()
+        available.update(index_types)
+        for index_type in index_types:
+            output = Path(cache_dir) / index_type
+            output.mkdir(parents=True, exist_ok=True)
+            marker = "config.json" if index_type == "vector" else "mock-artifact"
+            (output / marker).write_text("{}", encoding="utf-8")
+        calls["manifest"] = manifest_for(
+            cache_dir,
+            available,
+            kwargs["source_selection"],
+        )
+        return calls["manifest"]
 
     def fake_load_bm25(cache_dir):
         calls["loaded"].append("bm25")
@@ -266,9 +351,22 @@ def mocked_build(monkeypatch):
         return object()
 
     monkeypatch.setattr(skill_context, "_run_compiler", fake_run_compiler)
+    monkeypatch.setattr(
+        skill_context,
+        "_current_skill_manifest",
+        fake_current_manifest,
+    )
     monkeypatch.setattr(skill_context, "_load_bm25", fake_load_bm25)
     monkeypatch.setattr(skill_context, "_load_vector", fake_load_vector)
     monkeypatch.setattr(skill_context, "_load_symbol_graph", fake_load_graph)
+    monkeypatch.setattr(
+        "codenib.index.embedding.artifact_integrity.capture_authenticated_vector_view",
+        lambda path: nullcontext(SimpleNamespace(ownership=object(), root=path)),
+    )
+    monkeypatch.setattr(
+        "codenib.native_index_authorization._mint_trusted_local_admin_authorization",
+        lambda *_args, **_kwargs: compiled_authorization,
+    )
     return calls
 
 
@@ -328,6 +426,7 @@ def test_build_injects_native_provider_into_cpp_expand_context(
             "project_root": str(tmp_path),
             "languages": ("cpp",),
             "symbol_graph": contexts["expand"].code_graph,
+            "source_selection": RepositorySourceSelection(),
         }
     ]
 
@@ -459,6 +558,52 @@ def test_missing_index_triggers_build(registry, mocked_build, tmp_path):
     assert mocked_build["loaded"] == ["bm25"]
 
 
+def test_custom_selection_never_reuses_default_manifest_artifact(
+    registry,
+    monkeypatch,
+    tmp_path,
+):
+    cache = tmp_path / "cache"
+    old_path = cache / "old-bm25"
+    old_path.mkdir(parents=True)
+    old_manifest = _current_manifest({"bm25": _fresh_entry("bm25", str(old_path))})
+    cache.mkdir(parents=True, exist_ok=True)
+    old_manifest.save(cache / MANIFEST_FILENAME)
+
+    selection = RepositorySourceSelection(("private",))
+    new_path = cache / "selected-bm25"
+    new_path.mkdir()
+    new_manifest = _current_manifest({"bm25": _fresh_entry("bm25", str(new_path))})
+    new_manifest.source_selection = selection
+    new_manifest.last_indexed_source_selection_digest = selection.digest
+    new_manifest.indexes["bm25"].source_selection_digest = selection.digest
+    compiled = []
+    loaded = []
+
+    def compile_selected(_repo_path, index_types, _cache_dir, **kwargs):
+        compiled.append((tuple(index_types), kwargs["source_selection"]))
+        return new_manifest
+
+    monkeypatch.setattr(skill_context, "_run_compiler", compile_selected)
+    monkeypatch.setattr(
+        skill_context,
+        "_load_bm25",
+        lambda path: loaded.append(path) or object(),
+    )
+
+    contexts = skill_context.build_skill_contexts(
+        repo_path=str(tmp_path),
+        skill_ids=["bm25_search"],
+        cache_dir=str(cache),
+        skill_registry=registry,
+        source_selection=selection,
+    )
+
+    assert contexts["retrieve"].bm25 is not None
+    assert compiled == [(("bm25",), selection)]
+    assert loaded == [str(new_path)]
+
+
 def test_rebuild_forces_full_recompile(registry, mocked_build, tmp_path):
     """Even with all dirs populated, ``rebuild=True`` rebuilds everything."""
     cache = tmp_path / "cache"
@@ -505,8 +650,8 @@ def test_embedding_resource_limits_reach_builder_and_loader(
             "embedding_kwargs": {"max_seq_length": 8192},
             "trust_remote_code": False,
             "default_batch_size": 4,
-            "artifact_metadata": None,
-            "native_index_authorization": None,
+            "artifact_metadata": {},
+            "native_index_authorization": mocked_build["compiled_authorization"],
         }
     ]
 
@@ -535,8 +680,8 @@ def test_bundled_embedding_policy_reaches_builder_and_loader(
             "embedding_kwargs": None,
             "trust_remote_code": True,
             "default_batch_size": None,
-            "artifact_metadata": None,
-            "native_index_authorization": None,
+            "artifact_metadata": {},
+            "native_index_authorization": mocked_build["compiled_authorization"],
         }
     ]
 
@@ -578,7 +723,7 @@ def test_compiler_owned_vector_mints_exact_manifest_contract(
         status="fresh",
         config=contract,
     )
-    manifest = RepoManifest(indexes={"vector": entry})
+    manifest = _current_manifest({"vector": entry})
     ownership = object()
     authorization = object()
     minted = []
@@ -627,8 +772,8 @@ def test_existing_vector_token_uses_current_manifest_contract(
     vector.mkdir(parents=True)
     (vector / "existing").write_text("captured", encoding="utf-8")
     contract = {"embedding_fingerprint": "sha256:expected"}
-    RepoManifest(
-        indexes={
+    _current_manifest(
+        {
             "vector": IndexEntry(
                 index_type="vector",
                 path=str(vector),
@@ -637,7 +782,7 @@ def test_existing_vector_token_uses_current_manifest_contract(
                 status="fresh",
                 config=contract,
             )
-        }
+        },
     ).save(cache / MANIFEST_FILENAME)
     authorization = object()
 
@@ -674,7 +819,7 @@ def test_existing_vector_resolver_receives_exact_current_manifest_entry(
         status="fresh",
         config=contract,
     )
-    RepoManifest(indexes={"vector": expected_entry}).save(cache / MANIFEST_FILENAME)
+    _current_manifest({"vector": expected_entry}).save(cache / MANIFEST_FILENAME)
     authorization = object()
     resolved = []
 
@@ -1037,11 +1182,11 @@ def test_manifest_loads_optional_index_when_fresh(mixed_registry, mocked_build):
     """``mixed_search`` requires ``bm25`` and optionally uses ``symbol_graph``.
     When the manifest has a fresh ``symbol_graph`` entry it is loaded and an
     ``expand`` context is packaged."""
-    manifest = RepoManifest(
-        indexes={
+    manifest = _current_manifest(
+        {
             "bm25": _fresh_entry("bm25", "/idx/bm25"),
             "symbol_graph": _fresh_entry("symbol_graph", "/idx/graph"),
-        }
+        },
     )
     contexts = skill_context.load_contexts_from_manifest(
         manifest,
@@ -1057,10 +1202,10 @@ def test_manifest_skips_optional_index_when_absent(mixed_registry, mocked_build)
     """When the optional ``symbol_graph`` is absent from the manifest it is
     skipped silently (no raise) — only the required ``bm25`` is loaded and no
     ``expand`` context is created."""
-    manifest = RepoManifest(
-        indexes={
+    manifest = _current_manifest(
+        {
             "bm25": _fresh_entry("bm25", "/idx/bm25"),
-        }
+        },
     )
     contexts = skill_context.load_contexts_from_manifest(
         manifest,
@@ -1075,11 +1220,11 @@ def test_manifest_skips_optional_index_when_absent(mixed_registry, mocked_build)
 def test_manifest_optional_vector_without_authority_preserves_bm25_fallback(
     mocked_build,
 ):
-    manifest = RepoManifest(
-        indexes={
+    manifest = _current_manifest(
+        {
             "bm25": _fresh_entry("bm25", "/idx/bm25"),
             "vector": _fresh_entry("vector", "/idx/vector"),
-        }
+        },
     )
 
     contexts = skill_context.load_contexts_from_manifest(
@@ -1115,7 +1260,7 @@ def test_manifest_required_vector_without_authority_fails_before_model_init(
 
     with pytest.raises(ValueError, match="requires external authorization"):
         skill_context.load_contexts_from_manifest(
-            RepoManifest(indexes={"vector": entry}),
+            _current_manifest({"vector": entry}),
             skill_ids=["embedding_search"],
             skill_registry=registry,
         )
@@ -1138,7 +1283,7 @@ def test_manifest_vector_resolver_receives_exact_loaded_entry(
     resolved = []
 
     contexts = skill_context.load_contexts_from_manifest(
-        RepoManifest(indexes={"vector": entry}),
+        _current_manifest({"vector": entry}),
         skill_ids=["embedding_search"],
         skill_registry=registry,
         native_index_authorization_resolver=lambda candidate: (
@@ -1180,10 +1325,10 @@ def test_skill_vector_rejects_invalid_authority_before_model_init(
 def test_manifest_missing_required_index_raises(mixed_registry, mocked_build):
     """A *required* index that the manifest lacks must raise loudly, rather
     than deferring to a "Skill not available" error at tool-call time."""
-    manifest = RepoManifest(
-        indexes={
+    manifest = _current_manifest(
+        {
             "symbol_graph": _fresh_entry("symbol_graph", "/idx/graph"),
-        }
+        },
     )
     with pytest.raises(ValueError, match="bm25"):
         skill_context.load_contexts_from_manifest(
@@ -1206,7 +1351,7 @@ def test_manifest_rejects_bm25_artifact_that_no_longer_matches(
         bm25_dir
     )
     documents.write_text(documents.read_text().replace("alpha", "omega"))
-    manifest = RepoManifest(indexes={"bm25": entry})
+    manifest = _current_manifest({"bm25": entry})
 
     with pytest.raises(ValueError, match="manifest fingerprints"):
         skill_context.load_contexts_from_manifest(
@@ -1237,6 +1382,20 @@ def test_corrupt_optional_graph_degrades_not_crash(
 
     monkeypatch.setattr(skill_context, "_run_compiler", lambda *a, **k: None)
     monkeypatch.setattr(skill_context, "_load_bm25", lambda d: object())
+    manifest = _current_manifest(
+        {
+            "bm25": _fresh_entry("bm25", str(cache / "bm25")),
+            "symbol_graph": _fresh_entry(
+                "symbol_graph",
+                str(cache / "symbol_graph"),
+            ),
+        }
+    )
+    monkeypatch.setattr(
+        skill_context,
+        "_current_skill_manifest",
+        lambda *_args, **_kwargs: manifest,
+    )
 
     def boom(_dir):
         raise ValueError("schema_version mismatch")

--- a/test/eval/test_policy_compat.py
+++ b/test/eval/test_policy_compat.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import pickle
 import subprocess
@@ -29,8 +30,20 @@ from codenib.eval.benchmarks.policy_compat import (
     write_json_atomic,
 )
 from codenib.graph.code_graph import CodeGraph
+from codenib.repository_source_selection import DEFAULT_REPOSITORY_SOURCE_SELECTION
 
 COMMIT = "a" * 40
+SOURCE_FINGERPRINT = "sha256-v2:" + ("a" * 64)
+SOURCE_SELECTION_DIGEST = DEFAULT_REPOSITORY_SOURCE_SELECTION.digest
+
+
+def _graph_artifact_receipt(path: Path) -> dict[str, object]:
+    content = path.read_bytes()
+    return {
+        "relative_path": "graph.pkl",
+        "size": len(content),
+        "sha256": hashlib.sha256(content).hexdigest(),
+    }
 
 
 def _case_record(root: Path, *, instance_id: str = "demo__repo-1") -> dict:
@@ -135,6 +148,9 @@ def test_eligibility_checks_checkout_manifest_commit_and_capabilities(
         repo_path=str(repo),
         commit=commit,
         last_indexed_commit=commit,
+        source_fingerprint=SOURCE_FINGERPRINT,
+        last_indexed_source_fingerprint=SOURCE_FINGERPRINT,
+        last_indexed_source_selection_digest=SOURCE_SELECTION_DIGEST,
         indexes={
             "symbol_graph": IndexEntry(
                 index_type="symbol_graph",
@@ -142,7 +158,10 @@ def test_eligibility_checks_checkout_manifest_commit_and_capabilities(
                 built_at="2026-08-02T00:00:00Z",
                 built_at_epoch=0.0,
                 status="fresh",
+                config={"graph_artifact": _graph_artifact_receipt(graph_path)},
                 commit=commit,
+                source_fingerprint=SOURCE_FINGERPRINT,
+                source_selection_digest=SOURCE_SELECTION_DIGEST,
             )
         },
         capabilities={"symbol_navigation": True},
@@ -180,6 +199,10 @@ def test_eligibility_checks_checkout_manifest_commit_and_capabilities(
     stale_graph["schema_version"] = 4
     with graph_path.open("wb") as handle:
         pickle.dump(stale_graph, handle)
+    manifest.indexes["symbol_graph"].config["graph_artifact"] = _graph_artifact_receipt(
+        graph_path
+    )
+    manifest.save(record["manifest_path"])
     stale = inspect_case_eligibility(
         case,
         agent="orcaloca",
@@ -195,6 +218,8 @@ def test_eligibility_checks_checkout_manifest_commit_and_capabilities(
 
     manifest.capabilities.clear()
     manifest.commit = "b" * 40
+    manifest.last_indexed_commit = manifest.commit
+    manifest.indexes["symbol_graph"].commit = manifest.commit
     manifest.save(record["manifest_path"])
     rejected = inspect_case_eligibility(
         case,

--- a/test/eval/test_swe_explore_runner.py
+++ b/test/eval/test_swe_explore_runner.py
@@ -15,6 +15,11 @@ from codenib.compiler.index_builders import BM25IndexBuilder
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.eval.benchmarks import swe_explore_runner
 from codenib.eval.benchmarks.swe_explore import SWE_EXPLORE_METRICS
+from codenib.repository_source_selection import DEFAULT_REPOSITORY_SOURCE_SELECTION
+
+COMMIT = "a" * 40
+SOURCE_FINGERPRINT = "sha256-v2:" + ("b" * 64)
+SOURCE_SELECTION_DIGEST = DEFAULT_REPOSITORY_SOURCE_SELECTION.digest
 
 
 def test_runner_reports_failures_separately_from_quality_metrics(
@@ -113,6 +118,11 @@ def test_bm25_profile_validation_rejects_incompatible_artifact(tmp_path) -> None
     profile = BM25IndexBuilder(languages=["python"]).artifact_identity()
     profile["max_k"] = 15
     manifest = RepoManifest(
+        commit=COMMIT,
+        last_indexed_commit=COMMIT,
+        source_fingerprint=SOURCE_FINGERPRINT,
+        last_indexed_source_fingerprint=SOURCE_FINGERPRINT,
+        last_indexed_source_selection_digest=SOURCE_SELECTION_DIGEST,
         indexes={
             "bm25": IndexEntry(
                 index_type="bm25",
@@ -121,8 +131,11 @@ def test_bm25_profile_validation_rejects_incompatible_artifact(tmp_path) -> None
                 built_at_epoch=0.0,
                 status="fresh",
                 config=profile,
+                commit=COMMIT,
+                source_fingerprint=SOURCE_FINGERPRINT,
+                source_selection_digest=SOURCE_SELECTION_DIGEST,
             )
-        }
+        },
     )
     manifest.save(manifest_path)
 
@@ -145,6 +158,11 @@ def test_bm25_profile_validation_records_exact_artifact(tmp_path) -> None:
     artifact_files = bm25_artifact_file_fingerprints(artifact_path)
     profile = BM25IndexBuilder(languages=["python", "go"]).artifact_identity()
     manifest = RepoManifest(
+        commit=COMMIT,
+        last_indexed_commit=COMMIT,
+        source_fingerprint=SOURCE_FINGERPRINT,
+        last_indexed_source_fingerprint=SOURCE_FINGERPRINT,
+        last_indexed_source_selection_digest=SOURCE_SELECTION_DIGEST,
         indexes={
             "bm25": IndexEntry(
                 index_type="bm25",
@@ -156,10 +174,11 @@ def test_bm25_profile_validation_records_exact_artifact(tmp_path) -> None:
                     **profile,
                     "artifact_file_fingerprints": artifact_files,
                 },
-                commit="abc123",
-                source_fingerprint="sha256:source",
+                commit=COMMIT,
+                source_fingerprint=SOURCE_FINGERPRINT,
+                source_selection_digest=SOURCE_SELECTION_DIGEST,
             )
-        }
+        },
     )
     manifest.save(manifest_path)
 
@@ -171,8 +190,8 @@ def test_bm25_profile_validation_records_exact_artifact(tmp_path) -> None:
 
     assert observed == {
         "config": profile,
-        "commit": "abc123",
-        "source_fingerprint": "sha256:source",
+        "commit": COMMIT,
+        "source_fingerprint": SOURCE_FINGERPRINT,
         "artifact_path": str(artifact_path),
         "artifact_file_fingerprints": artifact_files,
     }
@@ -193,7 +212,11 @@ def test_view_profile_validation_records_native_policy_artifacts(tmp_path) -> No
     vector_path.mkdir()
     graph_path.write_bytes(b"graph")
     manifest = RepoManifest(
-        commit="abc123",
+        commit=COMMIT,
+        last_indexed_commit=COMMIT,
+        source_fingerprint=SOURCE_FINGERPRINT,
+        last_indexed_source_fingerprint=SOURCE_FINGERPRINT,
+        last_indexed_source_selection_digest=SOURCE_SELECTION_DIGEST,
         indexes={
             "vector": IndexEntry(
                 index_type="vector",
@@ -202,8 +225,9 @@ def test_view_profile_validation_records_native_policy_artifacts(tmp_path) -> No
                 built_at_epoch=0.0,
                 status="fresh",
                 config={"embedding_model": "fixture"},
-                commit="abc123",
-                source_fingerprint="sha256:source",
+                commit=COMMIT,
+                source_fingerprint=SOURCE_FINGERPRINT,
+                source_selection_digest=SOURCE_SELECTION_DIGEST,
             ),
             "symbol_graph": IndexEntry(
                 index_type="symbol_graph",
@@ -212,8 +236,9 @@ def test_view_profile_validation_records_native_policy_artifacts(tmp_path) -> No
                 built_at_epoch=0.0,
                 status="fresh",
                 config={"builder_schema": 3},
-                commit="abc123",
-                source_fingerprint="sha256:source",
+                commit=COMMIT,
+                source_fingerprint=SOURCE_FINGERPRINT,
+                source_selection_digest=SOURCE_SELECTION_DIGEST,
             ),
         },
     )

--- a/test/eval/test_swebench_policy_cases.py
+++ b/test/eval/test_swebench_policy_cases.py
@@ -25,7 +25,10 @@ from codenib.eval.benchmarks.swebench_policy_cases import (
     load_dataset_records,
     select_balanced_repository_cases,
 )
+from codenib.repository_source_selection import DEFAULT_REPOSITORY_SOURCE_SELECTION
 from codenib.scip_interface.scip_pb2 import Index as SCIPIndex
+
+SOURCE_SELECTION_DIGEST = DEFAULT_REPOSITORY_SOURCE_SELECTION.digest
 
 
 def test_scip_provenance_records_resolved_tool_and_timeout(monkeypatch) -> None:
@@ -141,7 +144,7 @@ def test_build_policy_manifest_rebuilds_a_current_graph_that_fails_audit(
     artifact_dir = tmp_path / "artifact"
     indexes = artifact_dir / "indexes"
     commit = "a" * 40
-    source_fingerprint = "sha256:fixture"
+    source_fingerprint = "sha256-v2:" + ("c" * 64)
     now = 1.0
     manifest = RepoManifest(
         repo_path=str(checkout),
@@ -149,6 +152,7 @@ def test_build_policy_manifest_rebuilds_a_current_graph_that_fails_audit(
         last_indexed_commit=commit,
         source_fingerprint=source_fingerprint,
         last_indexed_source_fingerprint=source_fingerprint,
+        last_indexed_source_selection_digest=SOURCE_SELECTION_DIGEST,
         languages=["python"],
         file_count=1,
         indexes={
@@ -161,6 +165,7 @@ def test_build_policy_manifest_rebuilds_a_current_graph_that_fails_audit(
                 metadata={"node_count": 1},
                 commit=commit,
                 source_fingerprint=source_fingerprint,
+                source_selection_digest=SOURCE_SELECTION_DIGEST,
             )
             for name in ("bm25", "symbol_graph")
         },

--- a/test/graph/test_source_coverage.py
+++ b/test/graph/test_source_coverage.py
@@ -9,6 +9,7 @@ import subprocess
 from codenib.git_snapshot import GitSourceSurface
 from codenib.graph.code_graph import CodeGraph
 from codenib.graph.source_coverage import supplement_graph_source_coverage
+from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.types import EDGE_TYPE_CONTAIN
 
 
@@ -116,3 +117,37 @@ def test_source_coverage_records_parser_failure_without_aborting(tmp_path, monke
     assert report["unreadable_files"] == ["broken.py"]
     assert report["unreadable_errors"] == {"broken.py": "ValueError: parser failed"}
     assert report["coverage_after"] == 0.0
+
+
+def test_source_coverage_excludes_unselected_subtrees(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "src").mkdir()
+    (repo / "private").mkdir()
+    (repo / "src" / "kept.py").write_text("def kept(): pass\n", encoding="utf-8")
+    (repo / "private" / "secret.py").write_text(
+        "def secret(): pass\n", encoding="utf-8"
+    )
+    _git(repo, "add", "src/kept.py", "private/secret.py")
+    _git(repo, "commit", "-m", "initial")
+    graph = CodeGraph(str(repo))
+    graph.add_root_node(str(repo))
+
+    selection = RepositorySourceSelection(["private"])
+    report = supplement_graph_source_coverage(
+        graph,
+        repo_root=repo,
+        surface=GitSourceSurface.load(repo),
+        extensions={".py"},
+        represented_paths={"src/kept.py"},
+        source_selection=selection,
+    )
+
+    assert report["source_selection_digest"] == selection.digest
+    assert report["tracked_source_files"] == 1
+    assert report["candidate_files"] == 0
+    assert report["coverage_after"] == 1.0
+    assert "private/secret.py" not in graph.name_to_vertex

--- a/test/index/test_embedding_builders.py
+++ b/test/index/test_embedding_builders.py
@@ -14,6 +14,7 @@ from codenib.native_index_authorization import (
     InvalidNativeIndexAuthorizationError,
     _mint_trusted_local_admin_authorization,
 )
+from codenib.repository_source_selection import RepositorySourceSelection
 
 
 def _write_fake_vector_store(path, *, model_suffix, levels):
@@ -37,6 +38,16 @@ def _file_snapshot(root: Path) -> dict[str, bytes]:
         for path in root.rglob("*")
         if path.is_file()
     }
+
+
+def _record_fake_documents(store, chunks, level):
+    documents = getattr(store, f"{level}_documents")
+    for chunk in chunks:
+        if isinstance(chunk, dict):
+            source_path = chunk.get("file")
+        else:
+            source_path = getattr(chunk, "file", None)
+        documents.append(SimpleNamespace(metadata={"file": source_path}))
 
 
 def test_cached_builder_closes_store_when_load_fails(monkeypatch, tmp_path):
@@ -93,7 +104,7 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
 
     class FakeChunker:
         def __init__(self, **kwargs):
-            pass
+            captured["repo_config"] = kwargs["repo_config"]
 
         def chunk_repository(self, repo_path, *, strict=False):
             captured["strict_chunking"] = strict
@@ -108,7 +119,9 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
             self.l2_documents = []
 
         def add_code_chunks(self, chunks, level):
-            self.l2_documents.extend(chunks)
+            self.l2_documents.extend(
+                SimpleNamespace(metadata={"file": chunk["file"]}) for chunk in chunks
+            )
 
         def save(self, path):
             _write_fake_vector_store(
@@ -146,6 +159,7 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
     for path in stale_state_files:
         path.write_bytes(b"stale-generation-state")
 
+    selection = RepositorySourceSelection(["src/private"])
     result = builders.build_hierarchical_vector_store(
         repo_path=str(tmp_path),
         index_path=str(tmp_path / "index"),
@@ -158,15 +172,100 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
         artifact_metadata={"commit": "a" * 40},
         force_rebuild=True,
         strict_chunking=True,
+        source_selection=selection,
     )
 
     assert captured["embedding"] is embedding
     assert captured["artifact_metadata"] == {"commit": "a" * 40}
     assert captured["strict_chunking"] is True
+    assert captured["repo_config"].source_selection == selection
+    assert captured["repo_config"].source_selection is not selection
     assert result.l2_documents
     assert all(not path.exists() for path in stale_files)
     assert all(not path.exists() for path in stale_state_files)
     assert unrelated.read_bytes() == b"other"
+
+
+def test_hierarchical_builder_rejects_excluded_chunk_results(
+    monkeypatch,
+    tmp_path,
+):
+    class FakeChunker:
+        def __init__(self, **_kwargs):
+            pass
+
+        def chunk_repository(self, repo_path, *, strict=False):
+            assert strict is True
+            assert repo_path == str(tmp_path)
+            return [SimpleNamespace(file="src/private/secret.py")]
+
+    monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
+
+    with pytest.raises(RuntimeError, match="vector l2 chunks leaked excluded"):
+        builders.build_hierarchical_vector_store(
+            repo_path=str(tmp_path),
+            index_path=str(tmp_path / "index"),
+            languages=["python"],
+            build_levels=["l2"],
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+            force_rebuild=True,
+            strict_chunking=True,
+            source_selection=RepositorySourceSelection(["src/private"]),
+        )
+
+
+def test_hierarchical_builder_rejects_excluded_materialized_documents(
+    monkeypatch,
+    tmp_path,
+):
+    source = tmp_path / "source.py"
+    source.write_text("value = 1\n", encoding="utf-8")
+    chunk = SimpleNamespace(
+        file="source.py",
+        _asdict=lambda: {"file": "source.py", "content": "value = 1\n"},
+    )
+
+    class FakeChunker:
+        def __init__(self, **_kwargs):
+            pass
+
+        def chunk_repository(self, repo_path, *, strict=False):
+            assert strict is True
+            assert repo_path == str(tmp_path)
+            return [chunk]
+
+    class FakeStore:
+        def __init__(self, **_kwargs):
+            self.l0_documents = []
+            self.l2_documents = []
+
+        def add_code_chunks(self, _chunks, level):
+            assert level == "l2"
+            self.l2_documents = [
+                SimpleNamespace(metadata={"file": "src/private/secret.py"})
+            ]
+
+        def save(self, _path):
+            raise AssertionError("excluded documents must be rejected before save")
+
+    monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
+    monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
+
+    with pytest.raises(RuntimeError, match="vector l2 documents leaked excluded"):
+        builders.build_hierarchical_vector_store(
+            repo_path=str(tmp_path),
+            index_path=str(tmp_path / "index"),
+            languages=["python"],
+            build_levels=["l2"],
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+            force_rebuild=True,
+            strict_chunking=True,
+            source_selection=RepositorySourceSelection(["src/private"]),
+        )
 
 
 def test_cached_index_without_authority_is_rebuilt_from_source(
@@ -205,7 +304,7 @@ def test_cached_index_without_authority_is_rebuilt_from_source(
 
         def add_code_chunks(self, chunks, level):
             assert level == "l2"
-            self.l2_documents.extend(chunks)
+            _record_fake_documents(self, chunks, level)
 
         def save(self, _path):
             calls["save"] += 1
@@ -423,7 +522,7 @@ def test_failed_staged_save_preserves_existing_cache(monkeypatch, tmp_path):
             self.l2_documents = []
 
         def add_code_chunks(self, chunks, level):
-            getattr(self, f"{level}_documents").extend(chunks)
+            _record_fake_documents(self, chunks, level)
 
         def save(self, path):
             _write_fake_vector_store(
@@ -526,7 +625,7 @@ def test_unrequested_symlink_level_rejects_rebuild_without_mutation(
             self.l2_documents = []
 
         def add_code_chunks(self, chunks, level):
-            getattr(self, f"{level}_documents").extend(chunks)
+            _record_fake_documents(self, chunks, level)
 
         def save(self, path):
             _write_fake_vector_store(
@@ -597,7 +696,7 @@ def test_requested_symlink_level_rejects_publish_without_mutation(
             self.l2_documents = []
 
         def add_code_chunks(self, chunks, level):
-            getattr(self, f"{level}_documents").extend(chunks)
+            _record_fake_documents(self, chunks, level)
 
         def save(self, path):
             _write_fake_vector_store(
@@ -660,7 +759,7 @@ def test_interrupted_directory_switch_restores_old_cache(monkeypatch, tmp_path):
             self.l2_documents = []
 
         def add_code_chunks(self, chunks, level):
-            getattr(self, f"{level}_documents").extend(chunks)
+            _record_fake_documents(self, chunks, level)
 
         def save(self, path):
             _write_fake_vector_store(
@@ -750,7 +849,7 @@ def test_private_build_root_replacement_cannot_publish_or_write_outside(
             self.l2_documents = []
 
         def add_code_chunks(self, chunks, level):
-            getattr(self, f"{level}_documents").extend(chunks)
+            _record_fake_documents(self, chunks, level)
 
         def save(self, path):
             anchored_root = Path(path)

--- a/test/integrations/conftest.py
+++ b/test/integrations/conftest.py
@@ -9,9 +9,12 @@ from typing import Any
 
 import pytest
 
+from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
 from codenib.compiler.index_builders import BM25IndexBuilder
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.graph.code_graph import CodeGraph
+from codenib.repository_source_selection import RepositorySourceSelection
+from codenib.source_fingerprint import fingerprint_repository
 from codenib.types import (
     EDGE_TYPE_CONTAIN,
     EDGE_TYPE_IMPORT,
@@ -170,13 +173,45 @@ def _build_source_bm25(
     repo_root: Path,
     languages: list[str],
     output_dir: Path,
-) -> None:
+) -> dict[str, Any]:
     """Build the fixture BM25 view through the production chunk contract."""
-    BM25IndexBuilder(languages=languages).build(
-        scope="current_repo",
-        repo_path=str(repo_root),
-        output_dir=str(output_dir),
+    return (
+        BM25IndexBuilder(languages=languages)
+        .build(
+            scope="current_repo",
+            repo_path=str(repo_root),
+            output_dir=str(output_dir),
+        )
+        .metadata
     )
+
+
+def _graph_artifact_receipt(graph_path: Path) -> dict[str, Any]:
+    return {
+        "relative_path": "graph.pkl",
+        **regular_file_fingerprint(graph_path),
+    }
+
+
+def _refresh_manifest_source_closure(
+    manifest: RepoManifest,
+    repo_root: Path,
+) -> None:
+    selection = manifest.source_selection
+    if type(selection) is not RepositorySourceSelection:
+        raise AssertionError("integration manifest requires v1.2 source selection")
+    source = fingerprint_repository(repo_root, selection=selection)
+    manifest.source_fingerprint = source.value
+    manifest.last_indexed_source_fingerprint = source.value
+    manifest.last_indexed_commit = manifest.commit
+    manifest.last_indexed_source_selection_digest = selection.digest
+    manifest.file_count = source.file_count
+    for entry in manifest.indexes.values():
+        if entry.status != "fresh":
+            continue
+        entry.commit = manifest.commit
+        entry.source_fingerprint = source.value
+        entry.source_selection_digest = selection.digest
 
 
 @pytest.fixture()
@@ -191,19 +226,21 @@ def integration_manifest(tmp_path: Path) -> Path:
     graph.save_graph(str(graph_path))
 
     bm25_dir = tmp_path / "bm25"
-    _build_source_bm25(repo_root, ["python"], bm25_dir)
+    bm25_config = _build_source_bm25(repo_root, ["python"], bm25_dir)
 
     manifest = RepoManifest(
         repo_path=str(repo_root),
         commit="integration-fixture",
+        source_selection=RepositorySourceSelection(),
         languages=["python"],
         indexes={
             "symbol_graph": IndexEntry(
                 index_type="symbol_graph",
-                path=str(graph_path),
+                path=str(graph_dir),
                 built_at="2026-07-30T00:00:00Z",
                 built_at_epoch=1_785_369_600.0,
                 status="fresh",
+                config={"graph_artifact": _graph_artifact_receipt(graph_path)},
             ),
             "bm25": IndexEntry(
                 index_type="bm25",
@@ -211,9 +248,12 @@ def integration_manifest(tmp_path: Path) -> Path:
                 built_at="2026-07-30T00:00:00Z",
                 built_at_epoch=1_785_369_600.0,
                 status="fresh",
+                config=dict(bm25_config),
+                metadata=dict(bm25_config),
             ),
         },
     )
+    _refresh_manifest_source_closure(manifest, repo_root)
     manifest.derive_capabilities()
     manifest_path = tmp_path / "repo_manifest.json"
     manifest.save(manifest_path)
@@ -241,7 +281,7 @@ def multilanguage_integration_manifest(integration_manifest: Path) -> Path:
         encoding="utf-8",
     )
 
-    graph_path = Path(manifest.indexes["symbol_graph"].path)
+    graph_path = Path(manifest.indexes["symbol_graph"].path) / "graph.pkl"
     graph = CodeGraph.load_graph(str(graph_path))
     _add_vertex(graph, "service.ts", kind=NODE_TYPE_FILE)
     _add_vertex(graph, "tax.go", kind=NODE_TYPE_FILE)
@@ -289,13 +329,19 @@ def multilanguage_integration_manifest(integration_manifest: Path) -> Path:
     )
     graph.build_range_indexes()
     graph.save_graph(str(graph_path))
+    manifest.indexes["symbol_graph"].config["graph_artifact"] = _graph_artifact_receipt(
+        graph_path
+    )
 
     manifest.languages = ["python", "typescript", "go"]
-    _build_source_bm25(
+    bm25_config = _build_source_bm25(
         repo_root,
         manifest.languages,
         Path(manifest.indexes["bm25"].path),
     )
+    manifest.indexes["bm25"].config = dict(bm25_config)
+    manifest.indexes["bm25"].metadata = dict(bm25_config)
+    _refresh_manifest_source_closure(manifest, repo_root)
     manifest.save(integration_manifest)
     return integration_manifest
 
@@ -328,7 +374,7 @@ def orcaloca_contract_manifest(integration_manifest: Path) -> Path:
         encoding="utf-8",
     )
 
-    graph_path = Path(manifest.indexes["symbol_graph"].path)
+    graph_path = Path(manifest.indexes["symbol_graph"].path) / "graph.pkl"
     graph = CodeGraph.load_graph(str(graph_path))
     _add_vertex(graph, "src/contract.py", kind=NODE_TYPE_FILE)
     _add_vertex(
@@ -400,4 +446,9 @@ def orcaloca_contract_manifest(integration_manifest: Path) -> Path:
     )
     graph.build_range_indexes()
     graph.save_graph(str(graph_path))
+    manifest.indexes["symbol_graph"].config["graph_artifact"] = _graph_artifact_receipt(
+        graph_path
+    )
+    _refresh_manifest_source_closure(manifest, repo_root)
+    manifest.save(integration_manifest)
     return integration_manifest

--- a/test/integrations/test_reponavigator.py
+++ b/test/integrations/test_reponavigator.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
+from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
 from codenib.compiler.manifest import RepoManifest
 from codenib.integrations._repository import IntegrationCapabilityError
 from codenib.integrations.reponavigator import (
@@ -61,41 +62,61 @@ class NativeOccurrenceIndexStub:
         return []
 
 
+def _write_manifest_occurrence_index(
+    manifest_path: Path,
+    occurrence_index: SCIPOccurrenceIndex,
+) -> Path:
+    manifest = RepoManifest.load(manifest_path)
+    entry = manifest.indexes["symbol_graph"]
+    generation = Path(entry.path)
+    index_path = generation / "lsp_index.pkl"
+    occurrence_index.save(index_path)
+    receipt = {
+        "relative_path": "lsp_index.pkl",
+        **regular_file_fingerprint(index_path),
+    }
+    entry.config["lsp_occurrence_artifact"] = dict(receipt)
+    entry.metadata["lsp_occurrence_artifact"] = dict(receipt)
+    manifest.save(manifest_path)
+    return index_path
+
+
 @pytest.fixture()
 def semantic_manifest(integration_manifest: Path) -> Path:
-    manifest = RepoManifest.load(integration_manifest)
-    graph_path = Path(manifest.indexes["symbol_graph"].path)
-    SCIPOccurrenceIndex(
-        [
-            SCIPOccurrence(
-                "src/service.py",
-                0,
-                6,
-                0,
-                20,
-                "scip-python fixture BillingService#",
-                1,
-            ),
-            SCIPOccurrence(
-                "src/service.py",
-                3,
-                15,
-                3,
-                21,
-                "scip-python fixture helper().",
-                8,
-            ),
-            SCIPOccurrence(
-                "src/service.py",
-                5,
-                4,
-                5,
-                10,
-                "scip-python fixture helper().",
-                1,
-            ),
-        ]
-    ).save(graph_path.with_name("lsp_index.pkl"))
+    _write_manifest_occurrence_index(
+        integration_manifest,
+        SCIPOccurrenceIndex(
+            [
+                SCIPOccurrence(
+                    "src/service.py",
+                    0,
+                    6,
+                    0,
+                    20,
+                    "scip-python fixture BillingService#",
+                    1,
+                ),
+                SCIPOccurrence(
+                    "src/service.py",
+                    3,
+                    15,
+                    3,
+                    21,
+                    "scip-python fixture helper().",
+                    8,
+                ),
+                SCIPOccurrence(
+                    "src/service.py",
+                    5,
+                    4,
+                    5,
+                    10,
+                    "scip-python fixture helper().",
+                    1,
+                ),
+            ]
+        ),
+    )
     return integration_manifest
 
 
@@ -149,9 +170,7 @@ def test_graph_only_manifest_requires_explicit_degraded_opt_in(
 def test_empty_occurrence_signal_is_not_reported_as_semantic(
     integration_manifest: Path,
 ) -> None:
-    manifest = RepoManifest.load(integration_manifest)
-    graph_path = Path(manifest.indexes["symbol_graph"].path)
-    SCIPOccurrenceIndex([]).save(graph_path.with_name("lsp_index.pkl"))
+    _write_manifest_occurrence_index(integration_manifest, SCIPOccurrenceIndex([]))
 
     with pytest.raises(IntegrationCapabilityError, match="semantic definition signal"):
         RepoNavigatorRepositoryProvider.from_manifest(integration_manifest)
@@ -165,6 +184,36 @@ def test_empty_occurrence_signal_is_not_reported_as_semantic(
     assert provider.jump("src/service.py", "helper").startswith(
         'The definition of symbol "helper" is:'
     )
+
+
+def test_unreceipted_occurrence_sidecar_is_not_loaded_from_mutable_path(
+    integration_manifest: Path,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    generation = Path(manifest.indexes["symbol_graph"].path)
+    SCIPOccurrenceIndex(
+        [
+            SCIPOccurrence(
+                "src/service.py",
+                3,
+                15,
+                3,
+                21,
+                "scip-python fixture helper().",
+                8,
+            )
+        ]
+    ).save(generation / "lsp_index.pkl")
+
+    with pytest.raises(IntegrationCapabilityError, match="semantic definition signal"):
+        RepoNavigatorRepositoryProvider.from_manifest(integration_manifest)
+
+    provider = RepoNavigatorRepositoryProvider.from_manifest(
+        integration_manifest,
+        allow_graph_fallback=True,
+    )
+    assert provider.definition_signal.backend == "symbol_graph_fallback"
+    assert getattr(provider.context.symbol_graph, "lsp_occurrence_index", None) is None
 
 
 def test_empty_graph_attached_occurrence_rebinds_to_graph_only_provider(

--- a/test/integrations/test_swe_explore.py
+++ b/test/integrations/test_swe_explore.py
@@ -17,7 +17,38 @@ from codenib.agent.runtime.explorer import (
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.integrations.swe_explore import CodeNibSWEExploreExplorer
 from codenib.mcp.context import ServerContext
+from codenib.repository_source_selection import RepositorySourceSelection
+from codenib.source_fingerprint import fingerprint_repository
 from codenib.types import NodeInfo
+
+
+def _manifest_with_current_views(repo, output_root, *views: str) -> RepoManifest:
+    selection = RepositorySourceSelection()
+    source = fingerprint_repository(repo, selection=selection)
+    commit = "integration-fixture"
+    return RepoManifest(
+        repo_path=str(repo),
+        commit=commit,
+        last_indexed_commit=commit,
+        source_fingerprint=source.value,
+        last_indexed_source_fingerprint=source.value,
+        source_selection=selection,
+        last_indexed_source_selection_digest=selection.digest,
+        file_count=source.file_count,
+        indexes={
+            view: IndexEntry(
+                index_type=view,
+                path=str(output_root / view),
+                built_at="2026-08-04T00:00:00Z",
+                built_at_epoch=0.0,
+                status="fresh",
+                commit=commit,
+                source_fingerprint=source.value,
+                source_selection_digest=selection.digest,
+            )
+            for view in views
+        },
+    )
 
 
 def test_explorer_defers_view_loading_until_query_planning(
@@ -147,19 +178,7 @@ def test_auto_mixed_query_loads_and_fuses_sparse_and_dense_views(tmp_path) -> No
     source = repo / "src" / "service.py"
     source.parent.mkdir(parents=True)
     source.write_text("def calculate_tax():\n    return 1\n", encoding="utf-8")
-    manifest = RepoManifest(
-        repo_path=str(repo),
-        indexes={
-            view: IndexEntry(
-                index_type=view,
-                path=str(tmp_path / view),
-                built_at="2026-08-04T00:00:00Z",
-                built_at_epoch=0.0,
-                status="fresh",
-            )
-            for view in ("bm25", "vector")
-        },
-    )
+    manifest = _manifest_with_current_views(repo, tmp_path, "bm25", "vector")
     sparse = SimpleNamespace(
         max_k=100,
         search=lambda **_kwargs: [
@@ -240,19 +259,7 @@ def test_auto_falls_back_to_an_available_view_after_load_failure(tmp_path) -> No
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / "service.py").write_text("def price():\n    return 1\n", encoding="utf-8")
-    manifest = RepoManifest(
-        repo_path=str(repo),
-        indexes={
-            view: IndexEntry(
-                index_type=view,
-                path=str(tmp_path / view),
-                built_at="2026-08-04T00:00:00Z",
-                built_at_epoch=0.0,
-                status="fresh",
-            )
-            for view in ("bm25", "vector")
-        },
-    )
+    manifest = _manifest_with_current_views(repo, tmp_path, "bm25", "vector")
     sparse = SimpleNamespace(
         max_k=100,
         search=lambda **_kwargs: [

--- a/test/mcp/test_mcp_server.py
+++ b/test/mcp/test_mcp_server.py
@@ -11,7 +11,6 @@ Tests server initialization, tool registration, and resource endpoints.
 from __future__ import annotations
 
 import asyncio
-import json
 import subprocess
 import sys
 from pathlib import Path
@@ -25,6 +24,7 @@ from mcp.types import LATEST_PROTOCOL_VERSION
 
 # Import server module components
 import codenib.mcp.server as server_module
+from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.index.embedding.vector_store import CodeVectorStore
 from codenib.mcp.context import ServerContext
 from codenib.mcp.tools.lsp import (
@@ -32,6 +32,10 @@ from codenib.mcp.tools.lsp import (
     lsp_references_impl,
     lsp_route_impl,
 )
+from codenib.repository_source_selection import DEFAULT_REPOSITORY_SOURCE_SELECTION
+
+SOURCE_FINGERPRINT = "sha256-v2:" + ("a" * 64)
+SOURCE_SELECTION_DIGEST = DEFAULT_REPOSITORY_SOURCE_SELECTION.digest
 
 
 def test_server_import_keeps_optional_index_runtimes_lazy() -> None:
@@ -131,34 +135,41 @@ def test_search_tool_schemas_publish_bounded_inputs() -> None:
 @pytest.fixture
 def mock_manifest(tmp_path: Path) -> Path:
     """Create a mock manifest file."""
-    manifest_data = {
-        "repo_path": "/fake/repo",
-        "commit": "abc123",
-        "languages": ["python"],
-        "file_count": 100,
-        "capabilities": {"vector_search": True},
-        "compiled_at": "2026-04-20T12:00:00Z",
-        "compiled_at_epoch": 1745323200.0,
-        "indexes": {
-            "vector": {
-                "index_type": "vector",
-                "path": str(tmp_path / "vector"),
-                "built_at": "2026-04-20T12:00:00Z",
-                "built_at_epoch": 1745323200.0,
-                "status": "fresh",
-                "config": {
+    commit = "a" * 40
+    manifest = RepoManifest(
+        repo_path="/fake/repo",
+        commit=commit,
+        last_indexed_commit=commit,
+        source_fingerprint=SOURCE_FINGERPRINT,
+        last_indexed_source_fingerprint=SOURCE_FINGERPRINT,
+        last_indexed_source_selection_digest=SOURCE_SELECTION_DIGEST,
+        languages=["python"],
+        file_count=100,
+        capabilities={"vector_search": True},
+        compiled_at="2026-04-20T12:00:00Z",
+        compiled_at_epoch=1745323200.0,
+        indexes={
+            "vector": IndexEntry(
+                index_type="vector",
+                path=str(tmp_path / "vector"),
+                built_at="2026-04-20T12:00:00Z",
+                built_at_epoch=1745323200.0,
+                status="fresh",
+                config={
                     "embedding_model": "text-embedding-3-small",
                     "embedding_provider": "openai",
                     "dimension": 1536,
                     "index_metric": "ip",
                 },
-                "metadata": {},
-            }
+                commit=commit,
+                source_fingerprint=SOURCE_FINGERPRINT,
+                source_selection_digest=SOURCE_SELECTION_DIGEST,
+            )
         },
-    }
+    )
 
     manifest_path = tmp_path / "repo_manifest.json"
-    manifest_path.write_text(json.dumps(manifest_data, indent=2))
+    manifest.save(manifest_path)
     return manifest_path
 
 

--- a/test/mcp_server/test_context.py
+++ b/test/mcp_server/test_context.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import subprocess
 import sys
@@ -16,12 +17,46 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
-from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.compiler.manifest import LEGACY_MANIFEST_VERSION, IndexEntry, RepoManifest
 from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
 from codenib.mcp.context import RUNTIME_VIEW_NAMES, ServerContext
 from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 from codenib.provider_routes import resolve_inference_route
+from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.source_fingerprint import capture_repository_source, fingerprint_repository
+
+_TEST_COMMIT = "c" * 40
+_TEST_SOURCE_FINGERPRINT = "sha256-v2:" + ("d" * 64)
+_TEST_SOURCE_SELECTION = RepositorySourceSelection()
+
+
+def _bind_fresh_entry(manifest: RepoManifest, entry: IndexEntry) -> IndexEntry:
+    entry.commit = manifest.commit
+    entry.source_fingerprint = manifest.source_fingerprint
+    entry.source_selection_digest = manifest.source_selection_digest or ""
+    return entry
+
+
+def _current_manifest(
+    repo_path: Path,
+    indexes: dict[str, IndexEntry],
+    *,
+    languages: list[str] | None = None,
+) -> RepoManifest:
+    manifest = RepoManifest(
+        repo_path=str(repo_path),
+        commit=_TEST_COMMIT,
+        last_indexed_commit=_TEST_COMMIT,
+        source_fingerprint=_TEST_SOURCE_FINGERPRINT,
+        last_indexed_source_fingerprint=_TEST_SOURCE_FINGERPRINT,
+        source_selection=_TEST_SOURCE_SELECTION,
+        last_indexed_source_selection_digest=_TEST_SOURCE_SELECTION.digest,
+        languages=[] if languages is None else languages,
+        indexes=indexes,
+    )
+    for entry in manifest.indexes.values():
+        _bind_fresh_entry(manifest, entry)
+    return manifest
 
 
 class _PendingSourceOwner:
@@ -61,9 +96,9 @@ def _portable_vector_manifest(tmp_path: Path) -> tuple[RepoManifest, Path]:
         "embedding_kwargs": {},
     }
     return (
-        RepoManifest(
-            repo_path=str(tmp_path),
-            indexes={
+        _current_manifest(
+            tmp_path,
+            {
                 "vector": IndexEntry(
                     index_type="vector",
                     path=str(vector_dir),
@@ -419,9 +454,11 @@ def test_local_bm25_without_source_binding_is_persisted_only(
     )
     legacy = "sha256:" + "a" * 64
     manifest = RepoManifest(
+        version=LEGACY_MANIFEST_VERSION,
         repo_path=str(tmp_path),
         source_fingerprint=legacy,
         last_indexed_source_fingerprint=legacy,
+        source_selection=None,
         indexes={
             "bm25": IndexEntry(
                 index_type="bm25",
@@ -489,11 +526,9 @@ def manifest_dir(tmp_path: Path) -> Path:
         json.dumps({"project_root": str(tmp_path), "max_k": 10, "language": "english"})
     )
 
-    manifest = RepoManifest(
-        repo_path=str(tmp_path),
-        commit="abc123",
-        languages=["python"],
-        indexes={
+    manifest = _current_manifest(
+        tmp_path,
+        {
             "bm25": IndexEntry(
                 index_type="bm25",
                 path=str(bm25_dir),
@@ -502,6 +537,7 @@ def manifest_dir(tmp_path: Path) -> Path:
                 status="fresh",
             ),
         },
+        languages=["python"],
     )
     manifest.derive_capabilities()
     manifest_path = tmp_path / "repo_manifest.json"
@@ -829,9 +865,9 @@ def test_load_with_bm25_only(manifest_dir: Path) -> None:
 
 def test_load_missing_bm25_path(tmp_path: Path) -> None:
     """BM25 load failure is recorded in errors, not raised."""
-    manifest = RepoManifest(
-        repo_path=str(tmp_path),
-        indexes={
+    manifest = _current_manifest(
+        tmp_path,
+        {
             "bm25": IndexEntry(
                 index_type="bm25",
                 path=str(tmp_path / "nonexistent"),
@@ -891,9 +927,9 @@ def test_skip_non_fresh_index(tmp_path: Path) -> None:
 def test_load_vector_accepts_compiler_manifest_identity(tmp_path: Path) -> None:
     vector_dir = tmp_path / "vector"
     vector_dir.mkdir()
-    manifest = RepoManifest(
-        repo_path=str(tmp_path),
-        indexes={
+    manifest = _current_manifest(
+        tmp_path,
+        {
             "vector": IndexEntry(
                 index_type="vector",
                 path=str(vector_dir),
@@ -1083,9 +1119,9 @@ def test_validate_views_probes_vector_without_loading_embedding_model(
 ) -> None:
     vector_dir = tmp_path / "vector"
     vector_dir.mkdir()
-    manifest = RepoManifest(
-        repo_path=str(tmp_path),
-        indexes={
+    manifest = _current_manifest(
+        tmp_path,
+        {
             "vector": IndexEntry(
                 index_type="vector",
                 path=str(vector_dir),
@@ -1149,9 +1185,9 @@ def test_load_vector_rebinds_openai_credential_without_persisting_it(
         "embedding_route": route.public_identity(),
         "embedding_fingerprint": route.compatibility_fingerprint,
     }
-    manifest = RepoManifest(
-        repo_path=str(tmp_path),
-        indexes={
+    manifest = _current_manifest(
+        tmp_path,
+        {
             "vector": IndexEntry(
                 index_type="vector",
                 path=str(vector_dir),
@@ -1213,9 +1249,9 @@ def test_validate_views_does_not_require_remote_embedding_credentials(
         "embedding_route": route.public_identity(),
         "embedding_fingerprint": route.compatibility_fingerprint,
     }
-    manifest = RepoManifest(
-        repo_path=str(tmp_path),
-        indexes={
+    manifest = _current_manifest(
+        tmp_path,
+        {
             "vector": IndexEntry(
                 index_type="vector",
                 path=str(vector_dir),
@@ -1257,9 +1293,9 @@ def test_validate_views_does_not_require_remote_embedding_credentials(
 def test_validate_views_rejects_empty_vector_artifact(tmp_path: Path) -> None:
     vector_dir = tmp_path / "vector"
     vector_dir.mkdir()
-    manifest = RepoManifest(
-        repo_path=str(tmp_path),
-        indexes={
+    manifest = _current_manifest(
+        tmp_path,
+        {
             "vector": IndexEntry(
                 index_type="vector",
                 path=str(vector_dir),
@@ -1315,17 +1351,27 @@ def test_regex_index_built_when_graph_available(manifest_dir: Path) -> None:
     mock_graph.get_node_content.return_value = "def my_func(): pass"
 
     manifest = RepoManifest.load(manifest_dir / "repo_manifest.json")
-    manifest.indexes["symbol_graph"] = IndexEntry(
-        index_type="symbol_graph",
-        path=str(graph_dir / "graph.pkl"),
-        built_at="2026-01-01T00:00:00",
-        built_at_epoch=0.0,
-        status="fresh",
+    manifest.indexes["symbol_graph"] = _bind_fresh_entry(
+        manifest,
+        IndexEntry(
+            index_type="symbol_graph",
+            path=str(graph_dir),
+            built_at="2026-01-01T00:00:00",
+            built_at_epoch=0.0,
+            status="fresh",
+            config={
+                "graph_artifact": {
+                    "relative_path": "graph.pkl",
+                    "size": 0,
+                    "sha256": "0" * 64,
+                }
+            },
+        ),
     )
     manifest.save(manifest_dir / "repo_manifest.json")
 
     with patch(
-        "codenib.graph.code_graph.CodeGraph.load_graph",
+        "codenib.compiler.graph_artifact.load_authenticated_graph_artifact",
         return_value=mock_graph,
     ):
         ctx = ServerContext.load(manifest_dir / "repo_manifest.json")
@@ -1341,13 +1387,50 @@ def test_regex_index_built_when_graph_available(manifest_dir: Path) -> None:
 
 
 def _add_zoekt_entry(manifest_path: Path, shard_dir: Path) -> None:
+    if not any(shard_dir.iterdir()):
+        (shard_dir / "repository_v16.00000.zoekt").write_bytes(b"zoekt-shard")
+    files = [
+        {
+            "path": child.name,
+            "size": child.stat().st_size,
+            "sha256": hashlib.sha256(child.read_bytes()).hexdigest(),
+        }
+        for child in sorted(shard_dir.iterdir(), key=lambda path: path.name.encode())
+    ]
+    canonical = json.dumps(
+        {
+            "schema": "codenib.zoekt-shard-tree.v1",
+            "files": files,
+        },
+        allow_nan=False,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("ascii")
+    receipt = {
+        "schema": "codenib.zoekt-shard-tree.v1",
+        "digest": f"sha256:{hashlib.sha256(canonical).hexdigest()}",
+        "file_count": len(files),
+        "total_bytes": sum(file["size"] for file in files),
+        "files": files,
+    }
+    identity = {
+        "builder_schema": 3,
+        "shard_tree_receipt_schema": "codenib.zoekt-shard-tree.v1",
+        "shard_tree_receipt": receipt,
+    }
     manifest = RepoManifest.load(manifest_path)
-    manifest.indexes["zoekt"] = IndexEntry(
-        index_type="zoekt",
-        path=str(shard_dir),
-        built_at="2026-01-01T00:00:00",
-        built_at_epoch=0.0,
-        status="fresh",
+    manifest.indexes["zoekt"] = _bind_fresh_entry(
+        manifest,
+        IndexEntry(
+            index_type="zoekt",
+            path=str(shard_dir),
+            built_at="2026-01-01T00:00:00",
+            built_at_epoch=0.0,
+            status="fresh",
+            config=dict(identity),
+            metadata=dict(identity),
+        ),
     )
     manifest.save(manifest_path)
 
@@ -1364,12 +1447,202 @@ def test_zoekt_started_when_entry_fresh(manifest_dir: Path) -> None:
     with patch(
         "codenib.index.trigram.ZoektSearcher",
         return_value=fake_searcher,
-    ):
+    ) as searcher_class:
         ctx = ServerContext.load(manifest_dir / "repo_manifest.json")
 
     fake_searcher.start.assert_called_once()
     assert ctx.zoekt is fake_searcher
     assert "zoekt" not in ctx.errors
+    private_path = Path(searcher_class.call_args.kwargs["index_dir"])
+    assert private_path != shard_dir
+    assert (private_path / "repository_v16.00000.zoekt").read_bytes() == (
+        b"zoekt-shard"
+    )
+
+    ctx.close()
+
+    fake_searcher.stop.assert_called_once_with()
+    assert not private_path.exists()
+
+
+@pytest.mark.parametrize("mutation", ["mutate", "add", "remove", "symlink"])
+def test_zoekt_receipt_mismatch_fails_before_searcher_construction(
+    manifest_dir: Path,
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    shard_dir = manifest_dir / "zoekt"
+    shard_dir.mkdir()
+    shard = shard_dir / "repository_v16.00000.zoekt"
+    shard.write_bytes(b"receipt-bound-shard")
+    _add_zoekt_entry(manifest_dir / "repo_manifest.json", shard_dir)
+
+    if mutation == "mutate":
+        shard.write_bytes(b"changed-shard")
+    elif mutation == "add":
+        (shard_dir / "unexpected.zoekt").write_bytes(b"unexpected")
+    elif mutation == "remove":
+        shard.unlink()
+    else:
+        target = tmp_path / "outside.zoekt"
+        target.write_bytes(b"receipt-bound-shard")
+        shard.unlink()
+        shard.symlink_to(target)
+
+    with patch("codenib.index.trigram.ZoektSearcher") as searcher_class:
+        ctx = ServerContext.load(
+            manifest_dir / "repo_manifest.json",
+            views={"zoekt"},
+        )
+
+    searcher_class.assert_not_called()
+    assert ctx.zoekt is None
+    assert "zoekt" in ctx.errors
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        pytest.param("builder_schema", 2, id="legacy-builder"),
+        pytest.param("shard_tree_receipt_schema", "legacy", id="legacy-receipt"),
+        pytest.param("shard_tree_receipt", None, id="missing-receipt"),
+    ],
+)
+def test_zoekt_legacy_or_missing_receipt_fails_before_searcher_construction(
+    manifest_dir: Path,
+    field: str,
+    replacement: object,
+) -> None:
+    shard_dir = manifest_dir / "zoekt"
+    shard_dir.mkdir()
+    manifest_path = manifest_dir / "repo_manifest.json"
+    _add_zoekt_entry(manifest_path, shard_dir)
+    manifest = RepoManifest.load(manifest_path)
+    entry = manifest.indexes["zoekt"]
+    if replacement is None:
+        entry.config.pop(field)
+        entry.metadata.pop(field)
+    else:
+        entry.config[field] = replacement
+        entry.metadata[field] = replacement
+    manifest.save(manifest_path)
+
+    with patch("codenib.index.trigram.ZoektSearcher") as searcher_class:
+        ctx = ServerContext.load(manifest_path, views={"zoekt"})
+
+    searcher_class.assert_not_called()
+    assert ctx.zoekt is None
+    assert "zoekt" in ctx.errors
+
+
+def test_zoekt_rejects_mismatched_manifest_receipt_copies_before_spawn(
+    manifest_dir: Path,
+) -> None:
+    shard_dir = manifest_dir / "zoekt"
+    shard_dir.mkdir()
+    manifest_path = manifest_dir / "repo_manifest.json"
+    _add_zoekt_entry(manifest_path, shard_dir)
+    manifest = RepoManifest.load(manifest_path)
+    manifest.indexes["zoekt"].metadata["shard_tree_receipt"]["digest"] = "sha256:" + (
+        "0" * 64
+    )
+    manifest.save(manifest_path)
+
+    with patch("codenib.index.trigram.ZoektSearcher") as searcher_class:
+        ctx = ServerContext.load(manifest_path, views={"zoekt"})
+
+    searcher_class.assert_not_called()
+    assert ctx.zoekt is None
+    assert "zoekt" in ctx.errors
+
+
+def test_zoekt_rejects_non_exact_receipt_shape_before_spawn(
+    manifest_dir: Path,
+) -> None:
+    shard_dir = manifest_dir / "zoekt"
+    shard_dir.mkdir()
+    manifest_path = manifest_dir / "repo_manifest.json"
+    _add_zoekt_entry(manifest_path, shard_dir)
+    manifest = RepoManifest.load(manifest_path)
+    for values in (
+        manifest.indexes["zoekt"].config,
+        manifest.indexes["zoekt"].metadata,
+    ):
+        values["shard_tree_receipt"]["unexpected"] = True
+    manifest.save(manifest_path)
+
+    with patch("codenib.index.trigram.ZoektSearcher") as searcher_class:
+        ctx = ServerContext.load(manifest_path, views={"zoekt"})
+
+    searcher_class.assert_not_called()
+    assert ctx.zoekt is None
+    assert "invalid shape" in ctx.errors["zoekt"]
+
+
+def test_zoekt_uses_private_snapshot_when_published_tree_is_replaced(
+    manifest_dir: Path,
+) -> None:
+    shard_dir = manifest_dir / "zoekt"
+    shard_dir.mkdir()
+    shard = shard_dir / "repository_v16.00000.zoekt"
+    shard.write_bytes(b"receipt-bound-shard")
+    manifest_path = manifest_dir / "repo_manifest.json"
+    _add_zoekt_entry(manifest_path, shard_dir)
+    searcher = MagicMock()
+    searcher.port = 9999
+
+    def replace_published_tree() -> None:
+        shard.rename(shard_dir / "old.zoekt")
+        shard.write_bytes(b"untrusted-replacement")
+
+    searcher.start.side_effect = replace_published_tree
+    with patch(
+        "codenib.index.trigram.ZoektSearcher",
+        return_value=searcher,
+    ) as searcher_class:
+        ctx = ServerContext.load(manifest_path, views={"zoekt"})
+
+    private_path = Path(searcher_class.call_args.kwargs["index_dir"])
+    assert private_path != shard_dir
+    assert (private_path / "repository_v16.00000.zoekt").read_bytes() == (
+        b"receipt-bound-shard"
+    )
+    assert ctx.zoekt is searcher
+
+    ctx.close()
+    assert not private_path.exists()
+
+
+def test_zoekt_snapshot_copy_cancellation_cleans_private_stage(
+    manifest_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.compiler import zoekt_artifact
+
+    shard_dir = manifest_dir / "zoekt"
+    shard_dir.mkdir()
+    manifest_path = manifest_dir / "repo_manifest.json"
+    _add_zoekt_entry(manifest_path, shard_dir)
+    interruption = KeyboardInterrupt("snapshot copy interrupted")
+    private_paths: list[Path] = []
+
+    def interrupt_copy(stage, *args, **kwargs) -> None:
+        private_paths.append(stage.path)
+        raise interruption
+
+    monkeypatch.setattr(
+        zoekt_artifact.OwnedDirectoryStage,
+        "write_file",
+        interrupt_copy,
+    )
+    with patch("codenib.index.trigram.ZoektSearcher") as searcher_class:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            ServerContext.load(manifest_path, views={"zoekt"})
+
+    assert caught.value is interruption
+    searcher_class.assert_not_called()
+    assert private_paths
+    assert all(not path.exists() for path in private_paths)
 
 
 def test_validate_views_stops_zoekt_probe(manifest_dir: Path) -> None:
@@ -1506,12 +1779,13 @@ def test_zoekt_start_cancellation_stops_unpublished_searcher(
     with patch(
         "codenib.index.trigram.ZoektSearcher",
         return_value=searcher,
-    ):
+    ) as searcher_class:
         with pytest.raises(KeyboardInterrupt) as caught:
             ServerContext.load(manifest_dir / "repo_manifest.json", views={"zoekt"})
 
     assert caught.value is interruption
     searcher.stop.assert_called_once_with()
+    assert not Path(searcher_class.call_args.kwargs["index_dir"]).exists()
 
 
 def test_zoekt_cleanup_cancellation_exposes_retryable_context_owner(

--- a/test/mcp_server/test_integration.py
+++ b/test/mcp_server/test_integration.py
@@ -19,11 +19,14 @@ from pathlib import Path
 
 import pytest
 
+from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
+from codenib.compiler.index_builders import BM25IndexBuilder
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.graph.code_graph import CodeGraph
-from codenib.index.sparse_idx import BM25CodeIndexer
 from codenib.mcp.context import ServerContext
 from codenib.mcp.tools.search import search_bm25_impl, search_regex_impl
+from codenib.repository_source_selection import RepositorySourceSelection
+from codenib.source_fingerprint import fingerprint_repository
 
 # Synthetic repo: three small Python files with predictable symbols so that
 # both keyword (BM25) and regex search have something to match.
@@ -97,17 +100,33 @@ def manifest_path(tmp_path: Path) -> Path:
     graph_pkl = graph_dir / "graph.pkl"
     graph.save_graph(str(graph_pkl))
 
-    # Build and persist the BM25 index from the same graph
+    selection = RepositorySourceSelection()
+
+    # Build and persist the BM25 index through its current compiler contract.
     bm25_dir = tmp_path / "bm25"
-    bm25_dir.mkdir()
-    indexer = BM25CodeIndexer()
-    indexer.build_index_from_graph(graph)
-    indexer.save_index(str(bm25_dir))
+    bm25_status = BM25IndexBuilder(
+        languages=["python"],
+        source_selection=selection,
+    ).build(
+        scope="current_repo",
+        repo_path=str(repo_dir),
+        output_dir=str(bm25_dir),
+        source_selection=selection,
+    )
+    source = fingerprint_repository(repo_dir, selection=selection)
+    commit = "integration-test"
+    selection_digest = selection.digest
 
     manifest = RepoManifest(
         repo_path=str(repo_dir),
-        commit="integration-test",
+        commit=commit,
+        last_indexed_commit=commit,
+        source_fingerprint=source.value,
+        last_indexed_source_fingerprint=source.value,
+        source_selection=selection,
+        last_indexed_source_selection_digest=selection_digest,
         languages=["python"],
+        file_count=source.file_count,
         indexes={
             "bm25": IndexEntry(
                 index_type="bm25",
@@ -115,13 +134,27 @@ def manifest_path(tmp_path: Path) -> Path:
                 built_at="2026-01-01T00:00:00",
                 built_at_epoch=1735689600.0,
                 status="fresh",
+                config=dict(bm25_status.metadata),
+                metadata=dict(bm25_status.metadata),
+                commit=commit,
+                source_fingerprint=source.value,
+                source_selection_digest=selection_digest,
             ),
             "symbol_graph": IndexEntry(
                 index_type="symbol_graph",
-                path=str(graph_pkl),
+                path=str(graph_dir),
                 built_at="2026-01-01T00:00:00",
                 built_at_epoch=1735689600.0,
                 status="fresh",
+                config={
+                    "graph_artifact": {
+                        "relative_path": "graph.pkl",
+                        **regular_file_fingerprint(graph_pkl),
+                    }
+                },
+                commit=commit,
+                source_fingerprint=source.value,
+                source_selection_digest=selection_digest,
             ),
         },
     )

--- a/test/mcp_server/test_source_tool.py
+++ b/test/mcp_server/test_source_tool.py
@@ -18,7 +18,7 @@ import codenib.artifacts.runtime as artifact_runtime_module
 import codenib.mcp.server as server_module
 import codenib.source_fingerprint as source_fingerprint_module
 from codenib._contained_source import read_repository_file
-from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.compiler.manifest import LEGACY_MANIFEST_VERSION, IndexEntry, RepoManifest
 from codenib.mcp.tools._validation import MAX_SOURCE_CONTENT_CHARS
 from codenib.mcp.tools.source import read_source_impl
 from codenib.source_fingerprint import RepositorySourceBinding, fingerprint_repository
@@ -557,8 +557,10 @@ def test_init_server_never_treats_explicit_legacy_identity_as_verified(
 ) -> None:
     legacy_fingerprint = "sha256:" + "a" * 64
     manifest = RepoManifest(
+        version=LEGACY_MANIFEST_VERSION,
         repo_path="/unavailable",
         source_fingerprint=legacy_fingerprint,
+        source_selection=None,
         indexes={
             "vector": IndexEntry(
                 index_type="vector",

--- a/test/sandbox/test_docker.py
+++ b/test/sandbox/test_docker.py
@@ -654,6 +654,38 @@ def test_revision_snapshot_archives_git_objects_not_worktree(monkeypatch, tmp_pa
     session.close()
 
 
+def test_revision_snapshot_fingerprints_the_requested_source_selection(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
+    )
+    source, revision = _git_repo(tmp_path)
+    selection = RepositorySourceSelection(("generated",))
+    spec = SandboxSpec(
+        source_dir=source,
+        source_revision=revision,
+        image=IMAGE,
+        platform="linux/amd64",
+        source_selection=selection,
+    )
+    cli = RecordingCLI()
+
+    session = _provider(tmp_path, cli).create(spec)
+
+    fingerprint_call = next(
+        _docker_subcommand(argv)
+        for argv, _kwargs in cli.calls
+        if "codenib-source-fingerprint" in " ".join(argv)
+    )
+    assert fingerprint_call[-2:] == [
+        selection.canonical_json(),
+        selection.digest,
+    ]
+    session.close()
+
+
 def test_revision_snapshot_rejects_submodules(monkeypatch, tmp_path):
     monkeypatch.setattr(
         "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY

--- a/test/sandbox/test_docker.py
+++ b/test/sandbox/test_docker.py
@@ -16,6 +16,10 @@ from types import SimpleNamespace
 import pytest
 
 from codenib.repository_filters import REPOSITORY_FILTER_POLICY_VERSION
+from codenib.repository_source_selection import (
+    DEFAULT_REPOSITORY_SOURCE_SELECTION,
+    RepositorySourceSelection,
+)
 from codenib.sandbox import (
     DockerSandboxProvider,
     ExecRequest,
@@ -39,6 +43,21 @@ DIGEST = "sha256:" + "a" * 64
 IMAGE = f"registry.example/codenib-agent@{DIGEST}"
 SOURCE_FINGERPRINT = "sha256-v2:" + "e" * 64
 TEST_DOCKER_BINARY = str(Path(sys.executable).resolve(strict=True))
+
+
+def _fingerprint_helper_arguments(
+    source_root: Path | str,
+    *,
+    selection: RepositorySourceSelection = DEFAULT_REPOSITORY_SOURCE_SELECTION,
+) -> list[str]:
+    return [
+        "[]",
+        str(SOURCE_FINGERPRINT_VERSION),
+        str(REPOSITORY_FILTER_POLICY_VERSION),
+        str(source_root),
+        selection.canonical_json(),
+        selection.digest,
+    ]
 
 
 class RecordingCLI:
@@ -146,8 +165,15 @@ def test_container_fingerprint_helper_matches_host_v2_framing(tmp_path: Path) ->
     (source / "package" / "module.py").write_bytes(b"VALUE = 1\n")
     try:
         (source / "relative-link").symlink_to("b")
+        (source / "absolute-link").symlink_to(source / "b")
+        (source / "absolute-lexical-link").symlink_to(source / "package" / ".." / "b")
         (source / "relative-directory-link").symlink_to("package")
+        (source / "absolute-directory-link").symlink_to(source / "package")
         (source / "relative-root-link").symlink_to(".", target_is_directory=True)
+        (source / "absolute-root-link").symlink_to(
+            source,
+            target_is_directory=True,
+        )
         (source / "broken-link").symlink_to("missing")
         (source / "loop-link").symlink_to("loop-link")
         os.mkfifo(source / ".codenib-hidden-pipe")
@@ -181,10 +207,7 @@ def test_container_fingerprint_helper_matches_host_v2_framing(tmp_path: Path) ->
             "-S",
             "-c",
             script,
-            "[]",
-            str(SOURCE_FINGERPRINT_VERSION),
-            str(REPOSITORY_FILTER_POLICY_VERSION),
-            source_label,
+            *_fingerprint_helper_arguments(source_label),
         ],
         check=True,
         capture_output=True,
@@ -225,10 +248,7 @@ def test_container_fingerprint_helper_rejects_outside_directory_symlink(
             "-S",
             "-c",
             script,
-            "[]",
-            str(SOURCE_FINGERPRINT_VERSION),
-            str(REPOSITORY_FILTER_POLICY_VERSION),
-            str(baseline),
+            *_fingerprint_helper_arguments(baseline),
         ],
         check=False,
         capture_output=True,
@@ -236,8 +256,112 @@ def test_container_fingerprint_helper_rejects_outside_directory_symlink(
     )
 
     assert completed.returncode != 0
-    expected_error = "target must be relative" if absolute else "outside the repository"
-    assert expected_error in completed.stderr
+    assert "outside the repository" in completed.stderr
+
+
+def test_container_fingerprint_helper_rejects_absolute_prefix_collision(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "repo"
+    collision = tmp_path / "repo-foreign"
+    source.mkdir()
+    collision.mkdir()
+    (collision / "target.py").write_bytes(b"SECRET = 1\n")
+    (source / "current.py").symlink_to(collision / "target.py")
+
+    with pytest.raises(RepositoryChangedError):
+        fingerprint_repository(source)
+
+    script = _FINGERPRINT_SOURCE_SCRIPT.replace(
+        "pathlib.Path('/workspace')",
+        f"pathlib.Path({str(source)!r})",
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-c",
+            script,
+            *_fingerprint_helper_arguments(source),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "outside the repository" in completed.stderr
+
+
+def test_container_fingerprint_helper_rejects_absolute_escape_and_reentry(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "repo"
+    source.mkdir()
+    (source / "target.py").write_bytes(b"VALUE = 1\n")
+    raw_target = source / ".." / source.name / "target.py"
+    (source / "current.py").symlink_to(raw_target)
+
+    with pytest.raises(RepositoryChangedError):
+        fingerprint_repository(source)
+
+    script = _FINGERPRINT_SOURCE_SCRIPT.replace(
+        "pathlib.Path('/workspace')",
+        f"pathlib.Path({str(source)!r})",
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-c",
+            script,
+            *_fingerprint_helper_arguments(source),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "outside the repository" in completed.stderr
+
+
+def test_container_fingerprint_helper_applies_exact_source_selection(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    (source / "ios" / "Pods").mkdir(parents=True)
+    (source / "packages" / "mobile" / "ios" / "Pods").mkdir(parents=True)
+    (source / "ios" / "Pods" / "dependency.py").write_text("EXCLUDED = 1\n")
+    retained = source / "packages" / "mobile" / "ios" / "Pods" / "app.py"
+    retained.write_text("RETAINED = 1\n")
+    selection = RepositorySourceSelection(("ios/Pods",))
+    expected = fingerprint_repository(source, selection=selection)
+    script = _FINGERPRINT_SOURCE_SCRIPT.replace(
+        "pathlib.Path('/workspace')",
+        f"pathlib.Path({str(source)!r})",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-c",
+            script,
+            *_fingerprint_helper_arguments(source, selection=selection),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(completed.stdout) == {
+        "file_count": expected.file_count,
+        "source_fingerprint": expected.value,
+    }
 
 
 def _spec(tmp_path: Path, *, limits=None):

--- a/test/scip/test_lsp_occurrence_index.py
+++ b/test/scip/test_lsp_occurrence_index.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from io import BytesIO
+
 from codenib.scip_interface.lsp_occurrence_index import SCIPOccurrenceIndex
 
 _DECODED = r"""
@@ -116,3 +118,18 @@ def test_occurrence_index_round_trips(tmp_path):
 
     assert loaded.occurrence_at("pkg/reader.go", 3, 6).is_definition
     assert len(loaded.occurrences) == 6
+
+
+def test_occurrence_index_loads_from_caller_owned_stream(tmp_path):
+    path = tmp_path / "lsp_index.pkl"
+    SCIPOccurrenceIndex.from_decoded_text(_DECODED).save(path)
+    stream = BytesIO(path.read_bytes())
+
+    loaded = SCIPOccurrenceIndex.load_stream(
+        stream,
+        input_label="authenticated lsp_index.pkl",
+    )
+
+    assert loaded.occurrence_at("pkg/reader.go", 3, 6).is_definition
+    assert len(loaded.occurrences) == 6
+    assert not stream.closed

--- a/test/scip/test_scip_query.py
+++ b/test/scip/test_scip_query.py
@@ -24,11 +24,21 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
     import tomli as tomllib
 
 from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
-from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.compiler.manifest import (
+    LEGACY_MANIFEST_VERSION,
+    MANIFEST_VERSION,
+    IndexEntry,
+    RepoManifest,
+)
+from codenib.compiler.manifest_source import (
+    fingerprint_repository_for_manifest,
+    repository_filter_policy_for_manifest,
+)
 from codenib.repository_filters import (
     REPOSITORY_FILTER_POLICY_VERSION,
     default_exclude_patterns,
 )
+from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.scip_interface.scip_filter import (
     matches_exclude_patterns,
     normalize_scip_path,
@@ -317,6 +327,8 @@ def _write_candidate_manifest(
     rust_workspace: bool = False,
     node_count: int = 5,
     edge_count: int = 4,
+    manifest_version: str = MANIFEST_VERSION,
+    source_selection: RepositorySourceSelection | None = None,
 ) -> tuple[Path, RepoManifest]:
     root = tmp_path / "repo"
     root.mkdir(parents=True)
@@ -399,7 +411,20 @@ def _write_candidate_manifest(
     serial_graph.save_graph(str(graph_file))
     index_fingerprint = regular_file_fingerprint(decoded)
     graph_fingerprint = regular_file_fingerprint(graph_file)
-    source = fingerprint_repository(root, exclude_roots=(cache,))
+    persisted_selection = None
+    if manifest_version != LEGACY_MANIFEST_VERSION:
+        persisted_selection = source_selection or RepositorySourceSelection()
+    identity_manifest = RepoManifest(
+        version=manifest_version,
+        repo_path=str(root),
+        source_selection=persisted_selection,
+    )
+    source = fingerprint_repository_for_manifest(
+        root,
+        identity_manifest,
+        exclude_roots=(cache,),
+    )
+    repository_filter_policy = repository_filter_policy_for_manifest(identity_manifest)
     patterns = sorted(default_exclude_patterns())
     artifacts = {
         language: {
@@ -430,7 +455,7 @@ def _write_candidate_manifest(
             }
         }
     metadata = {
-        "builder_schema": 4,
+        "builder_schema": (4 if manifest_version == LEGACY_MANIFEST_VERSION else 6),
         "languages": [language],
         "graph_route": "active",
         "exclude_patterns": patterns,
@@ -438,7 +463,7 @@ def _write_candidate_manifest(
         "allow_partial_index": False,
         "source_coverage_fallback": False,
         "target_dir": None,
-        "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
+        "repository_filter_policy": repository_filter_policy,
         "node_count": node_count,
         "edge_count": edge_count,
         "language": language,
@@ -456,6 +481,25 @@ def _write_candidate_manifest(
         "failed_languages": {},
         "partial": False,
     }
+    if persisted_selection is not None:
+        metadata.update(
+            {
+                "allow_project_preparation": True,
+                "lsp_occurrence_artifact": None,
+                "source_selection_digest": persisted_selection.digest,
+                "source_selection_report": {
+                    "source_selection_digest": persisted_selection.digest,
+                    "nodes_before": node_count,
+                    "nodes_after": node_count,
+                    "edges_before": edge_count,
+                    "edges_after": edge_count,
+                    "removed_excluded_path_count": 0,
+                    "excluded_path_count_after": 0,
+                    "invalid_path_count_before": 0,
+                    "invalid_path_count_after": 0,
+                },
+            }
+        )
     entry = IndexEntry(
         index_type="symbol_graph",
         path=str(artifact_root),
@@ -466,11 +510,19 @@ def _write_candidate_manifest(
         metadata={**copy.deepcopy(metadata), "build_duration_seconds": 1.0},
         commit="",
         source_fingerprint=source.value,
+        source_selection_digest=(
+            "" if persisted_selection is None else persisted_selection.digest
+        ),
     )
     manifest = RepoManifest(
+        version=manifest_version,
         repo_path=str(root),
         source_fingerprint=source.value,
         last_indexed_source_fingerprint=source.value,
+        source_selection=persisted_selection,
+        last_indexed_source_selection_digest=(
+            "" if persisted_selection is None else persisted_selection.digest
+        ),
         languages=[language],
         file_count=source.file_count,
         indexes={"symbol_graph": entry},
@@ -853,14 +905,27 @@ def test_manifest_candidate_binds_source_filter_index_and_native_receipts(
 
     assert candidate.has_symbol("demo") is True
     assert candidate.receipt["language"] == "python"
-    assert candidate.receipt["manifest"]["version"] == "1.1"
+    assert candidate.receipt["manifest"]["version"] == MANIFEST_VERSION
     manifest_fingerprint = regular_file_fingerprint(manifest_path)
     assert candidate.receipt["manifest"]["size_bytes"] == manifest_fingerprint["size"]
     assert candidate.receipt["manifest"]["sha256"] == manifest_fingerprint["sha256"]
-    assert candidate.receipt["manifest"]["builder_schema"] == 4
+    assert candidate.receipt["manifest"]["builder_schema"] == 6
     assert candidate.receipt["manifest"]["document_count"] == 1
     assert candidate.receipt["graph"]["relative_path"] == "graph.pkl"
-    assert candidate.receipt["filters"]["repository_filter_policy"] == 3
+    assert (
+        candidate.receipt["filters"]["repository_filter_policy"]
+        == REPOSITORY_FILTER_POLICY_VERSION
+    )
+    expected_selection = RepositorySourceSelection()
+    assert candidate.receipt["manifest"]["source_selection"] == (
+        expected_selection.to_dict()
+    )
+    assert candidate.receipt["source"]["source_selection_digest"] == (
+        expected_selection.digest
+    )
+    assert candidate.receipt["filters"]["source_selection_digest"] == (
+        expected_selection.digest
+    )
     assert candidate.receipt["filter_identity"]["identity"] is True
     assert candidate.receipt["filter_identity"]["reference_only_count"] == 1
     assert (
@@ -869,6 +934,43 @@ def test_manifest_candidate_binds_source_filter_index_and_native_receipts(
     )
     assert len(candidate.receipt["receipt_sha256"]) == 64
     assert core.calls[0]["language"] == "python"
+
+
+def test_manifest_candidate_preserves_legacy_v11_source_policy(tmp_path: Path) -> None:
+    manifest_path, _ = _write_candidate_manifest(
+        tmp_path,
+        manifest_version=LEGACY_MANIFEST_VERSION,
+    )
+
+    candidate = load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+    assert candidate.receipt["manifest"]["version"] == LEGACY_MANIFEST_VERSION
+    assert candidate.receipt["manifest"]["source_selection"] is None
+    assert candidate.receipt["source"]["source_selection_digest"] is None
+    assert candidate.receipt["filters"]["repository_filter_policy"] == 3
+    assert candidate.receipt["filter_identity"]["source_selection_digest"] is None
+
+
+def test_manifest_candidate_excludes_selected_subtrees_from_native_proof(
+    tmp_path: Path,
+) -> None:
+    selection = RepositorySourceSelection(("generated",))
+    manifest_path, manifest = _write_candidate_manifest(
+        tmp_path,
+        source_selection=selection,
+    )
+    generated = Path(manifest.repo_path) / "generated" / "ignored.py"
+    generated.parent.mkdir()
+    generated.write_text("SHOULD_NOT_BE_READ = True\n", encoding="utf-8")
+    core = _MockCore()
+
+    candidate = load_fact_query_candidate(manifest_path, core_module=core)
+
+    assert "generated/ignored.py" not in core.index.allowed_files
+    assert candidate.receipt["source"]["source_selection"] == selection.to_dict()
+    assert candidate.receipt["filter_identity"]["source_selection_digest"] == (
+        selection.digest
+    )
 
 
 def test_manifest_change_during_native_decode_rejects_mixed_generation(
@@ -948,7 +1050,7 @@ def test_candidate_rejects_unknown_builder_field_and_report_shape(
     entry.config["unknown"] = "unsafe"
     entry.metadata["unknown"] = "unsafe"
     manifest.save(manifest_path)
-    with pytest.raises(FactQueryCandidateRejected, match="schema v4"):
+    with pytest.raises(FactQueryCandidateRejected, match="builder schema"):
         load_fact_query_candidate(manifest_path, core_module=_MockCore())
 
     manifest_path, manifest = _write_candidate_manifest(tmp_path / "report")
@@ -999,7 +1101,10 @@ def test_candidate_rejects_nonfinite_manifest_times(tmp_path: Path, field: str) 
         entry.built_at_epoch = float("inf")
     else:
         entry.metadata[field] = float("nan")
-    manifest.save(manifest_path)
+    manifest_path.write_text(
+        json.dumps(manifest.to_dict(), allow_nan=True),
+        encoding="utf-8",
+    )
 
     with pytest.raises(FactQueryCandidateRejected, match="malformed"):
         load_fact_query_candidate(manifest_path, core_module=_MockCore())
@@ -1065,6 +1170,7 @@ def test_candidate_binds_live_git_head_before_decode(tmp_path: Path) -> None:
         ("partial", True),
         ("partial_index", True),
         ("source_coverage_fallback", True),
+        ("lsp_occurrence_artifact", {}),
     ],
 )
 def test_manifest_candidate_rejects_unsafe_builder_states(
@@ -1272,7 +1378,7 @@ def test_candidate_rejects_symlinks_old_manifest_and_missing_build_keys(
     del entry.config["target_dir"]
     del entry.metadata["target_dir"]
     manifest.save(manifest_path)
-    with pytest.raises(FactQueryCandidateRejected, match="schema v4"):
+    with pytest.raises(FactQueryCandidateRejected, match="builder schema"):
         load_fact_query_candidate(manifest_path, core_module=_MockCore())
 
     manifest_path, manifest = _write_candidate_manifest(tmp_path / "artifact-link")

--- a/test/scip/test_scip_query_provider.py
+++ b/test/scip/test_scip_query_provider.py
@@ -21,12 +21,15 @@ import pytest
 
 from codenib.agent.lsp_provider import LSPProviderNodes, StaticLSPProvider
 from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
+from codenib.compiler.manifest import MANIFEST_VERSION, IndexEntry, RepoManifest
+from codenib.compiler.manifest_source import repository_filter_policy_for_manifest
 from codenib.graph.code_graph import CodeGraph
 from codenib.mcp.tools.lsp import (
     lsp_definition_impl,
     lsp_references_impl,
     lsp_route_impl,
 )
+from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.scip_interface.query_surface import query_surface_sha256
 from codenib.scip_interface.scip_query import (
     FACT_QUERY_CAPABILITIES,
@@ -154,6 +157,35 @@ def _provider(
         public_fallback_reason=public_fallback_reason,
     )
     return provider, native
+
+
+def test_default_graph_loader_uses_authenticated_artifact_receipt(
+    tmp_path: Path,
+) -> None:
+    graph = _graph(tmp_path)
+    candidate, native = _candidate(graph, tmp_path)
+    graph_path = Path(candidate.receipt["manifest"]["entry_path"]) / "graph.pkl"
+    graph.save_graph(str(graph_path))
+    payload = graph_path.read_bytes()
+    candidate.receipt["graph"].update(
+        {
+            "size_bytes": len(payload),
+            "sha256": hashlib.sha256(payload).hexdigest(),
+        }
+    )
+    provider = SCIPHybridQueryProvider(
+        FactQueryCandidate(
+            index=native,
+            receipt=candidate.receipt,
+            timings={},
+        ),
+        snapshot_observer=lambda _receipt: {"generation": 1},
+    )
+
+    result = provider.definition(file_path="caller.py", line=2, top_k=8)
+
+    assert result
+    assert provider.diagnostics()["state"] == GRAPH_READY
 
 
 def _serialized(value: Any) -> bytes:
@@ -685,12 +717,10 @@ def _observer_receipt(tmp_path: Path) -> tuple[dict[str, Any], Path, Path]:
     graph_root = cache / "symbol_graph"
     graph_root.mkdir(parents=True)
     manifest_path = cache / "repo_manifest.json"
-    manifest_path.write_text("{}\n", encoding="utf-8")
     index_path = graph_root / "index.decoded"
     graph_path = graph_root / "graph.pkl"
     index_path.write_bytes(b"decoded-index")
     graph_path.write_bytes(b"persisted-graph")
-    manifest_fp = regular_file_fingerprint(manifest_path)
     index_fp = regular_file_fingerprint(index_path)
     graph_fp = regular_file_fingerprint(graph_path)
     source, allowed_files = _source_and_allowed_files(
@@ -700,6 +730,32 @@ def _observer_receipt(tmp_path: Path) -> tuple[dict[str, Any], Path, Path]:
         target_dir=None,
     )
     assert source == fingerprint_repository(root, exclude_roots=(cache,))
+    selection = RepositorySourceSelection()
+    entry = IndexEntry(
+        index_type="symbol_graph",
+        path=str(graph_root),
+        built_at="2026-01-01T00:00:00+00:00",
+        built_at_epoch=0.0,
+        status="fresh",
+        commit=commit,
+        source_fingerprint=source.value,
+        source_selection_digest=selection.digest,
+    )
+    embedded_manifest = RepoManifest(
+        repo_path=str(root),
+        commit=commit,
+        last_indexed_commit=commit,
+        source_fingerprint=source.value,
+        last_indexed_source_fingerprint=source.value,
+        source_selection=selection,
+        last_indexed_source_selection_digest=selection.digest,
+        languages=["python"],
+        file_count=source.file_count,
+        indexes={"symbol_graph": entry},
+    )
+    embedded_manifest.save(manifest_path)
+    manifest_fp = regular_file_fingerprint(manifest_path)
+    repository_filter_policy = repository_filter_policy_for_manifest(embedded_manifest)
     query_digest = hashlib.sha256(b"query-surface").hexdigest()
     receipt: dict[str, Any] = {
         "schema_version": 1,
@@ -707,7 +763,7 @@ def _observer_receipt(tmp_path: Path) -> tuple[dict[str, Any], Path, Path]:
         "project_root": str(root),
         "manifest": {
             "path": str(manifest_path),
-            "version": "1.1",
+            "version": MANIFEST_VERSION,
             "size_bytes": manifest_fp["size"],
             "sha256": manifest_fp["sha256"],
             "commit": commit,
@@ -718,9 +774,12 @@ def _observer_receipt(tmp_path: Path) -> tuple[dict[str, Any], Path, Path]:
             "query_surface_sha256": query_digest,
             "source_fingerprint": source.value,
             "file_count": source.file_count,
+            "source_selection": selection.to_dict(),
+            "source_selection_digest": selection.digest,
             "entry_path": str(graph_root),
             "entry_commit": commit,
             "entry_source_fingerprint": source.value,
+            "entry_source_selection_digest": selection.digest,
         },
         "index": {
             "relative_path": "index.decoded",
@@ -741,12 +800,16 @@ def _observer_receipt(tmp_path: Path) -> tuple[dict[str, Any], Path, Path]:
         "source": {
             "fingerprint": source.value,
             "file_count": source.file_count,
-            "repository_filter_policy": 3,
+            "repository_filter_policy": repository_filter_policy,
+            "source_selection": selection.to_dict(),
+            "source_selection_digest": selection.digest,
         },
         "filters": {
             "graph_route": "active",
             "update_mode": "full_rebuild",
-            "repository_filter_policy": 3,
+            "repository_filter_policy": repository_filter_policy,
+            "source_selection": selection.to_dict(),
+            "source_selection_digest": selection.digest,
             "exclude_patterns": [],
             "target_dir": None,
             "allow_partial_languages": False,
@@ -769,7 +832,13 @@ def _observer_receipt(tmp_path: Path) -> tuple[dict[str, Any], Path, Path]:
                 "internal_crates": [],
             },
         },
-        "filter_identity": {"identity": True},
+        "filter_identity": {
+            "identity": True,
+            "repository_filter_policy": repository_filter_policy,
+            "source_selection_digest": selection.digest,
+            "allowed_file_count": len(allowed_files),
+            "allowed_files_sha256": _allowed_files_digest(allowed_files),
+        },
     }
     unsigned = json.dumps(
         receipt,

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -532,7 +532,8 @@ def test_artifact_import_cache_uses_frozen_authorities_and_closes_before_output(
     suggested = workspace_root / f".codenib-cache-import-{nonce}-materialized"
     events: list[str] = []
     bridge_calls: list[tuple[Path, dict[str, object]]] = []
-    capture_calls: list[tuple[Path, tuple[Path, ...]]] = []
+    source_selection = RepositorySourceSelection(("generated",))
+    capture_calls: list[tuple[Path, tuple[Path, ...], RepositorySourceSelection]] = []
 
     class Provider:
         def __init__(self, root: Path) -> None:
@@ -563,10 +564,11 @@ def test_artifact_import_cache_uses_frozen_authorities_and_closes_before_output(
         root: Path,
         *,
         exclude_roots: tuple[Path, ...],
+        selection: RepositorySourceSelection,
         _source_owner,
     ) -> Closeable:
         events.append("capture")
-        capture_calls.append((root, exclude_roots))
+        capture_calls.append((root, exclude_roots, selection))
         _source_owner(source)
         return source
 
@@ -612,6 +614,11 @@ def test_artifact_import_cache_uses_frozen_authorities_and_closes_before_output(
         "import_compiler_cache_bm25",
         import_cache,
     )
+    monkeypatch.setattr(
+        cache_import_module,
+        "compiler_cache_source_selection",
+        lambda _cache: source_selection,
+    )
     real_print = print
 
     def print_after_cleanup(*values: object, **kwargs: object) -> None:
@@ -630,6 +637,7 @@ def test_artifact_import_cache_uses_frozen_authorities_and_closes_before_output(
         (
             Path(args.repo),
             (cache, bm25_destination, context_destination, suggested),
+            source_selection,
         )
     ]
     assert len(bridge_calls) == 1
@@ -741,6 +749,11 @@ def test_artifact_import_cache_failure_preserves_primary_and_published_outputs(
         cache_import_module,
         "import_compiler_cache_bm25",
         fail_after_publication,
+    )
+    monkeypatch.setattr(
+        cache_import_module,
+        "compiler_cache_source_selection",
+        lambda _cache: RepositorySourceSelection(),
     )
 
     with pytest.raises(KeyboardInterrupt) as raised:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -26,9 +26,33 @@ import codenib.source_fingerprint as source_fingerprint_module
 import codenib.storage as storage_module
 import codenib.web.local as local_module
 from codenib import cli
+from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.source_fingerprint import RepositorySourceBinding
 from codenib.web import launcher
 from codenib.web.local import prepare_local_wiki
+
+_TEST_COMMIT = "c" * 40
+_TEST_SOURCE_FINGERPRINT = "sha256-v2:" + ("d" * 64)
+
+
+def _current_manifest_with_fresh_index(repo: Path, entry) -> object:
+    from codenib.compiler.manifest import RepoManifest
+
+    selection = RepositorySourceSelection()
+    entry.commit = _TEST_COMMIT
+    entry.source_fingerprint = _TEST_SOURCE_FINGERPRINT
+    entry.source_selection_digest = selection.digest
+    return RepoManifest(
+        repo_path=str(repo),
+        commit=_TEST_COMMIT,
+        last_indexed_commit=_TEST_COMMIT,
+        source_fingerprint=_TEST_SOURCE_FINGERPRINT,
+        last_indexed_source_fingerprint=_TEST_SOURCE_FINGERPRINT,
+        source_selection=selection,
+        last_indexed_source_selection_digest=selection.digest,
+        languages=["python"],
+        indexes={entry.index_type: entry},
+    )
 
 
 def _cleanup_notes(error: BaseException) -> tuple[str, ...]:
@@ -55,6 +79,97 @@ def test_parser_exposes_release_commands() -> None:
 
     publish = parser.parse_args(["publish", "."])
     assert publish.preset == "auto"
+
+
+def test_index_parser_accepts_exact_source_exclusions() -> None:
+    args = cli.build_parser().parse_args(
+        [
+            "index",
+            ".",
+            "--exclude-dir",
+            "ios/Pods",
+            "--exclude-dir",
+            "generated/api",
+        ]
+    )
+
+    assert args.exclude_dir == ["ios/Pods", "generated/api"]
+    assert args.clear_exclude_dirs is False
+
+
+def test_source_selection_flags_are_mutually_exclusive() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        cli.build_parser().parse_args(
+            [
+                "codegraph",
+                "init",
+                ".",
+                "--exclude-dir",
+                "ios",
+                "--clear-exclude-dirs",
+            ]
+        )
+
+    assert exc_info.value.code == 2
+
+
+def test_source_selection_reuses_the_persisted_manifest_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.compiler.manifest import MANIFEST_FILENAME, RepoManifest
+    from codenib.paths import repo_index_dir
+
+    monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "state"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    selection = RepositorySourceSelection(("generated/api", "ios/Pods"))
+    RepoManifest(repo_path=str(repo), source_selection=selection).save(
+        repo_index_dir(repo) / MANIFEST_FILENAME
+    )
+    args = cli.build_parser().parse_args(["index", str(repo), "--preset", "fast"])
+
+    resolved = cli._resolve_repository_source_selection(repo, args)
+
+    assert resolved.action == "reuse"
+    assert resolved.selection == selection
+    assert resolved.selection is not selection
+
+
+def test_source_selection_migrates_legacy_manifest_without_aliasing_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.compiler.manifest import (
+        LEGACY_MANIFEST_VERSION,
+        MANIFEST_FILENAME,
+        RepoManifest,
+    )
+    from codenib.paths import repo_index_dir
+
+    monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "state"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    RepoManifest(
+        version=LEGACY_MANIFEST_VERSION,
+        repo_path=str(repo),
+        source_selection=None,
+    ).save(repo_index_dir(repo) / MANIFEST_FILENAME)
+    args = cli.build_parser().parse_args(["index", str(repo), "--preset", "fast"])
+
+    resolved = cli._resolve_repository_source_selection(repo, args)
+
+    assert resolved.action == "migrate"
+    assert resolved.selection == RepositorySourceSelection()
+
+
+def test_source_selection_rejects_noncanonical_cli_paths(tmp_path: Path) -> None:
+    args = cli.build_parser().parse_args(
+        ["index", str(tmp_path), "--exclude-dir", "ios/../secrets"]
+    )
+
+    with pytest.raises(cli.CLIError, match="invalid --exclude-dir"):
+        cli._resolve_repository_source_selection(tmp_path, args)
 
 
 def test_mcp_artifact_repo_is_explicit() -> None:
@@ -138,6 +253,8 @@ def test_publish_and_artifact_parsers_expose_distribution_options() -> None:
             "/project",
             "--embedding-provider",
             "openai",
+            "--exclude-dir",
+            "ios/Pods",
         ]
     )
     artifact = cli.build_parser().parse_args(
@@ -157,6 +274,8 @@ def test_publish_and_artifact_parsers_expose_distribution_options() -> None:
     assert publish.context_output == "/tmp/context"
     assert publish.repository == "example/project"
     assert publish.embedding_provider == "openai"
+    assert publish.exclude_dir == ["ios/Pods"]
+    assert publish.clear_exclude_dirs is False
     assert artifact.artifact_command == "pack"
     assert artifact.view == ["bm25,vector"]
 
@@ -2784,6 +2903,65 @@ def test_detect_languages_orders_by_file_count_and_skips_generated_dirs(
     assert cli.detect_languages(tmp_path) == ["python", "go"]
 
 
+def test_detect_languages_uses_exact_repository_source_selection(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "kept.py").write_text("VALUE = 1\n")
+    (tmp_path / "ios" / "Pods").mkdir(parents=True)
+    (tmp_path / "ios" / "Pods" / "excluded.go").write_text("package hidden\n")
+    (tmp_path / "packages" / "ios" / "Pods").mkdir(parents=True)
+    (tmp_path / "packages" / "ios" / "Pods" / "kept.go").write_text("package kept\n")
+
+    assert cli.detect_languages(
+        tmp_path,
+        source_selection=RepositorySourceSelection(("ios/Pods",)),
+    ) == ["go", "python"]
+
+
+def test_index_command_resolves_selection_before_language_detection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "kept.py").write_text("VALUE = 1\n")
+    (tmp_path / "ios").mkdir()
+    (tmp_path / "ios" / "excluded.go").write_text("package hidden\n")
+    captured: dict[str, object] = {}
+
+    def fake_index(repo_path, **kwargs):
+        captured.update(repo_path=repo_path, **kwargs)
+        return (
+            SimpleNamespace(
+                repo_path=str(repo_path),
+                languages=kwargs["languages"],
+                source_selection=kwargs["source_selection"],
+                indexes={
+                    "bm25": SimpleNamespace(status="fresh", metadata={}),
+                },
+            ),
+            [],
+        )
+
+    monkeypatch.setattr(cli, "index_repository", fake_index)
+
+    assert (
+        cli.run(
+            [
+                "index",
+                str(tmp_path),
+                "--preset",
+                "fast",
+                "--exclude-dir",
+                "ios",
+            ]
+        )
+        == 0
+    )
+    assert captured["languages"] == ["python"]
+    assert captured["source_selection"] == RepositorySourceSelection(("ios",))
+
+
 def test_normalize_languages_accepts_aliases_and_commas() -> None:
     assert cli.normalize_languages(["py,typescript", "c++"]) == [
         "python",
@@ -2826,11 +3004,12 @@ def test_index_command_auto_preset_falls_back_without_dense_dependencies(
     captured = {}
     monkeypatch.setattr(cli, "_check_module", lambda _module: False)
 
-    def fake_index(repo_path, *, languages, views, rebuild):
+    def fake_index(repo_path, *, languages, views, source_selection, rebuild):
         captured.update(
             repo_path=repo_path,
             languages=languages,
             views=views,
+            source_selection=source_selection,
             rebuild=rebuild,
         )
         entry = SimpleNamespace(
@@ -2851,6 +3030,7 @@ def test_index_command_auto_preset_falls_back_without_dense_dependencies(
         "repo_path": tmp_path,
         "languages": ["python"],
         "views": ["bm25"],
+        "source_selection": RepositorySourceSelection(),
         "rebuild": False,
     }
 
@@ -2883,14 +3063,16 @@ def test_fast_index_builds_fresh_bm25_manifest(
     from codenib.paths import repo_index_dir
 
     monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "home"))
-    (tmp_path / "sample.py").write_text(
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.py").write_text(
         "def greet(name: str) -> str:\n"
         '    """Return a greeting."""\n'
         '    return f"hello {name}"\n'
     )
 
     manifest, failed = cli.index_repository(
-        tmp_path,
+        repo,
         languages=["python"],
         views=["bm25"],
     )
@@ -2898,8 +3080,86 @@ def test_fast_index_builds_fresh_bm25_manifest(
     assert failed == []
     assert manifest.languages == ["python"]
     assert manifest.indexes["bm25"].status == "fresh"
-    assert (repo_index_dir(tmp_path) / "repo_manifest.json").is_file()
-    assert not (tmp_path / ".codenib_cache").exists()
+    assert (repo_index_dir(repo) / "repo_manifest.json").is_file()
+    assert not (repo / ".codenib_cache").exists()
+
+
+def test_fast_index_accepts_expo_style_contained_absolute_directory_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if sys.platform == "win32":
+        pytest.skip("POSIX Expo-style absolute symlink fixture")
+    from codenib.paths import repo_index_dir
+
+    repo = tmp_path / "repo"
+    package = repo / "node_modules" / ".pnpm" / "dependency" / "package"
+    pods = repo / "ios" / "Pods"
+    package.mkdir(parents=True)
+    pods.mkdir(parents=True)
+    (repo / "sample.py").write_text("def sample():\n    return 1\n")
+    (package / "generated.py").write_text("raise AssertionError('ignored')\n")
+    (pods / "Dependency").symlink_to(package, target_is_directory=True)
+    monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "state"))
+
+    manifest, failed = cli.index_repository(
+        repo,
+        languages=["python"],
+        views=["bm25"],
+    )
+
+    assert failed == []
+    assert manifest.indexes["bm25"].status == "fresh"
+    assert (repo_index_dir(repo) / "repo_manifest.json").is_file()
+
+
+def test_index_exclusion_handles_expo_pods_symlink_and_is_reused(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if sys.platform == "win32":
+        pytest.skip("POSIX Expo-style absolute symlink fixture")
+    from codenib.compiler.manifest import MANIFEST_FILENAME, RepoManifest
+    from codenib.paths import repo_index_dir
+
+    repo = tmp_path / "repo"
+    package = repo / "node_modules" / ".pnpm" / "dependency" / "package"
+    pods = repo / "ios" / "Pods"
+    package.mkdir(parents=True)
+    pods.mkdir(parents=True)
+    (repo / "sample.py").write_text("def sample():\n    return 1\n")
+    (package / "generated.py").write_text("GENERATED = 1\n")
+    (pods / "Dependency").symlink_to(package, target_is_directory=True)
+    monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "state"))
+
+    first = cli.run(
+        [
+            "index",
+            str(repo),
+            "--preset",
+            "fast",
+            "--language",
+            "python",
+            "--exclude-dir",
+            "ios/Pods",
+        ]
+    )
+    second = cli.run(
+        [
+            "index",
+            str(repo),
+            "--preset",
+            "fast",
+            "--language",
+            "python",
+        ]
+    )
+    manifest = RepoManifest.load(repo_index_dir(repo) / MANIFEST_FILENAME)
+
+    assert first == 0
+    assert second == 0
+    assert manifest.source_selection == RepositorySourceSelection(("ios/Pods",))
+    assert manifest.indexes["bm25"].status == "fresh"
 
 
 def test_semantic_preset_reports_required_extra(
@@ -2971,7 +3231,8 @@ def test_graph_preset_selects_bm25_and_symbol_graph(
     (tmp_path / "sample.py").write_text("def sample():\n    return 1\n")
     captured = {}
 
-    def fake_index(repo_path, *, languages, views, rebuild):
+    def fake_index(repo_path, *, languages, views, source_selection, rebuild):
+        assert source_selection == RepositorySourceSelection()
         captured["views"] = views
         entries = {view: SimpleNamespace(status="fresh", metadata={}) for view in views}
         return (
@@ -3527,9 +3788,11 @@ def test_wiki_audit_exits_without_starting_frontend(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    from codenib.compiler.manifest import RepoManifest
+
     (tmp_path / "sample.py").write_text("def sample():\n    return 1\n")
     manifest = tmp_path / "repo_manifest.json"
-    manifest.write_text("{}")
+    RepoManifest(repo_path=str(tmp_path)).save(manifest)
     prepared = SimpleNamespace(repo_id="sample")
     monkeypatch.setattr(cli, "_check_module", lambda _module: True)
     monkeypatch.setattr(cli, "resolve_manifest_path", lambda _value: manifest)
@@ -3570,22 +3833,19 @@ def test_wiki_generate_resolves_openai_route(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from codenib.compiler.manifest import IndexEntry, RepoManifest
+    from codenib.compiler.manifest import IndexEntry
 
     (tmp_path / "sample.py").write_text("def sample():\n    return 1\n")
     manifest_path = tmp_path / "repo_manifest.json"
-    RepoManifest(
-        repo_path=str(tmp_path),
-        languages=["python"],
-        indexes={
-            "bm25": IndexEntry(
-                index_type="bm25",
-                path=str(tmp_path / "bm25"),
-                built_at="2026-08-04T00:00:00+00:00",
-                built_at_epoch=0.0,
-                status="fresh",
-            )
-        },
+    _current_manifest_with_fresh_index(
+        tmp_path,
+        IndexEntry(
+            index_type="bm25",
+            path=str(tmp_path / "bm25"),
+            built_at="2026-08-04T00:00:00+00:00",
+            built_at_epoch=0.0,
+            status="fresh",
+        ),
     ).save(manifest_path)
     captured = {}
     local = SimpleNamespace(runtime_env={})
@@ -3634,23 +3894,20 @@ def test_wiki_rejects_embedding_route_that_disagrees_with_artifact(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     from codenib.compiler.index_builders import VectorIndexBuilder
-    from codenib.compiler.manifest import IndexEntry, RepoManifest
+    from codenib.compiler.manifest import IndexEntry
 
     (tmp_path / "sample.py").write_text("VALUE = 1\n")
     manifest_path = tmp_path / "repo_manifest.json"
-    RepoManifest(
-        repo_path=str(tmp_path),
-        languages=["python"],
-        indexes={
-            "vector": IndexEntry(
-                index_type="vector",
-                path=str(tmp_path / "vector"),
-                built_at="2026-08-04T00:00:00+00:00",
-                built_at_epoch=0.0,
-                status="fresh",
-                config=VectorIndexBuilder().artifact_identity(),
-            )
-        },
+    _current_manifest_with_fresh_index(
+        tmp_path,
+        IndexEntry(
+            index_type="vector",
+            path=str(tmp_path / "vector"),
+            built_at="2026-08-04T00:00:00+00:00",
+            built_at_epoch=0.0,
+            status="fresh",
+            config=VectorIndexBuilder().artifact_identity(),
+        ),
     ).save(manifest_path)
     monkeypatch.setenv("OPENAI_API_KEY", "runtime-secret")
     monkeypatch.setattr(cli, "_check_module", lambda _module: True)

--- a/test/test_codegraph_onboarding.py
+++ b/test/test_codegraph_onboarding.py
@@ -96,6 +96,8 @@ def test_codegraph_parser_exposes_init_status_and_uninstall() -> None:
             "codex",
             "--agent",
             "claude",
+            "--exclude-dir",
+            "ios/Pods",
             "--dry-run",
         ]
     )
@@ -106,6 +108,7 @@ def test_codegraph_parser_exposes_init_status_and_uninstall() -> None:
 
     assert init.codegraph_command == "init"
     assert init.agent == ["codex", "claude"]
+    assert init.exclude_dir == ["ios/Pods"]
     assert init.dry_run is True
     assert status.codegraph_command == "status"
     assert status.json is True
@@ -644,12 +647,15 @@ def test_dry_run_reports_project_prerequisites_and_exits_nonzero(
             "codex",
             "--language",
             "go",
+            "--exclude-dir",
+            "generated/api",
             "--dry-run",
         ]
     )
 
     assert cli._run_codegraph_init(args) == 1
     output = capsys.readouterr().out
+    assert "Source selection: replace (generated/api)" in output
     assert "prerequisite: Go project prerequisite go.mod" in output
     assert "Readiness:  blocked" in output
     assert "no tools, indexes, receipts, or clients changed" in output
@@ -863,6 +869,48 @@ def test_human_status_does_not_call_a_graph_only_index_current(
 
 
 @pytest.mark.parametrize(
+    ("manifest_present", "expected"),
+    (
+        (False, "unrecorded (manifest missing)"),
+        (True, "unrecorded legacy policy"),
+    ),
+)
+def test_human_status_distinguishes_missing_and_legacy_source_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    manifest_present: bool,
+    expected: str,
+) -> None:
+    repo = _repository(tmp_path)
+    monkeypatch.setattr(
+        cli,
+        "_codegraph_status_report",
+        lambda _repo: {
+            "repository": str(repo),
+            "ready": False,
+            "index": {
+                "ready": False,
+                "detail": "manifest not current",
+                "manifest_present": manifest_present,
+                "source_selection": {
+                    "recorded": False,
+                    "exclude_subtrees": [],
+                    "digest": None,
+                },
+            },
+            "toolchain": {"ready": True, "missing": [], "notes": []},
+            "server_command": {"ready": True, "detail": "ready"},
+            "clients": [],
+        },
+    )
+    args = cli.build_parser().parse_args(["codegraph", "status", str(repo)])
+
+    assert cli._run_codegraph_status(args) == 1
+    assert expected in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
     ("mutation", "expected_detail"),
     [
         ("remove-bm25", "bm25 artifact is missing"),
@@ -938,7 +986,13 @@ def test_index_status_verifies_persisted_artifact_fingerprints(
         lambda *_args, **_kwargs: None,
     )
 
-    assert cli._codegraph_index_report(repo)["ready"] is True
+    current = cli._codegraph_index_report(repo)
+    assert current["ready"] is True
+    assert current["source_selection"] == {
+        "recorded": True,
+        "exclude_subtrees": [],
+        "digest": manifest.source_selection_digest,
+    }
     if mutation == "remove-bm25":
         (bm25 / "documents.json").unlink()
     else:

--- a/test/test_codegraph_onboarding.py
+++ b/test/test_codegraph_onboarding.py
@@ -915,6 +915,7 @@ def test_human_status_distinguishes_missing_and_legacy_source_policy(
     [
         ("remove-bm25", "bm25 artifact is missing"),
         ("corrupt-graph", "symbol_graph artifact is missing"),
+        ("corrupt-occurrence", "symbol_graph artifact is missing"),
     ],
 )
 def test_index_status_verifies_persisted_artifact_fingerprints(
@@ -941,6 +942,7 @@ def test_index_status_verifies_persisted_artifact_fingerprints(
     (bm25 / "documents.json").write_text("[]\n", encoding="utf-8")
     (bm25 / "bm25_metadata.json").write_text("{}\n", encoding="utf-8")
     (graph / "graph.pkl").write_bytes(b"graph-generation-one")
+    (graph / "lsp_index.pkl").write_bytes(b"occurrence-generation-one")
     fingerprint = "sha256-v2:" + "b" * 64
     manifest = RepoManifest(
         repo_path=str(repo),
@@ -974,6 +976,10 @@ def test_index_status_verifies_persisted_artifact_fingerprints(
                         "relative_path": "graph.pkl",
                         **regular_file_fingerprint(graph / "graph.pkl"),
                     },
+                    "lsp_occurrence_artifact": {
+                        "relative_path": "lsp_index.pkl",
+                        **regular_file_fingerprint(graph / "lsp_index.pkl"),
+                    },
                 },
                 source_fingerprint=fingerprint,
             ),
@@ -995,8 +1001,10 @@ def test_index_status_verifies_persisted_artifact_fingerprints(
     }
     if mutation == "remove-bm25":
         (bm25 / "documents.json").unlink()
-    else:
+    elif mutation == "corrupt-graph":
         (graph / "graph.pkl").write_bytes(b"graph-generation-two")
+    else:
+        (graph / "lsp_index.pkl").write_bytes(b"occurrence-generation-two")
 
     report = cli._codegraph_index_report(repo)
     assert report["ready"] is False

--- a/test/test_mcp_registry.py
+++ b/test/test_mcp_registry.py
@@ -18,11 +18,11 @@ def test_registry_metadata_matches_package_and_uvx_contract() -> None:
 
     version, server = registry.validate_registry_metadata(root)
 
-    assert version == "0.2.1"
+    assert version == "0.2.2"
     assert server["name"] == "ai.codenib/codenib"
     package = server["packages"][0]
     assert package["identifier"] == "codenib"
-    assert package["runtimeArguments"][0]["value"] == ("codenib[graph,mcp]==0.2.1")
+    assert package["runtimeArguments"][0]["value"] == ("codenib[graph,mcp]==0.2.2")
     assert package["packageArguments"][1]["format"] == "filepath"
 
 

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -185,8 +185,8 @@ def test_project_identity_and_tag_match_release_metadata() -> None:
     name, version = project_identity(root / "pyproject.toml")
 
     assert name == "codenib"
-    assert expected_tag(version) == "v0.2.1"
-    validate_tag("v0.2.1", version)
+    assert expected_tag(version) == "v0.2.2"
+    validate_tag("v0.2.2", version)
 
 
 def test_release_tag_must_match_project_version() -> None:
@@ -351,16 +351,16 @@ def test_select_compatible_wheel_rejects_unsupported_platform(tmp_path: Path) ->
         select_compatible_wheel(dist, system="linux", machine="ppc64le")
 
 
-def test_stable_release_notes_describe_the_codegraph_product_path() -> None:
+def test_stable_release_notes_describe_the_repository_source_contract() -> None:
     root = Path(__file__).resolve().parents[1]
-    notes = (root / "docs" / "releases" / "0.2.1.md").read_text(encoding="utf-8")
+    notes = (root / "docs" / "releases" / "0.2.2.md").read_text(encoding="utf-8")
 
-    assert '"codenib[graph,mcp]==0.2.1"' in notes
+    assert '"codenib[graph,mcp]==0.2.2"' in notes
     assert "codenib codegraph init" in notes
-    assert "explore_context" in notes
-    assert "dependency_subgraph" in notes
-    assert "Codex" in notes
-    assert "Claude Code" in notes
+    assert "--exclude-dir" in notes
+    assert "contained absolute symlinks" in notes.lower()
+    assert "Manifest 1.2" in notes
+    assert "Zoekt" in notes
     assert "test-files.pythonhosted.org" not in notes
     assert "--extra-index-url" not in notes
     assert "--index-url" not in notes
@@ -405,7 +405,7 @@ def test_public_install_commands_select_the_current_stable_release(
 
     assert install_lines
     assert "CODENIB_ALPHA_WHEEL=" not in text
-    assert all("==0.2.1" in line for line in install_lines)
+    assert all("==0.2.2" in line for line in install_lines)
 
 
 def test_registry_publishers_use_separate_workflows() -> None:

--- a/test/test_repository_source_selection.py
+++ b/test/test_repository_source_selection.py
@@ -1,0 +1,321 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from codenib.repository_filters import (
+    REPOSITORY_FILTER_POLICY_VERSION,
+    count_repository_files,
+    repository_path_is_visible,
+    walk_repository_files,
+)
+from codenib.repository_source_selection import (
+    REPOSITORY_SOURCE_SELECTION_POLICY_VERSION,
+    REPOSITORY_SOURCE_SELECTION_SCHEMA,
+    RepositorySourceSelection,
+    repository_relative_source_path,
+)
+
+
+def test_selection_normalizes_order_duplicates_and_covered_descendants() -> None:
+    selection = RepositorySourceSelection(
+        [
+            "vendor/generated",
+            "ios/Pods/Dependency",
+            "src/cache",
+            "ios/Pods",
+            "vendor",
+            "vendorized/generated",
+            "src/cache",
+        ]
+    )
+
+    assert selection.exclude_subtrees == (
+        "ios/Pods",
+        "src/cache",
+        "vendor",
+        "vendorized/generated",
+    )
+
+
+def test_selection_matches_only_exact_subtrees() -> None:
+    selection = RepositorySourceSelection(("ios/Pods", "src/generated"))
+
+    assert selection.excludes("ios/Pods")
+    assert selection.excludes("ios/Pods/Dependency/include/header.h")
+    assert not selection.allows("src/generated/output.py")
+    assert selection.allows("ios/Podspec")
+    assert selection.allows("ios/PodsExtra/file.swift")
+    assert selection.allows("nested/ios/Pods/file.swift")
+    assert selection.allows("src/generator.py")
+
+
+def test_selection_matches_non_utf8_observed_paths_without_persisting_them() -> None:
+    selection = RepositorySourceSelection(("vendor",))
+
+    assert selection.excludes("vendor/surrogate-\udcff.py")
+    assert selection.allows("src/surrogate-\udcff.py")
+
+
+def test_selection_allows_posix_filenames_with_literal_backslashes() -> None:
+    selection = RepositorySourceSelection(("vendor",))
+
+    assert selection.allows("src/odd\\name.py")
+    assert repository_path_is_visible("src/odd\\name.py", selection=selection)
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "",
+        ".",
+        "..",
+        "/absolute",
+        "../outside",
+        "nested/..",
+        "nested/../outside",
+        "./nested",
+        "nested/.",
+        "nested//child",
+        "nested/",
+        "windows\\path",
+        "nul\x00path",
+        "surrogate-\udcff",
+    ),
+)
+def test_selection_rejects_noncanonical_exclude_paths(path: str) -> None:
+    with pytest.raises(ValueError):
+        RepositorySourceSelection((path,))
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "/".join("a" for _ in range(257)),
+        "a" * 4097,
+    ),
+)
+def test_selection_rejects_paths_beyond_source_limits(path: str) -> None:
+    with pytest.raises(ValueError, match="supported limits"):
+        RepositorySourceSelection((path,))
+
+
+def test_selection_rejects_too_many_exclusions() -> None:
+    with pytest.raises(ValueError, match="too many exclusions"):
+        RepositorySourceSelection(f"generated/{index}" for index in range(4097))
+
+
+def test_selection_rejects_oversized_combined_policy() -> None:
+    component = "x" * 250
+    values = (
+        f"{index:04d}-{component}/{component}/{component}/{component}/{component}"
+        for index in range(4096)
+    )
+
+    with pytest.raises(ValueError, match="too large"):
+        RepositorySourceSelection(values)
+
+
+@pytest.mark.parametrize("path", ("", ".", "..", "/absolute", "a/../b", "a\x00b"))
+def test_selection_rejects_noncanonical_query_paths(path: str) -> None:
+    selection = RepositorySourceSelection(("excluded",))
+
+    with pytest.raises(ValueError):
+        selection.excludes(path)
+    with pytest.raises(ValueError):
+        selection.allows(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    ("../generated/x.py", "src/../generated/x.py", "/repo/generated/x.py"),
+)
+def test_repository_visibility_rejects_noncanonical_paths(path: str) -> None:
+    assert not repository_path_is_visible(
+        path,
+        selection=RepositorySourceSelection(("generated",)),
+    )
+
+
+def test_selection_rejects_non_string_paths_and_scalar_collection() -> None:
+    with pytest.raises(TypeError):
+        RepositorySourceSelection("ios/Pods")
+    with pytest.raises(TypeError):
+        RepositorySourceSelection((42,))  # type: ignore[arg-type]
+
+
+def test_selection_is_immutable_and_does_not_expose_mutable_state() -> None:
+    selection = RepositorySourceSelection(("ios/Pods",))
+    payload = selection.to_dict()
+
+    with pytest.raises(FrozenInstanceError):
+        selection.exclude_subtrees = ()
+    payload["exclude_subtrees"].append("src/generated")
+
+    assert selection.exclude_subtrees == ("ios/Pods",)
+    assert selection.allows("src/generated")
+
+
+def test_selection_has_stable_canonical_json_and_digest() -> None:
+    first = RepositorySourceSelection(("vendor/subtree", "ios/Pods", "vendor"))
+    second = RepositorySourceSelection(("vendor", "ios/Pods", "ios/Pods"))
+
+    expected_json = (
+        '{"exclude_subtrees":["ios/Pods","vendor"],'
+        '"repository_filter_policy":4,'
+        '"schema":"codenib.repository-source-selection.v1"}'
+    )
+    assert first.canonical_json() == expected_json
+    assert first.canonical_bytes() == expected_json.encode("ascii")
+    assert first.canonical_json() == second.canonical_json()
+    assert first.digest == second.digest
+    assert first.digest == (
+        "sha256:8b3047a1a7a2d7f7fda0927fb1d0b257" "5d8efa59f8bc277c3d4b7935e763793a"
+    )
+
+
+def test_selection_canonical_json_escapes_non_ascii_paths() -> None:
+    selection = RepositorySourceSelection(("生成/缓存",))
+
+    assert "生成" not in selection.canonical_json()
+    assert selection.canonical_bytes().isascii()
+
+
+def test_selection_from_dict_requires_canonical_persisted_payload() -> None:
+    selection = RepositorySourceSelection(("vendor", "ios/Pods"))
+
+    assert RepositorySourceSelection.from_dict(selection.to_dict()) == selection
+
+    noncanonical = selection.to_dict()
+    noncanonical["exclude_subtrees"] = ["vendor/subtree", "vendor", "ios/Pods"]
+    with pytest.raises(ValueError, match="not canonical"):
+        RepositorySourceSelection.from_dict(noncanonical)
+
+    class MappingSubclass(dict):
+        pass
+
+    with pytest.raises(ValueError, match="canonical fields"):
+        RepositorySourceSelection.from_dict(MappingSubclass(selection.to_dict()))
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {
+            "schema": "codenib.repository-source-selection.v2",
+            "repository_filter_policy": 4,
+            "exclude_subtrees": [],
+        },
+        {
+            "schema": REPOSITORY_SOURCE_SELECTION_SCHEMA,
+            "repository_filter_policy": 3,
+            "exclude_subtrees": [],
+        },
+        {
+            "schema": REPOSITORY_SOURCE_SELECTION_SCHEMA,
+            "repository_filter_policy": 4,
+            "exclude_subtrees": (),
+        },
+        {
+            "schema": REPOSITORY_SOURCE_SELECTION_SCHEMA,
+            "repository_filter_policy": 4,
+            "exclude_subtrees": [],
+            "extra": True,
+        },
+        {
+            "schema": REPOSITORY_SOURCE_SELECTION_SCHEMA,
+            "repository_filter_policy": 4,
+            "exclude_subtrees": [42],
+        },
+    ),
+)
+def test_selection_from_dict_rejects_noncanonical_contract(payload: dict) -> None:
+    with pytest.raises(ValueError):
+        RepositorySourceSelection.from_dict(payload)
+
+
+def test_repository_filter_policy_migrates_to_selection_policy_four() -> None:
+    assert REPOSITORY_FILTER_POLICY_VERSION == 4
+    assert (
+        REPOSITORY_FILTER_POLICY_VERSION == REPOSITORY_SOURCE_SELECTION_POLICY_VERSION
+    )
+
+
+def test_repository_filters_apply_selection_on_component_boundaries(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "repo"
+    (root / "generated").mkdir(parents=True)
+    (root / "generated-extra").mkdir()
+    (root / "src" / "cache").mkdir(parents=True)
+    (root / "generated" / "excluded.py").write_bytes(b"EXCLUDED = 1\n")
+    (root / "generated-extra" / "included.py").write_bytes(b"INCLUDED = 1\n")
+    (root / "src" / "cache" / "excluded.py").write_bytes(b"EXCLUDED = 2\n")
+    (root / "src" / "included.py").write_bytes(b"INCLUDED = 2\n")
+    selection = RepositorySourceSelection(("generated", "src/cache"))
+
+    assert not repository_path_is_visible("generated", selection=selection)
+    assert not repository_path_is_visible(
+        "generated/nested/source.py",
+        selection=selection,
+    )
+    assert repository_path_is_visible(
+        "generated-extra/source.py",
+        selection=selection,
+    )
+    assert repository_path_is_visible("src/cache-extra.py", selection=selection)
+
+    walked = {
+        path.relative_to(root).as_posix()
+        for path in walk_repository_files(root, selection=selection)
+    }
+    assert walked == {"generated-extra/included.py", "src/included.py"}
+    assert count_repository_files(root, selection=selection) == len(walked)
+
+
+def test_repository_filters_reject_non_selection_policy(tmp_path: Path) -> None:
+    with pytest.raises(TypeError, match="RepositorySourceSelection"):
+        repository_path_is_visible("source.py", selection=None)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="RepositorySourceSelection"):
+        list(
+            walk_repository_files(
+                tmp_path,
+                selection=None,  # type: ignore[arg-type]
+            )
+        )
+
+
+def test_repository_relative_source_path_accepts_contained_absolute_and_relative(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "repo"
+
+    assert repository_relative_source_path(root, "src/main.py") == "src/main.py"
+    assert (
+        repository_relative_source_path(
+            root,
+            str(root / "packages" / "mobile" / "main.py"),
+        )
+        == "packages/mobile/main.py"
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (None, "../outside.py", "nested/../outside.py", "sibling.py"),
+)
+def test_repository_relative_source_path_rejects_invalid_or_outside(
+    tmp_path: Path,
+    source: object,
+) -> None:
+    root = tmp_path / "repo"
+    value = str(tmp_path / source) if source == "sibling.py" else source
+
+    with pytest.raises((TypeError, ValueError)):
+        repository_relative_source_path(root, value)

--- a/test/test_repository_source_selection_cli.py
+++ b/test/test_repository_source_selection_cli.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Product-path coverage for persisted repository source selection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codenib import cli
+from codenib.compiler.manifest import MANIFEST_FILENAME, RepoManifest
+from codenib.paths import repo_index_dir
+from codenib.repository_source_selection import RepositorySourceSelection
+
+
+def _bm25_document_paths(manifest: RepoManifest) -> set[str]:
+    entry = manifest.indexes["bm25"]
+    payload = json.loads(
+        (Path(entry.path) / "documents.json").read_text(encoding="utf-8")
+    )
+    return {
+        document["metadata"]["file"]
+        for document in payload
+        if isinstance(document, dict)
+        and isinstance(document.get("metadata"), dict)
+        and isinstance(document["metadata"].get("file"), str)
+    }
+
+
+def test_index_cli_persists_reuses_and_clears_exact_source_selection(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "ios" / "Pods").mkdir(parents=True)
+    (repo / "packages" / "mobile" / "ios" / "Pods").mkdir(parents=True)
+    (repo / "src" / "kept.py").write_text("KEPT = 1\n", encoding="utf-8")
+    excluded = repo / "ios" / "Pods" / "excluded.py"
+    excluded.write_text("EXCLUDED = 1\n", encoding="utf-8")
+    sibling = repo / "packages" / "mobile" / "ios" / "Pods" / "kept.py"
+    sibling.write_text("SIBLING = 1\n", encoding="utf-8")
+    monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "state"))
+
+    assert (
+        cli.run(
+            [
+                "index",
+                str(repo),
+                "--preset",
+                "fast",
+                "--language",
+                "python",
+                "--exclude-dir",
+                "ios/Pods",
+            ]
+        )
+        == 0
+    )
+    manifest_path = repo_index_dir(repo) / MANIFEST_FILENAME
+    first = RepoManifest.load(manifest_path)
+    first_fingerprint = first.source_fingerprint
+    first_paths = _bm25_document_paths(first)
+
+    assert first.source_selection == RepositorySourceSelection(("ios/Pods",))
+    assert not any(path.startswith("ios/Pods/") for path in first_paths)
+    assert any(path.endswith("src/kept.py") for path in first_paths)
+    assert any(
+        path.endswith("packages/mobile/ios/Pods/kept.py") for path in first_paths
+    )
+
+    excluded.write_text("EXCLUDED = 2\n", encoding="utf-8")
+    assert (
+        cli.run(
+            [
+                "index",
+                str(repo),
+                "--preset",
+                "fast",
+                "--language",
+                "python",
+            ]
+        )
+        == 0
+    )
+    reused = RepoManifest.load(manifest_path)
+    assert reused.source_selection == first.source_selection
+    assert reused.source_fingerprint == first_fingerprint
+    assert not any(
+        path.startswith("ios/Pods/") for path in _bm25_document_paths(reused)
+    )
+
+    assert (
+        cli.run(
+            [
+                "index",
+                str(repo),
+                "--preset",
+                "fast",
+                "--language",
+                "python",
+                "--clear-exclude-dirs",
+            ]
+        )
+        == 0
+    )
+    cleared = RepoManifest.load(manifest_path)
+    assert cleared.source_selection == RepositorySourceSelection()
+    assert cleared.source_fingerprint != first_fingerprint
+    assert any(
+        path.endswith("ios/Pods/excluded.py") for path in _bm25_document_paths(cleared)
+    )

--- a/test/test_source_fingerprint.py
+++ b/test/test_source_fingerprint.py
@@ -24,7 +24,14 @@ import codenib._contained_source as contained_source_module
 import codenib._windows_fs_authority as windows_fs_module
 import codenib.source_fingerprint as source_fingerprint_module
 from codenib.artifacts.runtime import SourceBindingCleanupOwner
-from codenib.repository_filters import REPOSITORY_FILTER_POLICY_VERSION
+from codenib.repository_filters import (
+    REPOSITORY_FILTER_POLICY_VERSION,
+    walk_repository_files,
+)
+from codenib.repository_source_selection import (
+    DEFAULT_REPOSITORY_SOURCE_SELECTION,
+    RepositorySourceSelection,
+)
 from codenib.source_fingerprint import (
     SOURCE_FINGERPRINT_VERSION,
     RepositoryChangedError,
@@ -728,7 +735,13 @@ def test_fingerprint_final_gate_revalidates_excluded_link_target_state(
     real_scan = source_fingerprint_module._scan_pinned_repository
     changed = False
 
-    def change_before_final_link_check(descriptor, *, excluded, collect_entries):
+    def change_before_final_link_check(
+        descriptor,
+        *,
+        excluded,
+        selection,
+        collect_entries,
+    ):
         nonlocal changed
         if not collect_entries and not changed:
             changed = True
@@ -736,6 +749,7 @@ def test_fingerprint_final_gate_revalidates_excluded_link_target_state(
         return real_scan(
             descriptor,
             excluded=excluded,
+            selection=selection,
             collect_entries=collect_entries,
         )
 
@@ -786,6 +800,29 @@ def test_repository_source_identity_snapshot_is_detached(tmp_path: Path) -> None
 
         assert second.file_records[0].sha256 != "f" * 64
         assert binding.read_bytes("a.py", max_bytes=1024) == b"VALUE = 1\n"
+
+
+def test_repository_source_binding_rejects_retained_link_record_mutation(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "target.py").write_bytes(b"VALUE = 1\n")
+    (repo / "link.py").symlink_to("target.py")
+    binding = capture_repository_source(repo)
+    retained = binding._links["link.py"]
+    binding._links["link.py"] = source_fingerprint_module._RepositorySourceLinkRecord(
+        path=retained.path,
+        lexical_identity=retained.lexical_identity,
+        link_target="other.py",
+        target_state=retained.target_state,
+        windows_reparse_point=retained.windows_reparse_point,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="retained link records"):
+        binding.verify_snapshot()
+    assert not binding.usable
+    binding.close()
 
 
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
@@ -1727,6 +1764,9 @@ def _legacy_link_only_digest(path: bytes, target: bytes) -> str:
             "codenib-source-fingerprint:1:" f"{REPOSITORY_FILTER_POLICY_VERSION}\0"
         ).encode("ascii")
     )
+    digest.update(b"source-selection-digest\0")
+    digest.update(DEFAULT_REPOSITORY_SOURCE_SELECTION.digest.encode("ascii"))
+    digest.update(b"\0")
     digest.update(b"L\0" + path + b"\0" + target + b"\0")
     return f"sha256:{digest.hexdigest()}"
 
@@ -2051,6 +2091,256 @@ def test_v2_fingerprint_is_canonical_and_deterministic(tmp_path: Path) -> None:
     assert source_fingerprint_version(first.value) == 2
 
 
+def test_selection_identity_changes_v1_and_v2_without_matching_paths(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "module.py").write_bytes(b"VALUE = 1\n")
+    empty = RepositorySourceSelection()
+    latent = RepositorySourceSelection(("future/generated",))
+
+    empty_v2 = fingerprint_repository(tmp_path, selection=empty)
+    latent_v2 = fingerprint_repository(tmp_path, selection=latent)
+    empty_v1 = fingerprint_repository_v1_for_diagnostics(
+        tmp_path,
+        selection=empty,
+    )
+    latent_v1 = fingerprint_repository_v1_for_diagnostics(
+        tmp_path,
+        selection=latent,
+    )
+
+    assert empty_v2.file_count == latent_v2.file_count == 1
+    assert empty_v1.file_count == latent_v1.file_count == 1
+    assert empty_v2.value != latent_v2.value
+    assert empty_v1.value != latent_v1.value
+
+
+def test_selection_excludes_subtree_before_stat_open_or_content_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    generated = repo / "generated"
+    generated.mkdir(parents=True)
+    (repo / "included.py").write_bytes(b"INCLUDED = 1\n")
+    excluded_file = generated / "excluded.py"
+    excluded_file.write_bytes(b"EXCLUDED = 1\n")
+    selection = RepositorySourceSelection(("generated",))
+    real_stat = source_fingerprint_module.os.stat
+    real_open = source_fingerprint_module.os.open
+    real_resolve = source_fingerprint_module._resolved_repository_file_at
+
+    def reject_excluded_stat(path, *args, **kwargs):
+        if path == "generated" and kwargs.get("dir_fd") is not None:
+            raise AssertionError("excluded subtree was statted")
+        return real_stat(path, *args, **kwargs)
+
+    def reject_excluded_open(path, flags, *args, **kwargs):
+        if path == "generated" and kwargs.get("dir_fd") is not None:
+            raise AssertionError("excluded subtree was opened")
+        return real_open(path, flags, *args, **kwargs)
+
+    @contextmanager
+    def reject_excluded_read(root, descriptor, relative, **kwargs):
+        if relative == "generated" or relative.startswith("generated/"):
+            raise AssertionError("excluded subtree content was read")
+        with real_resolve(root, descriptor, relative, **kwargs) as binding:
+            yield binding
+
+    monkeypatch.setattr(source_fingerprint_module.os, "stat", reject_excluded_stat)
+    monkeypatch.setattr(source_fingerprint_module.os, "open", reject_excluded_open)
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_resolved_repository_file_at",
+        reject_excluded_read,
+    )
+
+    initial = fingerprint_repository(repo, selection=selection)
+    excluded_file.write_bytes(b"EXCLUDED = 2\n")
+    excluded_changed = fingerprint_repository(repo, selection=selection)
+    (repo / "included.py").write_bytes(b"INCLUDED = 2\n")
+    included_changed = fingerprint_repository(repo, selection=selection)
+
+    assert initial.file_count == 1
+    assert excluded_changed == initial
+    assert included_changed.value != initial.value
+
+
+def test_selection_and_internal_exclude_roots_remain_independent(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    generated = repo / "generated"
+    internal = repo / "runtime-artifact"
+    generated.mkdir(parents=True)
+    internal.mkdir()
+    (repo / "included.py").write_bytes(b"INCLUDED = 1\n")
+    generated_file = generated / "excluded.py"
+    generated_file.write_bytes(b"GENERATED = 1\n")
+    internal_file = internal / "state.bin"
+    internal_file.write_bytes(b"STATE = 1\n")
+    selection = RepositorySourceSelection(("generated",))
+
+    initial = fingerprint_repository(
+        repo,
+        exclude_roots=(internal,),
+        selection=selection,
+    )
+    generated_file.write_bytes(b"GENERATED = 2\n")
+    internal_file.write_bytes(b"STATE = 2\n")
+    excluded_changed = fingerprint_repository(
+        repo,
+        exclude_roots=(internal,),
+        selection=selection,
+    )
+    internal_included = fingerprint_repository(repo, selection=selection)
+
+    assert initial == excluded_changed
+    assert initial.file_count == 1
+    assert internal_included.file_count == 2
+    assert internal_included.value != initial.value
+
+
+def test_selection_uses_same_exact_policy_for_initial_and_final_posix_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    generated = repo / "generated"
+    generated.mkdir(parents=True)
+    (repo / "included.py").write_bytes(b"INCLUDED = 1\n")
+    excluded_file = generated / "excluded.py"
+    excluded_file.write_bytes(b"EXCLUDED = 1\n")
+    selection = RepositorySourceSelection(("generated",))
+    real_scan = source_fingerprint_module._scan_pinned_repository
+    observed: list[tuple[RepositorySourceSelection, bool]] = []
+
+    def mutate_after_initial(
+        descriptor,
+        *,
+        excluded,
+        selection,
+        collect_entries,
+    ):
+        scan = real_scan(
+            descriptor,
+            excluded=excluded,
+            selection=selection,
+            collect_entries=collect_entries,
+        )
+        observed.append((selection, collect_entries))
+        if collect_entries:
+            excluded_file.write_bytes(b"EXCLUDED = 2\n")
+        return scan
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_scan_pinned_repository",
+        mutate_after_initial,
+    )
+
+    fingerprint = fingerprint_repository(repo, selection=selection)
+
+    assert fingerprint.file_count == 1
+    assert observed == [(selection, True), (selection, False)]
+
+
+def test_selection_walk_and_authenticated_records_have_path_parity(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    (repo / "generated").mkdir(parents=True)
+    (repo / "generated-extra").mkdir()
+    (repo / "src" / "cache").mkdir(parents=True)
+    (repo / "generated" / "excluded.py").write_bytes(b"EXCLUDED = 1\n")
+    (repo / "generated-extra" / "included.py").write_bytes(b"INCLUDED = 1\n")
+    (repo / "src" / "cache" / "excluded.py").write_bytes(b"EXCLUDED = 2\n")
+    (repo / "src" / "included.py").write_bytes(b"INCLUDED = 2\n")
+    selection = RepositorySourceSelection(("generated", "src/cache"))
+
+    walked = {
+        path.relative_to(repo).as_posix()
+        for path in walk_repository_files(
+            repo,
+            selection=selection,
+        )
+    }
+    with capture_repository_source(repo, selection=selection) as binding:
+        captured = {record.path for record in binding.file_records}
+
+    assert walked == captured == {"generated-extra/included.py", "src/included.py"}
+
+
+def test_retained_binding_detaches_and_reuses_exact_selection(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    generated = repo / "generated"
+    generated.mkdir(parents=True)
+    included = repo / "included.py"
+    included.write_bytes(b"INCLUDED = 1\n")
+    excluded_file = generated / "excluded.py"
+    excluded_file.write_bytes(b"EXCLUDED = 1\n")
+    caller_selection = RepositorySourceSelection(("generated",))
+    binding = capture_repository_source(repo, selection=caller_selection)
+
+    object.__setattr__(caller_selection, "exclude_subtrees", ())
+    first = binding.authenticated_identity_snapshot()
+    assert first.source_selection == RepositorySourceSelection(("generated",))
+    assert first.source_selection is not binding._selection
+    assert first.source_selection is not None
+    object.__setattr__(first.source_selection, "exclude_subtrees", ("forged",))
+    second = binding.authenticated_identity_snapshot()
+    assert second.source_selection == RepositorySourceSelection(("generated",))
+
+    excluded_file.write_bytes(b"EXCLUDED = 2\n")
+    binding.verify_snapshot()
+    assert binding.read_bytes("included.py", max_bytes=64) == b"INCLUDED = 1\n"
+
+    included.write_bytes(b"INCLUDED = changed\n")
+    with pytest.raises(RepositoryChangedError, match="inventory changed"):
+        binding.verify_snapshot()
+    assert not binding.usable
+    binding.close()
+
+
+def test_legacy_manifest_v11_compat_identity_is_exact_and_explicit(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "module.py").write_bytes(b"VALUE = 1\n")
+
+    legacy = source_fingerprint_module._fingerprint_repository_legacy_manifest_v11(
+        tmp_path
+    )
+    current = fingerprint_repository(tmp_path)
+
+    assert legacy.value == (
+        "sha256-v2:8756a1746b8447cee00a0d9e89bcb7c2" "8df91376f2dd3d457b8050be76283d17"
+    )
+    assert legacy.file_count == current.file_count == 1
+    assert legacy.value != current.value
+
+    binding = source_fingerprint_module._capture_repository_source_legacy_manifest_v11(
+        tmp_path
+    )
+    try:
+        snapshot = binding.authenticated_identity_snapshot()
+        assert snapshot.fingerprint == legacy.value
+        assert snapshot.source_selection is None
+        assert binding.read_bytes("module.py", max_bytes=64) == b"VALUE = 1\n"
+    finally:
+        binding.close()
+
+
+def test_fingerprint_rejects_non_selection_policy(tmp_path: Path) -> None:
+    (tmp_path / "module.py").write_bytes(b"VALUE = 1\n")
+
+    with pytest.raises(TypeError, match="RepositorySourceSelection"):
+        fingerprint_repository(tmp_path, selection=None)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="RepositorySourceSelection"):
+        capture_repository_source(tmp_path, selection=None)  # type: ignore[arg-type]
+
+
 def test_windows_fake_regular_tree_matches_posix_v1_and_v2(
     tmp_path: Path,
 ) -> None:
@@ -2083,6 +2373,90 @@ def test_windows_fake_regular_tree_matches_posix_v1_and_v2(
     assert observed_v2 == expected_v2
     assert api.handles == {}
     assert set(api.created_paths) == {"C:\\"}
+
+
+def test_windows_fake_selection_matches_posix_initial_and_final_scans(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generated = tmp_path / "generated"
+    generated.mkdir()
+    generated_extra = tmp_path / "generated-extra"
+    generated_extra.mkdir()
+    (tmp_path / "module.py").write_bytes(b"VALUE = 1\n")
+    (generated / "excluded.py").write_bytes(b"EXCLUDED = 1\n")
+    (generated_extra / "included.py").write_bytes(b"INCLUDED = 1\n")
+    selection = RepositorySourceSelection(("generated",))
+    expected_v1 = fingerprint_repository_v1_for_diagnostics(
+        tmp_path,
+        selection=selection,
+    )
+    expected_v2 = fingerprint_repository(tmp_path, selection=selection)
+
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "module.py", b"VALUE = 1\n")
+    fake_generated = api.add_directory(api.root_id, "generated")
+    api.add_file(fake_generated, "excluded.py", b"EXCLUDED = 1\n")
+    fake_generated_extra = api.add_directory(api.root_id, "generated-extra")
+    api.add_file(fake_generated_extra, "included.py", b"INCLUDED = 1\n")
+
+    def reject_excluded_open(parent_id, name, file_id):
+        if parent_id == api.root_id and name == "generated":
+            raise AssertionError("excluded Windows subtree was opened")
+        return file_id
+
+    api.open_relative_hook = reject_excluded_open
+    real_scan = source_fingerprint_module._scan_pinned_windows_repository
+    observed: list[tuple[RepositorySourceSelection, bool]] = []
+
+    def observe_scan(
+        selected_api,
+        root_handle,
+        *,
+        excluded,
+        selection,
+        collect_entries,
+    ):
+        scan = real_scan(
+            selected_api,
+            root_handle,
+            excluded=excluded,
+            selection=selection,
+            collect_entries=collect_entries,
+        )
+        observed.append((selection, collect_entries))
+        return scan
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_scan_pinned_windows_repository",
+        observe_scan,
+    )
+
+    observed_v1 = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        selection=selection,
+        version=1,
+        api=api,
+    )
+    observed_v2 = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        selection=selection,
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+    )
+
+    assert observed_v1 == expected_v1
+    assert observed_v2 == expected_v2
+    assert observed == [
+        (selection, True),
+        (selection, False),
+        (selection, True),
+        (selection, False),
+    ]
+    assert api.handles == {}
 
 
 def test_windows_reparse_parser_is_bounded_and_exact() -> None:
@@ -2156,6 +2530,36 @@ def test_windows_fake_public_contained_read_and_hash_close_authority(
     )
 
     assert digest.hexdigest() == hashlib.sha256(b"VALUE = 1\n").hexdigest()
+    assert api.handles == {}
+
+
+def test_windows_fake_unbound_read_rejects_absolute_symlink(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "target.py", b"VALUE = 1\n")
+    api.add_symlink(
+        api.root_id,
+        "current.py",
+        r"C:\repo\target.py",
+        absolute=True,
+        substitute=r"\??\C:\repo\target.py",
+    )
+    monkeypatch.setattr(contained_source_module.sys, "platform", "win32")
+    monkeypatch.setattr(contained_source_module, "_windows_kernel_api", lambda: api)
+    monkeypatch.setattr(
+        contained_source_module,
+        "_shared_windows_require_source_api",
+        lambda _api: None,
+    )
+
+    with pytest.raises(ValueError, match="target must be relative"):
+        contained_source_module.read_repository_file(
+            r"C:\repo",
+            "current.py",
+            max_bytes=64,
+        )
+
     assert api.handles == {}
 
 
@@ -2240,9 +2644,66 @@ def test_windows_fake_excludes_contained_directory_and_root_links() -> None:
     assert api.handles == {}
 
 
-def test_windows_fake_rejects_absolute_contained_symlink() -> None:
+@pytest.mark.parametrize(
+    ("root", "target", "substitute"),
+    [
+        (r"C:\repo", r"C:\repo\target.py", r"C:\repo\target.py"),
+        (r"C:\repo", r"C:\repo\target.py", r"\??\C:\repo\target.py"),
+        (r"C:\repo", r"C:\repo\target.py", r"\\?\C:\repo\target.py"),
+        (r"C:\repo", r"C:\repo\target.py", r"\??\c:\REPO\target.py"),
+        (r"\\?\C:\repo", r"C:\repo\target.py", r"\??\C:\repo\target.py"),
+        (
+            r"\\server\share\repo",
+            r"\\server\share\repo\target.py",
+            r"\\server\share\repo\target.py",
+        ),
+        (
+            r"\\server\share\repo",
+            r"\\server\share\repo\target.py",
+            r"\??\UNC\server\share\repo\target.py",
+        ),
+        (
+            r"\\server\share\repo",
+            r"\\server\share\repo\target.py",
+            r"\\?\UNC\server\share\repo\target.py",
+        ),
+        (
+            r"\\?\UNC\server\share\repo",
+            r"\\server\share\repo\target.py",
+            r"\??\UNC\server\share\repo\target.py",
+        ),
+    ],
+)
+def test_windows_fake_accepts_absolute_contained_symlink(
+    root: str,
+    target: str,
+    substitute: str,
+) -> None:
     api = _FakeWindowsSourceApi()
     api.add_file(api.root_id, "target.py", b"VALUE = 1\n")
+    api.add_symlink(
+        api.root_id,
+        "current.py",
+        target,
+        absolute=True,
+        substitute=substitute,
+    )
+
+    observed = source_fingerprint_module._fingerprint_windows_repository(
+        root,
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+    )
+
+    assert observed.file_count == 2
+    assert observed.value.startswith("sha256-v2:")
+    assert api.handles == {}
+
+
+def test_windows_fake_absolute_symlink_retained_reads() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "target.py", b"FIRST = 1\r\nSECOND = 2\r\n")
     api.add_symlink(
         api.root_id,
         "current.py",
@@ -2250,15 +2711,27 @@ def test_windows_fake_rejects_absolute_contained_symlink() -> None:
         absolute=True,
         substitute=r"\??\C:\repo\target.py",
     )
+    binding = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+        retain_binding=True,
+    )
+    assert isinstance(binding, RepositorySourceBinding)
 
-    with pytest.raises(RepositoryChangedError, match="read consistently"):
-        source_fingerprint_module._fingerprint_windows_repository(
-            r"C:\repo",
-            exclude_roots=(),
-            version=SOURCE_FINGERPRINT_VERSION,
-            api=api,
+    assert binding.read_bytes("current.py", max_bytes=1024).startswith(b"FIRST")
+    assert binding.read_prefix("current.py", max_bytes=5) == b"FIRST"
+    assert (
+        binding.read_line_range(
+            "current.py",
+            start_line=2,
+            end_line=2,
+            max_bytes=1024,
         )
-
+        == b"SECOND = 2\r\n"
+    )
+    binding.close()
     assert api.handles == {}
 
 
@@ -2312,6 +2785,62 @@ def test_windows_fake_binds_initial_symlink_text(
     assert api.handles == {}
 
 
+def test_windows_fake_binds_initial_symlink_substitute_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "first.py", b"SAME\n")
+    api.add_file(api.root_id, "second.py", b"SAME\n")
+    link_id = api.add_symlink(
+        api.root_id,
+        "current.py",
+        r"C:\repo\first.py",
+        absolute=True,
+        substitute=r"\??\C:\repo\first.py",
+    )
+    original = api.nodes[link_id]["reparse"]
+    replacement = windows_fs_module.WindowsReparsePoint(
+        tag=windows_fs_module.IO_REPARSE_TAG_SYMLINK,
+        substitute_name=r"\??\C:\repo\second.py",
+        print_name=r"C:\repo\first.py",
+        flags=0,
+    )
+    real_resolve = source_fingerprint_module._resolved_windows_repository_file_at
+    swapped = False
+
+    @contextmanager
+    def swap_substitute(root, authority, relative, **kwargs):
+        nonlocal swapped
+        if swapped or relative != "current.py":
+            with real_resolve(root, authority, relative, **kwargs) as binding:
+                yield binding
+            return
+        swapped = True
+        api.nodes[link_id]["reparse"] = replacement
+        try:
+            with real_resolve(root, authority, relative, **kwargs) as binding:
+                yield binding
+        finally:
+            api.nodes[link_id]["reparse"] = original
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_resolved_windows_repository_file_at",
+        swap_substitute,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="read consistently"):
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert swapped
+    assert api.handles == {}
+
+
 def test_windows_fake_binding_revalidates_unresolved_excluded_target() -> None:
     api = _FakeWindowsSourceApi()
     hidden = api.add_directory(api.root_id, ".codenib-cache")
@@ -2338,6 +2867,28 @@ def test_windows_fake_binding_revalidates_unresolved_excluded_target() -> None:
     [
         (r"..\outside.py", False, None),
         (r"C:\outside.py", True, r"\??\C:\outside.py"),
+        (r"C:\repo\target.py", True, r"\??\D:\repo\target.py"),
+        (r"C:\repo\target.py", True, r"\??\C:\outside.py"),
+        (r"C:\repo\target.py", True, r"\??\C:\repository\target.py"),
+        (r"C:\repo\target.py", True, r"\??\C:\repo\target.py:stream"),
+        (
+            r"C:\repo\target.py",
+            True,
+            r"\??\C:\repo\hidden:stream\..\target.py",
+        ),
+        (
+            r"C:\repo\target.py",
+            True,
+            r"\??\C:\repo\..\repo\target.py",
+        ),
+        (r"C:\repo\target.py", True, r"\??\\\server\share\repo\target.py"),
+        (r"C:\repo\target.py", True, r"\??\GLOBALROOT\Device\target.py"),
+        (r"C:\repo\target.py", True, r"\\?\GLOBALROOT\Device\target.py"),
+        (r"C:\repo\target.py", True, r"\??\Volume{abc}\repo\target.py"),
+        (r"C:\repo\target.py", True, r"\??\UNCevil\repo\target.py"),
+        (r"C:\repo\target.py", True, r"\??\C:/repo/target.py"),
+        (r"C:\repo\target.py", True, "\\??\\Å:\\repo\\target.py"),
+        (r"C:\repo\target.py", True, r"\\.\C:\repo\target.py"),
     ],
 )
 def test_windows_fake_rejects_outside_symlink_without_handle_leak(
@@ -2357,6 +2908,37 @@ def test_windows_fake_rejects_outside_symlink_without_handle_leak(
     with pytest.raises(RepositoryChangedError, match="read consistently"):
         source_fingerprint_module._fingerprint_windows_repository(
             r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert api.handles == {}
+
+
+@pytest.mark.parametrize(
+    "substitute",
+    [
+        r"\??\UNC\server\share\repository\target.py",
+        r"\??\UNC\server\other\repo\target.py",
+        r"\??\UNC\other\share\repo\target.py",
+    ],
+)
+def test_windows_fake_rejects_absolute_unc_component_collision(
+    substitute: str,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_symlink(
+        api.root_id,
+        "current.py",
+        r"\\server\share\repo\target.py",
+        absolute=True,
+        substitute=substitute,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="read consistently"):
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"\\server\share\repo",
             exclude_roots=(),
             version=SOURCE_FINGERPRINT_VERSION,
             api=api,
@@ -3831,26 +4413,151 @@ def test_fingerprint_rejects_file_swap_in_walker_to_open_window(
     assert foreign.read_text(encoding="utf-8") == "VALUE = 'foreign'\n"
 
 
-def test_fingerprint_rejects_absolute_contained_symlink(tmp_path: Path) -> None:
+def test_fingerprint_accepts_absolute_contained_symlink_and_retained_reads(
+    tmp_path: Path,
+) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     target = repo / "target.py"
-    target.write_text("VALUE = 1\n", encoding="utf-8")
+    target.write_bytes(b"FIRST = 1\nSECOND = 2\n")
     (repo / "link.py").symlink_to(target)
 
+    observed = fingerprint_repository(repo)
+
+    with capture_repository_source(repo) as binding:
+        assert observed.file_count == binding.file_count == 2
+        assert observed.value == binding.fingerprint
+        assert binding.read_bytes("link.py", max_bytes=1024) == target.read_bytes()
+        assert binding.read_prefix("link.py", max_bytes=5) == b"FIRST"
+        assert (
+            binding.read_line_range(
+                "link.py",
+                start_line=2,
+                end_line=2,
+                max_bytes=1024,
+            )
+            == b"SECOND = 2\n"
+        )
+        binding.verify_snapshot()
+
+
+def test_absolute_symlink_retained_reads_use_authenticated_root(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "target.py"
+    target.write_bytes(b"FIRST = 1\nSECOND = 2\n")
+    (repo / "link.py").symlink_to(target)
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+
+    with capture_repository_source(repo) as binding:
+        with binding.read_session():
+            public_root = binding.root
+            object.__setattr__(binding, "root", foreign)
+            try:
+                assert binding.read_prefix("link.py", max_bytes=5) == b"FIRST"
+                assert (
+                    binding.read_line_range(
+                        "link.py",
+                        start_line=2,
+                        end_line=2,
+                        max_bytes=1024,
+                    )
+                    == b"SECOND = 2\n"
+                )
+            finally:
+                object.__setattr__(binding, "root", public_root)
+
+
+@pytest.mark.parametrize("operation", ["bytes", "prefix", "line-range"])
+def test_absolute_symlink_retained_reads_reject_retarget(
+    tmp_path: Path,
+    operation: str,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    first = repo / "first.py"
+    second = repo / "second.py"
+    first.write_bytes(b"SAME\n")
+    second.write_bytes(b"SAME\n")
+    link = repo / "link.py"
+    link.symlink_to(first)
+    binding = capture_repository_source(repo)
+    link.unlink()
+    link.symlink_to(second)
+
     with pytest.raises(RepositoryChangedError):
+        if operation == "bytes":
+            binding.read_bytes("link.py", max_bytes=1024)
+        elif operation == "prefix":
+            binding.read_prefix("link.py", max_bytes=4)
+        else:
+            binding.read_line_range(
+                "link.py",
+                start_line=1,
+                end_line=1,
+                max_bytes=1024,
+            )
+
+    assert not binding.usable
+    binding.close()
+
+
+def test_fingerprint_accepts_mixed_contained_symlink_chain(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    nested = repo / "nested"
+    nested.mkdir(parents=True)
+    (repo / "target.py").write_bytes(b"VALUE = 1\n")
+    (nested / "relative.py").symlink_to("../target.py")
+    (repo / "absolute.py").symlink_to(nested / "relative.py")
+
+    with capture_repository_source(repo) as binding:
+        assert binding.file_count == 3
+        assert binding.read_bytes("absolute.py", max_bytes=1024) == b"VALUE = 1\n"
+
+
+def test_fingerprint_preserves_contained_absolute_broken_link(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "missing.py"
+    (repo / "link.py").symlink_to(target)
+
+    observed = fingerprint_repository(repo)
+    legacy = fingerprint_repository_v1_for_diagnostics(repo)
+
+    assert observed.file_count == legacy.file_count == 1
+    assert legacy.value == _legacy_link_only_digest(
+        b"link.py",
+        os.fsencode(target),
+    )
+
+
+def test_fingerprint_rejects_absolute_target_that_leaves_and_reenters_root(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "target.py").write_bytes(b"VALUE = 1\n")
+    raw_target = repo / ".." / repo.name / "target.py"
+    (repo / "link.py").symlink_to(raw_target)
+
+    with pytest.raises(RepositoryChangedError, match="read consistently"):
         fingerprint_repository(repo)
 
 
+@pytest.mark.parametrize("absolute", [False, True])
 def test_fingerprint_excludes_contained_directory_symlink_in_v1_and_v2(
     tmp_path: Path,
+    absolute: bool,
 ) -> None:
     repo = tmp_path / "repo"
     package = repo / "package"
     package.mkdir(parents=True)
     (package / "module.py").write_text("VALUE = 1\n", encoding="utf-8")
     link = repo / "package-link"
-    link.symlink_to("package", target_is_directory=True)
+    link.symlink_to(package if absolute else "package", target_is_directory=True)
 
     current_with_link = fingerprint_repository(repo)
     legacy_with_link = fingerprint_repository_v1_for_diagnostics(repo)
@@ -3859,6 +4566,24 @@ def test_fingerprint_excludes_contained_directory_symlink_in_v1_and_v2(
     assert fingerprint_repository(repo) == current_with_link
     assert fingerprint_repository_v1_for_diagnostics(repo) == legacy_with_link
     assert current_with_link.file_count == legacy_with_link.file_count == 1
+
+
+def test_fingerprint_accepts_expo_pods_absolute_directory_link(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    dependency = repo / "node_modules" / ".pnpm" / "dependency" / "package"
+    dependency.mkdir(parents=True)
+    (dependency / "index.ts").write_bytes(b"export const value = 1;\n")
+    pod = repo / "ios" / "Pods" / "Dependency"
+    pod.parent.mkdir(parents=True)
+    pod.symlink_to(dependency, target_is_directory=True)
+
+    observed = fingerprint_repository(repo)
+    with capture_repository_source(repo) as binding:
+        binding.verify_snapshot()
+
+    assert observed.file_count == binding.file_count == 0
 
 
 @pytest.mark.parametrize("absolute", [False, True])
@@ -3871,13 +4596,6 @@ def test_fingerprint_excludes_repository_root_directory_symlink_in_v1_and_v2(
     (repo / "module.py").write_text("VALUE = 1\n", encoding="utf-8")
     link = repo / "root-link"
     link.symlink_to(repo if absolute else ".", target_is_directory=True)
-
-    if absolute:
-        with pytest.raises(RepositoryChangedError, match="read consistently"):
-            fingerprint_repository(repo)
-        with pytest.raises(RepositoryChangedError, match="read consistently"):
-            fingerprint_repository_v1_for_diagnostics(repo)
-        return
 
     current_with_link = fingerprint_repository(repo)
     legacy_with_link = fingerprint_repository_v1_for_diagnostics(repo)
@@ -4058,6 +4776,34 @@ def test_dirty_check_ignores_generated_dirs_but_detects_source_changes(tmp_path)
     assert repository_source_is_dirty(tmp_path) is True
 
 
+def test_dirty_check_ignores_changes_in_selected_exclusions(tmp_path: Path) -> None:
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.name", "Test"],
+        check=True,
+    )
+    generated = tmp_path / "generated" / "output.py"
+    generated.parent.mkdir()
+    generated.write_text("VALUE = 1\n")
+    (tmp_path / "module.py").write_text("VALUE = 1\n")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "."], check=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "commit", "-qm", "initial"],
+        check=True,
+    )
+    selection = RepositorySourceSelection(("generated",))
+
+    generated.write_text("VALUE = 2\n")
+    assert repository_source_is_dirty(tmp_path, selection=selection) is False
+
+    (tmp_path / "module.py").write_text("VALUE = 2\n")
+    assert repository_source_is_dirty(tmp_path, selection=selection) is True
+
+
 def test_dirty_check_never_resolves_replaceable_root_path(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -4122,6 +4868,7 @@ def test_windows_real_source_v2_regular_and_contained_symlink_node(
     target.write_bytes(b"VALUE = 1\n")
     try:
         (repo / "relative.py").symlink_to("target.py")
+        (repo / "absolute.py").symlink_to(target)
     except OSError as exc:  # pragma: no cover - Windows policy dependent
         pytest.skip(f"Windows symlink creation is unavailable: {exc}")
 
@@ -4130,7 +4877,7 @@ def test_windows_real_source_v2_regular_and_contained_symlink_node(
     legacy = fingerprint_repository_v1_for_diagnostics(repo)
 
     assert first == second
-    assert first.file_count == legacy.file_count == 2
+    assert first.file_count == legacy.file_count == 3
     assert first.value.startswith("sha256-v2:")
     assert legacy.value.startswith("sha256:")
 

--- a/test/test_vector_pre_model_authorization.py
+++ b/test/test_vector_pre_model_authorization.py
@@ -18,6 +18,7 @@ from codenib.native_index_authorization import (
     MissingNativeIndexAuthorizationError,
     _mint_trusted_local_admin_authorization,
 )
+from codenib.repository_source_selection import RepositorySourceSelection
 
 _VECTOR_CONTRACT = {
     "builder_schema": 2,
@@ -27,6 +28,9 @@ _VECTOR_CONTRACT = {
     "dimension": 4,
     "embedding_kwargs": {},
 }
+_SOURCE_COMMIT = "a" * 40
+_SOURCE_FINGERPRINT = "sha256-v2:" + ("b" * 64)
+_SOURCE_SELECTION = RepositorySourceSelection()
 
 
 def _mint_vector_authorization(root: Path, semantic_contract):
@@ -209,9 +213,21 @@ def _server_context(target: Path, authorization):
         built_at_epoch=0.0,
         status="fresh",
         config=dict(_VECTOR_CONTRACT),
+        commit=_SOURCE_COMMIT,
+        source_fingerprint=_SOURCE_FINGERPRINT,
+        source_selection_digest=_SOURCE_SELECTION.digest,
     )
     return ServerContext(
-        manifest=RepoManifest(indexes={"vector": entry}),
+        manifest=RepoManifest(
+            repo_path="/repo",
+            commit=_SOURCE_COMMIT,
+            last_indexed_commit=_SOURCE_COMMIT,
+            source_fingerprint=_SOURCE_FINGERPRINT,
+            last_indexed_source_fingerprint=_SOURCE_FINGERPRINT,
+            source_selection=_SOURCE_SELECTION,
+            last_indexed_source_selection_digest=_SOURCE_SELECTION.digest,
+            indexes={"vector": entry},
+        ),
         _native_index_authorization=authorization,
     )
 

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -15,6 +15,8 @@ from fastapi.testclient import TestClient
 
 import codenib.web.app as web_app
 import codenib.wiki.media_generation as media_generation
+from codenib.repository_source_selection import RepositorySourceSelection
+from codenib.source_fingerprint import capture_repository_source
 from codenib.web.schemas import ChatRequest, ChatResponse
 
 
@@ -59,6 +61,9 @@ def test_lifespan_injects_local_native_authority_resolver(monkeypatch):
         def list_infos(self):
             return []
 
+        def close(self):
+            captured["closed"] = True
+
     monkeypatch.setattr(web_app, "load_config", lambda: config)
     monkeypatch.setattr(web_app, "RepoRegistry", Registry)
     monkeypatch.setattr(web_app, "authorize_local_manifest_vector", resolver)
@@ -80,7 +85,36 @@ def test_lifespan_injects_local_native_authority_resolver(monkeypatch):
         "native_index_authorization_resolver": resolver,
         "allow_missing_native_index_authorization": True,
         "loaded": True,
+        "closed": True,
     }
+
+
+def test_lifespan_closes_registry_when_startup_is_cancelled(monkeypatch):
+    captured = {}
+    config = SimpleNamespace(registry_path="/tmp/qa_registry.json")
+
+    class Registry:
+        def __init__(self, _config, **_kwargs):
+            pass
+
+        def load_all(self):
+            raise asyncio.CancelledError()
+
+        def close(self):
+            captured["closed"] = True
+
+    monkeypatch.setattr(web_app, "load_config", lambda: config)
+    monkeypatch.setattr(web_app, "RepoRegistry", Registry)
+    application = SimpleNamespace(state=SimpleNamespace())
+
+    async def run_lifespan():
+        async with web_app.lifespan(application):
+            raise AssertionError("cancelled startup must not yield")
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(run_lifespan())
+
+    assert captured == {"closed": True}
 
 
 def test_oversized_chat_request_is_rejected_before_runtime_lookup(monkeypatch):
@@ -103,6 +137,7 @@ def test_oversized_chat_request_is_rejected_before_runtime_lookup(monkeypatch):
 def test_chat_maps_citations_off_loop_from_the_served_checkout(monkeypatch):
     calls = []
     runner_result = object()
+    source_reader = object()
 
     class Runner:
         def run(self, query, *, chat_history):
@@ -117,16 +152,17 @@ def test_chat_maps_citations_off_loop_from_the_served_checkout(monkeypatch):
         ),
         runner=Runner(),
         ensure_runtime=lambda: None,
+        source_reader=source_reader,
     )
 
     class Registry:
         def get(self, repo_id):
             return bundle if repo_id == "repo" else None
 
-    def fake_mapping(result, *, repo_path, repo_commit):
+    def fake_mapping(result, *, repo_path, source_reader: object):
         assert result is runner_result
         assert repo_path == "/served/checkout"
-        assert repo_commit == "a" * 40
+        assert source_reader is bundle.source_reader
         return ChatResponse(answer="answer")
 
     async def fake_to_thread(func, *args, **kwargs):
@@ -148,6 +184,44 @@ def test_chat_maps_citations_off_loop_from_the_served_checkout(monkeypatch):
 
     assert response.answer == "answer"
     assert calls == [bundle.ensure_runtime, bundle.runner.run, fake_mapping]
+
+
+def test_chat_fails_closed_without_authenticated_source_reader(monkeypatch):
+    class Runner:
+        def run(self, _query, *, chat_history):
+            assert chat_history == []
+            return object()
+
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(repo_dir="/served/checkout"),
+        runner=Runner(),
+        ensure_runtime=lambda: None,
+        source_reader=None,
+    )
+    monkeypatch.setattr(
+        web_app,
+        "_registry",
+        lambda: SimpleNamespace(get=lambda _repo_id: bundle),
+    )
+    monkeypatch.setattr(
+        web_app,
+        "agent_result_to_response",
+        lambda *_args, **_kwargs: pytest.fail(
+            "missing reader must not hydrate citations"
+        ),
+    )
+
+    with pytest.raises(web_app.HTTPException) as error:
+        asyncio.run(
+            web_app.chat(
+                ChatRequest(
+                    repo_id="repo",
+                    messages=[{"role": "user", "content": "Where is runtime?"}],
+                )
+            )
+        )
+
+    assert error.value.status_code == 503
 
 
 def test_wiki_generation_runs_off_event_loop(monkeypatch):
@@ -576,8 +650,12 @@ def test_commit_window_maps_use_only_selected_snapshot_metadata(monkeypatch):
         entry=SimpleNamespace(
             base_commit="1111111111111111", repo_dir="/tmp/repository"
         ),
+        manifest=SimpleNamespace(
+            source_selection=RepositorySourceSelection(("private",))
+        ),
         code_graph=lambda: None,
         hierarchical_graph=no_current_hierarchy,
+        source_reader=object(),
     )
 
     def fake_codemap(*args, **kwargs):
@@ -605,7 +683,47 @@ def test_commit_window_maps_use_only_selected_snapshot_metadata(monkeypatch):
     assert modulemap_result["commit"] == selected
     assert captured["codemap"][1]["repo_commit"] == selected
     assert captured["codemap"][1]["hierarchy_graph"] is None
+    assert captured["codemap"][1]["source_reader"] is None
+    assert captured["codemap"][1]["source_selection"] == RepositorySourceSelection(
+        ("private",)
+    )
     assert captured["modulemap"][1]["repo_commit"] == selected
+    assert captured["modulemap"][1]["source_reader"] is None
+    assert captured["modulemap"][1]["source_selection"] == (
+        RepositorySourceSelection(("private",))
+    )
+
+
+def test_current_codemap_uses_the_authenticated_source_reader(monkeypatch):
+    import codenib.web.codemap as codemap_builder
+
+    graph = object()
+    reader = object()
+    captured = {}
+
+    class Window:
+        available = False
+
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(base_commit="abc123", repo_dir="/tmp/repository"),
+        source_reader=reader,
+        code_graph=lambda: graph,
+        hierarchical_graph=lambda: None,
+    )
+
+    def fake_codemap(*args, **kwargs):
+        captured.update(kwargs)
+        return {"available": True, "nodes": [], "edges": []}
+
+    monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
+    monkeypatch.setattr(web_app, "_commit_window", lambda _repo_id: Window())
+    monkeypatch.setattr(codemap_builder, "build_codemap", fake_codemap)
+
+    result = asyncio.run(web_app.codemap("repo"))
+
+    assert result["commit"] == "abc123"
+    assert captured["source_reader"] is reader
+    assert captured["repo_commit"] is None
 
 
 def test_source_endpoint_reads_the_requested_window_commit(monkeypatch):
@@ -627,7 +745,12 @@ def test_source_endpoint_reads_the_requested_window_commit(monkeypatch):
                 "content": "historical\n",
             }
 
-    bundle = SimpleNamespace(entry=SimpleNamespace(base_commit="1" * 40))
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(base_commit="1" * 40),
+        manifest=SimpleNamespace(
+            source_selection=RepositorySourceSelection(("private",))
+        ),
+    )
     monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
     monkeypatch.setattr(web_app, "_commit_window", lambda _repo_id: Window())
     monkeypatch.setattr(
@@ -644,6 +767,39 @@ def test_source_endpoint_reads_the_requested_window_commit(monkeypatch):
 
     assert result["content"] == "historical\n"
     assert calls == [(selected, "src/runtime.py", 4, 8)]
+
+
+def test_source_endpoint_rejects_excluded_historical_source(monkeypatch):
+    selected = "abcdef1234567890"
+
+    class Window:
+        available = True
+
+        def resolve(self, commit):
+            return {"sha": selected} if commit == selected else None
+
+        def source_for(self, *_args):
+            raise AssertionError("excluded historical source must not reach Git")
+
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(base_commit="1" * 40),
+        manifest=SimpleNamespace(
+            source_selection=RepositorySourceSelection(("private",))
+        ),
+    )
+    monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
+    monkeypatch.setattr(web_app, "_commit_window", lambda _repo_id: Window())
+
+    with pytest.raises(web_app.HTTPException) as error:
+        asyncio.run(
+            web_app.source(
+                "repo",
+                "private/secret.py",
+                commit=selected,
+            )
+        )
+
+    assert error.value.status_code == 404
 
 
 def test_edge_label_uses_the_graph_payload_commit(monkeypatch):
@@ -677,6 +833,59 @@ def test_edge_label_uses_the_graph_payload_commit(monkeypatch):
     assert calls == [("repo", selected)]
 
 
+def test_historical_edge_labeler_gates_source_with_manifest_selection(monkeypatch):
+    import codenib.web.edge_label as edge_label_module
+
+    selected = "abcdef1234567890"
+    source_calls = []
+    captured = {}
+
+    class Window:
+        available = True
+
+        def resolve(self, commit):
+            return {"sha": selected} if commit == selected else None
+
+        def source_for(self, commit, file, start, end):
+            source_calls.append((commit, file, start, end))
+            return {"file": file, "content": "historical\n"}
+
+    class Labeler:
+        def __init__(self, *, source_fn, **_kwargs):
+            captured["source_fn"] = source_fn
+
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            base_commit="1" * 40,
+            instance_id="owner__repo-1",
+        ),
+        manifest=SimpleNamespace(
+            source_selection=RepositorySourceSelection(("private",))
+        ),
+    )
+    config = SimpleNamespace(
+        data_dir="/tmp/data",
+        edge_label_model=None,
+        wiki_generation_model="fake-model",
+        wiki_generation_api_base=None,
+        wiki_generation_api_key=None,
+    )
+    monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
+    monkeypatch.setattr(web_app, "_commit_window", lambda _repo_id: Window())
+    monkeypatch.setattr(web_app, "load_config", lambda: config)
+    monkeypatch.setattr(web_app, "_wiki_llm", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(edge_label_module, "EdgeLabeler", Labeler)
+    monkeypatch.setattr(web_app.app.state, "edge_labelers", {}, raising=False)
+
+    web_app._edge_labeler("repo", selected)
+    source_fn = captured["source_fn"]
+
+    assert source_fn("private/secret.py", 1, 2) is None
+    assert source_calls == []
+    assert source_fn("src/runtime.py", 3, 4)["content"] == "historical\n"
+    assert source_calls == [(selected, "src/runtime.py", 3, 4)]
+
+
 def test_source_endpoint_reads_the_live_checkout_without_building_the_wiki(
     tmp_path, monkeypatch
 ):
@@ -689,6 +898,8 @@ def test_source_endpoint_reads_the_live_checkout_without_building_the_wiki(
     bundle = SimpleNamespace(
         entry=SimpleNamespace(base_commit="1" * 40, repo_dir=str(tmp_path))
     )
+    binding = capture_repository_source(tmp_path)
+    bundle.source_reader = binding.borrow_reader()
     monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
     monkeypatch.setattr(web_app, "_commit_window", lambda _repo_id: Window())
     monkeypatch.setattr(
@@ -699,7 +910,10 @@ def test_source_endpoint_reads_the_live_checkout_without_building_the_wiki(
         ),
     )
 
-    result = asyncio.run(web_app.source("repo", "runtime.py", 2, 3))
+    try:
+        result = asyncio.run(web_app.source("repo", "runtime.py", 2, 3))
+    finally:
+        binding.close()
 
     assert result == {
         "file": "runtime.py",
@@ -707,3 +921,27 @@ def test_source_endpoint_reads_the_live_checkout_without_building_the_wiki(
         "end_line": 3,
         "content": "second\nthird\n",
     }
+
+
+def test_source_endpoint_returns_404_for_excluded_current_source(tmp_path, monkeypatch):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "runtime.py").write_text("visible\n")
+    (tmp_path / "excluded").mkdir()
+    (tmp_path / "excluded" / "secret.py").write_text("secret\n")
+    binding = capture_repository_source(
+        tmp_path,
+        selection=RepositorySourceSelection(("excluded",)),
+    )
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(base_commit="1" * 40, repo_dir=str(tmp_path)),
+        source_reader=binding.borrow_reader(),
+    )
+    monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
+
+    try:
+        with pytest.raises(web_app.HTTPException) as error:
+            asyncio.run(web_app.source("repo", "excluded/secret.py"))
+    finally:
+        binding.close()
+
+    assert error.value.status_code == 404

--- a/test/web/test_codemap.py
+++ b/test/web/test_codemap.py
@@ -8,6 +8,8 @@ import subprocess
 
 import codenib.web.codemap as codemap_module
 from codenib.graph.code_graph import CodeGraph
+from codenib.repository_source_selection import RepositorySourceSelection
+from codenib.source_fingerprint import capture_repository_source
 from codenib.web.codemap import (
     EDGE_ANCHOR_SAMPLE,
     _default_seed,
@@ -86,6 +88,51 @@ def test_codemap_bounds_anchor_samples_without_losing_exact_weight():
     assert [anchor["line"] for anchor in edge["anchors"]] == list(range(1, 13))
 
 
+def test_historical_codemap_filters_excluded_nodes_and_edge_anchors():
+    graph = CodeGraph()
+    for name, file_path in (
+        ("src/main.py:main()", "src/main.py"),
+        ("src/helper.py:helper()", "src/helper.py"),
+        ("private/secret.py:secret()", "private/secret.py"),
+    ):
+        graph._add_vertex(
+            name,
+            {
+                "type": "function",
+                "file": file_path,
+                "start_line": 0,
+                "end_line": 1,
+                "unified_name": name,
+            },
+        )
+    graph._add_edge(
+        "src/main.py:main()",
+        "src/helper.py:helper()",
+        "reference",
+        anchor_file="private/call.py",
+        anchor_line=2,
+    )
+    graph._add_edge(
+        "src/main.py:main()",
+        "private/secret.py:secret()",
+        "reference",
+        anchor_file="src/main.py",
+        anchor_line=3,
+    )
+
+    result = build_codemap(
+        graph,
+        symbol="main",
+        direction="callees",
+        depth=1,
+        max_nodes=10,
+        source_selection=RepositorySourceSelection(("private",)),
+    )
+
+    assert [node["file"] for node in result["nodes"]] == ["src/main.py"]
+    assert result["edges"] == []
+
+
 def test_anchor_collector_bounds_high_fanout_working_set():
     collector = _EdgeAnchorCollector()
     key = ("src/main.py:caller()", "src/helper.py:callee()")
@@ -129,6 +176,76 @@ def test_page_subgraph_bounds_repeated_anchor_collection():
     assert edge["weight"] == 100
     assert len(edge["anchors"]) == 12
     assert edge["hidden_anchors"] == 88
+
+
+def test_page_subgraph_filters_unbound_nodes_citations_and_anchors(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("main\n", encoding="utf-8")
+    (tmp_path / "src" / "helper.py").write_text("helper\n", encoding="utf-8")
+    (tmp_path / "private").mkdir()
+    (tmp_path / "private" / "secret.py").write_text("secret\n", encoding="utf-8")
+    graph = CodeGraph()
+    for name, file_path in (
+        ("src/main.py:main()", "src/main.py"),
+        ("src/helper.py:helper()", "src/helper.py"),
+        ("private/secret.py:secret()", "private/secret.py"),
+    ):
+        graph._add_vertex(
+            name,
+            {
+                "type": "function",
+                "file": file_path,
+                "start_line": 0,
+                "end_line": 0,
+                "unified_name": name,
+            },
+        )
+    graph._add_edge(
+        "src/main.py:main()",
+        "src/helper.py:helper()",
+        "reference",
+        anchor_file="private/secret.py",
+        anchor_line=0,
+    )
+    binding = capture_repository_source(
+        tmp_path,
+        selection=RepositorySourceSelection(("private",)),
+    )
+
+    try:
+        reader = binding.borrow_reader()
+        result = build_page_subgraph(
+            graph,
+            [
+                {"file": "src/main.py", "start_line": 1, "node_name": "main"},
+                {
+                    "file": "src/helper.py",
+                    "start_line": 1,
+                    "node_name": "helper",
+                },
+            ],
+            source_reader=reader,
+        )
+        excluded = build_page_subgraph(
+            graph,
+            [
+                {
+                    "file": "private/secret.py",
+                    "start_line": 1,
+                    "node_name": "secret",
+                }
+            ],
+            source_reader=reader,
+        )
+    finally:
+        binding.close()
+
+    assert {node["file"] for node in result["nodes"]} == {
+        "src/main.py",
+        "src/helper.py",
+    }
+    assert result["edges"] == []
+    assert excluded["available"] is False
 
 
 def test_page_subgraph_explains_missing_or_mismatched_graph_seeds():
@@ -661,6 +778,54 @@ def test_derived_file_scan_reads_the_selected_commit(tmp_path):
     assert _DerivedFiles(str(repo), generated_commit)("generated.py") is True
     assert _DerivedFiles(str(repo), handwritten_commit)("generated.py") is False
     assert _DerivedFiles(str(repo))("generated.py") is False
+
+
+def test_current_codemap_reads_file_metadata_only_through_bound_source(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "src" / "runtime.py"
+    source.parent.mkdir()
+    source.write_text("def serve():\n    return 1\n")
+    graph = CodeGraph()
+    graph._add_vertex(
+        "src/runtime.py:serve()",
+        {
+            "type": "function",
+            "file": "src/runtime.py",
+            "start_line": 0,
+            "end_line": 1,
+            "unified_name": "src/runtime.py:serve()",
+        },
+    )
+    binding = capture_repository_source(tmp_path)
+    monkeypatch.setattr(
+        codemap_module,
+        "discover_entry_points",
+        lambda _repo: (_ for _ in ()).throw(
+            AssertionError("bound codemap must not open repository manifests")
+        ),
+    )
+    monkeypatch.setattr(
+        codemap_module,
+        "_live_file_has_generated_marker",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("bound codemap must not stat current source paths")
+        ),
+    )
+
+    try:
+        result = build_codemap(
+            graph,
+            symbol="serve",
+            repo_dir=str(tmp_path),
+            source_reader=binding.borrow_reader(),
+        )
+    finally:
+        binding.close()
+
+    assert result["available"] is True
+    assert result["nodes"][0]["file"] == "src/runtime.py"
+    assert result["nodes"][0]["external"] is False
 
 
 def test_derived_file_scan_reuses_generated_paths_within_request(monkeypatch):

--- a/test/web/test_modulemap.py
+++ b/test/web/test_modulemap.py
@@ -5,6 +5,7 @@
 """Unit tests for the module-level dependency map."""
 
 from codenib.graph.code_graph import CodeGraph
+from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.web.modulemap import build_modulemap
 
 
@@ -94,6 +95,22 @@ def test_modulemap_projects_symbol_references_onto_files():
     assert edges[("src/render.js", "src/diff/index.js")] == 3
     assert edges[("src/render.js", "src/create-element.js")] == 1
     assert edges[("src/diff/index.js", "src/create-element.js")] == 1
+
+
+def test_modulemap_applies_historical_source_selection_to_nodes_and_anchors():
+    result = build_modulemap(
+        _repo_graph(),
+        granularity="file",
+        source_selection=RepositorySourceSelection(("src/diff",)),
+    )
+
+    paths = {node["path"] for node in result["nodes"]}
+    assert paths == {"src/render.js", "src/create-element.js"}
+    assert all(
+        not anchor["file"].startswith("src/diff/")
+        for edge in result["edges"]
+        for anchor in edge.get("anchors", [])
+    )
 
 
 def test_modulemap_excludes_tests_and_declarations_but_reports_the_count():
@@ -287,3 +304,30 @@ def test_modulemap_drops_files_with_neither_symbols_nor_dependencies():
 
     assert {node["path"] for node in result["nodes"]} == {"pkg/a.py", "pkg/b.py"}
     assert result["total_modules"] == 2
+
+
+def test_bound_modulemap_never_discovers_entry_points_from_checkout(monkeypatch):
+    class Reader:
+        def captured_relative_path(self, path):
+            return path if path.startswith("src/") else None
+
+        def read_prefix(self, _path, *, max_bytes):
+            assert max_bytes == 2048
+            return b""
+
+    def fail_discovery(_repo_dir):
+        raise AssertionError("bound modulemap must not scan the live checkout")
+
+    monkeypatch.setattr(
+        "codenib.web.modulemap.discover_entry_points",
+        fail_discovery,
+    )
+
+    result = build_modulemap(
+        _repo_graph(),
+        repo_dir="/replaceable/repository",
+        source_reader=Reader(),
+    )
+
+    assert result["available"] is True
+    assert all(node["path"].startswith("src/") for node in result["nodes"])

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -12,13 +12,19 @@ from types import SimpleNamespace
 import pytest
 
 from codenib.agent.skills.registry import SkillRegistry
-from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
+from codenib.compiler.artifact_fingerprints import (
+    bm25_artifact_file_fingerprints,
+    regular_file_fingerprint,
+)
 from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.graph.code_graph import CodeGraph
 from codenib.native_index_authorization import (
     InvalidNativeIndexAuthorizationError,
     MissingNativeIndexAuthorizationError,
     _mint_trusted_local_admin_authorization,
 )
+from codenib.repository_source_selection import RepositorySourceSelection
+from codenib.source_fingerprint import capture_repository_source, fingerprint_repository
 from codenib.web.config import (
     QAConfig,
     RepoEntry,
@@ -32,6 +38,33 @@ from codenib.web.repo_registry import (
     RepoRegistry,
     _fresh_registry,
 )
+
+
+def _write_source_manifest(repo, manifest_path, *, selection=None):
+    selected = selection or RepositorySourceSelection()
+    source = fingerprint_repository(repo, selection=selected)
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        commit="abc123",
+        source_fingerprint=source.value,
+        source_selection=selected,
+        languages=["python"],
+        file_count=source.file_count,
+    )
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest.save(manifest_path)
+    return manifest
+
+
+def _repo_entry(repo, manifest_path, *, instance_id="owner__repo-1"):
+    return RepoEntry(
+        instance_id=instance_id,
+        repo="owner/repo",
+        base_commit="abc123",
+        language="python",
+        repo_dir=str(repo),
+        manifest_path=str(manifest_path),
+    )
 
 
 @pytest.fixture
@@ -68,6 +101,331 @@ def test_ask_prompt_requires_resolving_discovered_identifiers():
     assert "unresolved candidate identifier" in _DEMO_SYSTEM_PROMPT
     assert "combine every unresolved identifier" in _DEMO_SYSTEM_PROMPT
     assert "under 500 words" in _DEMO_SYSTEM_PROMPT
+
+
+def test_registry_retains_manifest_selected_source_until_close(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "src" / "runtime.py").write_text("visible\n", encoding="utf-8")
+    (repo / "private").mkdir()
+    (repo / "private" / "secret.py").write_text("secret\n", encoding="utf-8")
+    manifest_path = tmp_path / "artifacts" / "repo_manifest.json"
+    _write_source_manifest(
+        repo,
+        manifest_path,
+        selection=RepositorySourceSelection(("private",)),
+    )
+    entry = _repo_entry(repo, manifest_path)
+    registry = RepoRegistry(QAConfig())
+
+    bundle = registry._load_repo_metadata(entry)
+    registry._bundles[entry.instance_id] = bundle
+    reader = bundle.source_reader
+
+    assert reader is not None
+    assert reader.file_paths == frozenset({"src/runtime.py"})
+    assert entry.instance_id in registry._source_bindings
+    registry.close()
+
+    assert bundle.source_reader is None
+    with pytest.raises(RuntimeError, match="source binding is"):
+        reader.read_prefix("src/runtime.py", max_bytes=32)
+
+
+def test_registry_closes_captured_source_when_manifest_verification_fails(
+    tmp_path, monkeypatch
+):
+    from codenib.compiler import manifest_source
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "runtime.py"
+    source.write_text("before\n", encoding="utf-8")
+    manifest_path = tmp_path / "artifacts" / "repo_manifest.json"
+    _write_source_manifest(repo, manifest_path)
+    source.write_text("after\n", encoding="utf-8")
+    entry = _repo_entry(repo, manifest_path)
+    registry = RepoRegistry(QAConfig())
+    captured = {}
+    original_capture = manifest_source.capture_repository_source_for_manifest
+
+    def observe_capture(*args, **kwargs):
+        binding = original_capture(*args, **kwargs)
+        captured["binding"] = binding
+        return binding
+
+    monkeypatch.setattr(
+        manifest_source,
+        "capture_repository_source_for_manifest",
+        observe_capture,
+    )
+
+    with pytest.raises(ValueError, match="does not match the manifest"):
+        registry._load_repo_metadata(entry)
+
+    assert captured["binding"].closed is True
+    assert registry._source_bindings == {}
+    assert registry._source_cleanup_owners == {}
+
+
+def test_registry_retains_failed_source_cleanup_for_retry(tmp_path, monkeypatch):
+    from codenib.compiler import manifest_source
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "runtime.py").write_text("runtime\n", encoding="utf-8")
+    manifest_path = tmp_path / "artifacts" / "repo_manifest.json"
+    _write_source_manifest(repo, manifest_path)
+    entry = _repo_entry(repo, manifest_path)
+    registry = RepoRegistry(QAConfig())
+
+    class Binding:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls >= 2
+
+        def authenticated_identity_snapshot(self):
+            raise ValueError("verification failed")
+
+        def close(self):
+            self.close_calls += 1
+            if self.close_calls == 1:
+                raise RuntimeError("cleanup interrupted")
+
+    binding = Binding()
+
+    def capture(*_args, _source_owner, **_kwargs):
+        _source_owner(binding)
+        return binding
+
+    monkeypatch.setattr(
+        manifest_source,
+        "capture_repository_source_for_manifest",
+        capture,
+    )
+
+    with pytest.raises(ValueError, match="verification failed"):
+        registry._load_repo_metadata(entry)
+
+    assert set(registry._source_cleanup_owners) == {entry.instance_id}
+    assert binding.close_calls == 1
+
+    registry.close()
+
+    assert binding.close_calls == 2
+    assert registry._source_cleanup_owners == {}
+
+
+def test_registry_reload_closes_the_previous_source_authority(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "runtime.py").write_text("runtime\n", encoding="utf-8")
+    manifest_path = tmp_path / "artifacts" / "repo_manifest.json"
+    _write_source_manifest(repo, manifest_path)
+    entry = _repo_entry(repo, manifest_path)
+    config = QAConfig(data_dir=str(tmp_path / "data"))
+    save_registry(config.registry_path, [entry])
+    registry = RepoRegistry(config)
+
+    registry.load_all()
+    first_reader = registry.get(entry.instance_id).source_reader
+    registry.load_all()
+    second_reader = registry.get(entry.instance_id).source_reader
+
+    assert first_reader is not second_reader
+    with pytest.raises(RuntimeError, match="source binding is"):
+        first_reader.read_prefix("runtime.py", max_bytes=32)
+    assert second_reader.read_prefix("runtime.py", max_bytes=32) == b"runtime\n"
+    registry.close()
+
+
+def test_registry_rejects_duplicate_instance_ids_without_replacing_owner(tmp_path):
+    entries = []
+    for name in ("first", "second"):
+        repo = tmp_path / name
+        repo.mkdir()
+        (repo / f"{name}.py").write_text(f"{name}\n", encoding="utf-8")
+        manifest_path = tmp_path / "artifacts" / name / "repo_manifest.json"
+        _write_source_manifest(repo, manifest_path)
+        entries.append(_repo_entry(repo, manifest_path, instance_id="duplicate"))
+    config = QAConfig(data_dir=str(tmp_path / "data"))
+    save_registry(config.registry_path, entries)
+    registry = RepoRegistry(config)
+
+    registry.load_all()
+    bundle = registry.get("duplicate")
+
+    assert bundle.source_reader.file_paths == frozenset({"first.py"})
+    assert len(registry._source_cleanup_owners) == 1
+    registry.close()
+
+
+def test_registry_retains_vector_cleanup_owner_for_retry():
+    class Vector:
+        def __init__(self):
+            self.close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+            if self.close_calls == 1:
+                raise RuntimeError("retry cleanup")
+
+    vector = Vector()
+    bundle = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+        vector_store=vector,
+    )
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = bundle
+
+    with pytest.raises(RuntimeError, match="retry cleanup"):
+        registry.close()
+
+    assert registry._bundles == {"repo": bundle}
+    assert bundle.vector_store is vector
+
+    registry.close()
+
+    assert vector.close_calls == 2
+    assert registry._bundles == {}
+
+
+def test_repo_views_reject_documents_outside_authenticated_selection(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "src" / "runtime.py").write_text("runtime\n", encoding="utf-8")
+    (repo / "private").mkdir()
+    (repo / "private" / "secret.py").write_text("secret\n", encoding="utf-8")
+    bm25_dir = tmp_path / "bm25"
+    bm25_dir.mkdir()
+    (bm25_dir / "documents.json").write_text(
+        '[{"page_content":"secret","metadata":{"file":"private/secret.py"}}]',
+        encoding="utf-8",
+    )
+    (bm25_dir / "bm25_metadata.json").write_text(
+        '{"max_k":10}',
+        encoding="utf-8",
+    )
+    entry = IndexEntry(
+        index_type="bm25",
+        path=str(bm25_dir),
+        built_at="2026-08-20T00:00:00Z",
+        built_at_epoch=0.0,
+        status="fresh",
+        config={
+            "artifact_file_fingerprints": bm25_artifact_file_fingerprints(bm25_dir)
+        },
+    )
+    instance_id = "owner__repo-1"
+    binding = capture_repository_source(
+        repo,
+        selection=RepositorySourceSelection(("private",)),
+    )
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(instance_id=instance_id),
+        manifest=SimpleNamespace(
+            indexes={"bm25": entry},
+            index_is_current=lambda _name: True,
+        ),
+        bm25=None,
+        vector_store=None,
+        source_reader=binding.borrow_reader(),
+    )
+    registry = RepoRegistry(QAConfig())
+    registry._source_bindings[instance_id] = binding
+
+    try:
+        with pytest.raises(ValueError, match="outside the authenticated"):
+            registry._load_repo_views(bundle)
+    finally:
+        binding.close()
+
+    assert bundle.bm25 is None
+
+
+def test_bundle_rejects_graph_paths_outside_authenticated_selection(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "src" / "runtime.py").write_text("runtime\n", encoding="utf-8")
+    (repo / "private").mkdir()
+    (repo / "private" / "secret.py").write_text("secret\n", encoding="utf-8")
+    graph_dir = tmp_path / "symbol_graph"
+    graph_dir.mkdir()
+    graph_path = graph_dir / "graph.pkl"
+    graph = CodeGraph()
+    graph._add_vertex(
+        "private/secret.py:secret()",
+        {
+            "type": "function",
+            "file": "private/secret.py",
+            "start_line": 0,
+            "end_line": 0,
+            "unified_name": "private/secret.py:secret()",
+        },
+    )
+    graph.save_graph(graph_path)
+    binding = capture_repository_source(
+        repo,
+        selection=RepositorySourceSelection(("private",)),
+    )
+    bundle = RepoBundle(
+        entry=SimpleNamespace(instance_id="owner__repo-1"),
+        manifest=SimpleNamespace(
+            commit="abc123",
+            source_fingerprint="",
+            indexes={
+                "symbol_graph": SimpleNamespace(
+                    status="fresh",
+                    commit="abc123",
+                    source_fingerprint="",
+                    path=str(graph_dir),
+                    config={
+                        "graph_artifact": {
+                            "relative_path": "graph.pkl",
+                            **regular_file_fingerprint(graph_path),
+                        }
+                    },
+                )
+            },
+        ),
+        source_reader=binding.borrow_reader(),
+    )
+
+    try:
+        assert bundle.code_graph() is None
+    finally:
+        binding.close()
+
+    assert "outside the authenticated" in bundle._code_graph_error
+
+
+def test_manifest_selected_bundle_never_falls_back_to_live_checkout(
+    tmp_path, monkeypatch
+):
+    bundle = RepoBundle(
+        entry=SimpleNamespace(repo_dir=str(tmp_path)),
+        manifest=SimpleNamespace(
+            source_fingerprint="sha256-v2:bound",
+            source_selection=RepositorySourceSelection(),
+            indexes={},
+        ),
+    )
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.read_repository_summary",
+        lambda *_args: pytest.fail("must not read the live checkout"),
+    )
+
+    assert bundle._description() == ""
+    assert bundle.code_graph() is None
+    assert bundle.hierarchical_graph() is None
+
+    registry = RepoRegistry(QAConfig())
+    with pytest.raises(RuntimeError, match="authenticated source reader"):
+        registry._load_repo_views(bundle)
 
 
 def test_bundle_loads_views_without_constructing_agent_runtime():
@@ -177,7 +535,11 @@ def test_repo_views_reject_bm25_that_no_longer_matches_manifest(tmp_path):
             "artifact_file_fingerprints": bm25_artifact_file_fingerprints(bm25_dir)
         },
     )
-    manifest = RepoManifest(indexes={"bm25": entry})
+    manifest = RepoManifest(
+        version="1.1",
+        source_selection=None,
+        indexes={"bm25": entry},
+    )
     documents.write_text(documents.read_text().replace("alpha", "omega"))
     bundle = SimpleNamespace(manifest=manifest, bm25=None, vector_store=None)
     registry = SimpleNamespace(_config=SimpleNamespace(index_types=lambda: ("bm25",)))

--- a/test/web/test_repository_files.py
+++ b/test/web/test_repository_files.py
@@ -11,7 +11,10 @@ from pathlib import Path
 
 import pytest
 
+from codenib.repository_source_selection import RepositorySourceSelection
+from codenib.source_fingerprint import capture_repository_source
 from codenib.web.repository_files import (
+    bound_source_slice,
     git_grep_paths,
     git_tree_paths,
     live_source_slice,
@@ -109,3 +112,32 @@ def test_live_source_slice_rejects_fifo_without_blocking(tmp_path: Path) -> None
 
     assert result is None
     assert time.monotonic() - started < 1
+
+
+def test_bound_source_slice_uses_authenticated_selection(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "runtime.py").write_text(
+        "first\nsecond\nthird\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "excluded").mkdir()
+    (tmp_path / "excluded" / "secret.py").write_text(
+        "SECRET = 'not selected'\n",
+        encoding="utf-8",
+    )
+    binding = capture_repository_source(
+        tmp_path,
+        selection=RepositorySourceSelection(("excluded",)),
+    )
+    try:
+        reader = binding.borrow_reader()
+
+        assert bound_source_slice(reader, "src/runtime.py", 2, 3) == {
+            "file": "src/runtime.py",
+            "start_line": 2,
+            "end_line": 3,
+            "content": "second\nthird\n",
+        }
+        assert bound_source_slice(reader, "excluded/secret.py") is None
+    finally:
+        binding.close()

--- a/test/web/test_schemas.py
+++ b/test/web/test_schemas.py
@@ -8,6 +8,8 @@ import pytest
 from pydantic import ValidationError
 
 from codenib.agent.agent_types import AgentResult, ToolCallRecord
+from codenib.repository_source_selection import RepositorySourceSelection
+from codenib.source_fingerprint import capture_repository_source
 from codenib.types import QueriedNode
 from codenib.web.schemas import (
     ChatRequest,
@@ -290,7 +292,9 @@ def test_citations_fall_back_to_five_retrieval_results():
     ]
 
 
-def test_citations_embed_exact_live_source_and_drop_empty_tabs(tmp_path):
+def test_current_citations_use_authenticated_source_and_drop_empty_tabs(
+    tmp_path, monkeypatch
+):
     source = tmp_path / "src"
     source.mkdir()
     (source / "runtime.py").write_text(
@@ -325,7 +329,27 @@ def test_citations_embed_exact_live_source_and_drop_empty_tabs(tmp_path):
         ],
     )
 
-    response = agent_result_to_response(result, repo_path=str(tmp_path))
+    binding = capture_repository_source(tmp_path)
+    monkeypatch.setattr(
+        "codenib.web.schemas.live_source_slice",
+        lambda *_args, **_kwargs: pytest.fail(
+            "current citations must not read the ambient checkout"
+        ),
+    )
+    monkeypatch.setattr(
+        "codenib.web.schemas.os.path.exists",
+        lambda *_args, **_kwargs: pytest.fail(
+            "current citation paths must use authenticated membership"
+        ),
+    )
+    try:
+        response = agent_result_to_response(
+            result,
+            repo_path=str(tmp_path),
+            source_reader=binding.borrow_reader(),
+        )
+    finally:
+        binding.close()
 
     assert len(response.citations) == 1
     assert response.citations[0].file == "src/runtime.py"
@@ -391,6 +415,83 @@ def test_citations_read_from_the_indexed_commit_instead_of_live_source(
     assert response.citations[0].content == (
         "def indexed_runtime():\n    return 'snapshot'\n"
     )
+
+
+def test_current_citations_reject_paths_outside_authenticated_selection(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "runtime.py").write_text("runtime\n", encoding="utf-8")
+    (tmp_path / "private").mkdir()
+    (tmp_path / "private" / "secret.py").write_text("secret\n", encoding="utf-8")
+    binding = capture_repository_source(
+        tmp_path,
+        selection=RepositorySourceSelection(("private",)),
+    )
+    result = AgentResult(
+        answer="`secret()` is implemented in `private/secret.py`.",
+        tool_calls=[
+            ToolCallRecord(
+                "1",
+                "repository_search",
+                {},
+                result=[
+                    _node(
+                        "private/secret.py",
+                        0,
+                        0,
+                        "private/secret.py:secret()",
+                    )
+                ],
+            )
+        ],
+    )
+
+    try:
+        response = agent_result_to_response(
+            result,
+            repo_path=str(tmp_path),
+            source_reader=binding.borrow_reader(),
+        )
+    finally:
+        binding.close()
+
+    assert response.citations == []
+
+
+def test_historical_citations_reject_manifest_excluded_paths(monkeypatch):
+    commit = "a" * 40
+    monkeypatch.setattr(
+        "codenib.web.schemas.git_source_slice",
+        lambda *_args, **_kwargs: pytest.fail(
+            "excluded historical citation must not reach Git"
+        ),
+    )
+    result = AgentResult(
+        answer="`secret()` is implemented in `private/secret.py`.",
+        tool_calls=[
+            ToolCallRecord(
+                "1",
+                "repository_search",
+                {},
+                result=[
+                    _node(
+                        "private/secret.py",
+                        1,
+                        2,
+                        "private/secret.py:secret()",
+                    )
+                ],
+            )
+        ],
+    )
+
+    response = agent_result_to_response(
+        result,
+        repo_path="/served/checkout",
+        repo_commit=commit,
+        source_selection=RepositorySourceSelection(("private",)),
+    )
+
+    assert response.citations == []
 
 
 def test_citations_keep_indexed_content_for_non_git_prebuilt_snapshot(tmp_path):

--- a/test/wiki/test_agent_wiki.py
+++ b/test/wiki/test_agent_wiki.py
@@ -51,6 +51,31 @@ class _FakeVectorStore:
         return self.nodes[:top_k]
 
 
+def test_rel_uses_bound_source_inventory_without_live_exists(monkeypatch):
+    class Reader:
+        def captured_relative_path(self, path):
+            return "src/app.py" if path.endswith("src/app.py") else None
+
+    def fail_exists(_path):
+        raise AssertionError("bound Wiki must not inspect the live checkout")
+
+    monkeypatch.setattr(os.path, "exists", fail_exists)
+    wiki = AgentWiki(
+        SimpleNamespace(
+            entry=SimpleNamespace(
+                repo="owner/repo",
+                repo_dir="/repo",
+                language="python",
+            ),
+            source_reader=Reader(),
+        ),
+        model="fake-model",
+    )
+
+    assert wiki._rel("/builder/root/src/app.py") == "src/app.py"
+    assert wiki._rel("/builder/root/private/secret.py") is None
+
+
 def test_markdown_cleanup_removes_outer_fence_and_uncited_prose():
     fenced = (
         "```markdown\n"
@@ -6596,6 +6621,39 @@ def test_agent_wiki_cache_key_tracks_view_source_identity(tmp_path):
     view.source_fingerprint = "sha256:second"
 
     assert wiki._key("outline") != before
+
+
+def test_agent_wiki_cache_key_tracks_source_selection_identity(tmp_path):
+    manifest = SimpleNamespace(
+        languages=["python"],
+        indexes={},
+        source_fingerprint="sha256:source",
+        source_selection_digest="sha256:first-selection",
+    )
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=None,
+        bm25=None,
+        manifest=manifest,
+    )
+    wiki = AgentWiki(
+        bundle,
+        model="fake-model",
+        cache_dir=str(tmp_path / "wiki-cache"),
+    )
+    before = wiki._key("outline")
+
+    assert len(wiki._cache_candidate_paths("outline")) == 1
+    manifest.source_selection_digest = "sha256:second-selection"
+
+    assert wiki._key("outline") != before
+    assert len(wiki._cache_candidate_paths("outline")) == 1
 
 
 def test_agent_wiki_cache_key_is_stable_across_lazy_client_creation(tmp_path):

--- a/test/wiki/test_builder.py
+++ b/test/wiki/test_builder.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.repository_summary import readme_summary
 from codenib.source_fingerprint import capture_repository_source
 from codenib.wiki.builder import (
@@ -106,6 +107,17 @@ def test_readme_summary_prefers_tagline():
     out = readme_summary(md)
     assert "fast, friendly library" in out
     assert "install" not in out.lower()
+
+
+def test_manifest_selected_wiki_requires_authenticated_source_reader(repo_dir):
+    bundle = _make_bundle(repo_dir)
+    bundle.manifest = SimpleNamespace(
+        source_fingerprint="sha256-v2:bound",
+        source_selection=RepositorySourceSelection(),
+    )
+
+    with pytest.raises(RuntimeError, match="authenticated source reader"):
+        WikiBuilder(bundle)
 
 
 def test_readme_summary_skips_labels_and_short_lines():
@@ -261,7 +273,8 @@ def test_bound_source_hydrates_far_offset_symbol_without_prefix_truncation(
     bundle.bm25 = SimpleNamespace(documents=[document])
 
     with capture_repository_source(tmp_path) as binding:
-        builder = WikiBuilder(bundle, source_reader=binding.borrow_reader())
+        bundle.source_reader = binding.borrow_reader()
+        builder = WikiBuilder(bundle)
 
         assert builder._symbols()[0].content == "def target(): return 'far-offset'"
         excerpt = builder.source("pkg/far.py", 17_001, 17_001)

--- a/test/wiki/test_outline.py
+++ b/test/wiki/test_outline.py
@@ -4,6 +4,10 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+from codenib.repository_source_selection import RepositorySourceSelection
+from codenib.source_fingerprint import capture_repository_source
 from codenib.wiki.builder import Symbol
 from codenib.wiki.outline import (
     _apply_outline_summary_rewrites,
@@ -17,7 +21,63 @@ from codenib.wiki.outline import (
     _readme_entry_files,
     _required_top_level_pages,
     _validate_outline,
+    generate_outline,
 )
+
+
+def _source_paths(root):
+    return sorted(
+        path.relative_to(root).as_posix() for path in root.rglob("*") if path.is_file()
+    )
+
+
+def test_outline_prompt_uses_only_authenticated_source_inventory(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "runtime.py").write_text(
+        "def run(): return 'visible'\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "private").mkdir()
+    (tmp_path / "private" / "secret.txt").write_text(
+        "EXCLUDED_PROMPT_SECRET\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "Run src/runtime.py to start the service.\n",
+        encoding="utf-8",
+    )
+    binding = capture_repository_source(
+        tmp_path,
+        selection=RepositorySourceSelection(("private",)),
+    )
+    captured = {}
+
+    class LLM:
+        def complete(self, messages, **_kwargs):
+            captured["prompt"] = messages[0]["content"]
+            raise RuntimeError("stop after prompt capture")
+
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            language="python",
+            commit_short="abc123",
+        ),
+        manifest=SimpleNamespace(languages=["python"], indexes={}, file_count=2),
+        vector_store=None,
+        bm25=SimpleNamespace(documents=[]),
+        source_reader=binding.borrow_reader(),
+    )
+
+    try:
+        generate_outline(bundle, "fake-model", llm=LLM())
+    finally:
+        binding.close()
+
+    assert "src/runtime.py" in captured["prompt"]
+    assert "private/secret.txt" not in captured["prompt"]
+    assert "EXCLUDED_PROMPT_SECRET" not in captured["prompt"]
 
 
 def test_outline_quality_rejects_marketing_and_document_meta_summaries():
@@ -331,7 +391,7 @@ def test_outline_requires_real_source_anchors(tmp_path):
 
     result = _validate_outline(
         data,
-        str(tmp_path),
+        _source_paths(tmp_path),
         symbols=symbols,
         fallback_files=["codenib/runner.py"],
     )
@@ -381,7 +441,7 @@ def test_non_evaluation_page_drops_supporting_eval_files(tmp_path):
                 }
             ]
         },
-        str(tmp_path),
+        _source_paths(tmp_path),
         symbols=symbols,
         fallback_files=files,
     )
@@ -430,7 +490,7 @@ def test_readme_entry_files_resolve_documented_workflows(tmp_path):
         "The missing path is examples/not_present.py.\n"
     )
 
-    assert _readme_entry_files(str(tmp_path), readme) == files[:2]
+    assert _readme_entry_files(_source_paths(tmp_path), readme) == files[:2]
 
 
 def test_readme_documented_workflow_retains_supporting_source(tmp_path):
@@ -460,7 +520,7 @@ def test_readme_documented_workflow_retains_supporting_source(tmp_path):
                 },
             ]
         },
-        str(tmp_path),
+        _source_paths(tmp_path),
         fallback_files=[file],
         documented_files=[file],
     )
@@ -497,7 +557,7 @@ def test_evaluation_page_retains_explicit_eval_files(tmp_path):
                 }
             ]
         },
-        str(tmp_path),
+        _source_paths(tmp_path),
         symbols=symbols,
         fallback_files=[file],
     )
@@ -545,7 +605,7 @@ def test_overview_prefers_repository_root_readme(tmp_path):
                 }
             ]
         },
-        str(tmp_path),
+        _source_paths(tmp_path),
         symbols=[],
         fallback_files=["src/core.py"],
     )
@@ -571,7 +631,7 @@ def test_first_outline_page_is_canonical_overview(tmp_path):
                 }
             ]
         },
-        str(tmp_path),
+        _source_paths(tmp_path),
         symbols=[],
         fallback_files=["src/cli.py"],
     )
@@ -617,7 +677,7 @@ def test_overview_children_are_promoted_to_top_level(tmp_path):
                 }
             ]
         },
-        str(tmp_path),
+        _source_paths(tmp_path),
         symbols=symbols,
         fallback_files=["src/compiler.py"],
     )
@@ -658,7 +718,7 @@ def test_overview_prioritizes_product_entrypoints_over_backend_details(tmp_path)
                 }
             ]
         },
-        str(tmp_path),
+        _source_paths(tmp_path),
         symbols=[],
         fallback_files=files[1:],
     )
@@ -727,7 +787,7 @@ def test_outline_rejects_generic_concepts_with_unrelated_real_files(tmp_path):
                 },
             ]
         },
-        str(tmp_path),
+        _source_paths(tmp_path),
         symbols=symbols,
         fallback_files=files,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -572,7 +572,7 @@ wheels = [
 
 [[package]]
 name = "codenib"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
Resolve #641 and prepare the 0.2.2 source-surface release. Authenticated repository readers now support absolute symlinks whose lexical targets remain inside the pinned repository authority, while users can persist exact root-relative subtree exclusions across indexing, runtime, export, and CodeGraph workflows.

## Changes
- Accept contained absolute symlinks through pinned POSIX, Windows, retained-reader, and Docker authority paths; keep outside/device/prefix-confused targets fail closed.
- Add canonical `RepositorySourceSelection` exact-subtree exclusions with repeatable `--exclude-dir`, persisted reuse, and explicit `--clear-exclude-dirs`.
- Introduce RepoManifest v1.2 source-selection identity while retaining exact v1.1 read/import compatibility.
- Propagate the selection digest through compiler, BM25, vector, graph, SCIP, MCP, Web, Wiki, Ask, and historical projections.
- Authenticate graph plus optional occurrence sidecars and Zoekt build/runtime generations before native consumption.
- Disable unproved manifest-bound native clangd reuse and document the current safe fallback boundaries.
- Update README, guides, roadmap, changelog, release metadata, and the 0.2.2 release notes.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- Source selection, fingerprint, CLI, and CodeGraph — 381 passed, 5 skipped.
- Final review fixes for cache import, sandbox, graph receipts, and ordering — 264 passed.
- Compiler, chunking, embedding, and portable artifacts — 940 passed.
- MCP, SCIP, Web, Wiki, and agent runtime changed surface — 558 passed, 4 skipped.
- Unit tier — 6663 passed, 71 skipped, 191 deselected.
- Integration tier — 36 passed, 18 skipped.
- All changed-file pre-commit hooks and strict MkDocs build passed.
- Frontend production build, sdist/ABI3 wheel, twine checks, and isolated `codenib 0.2.2` install smoke passed.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published