### PR TITLE
fix(guardian): derive stable task-context locators

### DIFF
--- a/codenib/clients/guardian/types.py
+++ b/codenib/clients/guardian/types.py
@@ -33,7 +33,7 @@ def _task_context_id(
 
     material = "\0".join((content.strip(), source.value, fidelity.value))
     digest = hashlib.sha256(material.encode("utf-8")).hexdigest()
-    return f"CTX-{digest[:12]}"
+    return f"CTX-{digest}"
 
 
 def _solver_context_id(content: str) -> str:
@@ -45,7 +45,7 @@ def _solver_context_id(content: str) -> str:
     """
 
     digest = hashlib.sha256(content.strip().encode("utf-8")).hexdigest()
-    return f"CTX-solver-{digest[:8]}"
+    return f"CTX-solver-{digest}"
 
 
 class TaskContextSource(str, Enum):

--- a/codenib/clients/guardian/types.py
+++ b/codenib/clients/guardian/types.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import re
 import tempfile
 import uuid
@@ -18,6 +19,33 @@ from ..execution import AgentRunResult, ExecutionIsolation, TokenUsage
 
 _REVISION = re.compile(r"^[0-9a-f]{7,40}$")
 MAX_EXPLORERS = 12
+
+
+def _task_context_id(
+    content: str, source: TaskContextSource, fidelity: ContextFidelity
+) -> str:
+    """Derive a task-context locator that is stable across review cycles.
+
+    Callers rebuild task context on every cycle. A random locator would
+    invalidate remembered task evidence each time. Source and fidelity are
+    folded in so items that differ only by provenance keep distinct ids.
+    """
+
+    material = "\0".join((content.strip(), source.value, fidelity.value))
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()
+    return f"CTX-{digest[:12]}"
+
+
+def _solver_context_id(content: str) -> str:
+    """Derive a solver-message locator that is stable across review cycles.
+
+    A controller rebuilds the request from the same participant messages on
+    every cycle. A random locator would invalidate remembered solver evidence
+    each time and degrade every later review.
+    """
+
+    digest = hashlib.sha256(content.strip().encode("utf-8")).hexdigest()
+    return f"CTX-solver-{digest[:8]}"
 
 
 class TaskContextSource(str, Enum):
@@ -52,7 +80,9 @@ class TaskContext:
             and fidelity is not ContextFidelity.DERIVED
         ):
             raise ValueError("solver summaries must be marked as derived")
-        context_id = self.context_id.strip() or f"CTX-{uuid.uuid4().hex[:12]}"
+        context_id = self.context_id.strip() or _task_context_id(
+            content, source, fidelity
+        )
         object.__setattr__(self, "content", content)
         object.__setattr__(self, "source", source)
         object.__setattr__(self, "fidelity", fidelity)
@@ -467,7 +497,7 @@ class GuardianRequest:
                         content=message.content,
                         source=TaskContextSource.SOLVER_SUMMARY,
                         fidelity=ContextFidelity.DERIVED,
-                        context_id=f"CTX-solver-{uuid.uuid4().hex[:8]}",
+                        context_id=_solver_context_id(message.content),
                     ),
                 )
         if sum(len(item.content.encode("utf-8")) for item in task_context) > 512 * 1024:

--- a/test/clients/test_guardian.py
+++ b/test/clients/test_guardian.py
@@ -2632,7 +2632,9 @@ def test_solver_context_ids_are_stable_across_review_cycles(tmp_path: Path) -> N
         tmp_path, seed.workspace, seed.base_commit, seed.candidate_commit, 2
     )
 
-    assert _solver_context(first).context_id == _solver_context(second).context_id
+    first_id = _solver_context(first).context_id
+    assert first_id == _solver_context(second).context_id
+    assert len(first_id.removeprefix("CTX-solver-")) == 64
 
 
 def test_remembered_solver_evidence_stays_fresh_in_a_later_cycle(
@@ -2670,7 +2672,9 @@ def test_task_context_auto_ids_are_stable_for_equivalent_items() -> None:
             fidelity=ContextFidelity.VERBATIM,
         )
 
-    assert build().context_id == build().context_id
+    first_id = build().context_id
+    assert first_id == build().context_id
+    assert len(first_id.removeprefix("CTX-")) == 64
 
 
 def test_task_context_auto_ids_separate_distinct_sources() -> None:

--- a/test/clients/test_guardian.py
+++ b/test/clients/test_guardian.py
@@ -51,7 +51,11 @@ from codenib.clients.guardian.aggregation import (
     adjudicate_records,
 )
 from codenib.clients.guardian.contribution import explorer_contribution_report
-from codenib.clients.guardian.evidence import validate_candidates, validate_evidence
+from codenib.clients.guardian.evidence import (
+    revalidate_memory_evidence,
+    validate_candidates,
+    validate_evidence,
+)
 from codenib.clients.guardian.normalization import (
     GuardianResponseError,
     parse_explorer_output,
@@ -2590,3 +2594,96 @@ def test_canonical_repository_remains_unchanged(tmp_path: Path) -> None:
     assert result.status is ReviewStatus.COMPLETE
     assert _git(request.workspace, "status", "--porcelain=v1") == before
     assert _git(request.workspace, "rev-parse", "HEAD") == request.candidate_commit
+
+
+def _cycle_request(
+    tmp_path: Path, workspace: Path, base: str, candidate: str, cycle: int
+) -> GuardianRequest:
+    """Build the request a controller derives on one review cycle.
+
+    Each cycle re-reads the same participant messages and rebuilds the request,
+    so anything derived from them must be identical across cycles.
+    """
+
+    return GuardianRequest(
+        workspace=workspace,
+        base_commit=base,
+        candidate_commit=candidate,
+        change_patch="-    return {'mode': 'safe'}\n+    return {}",
+        context=(ContextMessage("I believe state copies are complete."),),
+        artifact_dir=tmp_path / f"artifacts-{cycle}",
+    )
+
+
+def _solver_context(request: GuardianRequest) -> TaskContext:
+    return next(
+        item
+        for item in request.task_context
+        if item.source is TaskContextSource.SOLVER_SUMMARY
+    )
+
+
+def test_solver_context_ids_are_stable_across_review_cycles(tmp_path: Path) -> None:
+    seed = _request(tmp_path)
+    first = _cycle_request(
+        tmp_path, seed.workspace, seed.base_commit, seed.candidate_commit, 1
+    )
+    second = _cycle_request(
+        tmp_path, seed.workspace, seed.base_commit, seed.candidate_commit, 2
+    )
+
+    assert _solver_context(first).context_id == _solver_context(second).context_id
+
+
+def test_remembered_solver_evidence_stays_fresh_in_a_later_cycle(
+    tmp_path: Path,
+) -> None:
+    seed = _request(tmp_path)
+    first = _cycle_request(
+        tmp_path, seed.workspace, seed.base_commit, seed.candidate_commit, 1
+    )
+    remembered = Evidence(
+        path=_solver_context(first).context_id,
+        line_start=1,
+        line_end=1,
+        description="The solver claims state copies are complete.",
+        source_type=EvidenceSourceType.SOLVER_MESSAGE,
+        authority=EvidenceAuthority.DERIVED,
+        evidence_id="EV-solver",
+        quote="I believe state copies are complete.",
+    )
+
+    second = _cycle_request(
+        tmp_path, seed.workspace, seed.base_commit, seed.candidate_commit, 2
+    )
+    revalidated, errors = revalidate_memory_evidence(second, (remembered,))
+
+    assert errors == ()
+    assert revalidated[0].fresh
+
+
+def test_task_context_auto_ids_are_stable_for_equivalent_items() -> None:
+    def build() -> TaskContext:
+        return TaskContext(
+            content="Every copied state must preserve its configured mode.",
+            source=TaskContextSource.ISSUE,
+            fidelity=ContextFidelity.VERBATIM,
+        )
+
+    assert build().context_id == build().context_id
+
+
+def test_task_context_auto_ids_separate_distinct_sources() -> None:
+    content = "Every copied state must preserve its configured mode."
+    verbatim = TaskContext(
+        content=content,
+        source=TaskContextSource.ISSUE,
+        fidelity=ContextFidelity.VERBATIM,
+    )
+    derived = TaskContext(
+        content=content,
+        source=TaskContextSource.SOLVER_SUMMARY,
+        fidelity=ContextFidelity.DERIVED,
+    )
+
+    assert verbatim.context_id != derived.context_id


### PR DESCRIPTION
## Summary

Task-context and solver-message locators were minted with `uuid4` on every `GuardianRequest` construction. A controller rebuilds the request from the same participant messages on each review cycle, so the locator changed each time, remembered task and solver evidence failed revalidation with `task-message locator does not exist in the request`, and every cycle after the first was reported `DEGRADED`.

The practical effect is that once a solver has posted any message, the checkpoint prints "Guardian analysis was degraded; this report must not be treated as a complete clean review" on every subsequent review — training operators to ignore the one honesty signal Guardian has.

## Changes

- derive the solver-message locator in `GuardianRequest.__post_init__` from a SHA-256 digest of the message content instead of `uuid4`;
- derive the `TaskContext` auto-id from a digest of content, source, and fidelity, so items differing only by provenance still keep distinct ids — this instance affects any caller that builds task context without explicit ids, not just the DeepSWE controller;
- add four regression tests: locator stability across cycles, remembered solver evidence staying fresh in a later cycle, `TaskContext` auto-id stability, and a guard that distinct sources do not collapse to one id.

`ContextMessage` carries no id field (the controller drops `GuardianMessage.id` when building context), so a content-derived locator fixes every caller without a harness API change, and matches the identity notion the adjacent dedup check already uses.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `pytest -q test/clients/ test/guardian/ test/sandbox/test_docker.py` — 163 passed.
- Both new behaviours were confirmed failing before the fix; the solver-evidence test reproduced the exact `task-message locator does not exist in the request` error that drives `degraded=True`.
- Black, isort (`--profile black`), and flake8 clean on both changed files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
