### PR TITLE
test(cpp): align manifest provider expectation

### DIFF
--- a/test/ls_index/test_clangd_fact_query.py
+++ b/test/ls_index/test_clangd_fact_query.py
@@ -1469,7 +1469,7 @@ def test_real_mcp_boundary_keeps_supported_native_queries_graph_free(
     assert decoder._graph_materialized is False
 
 
-def test_server_context_selects_native_and_portable_graph_fallback(
+def test_server_context_uses_persisted_graph_for_manifest_source_policy(
     clangd_fixture, monkeypatch
 ) -> None:
     root, idx_directory = clangd_fixture
@@ -1480,16 +1480,18 @@ def test_server_context_selects_native_and_portable_graph_fallback(
         symbol_graph=graph,
     )
 
-    native = context.configure_lsp_provider(allow_native=True)
+    manifest_bound = context.configure_lsp_provider(allow_native=True)
 
-    assert native["backend"] == "native-clangd-fact-query-v1"
-    assert native["index_snapshot"].startswith("clangd_fact_query:sha256:")
-    assert native["capabilities"] == {
+    assert manifest_bound["backend"] == "persisted-symbol-graph-v1"
+    assert manifest_bound["fallback_reason"] == (
+        "repository_source_policy_requires_persisted_graph"
+    )
+    assert manifest_bound["capabilities"] == {
         "definition": True,
         "references": True,
         "route": True,
     }
-    assert context.lsp_provider.decoder._graph_materialized is False
+    assert context.lsp_provider.graph is graph
 
     portable = context.configure_lsp_provider(
         allow_native=False,


### PR DESCRIPTION
## Summary
Align the C++ provider integration test with the 0.2.2 manifest-bound source policy.

## Changes
- Expect manifest-bound C/C++ queries to use the persisted symbol graph even when native execution is requested.
- Preserve coverage that direct unbound provider selection can still use the native clangd fact-query backend.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

- `PYTHONPATH=build/core make core-test` (`221 passed, 2 skipped`)
- targeted provider behavior (`4 passed`)
- pre-commit hooks on the changed file

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published