### PR TITLE
fix(guardian): retain cross-round specifications

### DIFF
--- a/codenib/clients/guardian/aggregation.py
+++ b/codenib/clients/guardian/aggregation.py
@@ -285,10 +285,10 @@ def _merge_memory(
     for candidate in candidates:
         for item in candidate.supporting_evidence + candidate.counterevidence:
             evidence_by_id[item.evidence_id] = replace(item, snapshot=snapshot)
-    records, task_evidence = _materialize_task_evidence(request, records)
+    combined = _merge_specification_records(memory.specifications, records)
+    combined, task_evidence = _materialize_task_evidence(request, combined)
     for item in task_evidence:
         evidence_by_id[item.evidence_id] = replace(item, snapshot=snapshot)
-    combined = _merge_specification_records(memory.specifications, records)
     evidence_by_id = _link_official_specifications(evidence_by_id, combined)
     combined = _drop_unlinked_references(combined, evidence_by_id)
     combined = adjudicate_records(combined, tuple(evidence_by_id.values()))

--- a/codenib/clients/guardian/aggregation.py
+++ b/codenib/clients/guardian/aggregation.py
@@ -285,9 +285,27 @@ def _merge_memory(
     for candidate in candidates:
         for item in candidate.supporting_evidence + candidate.counterevidence:
             evidence_by_id[item.evidence_id] = replace(item, snapshot=snapshot)
+    records, task_evidence = _materialize_task_evidence(request, records)
     combined = _merge_specification_records(memory.specifications, records)
-    combined, task_evidence = _materialize_task_evidence(request, combined)
+    specification_ids = {item.specification_id for item in combined}
     for item in task_evidence:
+        previous = evidence_by_id.get(item.evidence_id)
+        if (
+            previous is not None
+            and previous.fresh
+            and previous.source_type is item.source_type
+            and previous.authority is item.authority
+            and previous.quote == item.quote
+        ):
+            carried = tuple(
+                specification_id
+                for specification_id in previous.supports
+                if specification_id in specification_ids
+            )
+            item = replace(
+                item,
+                supports=tuple(dict.fromkeys((*carried, *item.supports))),
+            )
         evidence_by_id[item.evidence_id] = replace(item, snapshot=snapshot)
     evidence_by_id = _link_official_specifications(evidence_by_id, combined)
     combined = _drop_unlinked_references(combined, evidence_by_id)

--- a/codenib/clients/guardian/evidence.py
+++ b/codenib/clients/guardian/evidence.py
@@ -225,6 +225,8 @@ def _validate_non_file(
         # when an explorer supplied a paraphrase instead of an exact substring. Cite
         # the complete source so the aggregator can test entailment against the task,
         # rather than accidentally granting authority to the paraphrase itself.
+        if evidence.acquired_by == "controller" and quote is None:
+            return None, "controller task evidence no longer matches the task message"
         return (
             replace(
                 evidence,

--- a/codenib/clients/guardian/evidence.py
+++ b/codenib/clients/guardian/evidence.py
@@ -218,6 +218,7 @@ def _validate_non_file(
                     path=path,
                     quote=quote,
                     authority=EvidenceAuthority.DERIVED,
+                    fresh=True,
                 ),
                 "",
             )
@@ -225,14 +226,20 @@ def _validate_non_file(
         # when an explorer supplied a paraphrase instead of an exact substring. Cite
         # the complete source so the aggregator can test entailment against the task,
         # rather than accidentally granting authority to the paraphrase itself.
-        if evidence.acquired_by == "controller" and quote is None:
-            return None, "controller task evidence no longer matches the task message"
+        if evidence.acquired_by == "controller":
+            if evidence.quote != context.content:
+                return (
+                    None,
+                    "controller task evidence no longer matches the task message",
+                )
+            quote = context.content
         return (
             replace(
                 evidence,
                 path=path,
                 quote=quote or context.content,
                 authority=EvidenceAuthority.NORMATIVE,
+                fresh=True,
             ),
             "",
         )
@@ -241,14 +248,14 @@ def _validate_non_file(
             return None, "candidate-patch evidence must retain an exact quote"
         if evidence.quote not in request.change_patch:
             return None, "quoted content does not occur in the candidate patch"
-        return replace(evidence, authority=EvidenceAuthority.DERIVED), ""
+        return replace(evidence, authority=EvidenceAuthority.DERIVED, fresh=True), ""
     if evidence.source_type is EvidenceSourceType.RUNTIME_PROBE:
         if not evidence.command or (not evidence.output and evidence.exit_code is None):
             return (
                 None,
                 "runtime evidence must retain a command and an output or exit code",
             )
-        return replace(evidence, authority=EvidenceAuthority.BEHAVIORAL), ""
+        return replace(evidence, authority=EvidenceAuthority.BEHAVIORAL, fresh=True), ""
     return None, "unsupported evidence locator"
 
 

--- a/test/clients/test_guardian.py
+++ b/test/clients/test_guardian.py
@@ -2780,3 +2780,58 @@ def test_carried_over_specification_survives_a_round_that_omits_it(
         item for item in merged.evidence if item.evidence_id == task_context.context_id
     )
     assert task_evidence.supports == ("LS-001", "LS-002")
+
+
+def test_carried_specification_is_not_rebound_to_changed_task_text(
+    tmp_path: Path,
+) -> None:
+    request = _request(tmp_path)
+    task_context = next(
+        item
+        for item in request.task_context
+        if item.source is TaskContextSource.USER_INSTRUCTION
+    )
+    record = _supported_record(
+        "LS-001", "Copied state preserves its configured mode.", task_context.context_id
+    )
+    evidence = Evidence(
+        evidence_id=task_context.context_id,
+        path=task_context.context_id,
+        line_start=1,
+        line_end=1,
+        description="Verbatim requirement supplied to the coding system.",
+        source_type=EvidenceSourceType.TASK,
+        authority=EvidenceAuthority.NORMATIVE,
+        quote=task_context.content,
+        supports=(record.specification_id,),
+        acquired_by="controller",
+        fresh=True,
+    )
+    changed_request = replace(
+        request,
+        task_context=(
+            TaskContext(
+                content="Every copied state must preserve its retry budget.",
+                source=TaskContextSource.USER_INSTRUCTION,
+                fidelity=ContextFidelity.VERBATIM,
+                context_id=task_context.context_id,
+            ),
+        ),
+        context=(),
+        artifact_dir=tmp_path / "changed-task-artifacts",
+    )
+
+    revalidated, errors = revalidate_memory_evidence(changed_request, (evidence,))
+    assert errors
+    assert "no longer matches the task message" in errors[0]
+    assert not revalidated[0].fresh
+
+    merged = _merge_memory(
+        changed_request,
+        SpecificationMemory(specifications=(record,), evidence=revalidated),
+        (),
+        (),
+        snapshot=changed_request.candidate_commit,
+    )
+
+    assert merged.specifications[0].status is SpecificationStatus.REJECTED

--- a/test/clients/test_guardian.py
+++ b/test/clients/test_guardian.py
@@ -2811,7 +2811,11 @@ def test_carried_specification_is_not_rebound_to_changed_task_text(
         request,
         task_context=(
             TaskContext(
-                content="Every copied state must preserve its retry budget.",
+                content=(
+                    f"The old requirement was: {task_context.content}\n"
+                    "That requirement is withdrawn; copied state must only preserve "
+                    "its retry budget."
+                ),
                 source=TaskContextSource.USER_INSTRUCTION,
                 fidelity=ContextFidelity.VERBATIM,
                 context_id=task_context.context_id,
@@ -2835,3 +2839,44 @@ def test_carried_specification_is_not_rebound_to_changed_task_text(
     )
 
     assert merged.specifications[0].status is SpecificationStatus.REJECTED
+
+
+def test_carried_specification_recovers_when_task_text_is_restored(
+    tmp_path: Path,
+) -> None:
+    request = _request(tmp_path)
+    task_context = next(
+        item
+        for item in request.task_context
+        if item.source is TaskContextSource.USER_INSTRUCTION
+    )
+    record = _supported_record(
+        "LS-001", "Copied state preserves its configured mode.", task_context.context_id
+    )
+    stale_evidence = Evidence(
+        evidence_id=task_context.context_id,
+        path=task_context.context_id,
+        line_start=1,
+        line_end=1,
+        description="Verbatim requirement supplied to the coding system.",
+        source_type=EvidenceSourceType.TASK,
+        authority=EvidenceAuthority.NORMATIVE,
+        quote=task_context.content,
+        supports=(record.specification_id,),
+        acquired_by="controller",
+        fresh=False,
+    )
+
+    revalidated, errors = revalidate_memory_evidence(request, (stale_evidence,))
+    assert errors == ()
+    assert revalidated[0].fresh
+
+    merged = _merge_memory(
+        request,
+        SpecificationMemory(specifications=(record,), evidence=revalidated),
+        (),
+        (),
+        snapshot=request.candidate_commit,
+    )
+
+    assert merged.specifications[0].status is SpecificationStatus.SUPPORTED

--- a/test/clients/test_guardian.py
+++ b/test/clients/test_guardian.py
@@ -47,6 +47,7 @@ from codenib.clients.guardian import (
 )
 from codenib.clients.guardian.aggregation import (
     _materialize_task_evidence,
+    _merge_memory,
     _merge_specification_records,
     adjudicate_records,
 )
@@ -2691,3 +2692,82 @@ def test_task_context_auto_ids_separate_distinct_sources() -> None:
     )
 
     assert verbatim.context_id != derived.context_id
+
+
+def _supported_record(
+    specification_id: str, statement: str, evidence_id: str, round_number: int = 1
+) -> SpecificationRecord:
+    return SpecificationRecord(
+        specification_id=specification_id,
+        statement=statement,
+        condition="when state is copied",
+        scope=("contract.py",),
+        supporting_evidence=(evidence_id,),
+        counterevidence=(),
+        provenance=(),
+        status=SpecificationStatus.SUPPORTED,
+        status_reason="direct normative task evidence",
+        created_round=round_number,
+        updated_round=round_number,
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "_merge_memory materializes task evidence from the incoming round only, "
+        "so it overwrites the stored evidence supports and _drop_unlinked_"
+        "references then strips carried-over specifications. See aggregation.py."
+    ),
+)
+def test_carried_over_specification_survives_a_round_that_omits_it(
+    tmp_path: Path,
+) -> None:
+    """A later round must not retract a specification merely by not restating it.
+
+    The aggregation prompt requires provenance for every *candidate* it emits; it
+    never requires re-emitting specifications already held in memory.
+    """
+
+    request = _request(tmp_path)
+    task_context = next(
+        item
+        for item in request.task_context
+        if item.source is TaskContextSource.USER_INSTRUCTION
+    )
+    first_round = _supported_record(
+        "LS-001", "Copied state preserves its configured mode.", task_context.context_id
+    )
+    memory = SpecificationMemory(
+        specifications=(first_round,),
+        evidence=(
+            Evidence(
+                evidence_id=task_context.context_id,
+                path=task_context.context_id,
+                line_start=1,
+                line_end=1,
+                description="Verbatim requirement supplied to the coding system.",
+                source_type=EvidenceSourceType.TASK,
+                authority=EvidenceAuthority.NORMATIVE,
+                quote=task_context.content,
+                supports=("LS-001",),
+                acquired_by="controller",
+                fresh=True,
+            ),
+        ),
+        observed_snapshots=(request.base_commit,),
+    )
+    second_round = _supported_record(
+        "LS-002",
+        "Copied state preserves its configured retry budget.",
+        task_context.context_id,
+        round_number=2,
+    )
+
+    merged = _merge_memory(
+        request, memory, (second_round,), (), snapshot=request.candidate_commit
+    )
+
+    by_id = {item.specification_id: item for item in merged.specifications}
+    assert by_id["LS-001"].status is SpecificationStatus.SUPPORTED
+    assert by_id["LS-002"].status is SpecificationStatus.SUPPORTED

--- a/test/clients/test_guardian.py
+++ b/test/clients/test_guardian.py
@@ -2712,14 +2712,6 @@ def _supported_record(
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "_merge_memory materializes task evidence from the incoming round only, "
-        "so it overwrites the stored evidence supports and _drop_unlinked_"
-        "references then strips carried-over specifications. See aggregation.py."
-    ),
-)
 def test_carried_over_specification_survives_a_round_that_omits_it(
     tmp_path: Path,
 ) -> None:
@@ -2771,3 +2763,7 @@ def test_carried_over_specification_survives_a_round_that_omits_it(
     by_id = {item.specification_id: item for item in merged.specifications}
     assert by_id["LS-001"].status is SpecificationStatus.SUPPORTED
     assert by_id["LS-002"].status is SpecificationStatus.SUPPORTED
+    task_evidence = next(
+        item for item in merged.evidence if item.evidence_id == task_context.context_id
+    )
+    assert task_evidence.supports == ("LS-001", "LS-002")

--- a/test/clients/test_guardian.py
+++ b/test/clients/test_guardian.py
@@ -2721,7 +2721,20 @@ def test_carried_over_specification_survives_a_round_that_omits_it(
     never requires re-emitting specifications already held in memory.
     """
 
-    request = _request(tmp_path)
+    request = replace(
+        _request(tmp_path),
+        task_context=(
+            TaskContext(
+                content=(
+                    "Every copied state must preserve its configured mode and "
+                    "retry budget."
+                ),
+                source=TaskContextSource.USER_INSTRUCTION,
+                fidelity=ContextFidelity.VERBATIM,
+                context_id="CTX-task",
+            ),
+        ),
+    )
     task_context = next(
         item
         for item in request.task_context


### PR DESCRIPTION
## Summary

Preserve supported Guardian specifications when a later aggregation round does not restate them. The original contribution captured the failure as a strict xfail; the maintainer follow-up now fixes the merge and turns that scenario into a passing regression.

## Changes

- add the contributor-authored two-round regression for a carried specification;
- merge stored and incoming specification records before rematerializing canonical task evidence;
- preserve task-evidence support links for both carried and newly emitted specifications;
- remove the strict xfail now that the defect is fixed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- pytest -q test/clients --tb=short — 114 passed.
- Combined #649 + #650 unit tier — 6727 passed, 71 skipped, 191 deselected. The sole explicit deselection is the known unrelated Web caplog baseline.
- Black, isort, flake8, namespace, and changed-file pre-commit hooks passed.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published