### PR TITLE
feat(storage): import BM25 and vector compiler caches

### DIFF
--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -813,6 +813,17 @@ class PublicationDirectoryReader:
             return self._expected_ownership.file_records
         return self.capture_ownership().file_records
 
+    def _require_expected_ownership_token(self) -> _TreeOwnership:
+        """Return only framework-installed callback ownership, never recapturing."""
+
+        self._require_active()
+        if self._expected_ownership is None:
+            self._mark_authentication_failed()
+            raise RuntimeError(
+                "publication callback has no framework expected ownership"
+            )
+        return self._expected_ownership
+
     def authenticated_snapshot(
         self,
         relative: str | PurePosixPath,

--- a/codenib/artifacts/__init__.py
+++ b/codenib/artifacts/__init__.py
@@ -46,6 +46,7 @@ from .strict_context import (
     publish_planned_context_artifact_strict,
     stage_context_artifact_strict,
 )
+from .strict_vector import PlannedVectorView, recapture_vector_view_strict
 
 __all__ = [
     "CONTEXT_ARTIFACT_MANIFEST",
@@ -59,6 +60,7 @@ __all__ = [
     "PlannedBm25View",
     "PlannedContextArtifact",
     "PlannedContextView",
+    "PlannedVectorView",
     "SourceTrust",
     "VerifiedContextArtifact",
     "bind_context_artifact",
@@ -72,6 +74,7 @@ __all__ = [
     "publish_planned_context_artifact_strict",
     "query_context_artifact",
     "recapture_bm25_view_strict",
+    "recapture_vector_view_strict",
     "validate_portable_query_view",
     "resolve_github_context_artifact",
     "render_artifact_mcp_config",

--- a/codenib/artifacts/portable_views.py
+++ b/codenib/artifacts/portable_views.py
@@ -41,6 +41,7 @@ from .._contained_source import validate_repository_file
 from .._secret_fields import assert_no_secret_fields
 from ..index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
+    VECTOR_ROW_MAPPING_CONTRACT,
     VECTOR_VIEW_UPDATE_MARKER,
 )
 from ..index.embedding.model_policy import (
@@ -763,16 +764,29 @@ class _PublicationViewReader:
     def __init__(
         self,
         publication: PublicationDirectoryReader,
-        ownership: object,
+        ownership: object | None,
     ) -> None:
         # Synthetic only: callers use it for relative path arithmetic, never as
         # a filesystem authority.
         self.root = Path("/__codenib_publication_view__")
-        self.ownership = ownership
         self._publication = publication
-        records = tuple(
-            directory_ownership_file_records(ownership)  # type: ignore[arg-type]
-        )
+        if ownership is None:
+            # Private framework-sandwiched validators reuse the exact token
+            # already installed in the callback reader. Fail closed rather
+            # than letting fallback accessors recapture an unsandwiched tree.
+            expected = publication._require_expected_ownership_token()
+            records = tuple(directory_ownership_file_records(expected))
+            inventory = tuple(directory_ownership_inventory(expected))
+            self.ownership = self
+        else:
+            records = tuple(
+                directory_ownership_file_records(ownership)  # type: ignore[arg-type]
+            )
+            inventory = tuple(
+                directory_ownership_inventory(ownership)  # type: ignore[arg-type]
+            )
+            self.ownership = ownership
+        self._inventory = inventory
         self._records = {record.path: record for record in records}
         if len(self._records) != len(records):
             raise RuntimeError("publication view repeats a file record")
@@ -806,6 +820,12 @@ class _PublicationViewReader:
             raise ValueError(
                 f"publication view has no initial file record: {relative}"
             ) from exc
+
+    def file_records(self) -> tuple[TreeFileRecord, ...]:
+        return tuple(sorted(self._records.values(), key=lambda record: record.path))
+
+    def inventory(self) -> tuple[tuple[str, str], ...]:
+        return self._inventory
 
     @contextmanager
     def open_file(
@@ -883,15 +903,28 @@ class _PublicationViewReader:
     ) -> None:
         # ``keep_descriptor`` is deliberately ignored. Content-bound portable
         # validation never grants native parsing authority.
-        del keep_descriptor
+        # The complete publication was already hashed into ``ownership``.
+        # Config and document consumers subsequently reopen and compare their
+        # exact records; inert FAISS bytes are intentionally never reopened by
+        # this validator.  ``verify_root`` performs the full post-validation
+        # capture that closes the race window for every record-only binding.
+        del cache_bytes, keep_descriptor
         relative = self.require_fingerprint(path, expected)
-        limit = self.record(relative).size if max_bytes is None else max_bytes
-        del cache_bytes
-        with self.open_file(relative, max_bytes=limit) as source:
-            for _chunk in source.iter_bytes(chunk_size=_JSON_READ_CHUNK_BYTES):
-                pass
+        if max_bytes is not None:
+            if isinstance(max_bytes, bool) or not isinstance(max_bytes, int):
+                raise TypeError("portable publication stream limit must be an integer")
+            if max_bytes < 0:
+                raise ValueError("portable publication stream limit cannot be negative")
+            if self.record(relative).size > max_bytes:
+                raise ValueError(
+                    f"portable view file exceeds its {max_bytes}-byte limit: {relative}"
+                )
 
     def verify_root(self) -> None:
+        if self.ownership is self:
+            raise RuntimeError(
+                "framework-sandwiched publication validation owns no final capture"
+            )
         if self._publication.capture_ownership() != self.ownership:
             raise RuntimeError("publication view changed during validation")
 
@@ -905,6 +938,18 @@ class _PublicationViewReader:
 
 
 _ViewReader = _OwnedViewReader | _PublicationViewReader
+
+
+def _view_inventory(ownership: object) -> tuple[tuple[str, str], ...]:
+    if isinstance(ownership, _PublicationViewReader):
+        return ownership.inventory()
+    return tuple(directory_ownership_inventory(ownership))  # type: ignore[arg-type]
+
+
+def _view_file_records(ownership: object) -> tuple[TreeFileRecord, ...]:
+    if isinstance(ownership, _PublicationViewReader):
+        return ownership.file_records()
+    return tuple(directory_ownership_file_records(ownership))  # type: ignore[arg-type]
 
 
 def _reject_duplicate_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -1291,7 +1336,7 @@ def _normalize_pickle_documents(
 def _owned_inventory_paths(root: Path, ownership: object, *, kind: str) -> set[Path]:
     return {
         root.joinpath(*PurePosixPath(relative).parts)
-        for relative, observed_kind in directory_ownership_inventory(ownership)
+        for relative, observed_kind in _view_inventory(ownership)
         if observed_kind == kind
     }
 
@@ -1310,11 +1355,7 @@ def _authenticate_initial_file(
 
     relative = path.relative_to(root).as_posix()
     record = next(
-        (
-            item
-            for item in directory_ownership_file_records(ownership)
-            if item.path == relative
-        ),
+        (item for item in _view_file_records(ownership) if item.path == relative),
         None,
     )
     if record is None:
@@ -1766,6 +1807,34 @@ def _validate_vector_semantics(
             raise ValueError(
                 "portable vector persistence options do not match its view route"
             )
+
+    persisted_builder_schema = (
+        persisted_identity.get("builder_schema")
+        if isinstance(persisted_identity, Mapping)
+        else None
+    )
+    retained_schema_selected = (
+        type(builder_schema) is int and builder_schema >= 7
+    ) or (type(persisted_builder_schema) is int and persisted_builder_schema >= 7)
+    if retained_schema_selected and not (
+        type(builder_schema) is int
+        and type(persisted_builder_schema) is int
+        and persisted_builder_schema == builder_schema
+    ):
+        raise ValueError(
+            "portable vector persistence builder schema does not match its "
+            "view config"
+        )
+    schema_8_selected = type(builder_schema) is int and builder_schema == 8
+    if schema_8_selected:
+        if config.get("row_mapping") != VECTOR_ROW_MAPPING_CONTRACT:
+            raise ValueError(
+                "schema-8 portable vector persistence has an invalid row mapping"
+            )
+    elif config.get("row_mapping") is not None:
+        raise ValueError(
+            "legacy portable vector persistence has an unsupported row mapping"
+        )
 
     if route.dimension is None:
         raise ValueError("portable vector route is missing its embedding dimension")
@@ -2303,7 +2372,7 @@ def _assert_exact_view_tree(
         if parent != PurePosixPath(".")
     }
     observed_files: set[PurePosixPath] = set()
-    for raw_relative, kind in directory_ownership_inventory(ownership):
+    for raw_relative, kind in _view_inventory(ownership):
         relative = PurePosixPath(raw_relative)
         if kind == "directory":
             if relative not in allowed_directories:
@@ -3094,6 +3163,7 @@ def _validate_content_bound_portable_query_view_reader_with_identity(
     view_config: Mapping[str, Any] | None = None,
     forbidden_paths: Iterable[Path] = (),
     environ: Mapping[str, str] | None = None,
+    _framework_sandwiched: bool = False,
 ) -> None:
     """Validate one portable view through retained view and source authorities.
 
@@ -3134,8 +3204,14 @@ def _validate_content_bound_portable_query_view_reader_with_identity(
     if len(authenticated_source_files) != len(repository_records):
         raise RuntimeError("authenticated repository source repeats a file record")
 
-    initial_tree = publication.capture_ownership()
-    reader = _PublicationViewReader(publication, initial_tree)
+    if not isinstance(_framework_sandwiched, bool):
+        raise TypeError("portable framework sandwich selector must be a boolean")
+    if _framework_sandwiched:
+        reader = _PublicationViewReader(publication, None)
+        initial_tree: object = reader
+    else:
+        initial_tree = publication.capture_ownership()
+        reader = _PublicationViewReader(publication, initial_tree)
 
     def validate_semantics() -> None:
         with repository_source.read_session():
@@ -3169,18 +3245,23 @@ def _validate_content_bound_portable_query_view_reader_with_identity(
                     authenticated_source_files=authenticated_source_files,
                 )
 
-    _run_callback_with_post_validations(
-        validate_semantics,
+    final_checks = [
         (
+            "portable view reader cleanup also failed",
+            reader.close,
+        )
+    ]
+    if not _framework_sandwiched:
+        final_checks.insert(
+            0,
             (
                 "portable view final ownership validation also failed",
                 reader.verify_root,
             ),
-            (
-                "portable view reader cleanup also failed",
-                reader.close,
-            ),
-        ),
+        )
+    _run_callback_with_post_validations(
+        validate_semantics,
+        tuple(final_checks),
     )
 
 

--- a/codenib/artifacts/strict_bm25.py
+++ b/codenib/artifacts/strict_bm25.py
@@ -49,6 +49,7 @@ from .._workspace_provider import (
     StrictWorkspaceSession,
     run_strict_workspace,
 )
+from ..repository_source_selection import RepositorySourceSelection
 from ..source_fingerprint import (
     RepositorySourceBinding,
     RepositorySourceIdentitySnapshot,
@@ -63,6 +64,7 @@ _JSON_READ_CHUNK_BYTES = 1024 * 1024
 _WINDOWS_DRIVE_PREFIX = tuple(
     f"{letter}:" for letter in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 )
+_CURRENT_BM25_BUILDER_SCHEMA = 8
 _STRICT_BM25_PLAN_DOMAIN = b"codenib-portable-bm25-strict-workspace-v1"
 _STRICT_BM25_FILES = frozenset({"documents.json", "bm25_metadata.json"})
 
@@ -892,6 +894,25 @@ def _policy(
     forbidden_paths: tuple[Path, ...],
     environ: Mapping[str, str],
 ) -> tuple[str, tuple[Path, ...], frozenset[str]]:
+    has_selection_digest = "source_selection_digest" in view_config
+    if (
+        type(view_config.get("builder_schema")) is int
+        and view_config.get("builder_schema") == _CURRENT_BM25_BUILDER_SCHEMA
+        and not has_selection_digest
+    ):
+        raise ValueError("current BM25 view config requires a source selection digest")
+    if has_selection_digest:
+        source_selection = repository_identity.source_selection
+        selection_digest = view_config.get("source_selection_digest")
+        if (
+            type(source_selection) is not RepositorySourceSelection
+            or type(selection_digest) is not str
+            or selection_digest != source_selection.digest
+        ):
+            raise ValueError(
+                "BM25 view source selection differs from the authenticated "
+                "repository source"
+            )
     forbidden = (repository_identity.root, *forbidden_paths)
     assert_no_secret_fields(view_config, source="portable BM25 view config")
     _assert_authenticated_publishable_json_value(

--- a/codenib/artifacts/strict_vector.py
+++ b/codenib/artifacts/strict_vector.py
@@ -1,0 +1,1706 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Strict, missing-only recapture for schema-8 compiler vector caches."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import os
+from collections.abc import Iterable, Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from .._atomic_directory import (
+    PublicationAuthenticatedFile,
+    PublicationDirectoryReader,
+    TreeFileRecord,
+    _annotate_secondary_error,
+    capture_directory_ownership,
+    directory_ownership_digest,
+    directory_ownership_file_records,
+    directory_ownership_inventory,
+    lexical_directory_path,
+    reopen_authenticated_directory,
+)
+from .._bounded_json import (
+    canonical_json_array_chunks,
+    canonical_json_value_chunks,
+    iter_bounded_json_array,
+    validate_bounded_json_stream,
+    validate_json_complexity,
+)
+from .._captured_directory import (
+    PublishedWorkspaceReceiptOwner,
+    WorkspaceDirectory,
+    WorkspaceFile,
+    WorkspacePlan,
+    require_owned_workspace_publication_support,
+)
+from .._secret_fields import assert_no_secret_fields
+from .._workspace_provider import (
+    StrictWorkspaceProvider,
+    StrictWorkspaceRequest,
+    StrictWorkspaceSession,
+    run_strict_workspace,
+)
+from ..index.embedding.artifact_integrity import (
+    VECTOR_PERSISTENCE_SCHEMA,
+    VECTOR_ROW_MAPPING_CONTRACT,
+    validate_schema_8_vector_document_row,
+)
+from ..provider_routes import resolve_embedding_artifact_route
+from ..repository_source_selection import RepositorySourceSelection
+from ..source_fingerprint import (
+    RepositorySourceBinding,
+    RepositorySourceIdentitySnapshot,
+)
+from .portable_views import (
+    MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
+    MAX_PORTABLE_FAISS_INDEX_BYTES,
+    _validate_content_bound_portable_query_view_reader_with_identity,
+    validate_portable_vector_persistence_semantics,
+)
+from .security import assert_publishable_json_value
+
+_MAX_CONFIG_JSON_BYTES = 16 * 1024 * 1024
+_JSON_READ_CHUNK_BYTES = 1024 * 1024
+_MAX_SOURCE_PATH_BYTES = 4_096
+_MAX_SOURCE_PATH_COMPONENTS = 256
+_STRICT_VECTOR_BUILDER_SCHEMA = 8
+_STRICT_VECTOR_PLAN_DOMAIN = b"codenib-portable-vector-strict-workspace-v1"
+_VECTOR_LEVELS = ("l0", "l2")
+_RAW_MUTABLE_ROOT_FILES = frozenset(
+    {
+        "chunk_store.json",
+        "chunk_store.pkl",
+        "embeddings_cache.json",
+        "embeddings_cache.npz",
+        "embeddings_cache.pkl",
+        "incremental_state.json",
+    }
+)
+_REQUIRED_IDENTITY_FIELDS = frozenset(
+    {
+        "builder_schema",
+        "embedding_model",
+        "embedding_provider",
+        "embedding_dimension",
+        "dimension",
+        "embedding_endpoint",
+        "embedding_kwargs",
+        "embedding_route",
+        "embedding_fingerprint",
+        "index_metric",
+        "languages",
+        "levels",
+        "max_lines_per_chunk",
+        "chunking_failure_policy",
+        "repository_filter_policy",
+        "source_selection_digest",
+    }
+)
+_OPTIONAL_IDENTITY_FIELDS = frozenset(
+    {"additional_ignore_dirs", "embedding_document_max_chars"}
+)
+_ROOT_CONFIG_FIELDS = frozenset(
+    {
+        "embedding_model",
+        "embedding_provider",
+        "embedding_revision",
+        "dimension",
+        "index_type",
+        "index_metric",
+        "l0_documents",
+        "l2_documents",
+        "persistence_schema",
+        "row_mapping",
+        "level_artifacts",
+        "artifact",
+    }
+)
+_LEVEL_CONFIG_FIELDS = frozenset(
+    {
+        "embedding_model",
+        "embedding_provider",
+        "embedding_revision",
+        "dimension",
+        "index_type",
+        "index_metric",
+        "level",
+        "num_documents",
+    }
+)
+
+
+def _reject_duplicate_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        value[key] = item
+    return value
+
+
+def _reject_nonfinite_number(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _bounded_canonical_json_bytes(
+    value: Any,
+    *,
+    max_bytes: int,
+    label: str,
+) -> bytes:
+    payload = bytearray()
+    for chunk in canonical_json_value_chunks(value):
+        payload.extend(chunk)
+        if len(payload) + 1 > max_bytes:
+            raise ValueError(f"{label} exceeds its {max_bytes}-byte limit")
+    payload.extend(b"\n")
+    return bytes(payload)
+
+
+def _json_object_snapshot(
+    value: Mapping[str, Any],
+    *,
+    label: str,
+) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} requires a mapping")
+    detached = dict(value)
+    validate_json_complexity(detached, label=label)
+    try:
+        payload = _bounded_canonical_json_bytes(
+            detached,
+            max_bytes=_MAX_CONFIG_JSON_BYTES,
+            label=label,
+        )
+        snapshot = json.loads(
+            payload.decode("utf-8", errors="strict"),
+            object_pairs_hook=_reject_duplicate_object,
+            parse_constant=_reject_nonfinite_number,
+        )
+    except (RecursionError, TypeError, ValueError) as exc:
+        raise ValueError(f"{label} is not canonical JSON data") from exc
+    if not isinstance(snapshot, dict):  # pragma: no cover - detached is a dict
+        raise AssertionError(f"{label} snapshot is not an object")
+    return snapshot
+
+
+def _environment_snapshot(environ: Mapping[str, str] | None) -> dict[str, str]:
+    source = os.environ if environ is None else environ
+    if not isinstance(source, Mapping):
+        raise TypeError("strict vector environment must be a mapping")
+    snapshot = dict(source)
+    if any(
+        not isinstance(key, str) or not isinstance(value, str)
+        for key, value in snapshot.items()
+    ):
+        raise TypeError("strict vector environment must contain text pairs")
+    return snapshot
+
+
+def _preflight_recapture_authorities(
+    *,
+    repository_source: RepositorySourceBinding,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+) -> None:
+    if type(repository_source) is not RepositorySourceBinding:
+        raise TypeError("strict vector repository source has an invalid type")
+    if type(output_receipt_owner) is not PublishedWorkspaceReceiptOwner:
+        raise TypeError("strict vector output receipt owner has an invalid type")
+    if not repository_source.usable:
+        raise RuntimeError("strict vector repository source is not usable")
+    if output_receipt_owner.state != "empty":
+        raise RuntimeError("strict vector output receipt owner must be empty")
+
+    require_owned_workspace_publication_support()
+    for member in ("require_support", "run_workspace"):
+        try:
+            raw = inspect.getattr_static(workspace_provider, member)
+        except AttributeError as exc:
+            raise TypeError(
+                "strict workspace provider has an invalid contract"
+            ) from exc
+        if isinstance(raw, (classmethod, staticmethod)):
+            raw = raw.__func__
+        if not callable(raw):
+            raise TypeError("strict workspace provider has an invalid contract")
+
+
+def _authenticated_repository_identity(
+    repository_source: RepositorySourceBinding,
+) -> RepositorySourceIdentitySnapshot:
+    identity = repository_source.authenticated_identity_snapshot()
+    if type(identity) is not RepositorySourceIdentitySnapshot:
+        raise TypeError("strict vector repository identity has an invalid type")
+    return identity
+
+
+def _path_relation(path: Path, boundary: Path) -> str:
+    if path == boundary:
+        return "same"
+    if boundary in path.parents:
+        return "descendant"
+    if path in boundary.parents:
+        return "ancestor"
+    return "disjoint"
+
+
+def _resolved_recapture_path(path: Path, *, strict: bool, label: str) -> Path:
+    try:
+        return path.resolve(strict=strict)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(f"strict vector {label} cannot be authenticated") from exc
+
+
+def _require_missing_destination(destination: Path) -> None:
+    try:
+        destination.lstat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise ValueError(
+            "strict vector recapture destination cannot be authenticated"
+        ) from exc
+    raise FileExistsError("strict vector recapture destination must be missing")
+
+
+def _recapture_locations(
+    source: Path,
+    destination: Path,
+    *,
+    repository_identity: RepositorySourceIdentitySnapshot,
+) -> tuple[Path, Path]:
+    """Authenticate denial-only topology for one ordinary cache recapture."""
+
+    lexical_source = lexical_directory_path(source)
+    lexical_destination = lexical_directory_path(destination)
+    repository = lexical_directory_path(repository_identity.root)
+    source_relation = _path_relation(lexical_source, repository)
+    physical_source = _resolved_recapture_path(
+        lexical_source,
+        strict=True,
+        label="recapture source location",
+    )
+    physical_repository = _resolved_recapture_path(
+        repository,
+        strict=True,
+        label="repository location",
+    )
+    if source_relation != _path_relation(physical_source, physical_repository):
+        raise ValueError(
+            "strict vector recapture source has inconsistent lexical and physical "
+            "repository topology"
+        )
+    if source_relation in {"same", "ancestor"}:
+        raise ValueError(
+            "strict vector recapture source must not contain the source repository"
+        )
+    if source_relation == "descendant":
+        relative = lexical_source.relative_to(repository).as_posix()
+        prefix = relative + "/"
+        if any(
+            record.path == relative or record.path.startswith(prefix)
+            for record in repository_identity.file_records
+        ):
+            raise ValueError(
+                "strict vector recapture source inside the repository must be "
+                "excluded from its authenticated source identity"
+            )
+
+    physical_destination = _resolved_recapture_path(
+        lexical_destination,
+        strict=False,
+        label="recapture destination location",
+    )
+    if any(
+        _path_relation(candidate, boundary) != "disjoint"
+        for candidate, boundary in (
+            (lexical_destination, lexical_source),
+            (lexical_destination, repository),
+            (physical_destination, physical_source),
+            (physical_destination, physical_repository),
+        )
+    ):
+        raise ValueError(
+            "strict vector recapture destination must be disjoint from source and "
+            "repository"
+        )
+    _require_missing_destination(lexical_destination)
+    return lexical_source, lexical_destination
+
+
+def _assert_authenticated_publishable_json_value(
+    value: Any,
+    *,
+    forbidden_paths: Iterable[Path],
+    environ: Mapping[str, str],
+    label: str,
+) -> None:
+    assert_publishable_json_value(
+        value,
+        forbidden_paths=(),
+        environ=environ,
+        label=label,
+    )
+    forbidden: set[str] = set()
+    for path in forbidden_paths:
+        expanded = path.expanduser()
+        raw = os.fsdecode(os.fspath(expanded))
+        lexical = os.path.abspath(raw)
+        if os.path.isabs(raw):
+            forbidden.add(raw)
+        forbidden.update((lexical, Path(lexical).as_posix()))
+    patterns = tuple(sorted(pattern for pattern in forbidden if pattern))
+    stack = [value]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, Mapping):
+            for key, child in current.items():
+                if any(pattern in key for pattern in patterns):
+                    raise ValueError(f"{label} contains an absolute build-machine path")
+                stack.append(child)
+        elif isinstance(current, (list, tuple)):
+            stack.extend(current)
+        elif isinstance(current, str) and any(
+            pattern in current for pattern in patterns
+        ):
+            raise ValueError(f"{label} contains an absolute build-machine path")
+
+
+def _source_path(
+    value: object,
+    *,
+    source: str,
+    authenticated_source_files: frozenset[str],
+) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{source} must be a non-empty repository-relative path")
+    try:
+        encoded = value.encode("utf-8", errors="strict")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{source} is not a valid UTF-8 path") from exc
+    if len(encoded) > _MAX_SOURCE_PATH_BYTES:
+        raise ValueError(f"{source} exceeds {_MAX_SOURCE_PATH_BYTES} UTF-8 path bytes")
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise ValueError(f"{source} is not a portable repository-relative path")
+    raw_parts = value.split("/")
+    normalized = PurePosixPath(value)
+    if (
+        value.startswith(("/", "~"))
+        or "\\" in value
+        or normalized.is_absolute()
+        or any(part in {"", ".", ".."} for part in raw_parts)
+        or value != normalized.as_posix()
+        or len(normalized.parts) > _MAX_SOURCE_PATH_COMPONENTS
+    ):
+        raise ValueError(f"{source} is not a portable repository-relative path")
+    normalized_text = normalized.as_posix()
+    if normalized_text not in authenticated_source_files:
+        raise ValueError(f"{source} is not in the authenticated repository source")
+    return normalized_text
+
+
+def _raw_entry_policy(model_suffix: str):
+    root_config = f"config_{model_suffix}.json"
+    level_files = {
+        f"config_{model_suffix}.json": _MAX_CONFIG_JSON_BYTES,
+        f"documents_{model_suffix}.json": MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
+        f"index_{model_suffix}.faiss": MAX_PORTABLE_FAISS_INDEX_BYTES,
+    }
+    root_files = {
+        root_config: _MAX_CONFIG_JSON_BYTES,
+        "chunk_store.json": MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
+        "chunk_store.pkl": MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
+        "embeddings_cache.json": MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
+        "embeddings_cache.npz": MAX_PORTABLE_FAISS_INDEX_BYTES,
+        "embeddings_cache.pkl": MAX_PORTABLE_FAISS_INDEX_BYTES,
+        "incremental_state.json": _MAX_CONFIG_JSON_BYTES,
+    }
+
+    def policy(relative: str, kind: str, mode: int, size: int) -> None:
+        del mode
+        path = PurePosixPath(relative)
+        limit: int | None = None
+        if kind == "directory":
+            if len(path.parts) == 1 and path.name in _VECTOR_LEVELS:
+                return
+        elif kind == "file" and len(path.parts) == 1:
+            limit = root_files.get(path.name)
+        elif (
+            kind == "file" and len(path.parts) == 2 and path.parts[0] in _VECTOR_LEVELS
+        ):
+            limit = level_files.get(path.name)
+        if limit is None:
+            raise ValueError(f"schema-8 vector cache has an invalid entry: {relative}")
+        if size < 0 or size > limit:
+            raise ValueError(
+                f"schema-8 vector cache entry exceeds its {limit}-byte limit: "
+                f"{relative}"
+            )
+
+    return policy
+
+
+class _PublicationVectorReader:
+    """Vector facade over one callback-scoped publication reader."""
+
+    def __init__(
+        self,
+        publication: PublicationDirectoryReader,
+        ownership: object,
+    ) -> None:
+        self.root = Path("/__codenib_publication_vector__")
+        self.ownership = ownership
+        self._publication = publication
+        self._records = {
+            record.path: record
+            for record in directory_ownership_file_records(ownership)  # type: ignore[arg-type]
+        }
+
+    def record(self, relative: str | PurePosixPath) -> TreeFileRecord:
+        key = relative.as_posix() if isinstance(relative, PurePosixPath) else relative
+        try:
+            return self._records[key]
+        except KeyError as exc:
+            raise ValueError(
+                f"strict vector cache has no captured file: {key}"
+            ) from exc
+
+    @contextmanager
+    def open_file(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int,
+    ) -> Iterator[PublicationAuthenticatedFile]:
+        key = relative.as_posix() if isinstance(relative, PurePosixPath) else relative
+        expected = self.record(key)
+        with self._publication.open_authenticated_file(
+            PurePosixPath(key),
+            max_bytes=max_bytes,
+        ) as source:
+            yield source
+        if source.record != expected:
+            raise RuntimeError(f"strict vector file changed while reading: {key}")
+
+    def read_bytes(self, relative: str, *, max_bytes: int) -> bytes:
+        payload = bytearray()
+        with self.open_file(relative, max_bytes=max_bytes) as source:
+            for chunk in source.iter_bytes(chunk_size=_JSON_READ_CHUNK_BYTES):
+                payload.extend(chunk)
+        return bytes(payload)
+
+    def verify_root(self, *, entry_policy: Any) -> None:
+        observed = self._publication.capture_ownership(entry_policy=entry_policy)
+        if observed != self.ownership:
+            raise RuntimeError("strict vector cache changed during validation")
+
+
+def _load_json_object(
+    reader: _PublicationVectorReader,
+    relative: str,
+    *,
+    label: str,
+) -> dict[str, Any]:
+    with reader.open_file(relative, max_bytes=_MAX_CONFIG_JSON_BYTES) as source:
+        validate_bounded_json_stream(
+            source,
+            label=label,
+            max_bytes=_MAX_CONFIG_JSON_BYTES,
+        )
+    payload = reader.read_bytes(relative, max_bytes=_MAX_CONFIG_JSON_BYTES)
+    try:
+        value = json.loads(
+            payload.decode("utf-8", errors="strict"),
+            object_pairs_hook=_reject_duplicate_object,
+            parse_constant=_reject_nonfinite_number,
+        )
+    except (RecursionError, ValueError) as exc:
+        raise ValueError(f"{label} is invalid UTF-8 JSON") from exc
+    validate_json_complexity(value, label=label)
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return value
+
+
+def _record_chunks(
+    relative: str,
+    chunks: Iterable[bytes],
+    *,
+    max_bytes: int,
+) -> TreeFileRecord:
+    iterator = iter(chunks)
+    digest = hashlib.sha256()
+    size = 0
+    primary_error: BaseException | None = None
+    try:
+        for chunk in iterator:
+            if type(chunk) is not bytes:
+                raise TypeError("strict vector output chunks must be exact bytes")
+            size += len(chunk)
+            if size > max_bytes:
+                raise ValueError(
+                    f"strict vector output exceeds its {max_bytes}-byte limit: "
+                    f"{relative}"
+                )
+            digest.update(chunk)
+    except BaseException as exc:  # noqa: B036 - preserve generation fault
+        primary_error = exc
+    try:
+        close = getattr(iterator, "close", None)
+        if callable(close):
+            close()
+    except BaseException as close_error:  # noqa: B036 - cleanup is secondary
+        if primary_error is None:
+            raise
+        _annotate_secondary_error(
+            primary_error,
+            "strict vector output iterator close also failed",
+            close_error,
+        )
+    if primary_error is not None:
+        raise primary_error.with_traceback(primary_error.__traceback__)
+    return TreeFileRecord(
+        path=relative,
+        mode=0o600,
+        size=size,
+        sha256=digest.hexdigest(),
+    )
+
+
+def _normalized_documents(
+    reader: _PublicationVectorReader,
+    relative: str,
+    *,
+    level: str,
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
+    authenticated_source_files: frozenset[str],
+    counter: list[int] | None = None,
+) -> Iterable[dict[str, Any]]:
+    with reader.open_file(
+        relative,
+        max_bytes=MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
+    ) as source:
+        documents = iter_bounded_json_array(
+            source,
+            label=f"schema-8 vector {level} documents",
+        )
+        for index, document in enumerate(documents):
+            page_content, metadata = validate_schema_8_vector_document_row(
+                document,
+                row_index=index,
+                level=level,
+            )
+            assert_no_secret_fields(
+                metadata,
+                source=f"schema-8 vector {level} document {index} metadata",
+            )
+            normalized_metadata = dict(metadata)
+            normalized_metadata["file"] = _source_path(
+                metadata["file"],
+                source=f"schema-8 vector {level} document {index} file",
+                authenticated_source_files=authenticated_source_files,
+            )
+            normalized = {
+                "page_content": page_content,
+                "metadata": normalized_metadata,
+            }
+            _assert_authenticated_publishable_json_value(
+                normalized,
+                forbidden_paths=forbidden_paths,
+                environ=environ,
+                label=f"schema-8 vector {level} document {index}",
+            )
+            if counter is not None:
+                counter[0] += 1
+            yield normalized
+
+
+def _document_record(
+    reader: _PublicationVectorReader,
+    relative: str,
+    *,
+    level: str,
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
+    authenticated_source_files: frozenset[str],
+) -> tuple[TreeFileRecord, int]:
+    counter = [0]
+    record = _record_chunks(
+        relative,
+        canonical_json_array_chunks(
+            _normalized_documents(
+                reader,
+                relative,
+                level=level,
+                forbidden_paths=forbidden_paths,
+                environ=environ,
+                authenticated_source_files=authenticated_source_files,
+                counter=counter,
+            )
+        ),
+        max_bytes=MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
+    )
+    if record != TreeFileRecord(
+        path=relative,
+        mode=0o600,
+        size=reader.record(relative).size,
+        sha256=reader.record(relative).sha256,
+    ):
+        raise ValueError(
+            f"schema-8 vector {level} documents are not canonical producer bytes"
+        )
+    return record, counter[0]
+
+
+def _fingerprint_record(
+    value: object,
+    *,
+    expected_name: str,
+    label: str,
+) -> tuple[int, str]:
+    if not isinstance(value, Mapping) or set(value) != {"file", "size", "sha256"}:
+        raise ValueError(f"{label} has an invalid fingerprint shape")
+    if value.get("file") != expected_name:
+        raise ValueError(f"{label} has an invalid filename")
+    size = value.get("size")
+    digest = value.get("sha256")
+    if type(size) is not int or size < 0:
+        raise ValueError(f"{label} has an invalid size")
+    if (
+        not isinstance(digest, str)
+        or len(digest) != 64
+        or any(character not in "0123456789abcdef" for character in digest)
+    ):
+        raise ValueError(f"{label} has an invalid digest")
+    return size, digest
+
+
+def _require_record_fingerprint(
+    record: TreeFileRecord,
+    value: object,
+    *,
+    expected_name: str,
+    expected_record_path: str | None = None,
+    label: str,
+) -> None:
+    size, digest = _fingerprint_record(
+        value,
+        expected_name=expected_name,
+        label=label,
+    )
+    record_path = (
+        expected_name if expected_record_path is None else expected_record_path
+    )
+    if record.path != record_path or record.size != size or record.sha256 != digest:
+        raise ValueError(f"{label} does not match its captured file")
+
+
+def _repository_files(
+    repository_identity: RepositorySourceIdentitySnapshot,
+) -> frozenset[str]:
+    records = repository_identity.file_records
+    paths = frozenset(record.path for record in records)
+    if len(paths) != len(records):
+        raise RuntimeError("authenticated repository source repeats a file")
+    return paths
+
+
+@dataclass(frozen=True, slots=True)
+class _VectorPolicy:
+    config_digest: str
+    view_config: dict[str, Any]
+    forbidden_paths: tuple[Path, ...]
+    environment: dict[str, str]
+    authenticated_source_files: frozenset[str]
+    model_suffix: str
+
+
+def _policy(
+    repository_identity: RepositorySourceIdentitySnapshot,
+    view_config: Mapping[str, Any],
+    *,
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
+) -> _VectorPolicy:
+    if (
+        type(view_config.get("builder_schema")) is not int
+        or view_config.get("builder_schema") != _STRICT_VECTOR_BUILDER_SCHEMA
+    ):
+        raise ValueError(
+            "strict vector cache ingress requires builder schema 8; rebuild older "
+            "compiler caches"
+        )
+    if not _REQUIRED_IDENTITY_FIELDS <= set(view_config):
+        raise ValueError("schema-8 vector view config is missing producer identity")
+    source_selection = repository_identity.source_selection
+    if type(source_selection) is not RepositorySourceSelection:
+        raise ValueError(
+            "schema-8 vector ingress requires an authenticated source selection"
+        )
+    selection_digest = view_config.get("source_selection_digest")
+    if type(selection_digest) is not str or selection_digest != source_selection.digest:
+        raise ValueError(
+            "schema-8 vector source selection differs from the authenticated "
+            "repository source"
+        )
+    identity_fields = _REQUIRED_IDENTITY_FIELDS | (
+        set(view_config) & _OPTIONAL_IDENTITY_FIELDS
+    )
+    if any(field not in view_config for field in identity_fields):  # pragma: no cover
+        raise AssertionError("strict vector identity field snapshot is incomplete")
+    forbidden = (repository_identity.root, *forbidden_paths)
+    assert_no_secret_fields(view_config, source="schema-8 vector view config")
+    _assert_authenticated_publishable_json_value(
+        view_config,
+        forbidden_paths=forbidden,
+        environ=environ,
+        label="schema-8 vector view config",
+    )
+    route = resolve_embedding_artifact_route(view_config, environ={})
+    model_suffix = route.model.replace("/", "__")
+    if not model_suffix or "/" in model_suffix or "\\" in model_suffix:
+        raise ValueError("schema-8 vector model suffix is not portable")
+    config_bytes = _bounded_canonical_json_bytes(
+        dict(view_config),
+        max_bytes=_MAX_CONFIG_JSON_BYTES,
+        label="schema-8 vector view config",
+    )
+    return _VectorPolicy(
+        config_digest=hashlib.sha256(config_bytes).hexdigest(),
+        view_config=dict(view_config),
+        forbidden_paths=forbidden,
+        environment=dict(environ),
+        authenticated_source_files=_repository_files(repository_identity),
+        model_suffix=model_suffix,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _DerivedVector:
+    output_records: tuple[TreeFileRecord, ...]
+    root_config_payload: bytes
+    level_config_payloads: tuple[tuple[str, bytes], ...]
+    counts: tuple[tuple[str, int], ...]
+    model_suffix: str
+
+    @property
+    def count_map(self) -> dict[str, int]:
+        return dict(self.counts)
+
+    @property
+    def level_config_map(self) -> dict[str, bytes]:
+        return dict(self.level_config_payloads)
+
+
+def _validate_identity(
+    root_config: Mapping[str, Any],
+    view_config: Mapping[str, Any],
+) -> None:
+    artifact = root_config.get("artifact")
+    if not isinstance(artifact, Mapping):
+        raise ValueError("schema-8 vector root config has no artifact identity")
+    expected_fields = _REQUIRED_IDENTITY_FIELDS | (
+        set(view_config) & _OPTIONAL_IDENTITY_FIELDS
+    )
+    if set(artifact) != expected_fields:
+        raise ValueError("schema-8 vector root artifact identity has an invalid shape")
+    expected = {field: view_config[field] for field in expected_fields}
+    if dict(artifact) != expected:
+        raise ValueError("schema-8 vector root artifact identity differs from manifest")
+    if (
+        type(artifact.get("builder_schema")) is not int
+        or artifact.get("builder_schema") != _STRICT_VECTOR_BUILDER_SCHEMA
+    ):
+        raise ValueError("schema-8 vector root artifact identity is not schema 8")
+
+
+def _validate_document_count(
+    view_config: Mapping[str, Any],
+    counts: Mapping[str, int],
+) -> None:
+    raw = view_config.get("document_count")
+    if not isinstance(raw, Mapping):
+        raise ValueError("schema-8 vector view config requires document_count")
+    expected = {level: count for level, count in counts.items() if count > 0}
+    if dict(raw) != expected:
+        raise ValueError("schema-8 vector document_count differs from persistence")
+
+
+def _derived_vector(
+    reader: _PublicationVectorReader,
+    *,
+    policy: _VectorPolicy,
+) -> _DerivedVector:
+    root_name = f"config_{policy.model_suffix}.json"
+    root_config = _load_json_object(
+        reader,
+        root_name,
+        label="schema-8 vector root config",
+    )
+    if set(root_config) != _ROOT_CONFIG_FIELDS:
+        raise ValueError("schema-8 vector root config has an invalid shape")
+    assert_no_secret_fields(root_config, source="schema-8 vector root config")
+    _assert_authenticated_publishable_json_value(
+        root_config,
+        forbidden_paths=policy.forbidden_paths,
+        environ=policy.environment,
+        label="schema-8 vector root config",
+    )
+    if root_config.get("persistence_schema") != VECTOR_PERSISTENCE_SCHEMA:
+        raise ValueError(
+            "schema-8 vector root config has an invalid persistence schema"
+        )
+    if root_config.get("row_mapping") != VECTOR_ROW_MAPPING_CONTRACT:
+        raise ValueError("schema-8 vector root config has an invalid row mapping")
+    _validate_identity(root_config, policy.view_config)
+    validate_portable_vector_persistence_semantics(
+        root_config,
+        policy.view_config,
+    )
+    expected_root_fingerprint = policy.view_config.get("persistence_config_fingerprint")
+    _require_record_fingerprint(
+        reader.record(root_name),
+        expected_root_fingerprint,
+        expected_name=root_name,
+        label="schema-8 vector root config fingerprint",
+    )
+
+    levels = policy.view_config.get("levels")
+    if (
+        not isinstance(levels, list)
+        or not levels
+        or any(level not in _VECTOR_LEVELS for level in levels)
+        or len(set(levels)) != len(levels)
+    ):
+        raise ValueError("schema-8 vector build levels are invalid")
+    committed = root_config.get("level_artifacts")
+    if not isinstance(committed, Mapping) or not set(committed) <= set(_VECTOR_LEVELS):
+        raise ValueError("schema-8 vector committed levels are invalid")
+
+    output_records: list[TreeFileRecord] = []
+    level_config_payloads: list[tuple[str, bytes]] = []
+    counts: dict[str, int] = {}
+    normalized_committed: dict[str, dict[str, dict[str, Any]]] = {}
+    expected_query_files = {root_name}
+    expected_query_directories: set[str] = set()
+    for level in _VECTOR_LEVELS:
+        raw_count = root_config.get(f"{level}_documents")
+        if type(raw_count) is not int or raw_count < 0:
+            raise ValueError(f"schema-8 vector {level} count is invalid")
+        counts[level] = raw_count
+        artifacts = committed.get(level)
+        if raw_count == 0:
+            if artifacts is not None:
+                raise ValueError(f"schema-8 vector commits artifacts for empty {level}")
+            continue
+        if level not in levels:
+            raise ValueError(f"schema-8 vector commits unconfigured level {level}")
+        if not isinstance(artifacts, Mapping) or set(artifacts) != {
+            "index",
+            "documents",
+        }:
+            raise ValueError(f"schema-8 vector {level} artifacts are invalid")
+
+        level_root = f"{level}/"
+        config_name = level_root + f"config_{policy.model_suffix}.json"
+        documents_name = f"documents_{policy.model_suffix}.json"
+        documents_relative = level_root + documents_name
+        index_name = f"index_{policy.model_suffix}.faiss"
+        index_relative = level_root + index_name
+        expected_query_directories.add(level)
+        expected_query_files.update({config_name, documents_relative, index_relative})
+
+        _require_record_fingerprint(
+            reader.record(documents_relative),
+            artifacts["documents"],
+            expected_name=documents_name,
+            expected_record_path=documents_relative,
+            label=f"schema-8 vector {level} documents fingerprint",
+        )
+        _require_record_fingerprint(
+            reader.record(index_relative),
+            artifacts["index"],
+            expected_name=index_name,
+            expected_record_path=index_relative,
+            label=f"schema-8 vector {level} index fingerprint",
+        )
+        document_record, observed_count = _document_record(
+            reader,
+            documents_relative,
+            level=level,
+            forbidden_paths=policy.forbidden_paths,
+            environ=policy.environment,
+            authenticated_source_files=policy.authenticated_source_files,
+        )
+        if observed_count != raw_count:
+            raise ValueError(
+                f"schema-8 vector {level} document count differs from root config"
+            )
+
+        level_config = _load_json_object(
+            reader,
+            config_name,
+            label=f"schema-8 vector {level} config",
+        )
+        if set(level_config) != _LEVEL_CONFIG_FIELDS:
+            raise ValueError(f"schema-8 vector {level} config has an invalid shape")
+        checks = {
+            "embedding_model": root_config["embedding_model"],
+            "embedding_provider": root_config["embedding_provider"],
+            "embedding_revision": root_config["embedding_revision"],
+            "dimension": root_config["dimension"],
+            "index_type": root_config["index_type"],
+            "index_metric": root_config["index_metric"],
+            "level": level,
+            "num_documents": raw_count,
+        }
+        if level_config != checks:
+            raise ValueError(f"schema-8 vector {level} config differs from root")
+        _assert_authenticated_publishable_json_value(
+            level_config,
+            forbidden_paths=policy.forbidden_paths,
+            environ=policy.environment,
+            label=f"schema-8 vector {level} config",
+        )
+        level_payload = _bounded_canonical_json_bytes(
+            level_config,
+            max_bytes=_MAX_CONFIG_JSON_BYTES,
+            label=f"schema-8 vector {level} config",
+        )
+        level_config_payloads.append((config_name, level_payload))
+        output_records.extend(
+            (
+                TreeFileRecord(
+                    path=config_name,
+                    mode=0o600,
+                    size=len(level_payload),
+                    sha256=hashlib.sha256(level_payload).hexdigest(),
+                ),
+                document_record,
+                TreeFileRecord(
+                    path=index_relative,
+                    mode=0o600,
+                    size=reader.record(index_relative).size,
+                    sha256=reader.record(index_relative).sha256,
+                ),
+            )
+        )
+        normalized_committed[level] = {
+            "documents": {
+                "file": documents_name,
+                "size": document_record.size,
+                "sha256": document_record.sha256,
+            },
+            "index": {
+                "file": index_name,
+                "size": reader.record(index_relative).size,
+                "sha256": reader.record(index_relative).sha256,
+            },
+        }
+
+    if not any(counts.values()):
+        raise ValueError("schema-8 vector generation has no non-empty level")
+    _validate_document_count(policy.view_config, counts)
+    root_config["level_artifacts"] = normalized_committed
+    root_payload = _bounded_canonical_json_bytes(
+        root_config,
+        max_bytes=_MAX_CONFIG_JSON_BYTES,
+        label="schema-8 vector root config",
+    )
+    output_records.append(
+        TreeFileRecord(
+            path=root_name,
+            mode=0o600,
+            size=len(root_payload),
+            sha256=hashlib.sha256(root_payload).hexdigest(),
+        )
+    )
+
+    inventory = directory_ownership_inventory(reader.ownership)  # type: ignore[arg-type]
+    inventory_paths = {(relative, kind) for relative, kind in inventory}
+    required_raw_files = expected_query_files | _RAW_MUTABLE_ROOT_FILES
+    if any(
+        (relative, "file") not in inventory_paths for relative in required_raw_files
+    ):
+        raise ValueError("schema-8 vector cache is missing current producer state")
+    observed_directories = {
+        relative for relative, kind in inventory if kind == "directory"
+    }
+    if observed_directories != expected_query_directories:
+        raise ValueError("schema-8 vector cache level directories are not exact")
+
+    return _DerivedVector(
+        output_records=tuple(sorted(output_records, key=lambda item: item.path)),
+        root_config_payload=root_payload,
+        level_config_payloads=tuple(sorted(level_config_payloads)),
+        counts=tuple((level, counts[level]) for level in _VECTOR_LEVELS),
+        model_suffix=policy.model_suffix,
+    )
+
+
+def _frame(digest: Any, label: bytes, payload: bytes) -> None:
+    digest.update(len(label).to_bytes(2, "big"))
+    digest.update(label)
+    digest.update(len(payload).to_bytes(8, "big"))
+    digest.update(payload)
+
+
+def _record_frame(digest: Any, scope: bytes, record: TreeFileRecord) -> None:
+    _frame(digest, scope + b"-path", record.path.encode("utf-8"))
+    _frame(digest, scope + b"-mode", record.mode.to_bytes(4, "big"))
+    _frame(digest, scope + b"-size", record.size.to_bytes(8, "big"))
+    _frame(digest, scope + b"-sha256", bytes.fromhex(record.sha256))
+
+
+def _subject_digest(
+    *,
+    source_digest: str,
+    source_records: tuple[TreeFileRecord, ...],
+    output_records: tuple[TreeFileRecord, ...],
+    view_config_digest: str,
+    repository_fingerprint: str,
+) -> str:
+    digest = hashlib.sha256()
+    _frame(digest, b"domain", _STRICT_VECTOR_PLAN_DOMAIN)
+    _frame(digest, b"source-tree-sha256", bytes.fromhex(source_digest))
+    _frame(digest, b"view-config-sha256", bytes.fromhex(view_config_digest))
+    _frame(
+        digest,
+        b"repository-fingerprint",
+        repository_fingerprint.encode("utf-8"),
+    )
+    for record in source_records:
+        _record_frame(digest, b"source-record", record)
+    for record in output_records:
+        _record_frame(digest, b"output-record", record)
+    return digest.hexdigest()
+
+
+def _workspace_plan(
+    *,
+    source_digest: str,
+    source_records: tuple[TreeFileRecord, ...],
+    output_records: tuple[TreeFileRecord, ...],
+    view_config_digest: str,
+    repository_fingerprint: str,
+) -> WorkspacePlan:
+    directories = {
+        parent
+        for record in output_records
+        for parent in PurePosixPath(record.path).parents
+        if parent != PurePosixPath(".")
+    }
+    return WorkspacePlan(
+        subject_digest=_subject_digest(
+            source_digest=source_digest,
+            source_records=source_records,
+            output_records=output_records,
+            view_config_digest=view_config_digest,
+            repository_fingerprint=repository_fingerprint,
+        ),
+        directories=tuple(
+            WorkspaceDirectory(path, mode=0o700)
+            for path in sorted(directories, key=lambda item: item.as_posix())
+        ),
+        files=tuple(
+            WorkspaceFile(
+                PurePosixPath(record.path),
+                mode=record.mode,
+                max_bytes=record.size,
+            )
+            for record in output_records
+        ),
+        root_mode=0o700,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedVectorView:
+    """Immutable exact output plan for one schema-8 vector generation."""
+
+    plan: WorkspacePlan
+    source_ownership: object
+    source_digest: str
+    source_records: tuple[TreeFileRecord, ...]
+    output_records: tuple[TreeFileRecord, ...]
+    view_config_digest: str
+    repository_fingerprint: str
+    model_suffix: str
+    counts: tuple[tuple[str, int], ...]
+
+    def __post_init__(self) -> None:
+        source_records = tuple(self.source_records)
+        output_records = tuple(self.output_records)
+        counts = tuple(self.counts)
+        if type(self.plan) is not WorkspacePlan:
+            raise TypeError("strict vector plan must contain an exact WorkspacePlan")
+        if any(type(record) is not TreeFileRecord for record in source_records):
+            raise TypeError("strict vector source records have an invalid type")
+        if any(type(record) is not TreeFileRecord for record in output_records):
+            raise TypeError("strict vector output records have an invalid type")
+        if source_records != tuple(sorted(source_records, key=lambda item: item.path)):
+            raise ValueError("strict vector source records must be canonical")
+        if output_records != tuple(sorted(output_records, key=lambda item: item.path)):
+            raise ValueError("strict vector output records must be canonical")
+        if len({record.path for record in output_records}) != len(output_records):
+            raise ValueError("strict vector output records repeat a path")
+        if any(record.mode != 0o600 for record in output_records):
+            raise ValueError("strict vector output files must use mode 0600")
+        if (
+            not isinstance(self.model_suffix, str)
+            or not self.model_suffix
+            or "/" in self.model_suffix
+            or "\\" in self.model_suffix
+        ):
+            raise ValueError("strict vector model suffix is invalid")
+        if tuple(level for level, _count in counts) != _VECTOR_LEVELS or any(
+            type(count) is not int or count < 0 for _level, count in counts
+        ):
+            raise ValueError("strict vector counts are invalid")
+        expected_paths = {f"config_{self.model_suffix}.json"}
+        for level, count in counts:
+            if count <= 0:
+                continue
+            expected_paths.update(
+                {
+                    f"{level}/config_{self.model_suffix}.json",
+                    f"{level}/documents_{self.model_suffix}.json",
+                    f"{level}/index_{self.model_suffix}.faiss",
+                }
+            )
+        if {record.path for record in output_records} != expected_paths:
+            raise ValueError("strict vector output records are not exact")
+        object.__setattr__(self, "source_records", source_records)
+        object.__setattr__(self, "output_records", output_records)
+        object.__setattr__(self, "counts", counts)
+
+    @property
+    def adjustments(self) -> dict[str, Any]:
+        root_name = f"config_{self.model_suffix}.json"
+        root_record = next(
+            record for record in self.output_records if record.path == root_name
+        )
+        return {
+            "artifact_scope": "query-serving",
+            "portable_document_format": "codenib.vector-documents.v1",
+            "persistence_config_fingerprint": {
+                "file": root_name,
+                "size": root_record.size,
+                "sha256": root_record.sha256,
+            },
+        }
+
+
+def _captured_source_view(
+    expected_ownership: object,
+    publication: PublicationDirectoryReader,
+    *,
+    label: str,
+) -> tuple[object, tuple[TreeFileRecord, ...], _PublicationVectorReader]:
+    # Every caller enters through ``reopen_authenticated_directory``, whose
+    # pre/post whole-tree matches already bind this callback to the expected
+    # ownership.  Per-file reads compare against the same retained records.
+    ownership = expected_ownership
+    records = tuple(directory_ownership_file_records(ownership))  # type: ignore[arg-type]
+    if not records:
+        raise ValueError(f"{label} has no files")
+    return ownership, records, _PublicationVectorReader(publication, ownership)
+
+
+def _planned_view_from_publication(
+    publication: PublicationDirectoryReader,
+    expected_ownership: object,
+    *,
+    repository_identity: RepositorySourceIdentitySnapshot,
+    policy: _VectorPolicy,
+    source_label: str,
+) -> PlannedVectorView:
+    ownership, source_records, reader = _captured_source_view(
+        expected_ownership,
+        publication,
+        label=source_label,
+    )
+    derived = _derived_vector(
+        reader,
+        policy=policy,
+    )
+    source_digest = directory_ownership_digest(ownership)  # type: ignore[arg-type]
+    plan = _workspace_plan(
+        source_digest=source_digest,
+        source_records=source_records,
+        output_records=derived.output_records,
+        view_config_digest=policy.config_digest,
+        repository_fingerprint=repository_identity.fingerprint,
+    )
+    return PlannedVectorView(
+        plan=plan,
+        source_ownership=ownership,
+        source_digest=source_digest,
+        source_records=source_records,
+        output_records=derived.output_records,
+        view_config_digest=policy.config_digest,
+        repository_fingerprint=repository_identity.fingerprint,
+        model_suffix=derived.model_suffix,
+        counts=derived.counts,
+    )
+
+
+def _plan_recaptured_vector_view_with_identity(
+    lexical_source: Path,
+    *,
+    repository_source: RepositorySourceBinding,
+    repository_identity: RepositorySourceIdentitySnapshot,
+    view_config: Mapping[str, Any],
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
+) -> PlannedVectorView:
+    policy = _policy(
+        repository_identity,
+        view_config,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
+    )
+    entry_policy = _raw_entry_policy(policy.model_suffix)
+    source_ownership = capture_directory_ownership(
+        lexical_source,
+        entry_policy=entry_policy,
+    )
+
+    def consume_source(publication: PublicationDirectoryReader) -> PlannedVectorView:
+        return _planned_view_from_publication(
+            publication,
+            source_ownership,
+            repository_identity=repository_identity,
+            policy=policy,
+            source_label="strict vector recapture source",
+        )
+
+    with repository_source.read_session():
+        return reopen_authenticated_directory(
+            lexical_source,
+            source_ownership,  # type: ignore[arg-type]
+            consume_source,
+        )
+
+
+def _plan_recaptured_vector_view(
+    source: Path,
+    destination: Path,
+    *,
+    repository_source: RepositorySourceBinding,
+    view_config: Mapping[str, Any],
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> PlannedVectorView:
+    """Privately pre-plan a schema-8 vector cache without workspace mutation."""
+
+    if type(repository_source) is not RepositorySourceBinding:
+        raise TypeError("strict vector repository source has an invalid type")
+    if not repository_source.usable:
+        raise RuntimeError("strict vector repository source is not usable")
+    repository_identity = _authenticated_repository_identity(repository_source)
+    lexical_source, _lexical_destination = _recapture_locations(
+        source,
+        destination,
+        repository_identity=repository_identity,
+    )
+    config_snapshot = _json_object_snapshot(
+        view_config,
+        label="schema-8 vector view config",
+    )
+    environment = _environment_snapshot(environ)
+    forbidden_tail = tuple(forbidden_paths)
+    if any(type(path) is not type(Path()) for path in forbidden_tail):
+        raise TypeError("strict vector forbidden paths must be exact Path values")
+    return _plan_recaptured_vector_view_with_identity(
+        lexical_source,
+        repository_source=repository_source,
+        repository_identity=repository_identity,
+        view_config=config_snapshot,
+        forbidden_paths=forbidden_tail,
+        environ=environment,
+    )
+
+
+def _require_plan(
+    planned: PlannedVectorView,
+    *,
+    source_ownership: object,
+    repository_identity: RepositorySourceIdentitySnapshot,
+    policy: _VectorPolicy,
+) -> None:
+    if type(planned) is not PlannedVectorView:
+        raise TypeError("strict vector execution requires a PlannedVectorView")
+    if (
+        planned.source_ownership != source_ownership
+        or planned.source_records
+        != tuple(directory_ownership_file_records(source_ownership))  # type: ignore[arg-type]
+        or planned.source_digest
+        != directory_ownership_digest(source_ownership)  # type: ignore[arg-type]
+    ):
+        raise ValueError("strict vector plan belongs to another source generation")
+    if planned.repository_fingerprint != repository_identity.fingerprint:
+        raise ValueError("strict vector plan belongs to another repository source")
+    if planned.view_config_digest != policy.config_digest:
+        raise ValueError("strict vector plan belongs to another view config")
+    expected = _workspace_plan(
+        source_digest=planned.source_digest,
+        source_records=planned.source_records,
+        output_records=planned.output_records,
+        view_config_digest=planned.view_config_digest,
+        repository_fingerprint=planned.repository_fingerprint,
+    )
+    if planned.plan != expected:
+        raise ValueError("strict vector workspace plan is not canonical")
+
+
+def _replay_vector_source(
+    session: StrictWorkspaceSession,
+    publication: PublicationDirectoryReader,
+    *,
+    planned: PlannedVectorView,
+    policy: _VectorPolicy,
+) -> None:
+    ownership, source_records, reader = _captured_source_view(
+        planned.source_ownership,
+        publication,
+        label="strict vector recapture source",
+    )
+    if (
+        ownership != planned.source_ownership
+        or source_records != planned.source_records
+    ):
+        raise ValueError("strict vector recapture source changed after planning")
+
+    derived = _derived_vector(
+        reader,
+        policy=policy,
+    )
+    if (
+        derived.output_records != planned.output_records
+        or derived.model_suffix != planned.model_suffix
+        or derived.counts != planned.counts
+    ):
+        raise RuntimeError("strict vector replay derivation differs from its plan")
+
+    written: list[TreeFileRecord] = []
+    root_name = f"config_{planned.model_suffix}.json"
+    written.append(session.write_file(root_name, (derived.root_config_payload,)))
+    for relative, payload in derived.level_config_payloads:
+        written.append(session.write_file(relative, (payload,)))
+
+    for level, count in planned.counts:
+        if count <= 0:
+            continue
+        documents_relative = f"{level}/documents_{planned.model_suffix}.json"
+        # `_derived_vector` has just authenticated, semantically validated,
+        # canonicalized, and content-bound these exact source bytes.  Replay
+        # the retained descriptor once instead of parsing a 256 MiB document
+        # array a second time.
+        with reader.open_file(
+            documents_relative,
+            max_bytes=MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
+        ) as source:
+            written.append(
+                session.write_file(
+                    documents_relative,
+                    source.iter_bytes(chunk_size=_JSON_READ_CHUNK_BYTES),
+                )
+            )
+        index_relative = f"{level}/index_{planned.model_suffix}.faiss"
+        with reader.open_file(
+            index_relative,
+            max_bytes=MAX_PORTABLE_FAISS_INDEX_BYTES,
+        ) as source:
+            written.append(
+                session.write_file(
+                    index_relative,
+                    source.iter_bytes(chunk_size=_JSON_READ_CHUNK_BYTES),
+                )
+            )
+
+    if tuple(sorted(written, key=lambda item: item.path)) != planned.output_records:
+        raise RuntimeError("strict vector replay differs from its exact plan")
+
+
+def _candidate_records(
+    candidate: PublicationDirectoryReader,
+    *,
+    planned: PlannedVectorView,
+    repository_source: RepositorySourceBinding,
+    repository_identity: RepositorySourceIdentitySnapshot,
+    entry_policy: Any,
+    view_config: Mapping[str, Any],
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
+) -> tuple[TreeFileRecord, ...]:
+    observed = candidate.file_records()
+    observed_inventory = candidate.inventory()
+    records_by_path = {record.path: record for record in observed}
+    for relative, kind in observed_inventory:
+        if kind == "file":
+            record = records_by_path[relative]
+            entry_policy(relative, kind, record.mode, record.size)
+        else:
+            entry_policy(relative, kind, 0, 0)
+    expected_directories = {
+        parent.as_posix()
+        for record in planned.output_records
+        for parent in PurePosixPath(record.path).parents
+        if parent != PurePosixPath(".")
+    }
+    expected_inventory = {
+        *((record.path, "file") for record in planned.output_records),
+        *((relative, "directory") for relative in expected_directories),
+    }
+    if set(observed_inventory) != expected_inventory or observed != (
+        planned.output_records
+    ):
+        raise RuntimeError("strict vector candidate differs from its exact plan")
+
+    candidate_config = dict(view_config)
+    candidate_config.update(planned.adjustments)
+    _validate_content_bound_portable_query_view_reader_with_identity(
+        candidate,
+        repository_source=repository_source,
+        repository_identity=repository_identity,
+        view_type="vector",
+        view_config=candidate_config,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
+        _framework_sandwiched=True,
+    )
+    return observed
+
+
+def _publish_recaptured_vector_view_with_identity(
+    lexical_source: Path,
+    lexical_destination: Path,
+    *,
+    planned: PlannedVectorView,
+    repository_source: RepositorySourceBinding,
+    repository_identity: RepositorySourceIdentitySnapshot,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+    view_config: Mapping[str, Any],
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
+) -> dict[str, Any]:
+    policy = _policy(
+        repository_identity,
+        view_config,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
+    )
+    entry_policy = _raw_entry_policy(policy.model_suffix)
+    if type(planned) is not PlannedVectorView:
+        raise TypeError("strict vector execution requires a PlannedVectorView")
+    _require_plan(
+        planned,
+        source_ownership=planned.source_ownership,
+        repository_identity=repository_identity,
+        policy=policy,
+    )
+    observed_source_ownership = capture_directory_ownership(
+        lexical_source,
+        entry_policy=entry_policy,
+    )
+    _require_plan(
+        planned,
+        source_ownership=observed_source_ownership,
+        repository_identity=repository_identity,
+        policy=policy,
+    )
+    request = StrictWorkspaceRequest(
+        purpose="portable-vector-recapture",
+        destination=lexical_destination,
+        plan=planned.plan,
+        destination_expectation="missing",
+    )
+
+    def operation(session: StrictWorkspaceSession) -> None:
+        if session.request != request:
+            raise RuntimeError("strict vector provider changed its request")
+
+        def replay_source(publication: PublicationDirectoryReader) -> None:
+            _replay_vector_source(
+                session,
+                publication,
+                planned=planned,
+                policy=policy,
+            )
+
+        def validate_candidate(candidate: PublicationDirectoryReader) -> None:
+            with repository_source.read_session():
+                if (
+                    _candidate_records(
+                        candidate,
+                        planned=planned,
+                        repository_source=repository_source,
+                        repository_identity=repository_identity,
+                        entry_policy=entry_policy,
+                        view_config=policy.view_config,
+                        forbidden_paths=forbidden_paths,
+                        environ=policy.environment,
+                    )
+                    != planned.output_records
+                ):
+                    raise RuntimeError("strict vector candidate is not canonical")
+
+        with repository_source.read_session():
+            reopen_authenticated_directory(
+                lexical_source,
+                planned.source_ownership,  # type: ignore[arg-type]
+                replay_source,
+            )
+        session.publish_validated(validate_candidate)
+
+    # Recheck mutable authority state immediately before a workspace may be
+    # provisioned.  Planning never grants a provider permission to replace an
+    # existing destination.
+    _preflight_recapture_authorities(
+        repository_source=repository_source,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+    _require_missing_destination(lexical_destination)
+    run_strict_workspace(
+        workspace_provider,
+        request,
+        receipt_owner=output_receipt_owner,
+        operation=operation,
+    )
+    if not output_receipt_owner.active:
+        raise RuntimeError("strict vector publication returned without a receipt")
+    receipt = output_receipt_owner.receipt
+    if receipt.path != lexical_destination or receipt.plan != planned.plan:
+        raise RuntimeError("strict vector publication returned the wrong receipt")
+    return planned.adjustments
+
+
+def _publish_recaptured_vector_view(
+    source: Path,
+    destination: Path,
+    *,
+    planned: PlannedVectorView,
+    repository_source: RepositorySourceBinding,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+    view_config: Mapping[str, Any],
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Privately publish one exact pre-planned schema-8 vector tree."""
+
+    _preflight_recapture_authorities(
+        repository_source=repository_source,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+    repository_identity = _authenticated_repository_identity(repository_source)
+    lexical_source, lexical_destination = _recapture_locations(
+        source,
+        destination,
+        repository_identity=repository_identity,
+    )
+    config_snapshot = _json_object_snapshot(
+        view_config,
+        label="schema-8 vector view config",
+    )
+    environment = _environment_snapshot(environ)
+    forbidden_tail = tuple(forbidden_paths)
+    if any(type(path) is not type(Path()) for path in forbidden_tail):
+        raise TypeError("strict vector forbidden paths must be exact Path values")
+    return _publish_recaptured_vector_view_with_identity(
+        lexical_source,
+        lexical_destination,
+        planned=planned,
+        repository_source=repository_source,
+        repository_identity=repository_identity,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+        view_config=config_snapshot,
+        forbidden_paths=forbidden_tail,
+        environ=environment,
+    )
+
+
+def recapture_vector_view_strict(
+    source: Path,
+    destination: Path,
+    *,
+    repository_source: RepositorySourceBinding,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+    view_config: Mapping[str, Any],
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Recapture one schema-8 compiler vector tree into a missing workspace."""
+
+    _preflight_recapture_authorities(
+        repository_source=repository_source,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+    repository_identity = _authenticated_repository_identity(repository_source)
+    lexical_source, lexical_destination = _recapture_locations(
+        source,
+        destination,
+        repository_identity=repository_identity,
+    )
+    config_snapshot = _json_object_snapshot(
+        view_config,
+        label="schema-8 vector view config",
+    )
+    environment = _environment_snapshot(environ)
+    forbidden_tail = tuple(forbidden_paths)
+    if any(type(path) is not type(Path()) for path in forbidden_tail):
+        raise TypeError("strict vector forbidden paths must be exact Path values")
+    planned = _plan_recaptured_vector_view_with_identity(
+        lexical_source,
+        repository_source=repository_source,
+        repository_identity=repository_identity,
+        view_config=config_snapshot,
+        forbidden_paths=forbidden_tail,
+        environ=environment,
+    )
+    _preflight_recapture_authorities(
+        repository_source=repository_source,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+    lexical_source, lexical_destination = _recapture_locations(
+        lexical_source,
+        lexical_destination,
+        repository_identity=repository_identity,
+    )
+    return _publish_recaptured_vector_view_with_identity(
+        lexical_source,
+        lexical_destination,
+        planned=planned,
+        repository_source=repository_source,
+        repository_identity=repository_identity,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+        view_config=config_snapshot,
+        forbidden_paths=forbidden_tail,
+        environ=environment,
+    )
+
+
+__all__ = [
+    "PlannedVectorView",
+    "recapture_vector_view_strict",
+]

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -1871,6 +1871,22 @@ def _compiler_cache_import_selection(
     return selected_ref, generation
 
 
+_COMPILER_CACHE_IMPORT_VIEWS = ("bm25", "vector")
+
+
+def _compiler_cache_import_views(explicit: Iterable[str]) -> tuple[str, ...]:
+    """Normalize an explicit cache-ingress view set into canonical order."""
+
+    requested = _split_values(explicit)
+    if not requested:
+        return ("bm25",)
+    unknown = sorted(set(requested) - set(_COMPILER_CACHE_IMPORT_VIEWS))
+    if unknown:
+        raise CLIError(f"unsupported compiler cache view: {', '.join(unknown)}")
+    selected = set(requested)
+    return tuple(view for view in _COMPILER_CACHE_IMPORT_VIEWS if view in selected)
+
+
 def _new_compiler_cache_import_nonce() -> str:
     import secrets
 
@@ -1887,12 +1903,20 @@ class _CompilerCacheImportPaths:
     catalog_path: Path
     cas_root: Path
     workspace_root: Path
-    bm25_destination: Path
+    view_destinations: tuple[tuple[str, Path], ...]
     context_destination: Path
     suggested_materialization: Path
 
+    @property
+    def destination_map(self) -> dict[str, Path]:
+        return dict(self.view_destinations)
 
-def _compiler_cache_import_paths(args: argparse.Namespace) -> _CompilerCacheImportPaths:
+
+def _compiler_cache_import_paths(
+    args: argparse.Namespace,
+    *,
+    views: tuple[str, ...] = ("bm25",),
+) -> _CompilerCacheImportPaths:
     """Freeze all user paths and allocate missing-only generation names."""
 
     repo_path = resolve_repo_path(args.repo)
@@ -1918,13 +1942,16 @@ def _compiler_cache_import_paths(args: argparse.Namespace) -> _CompilerCacheImpo
 
     nonce = _new_compiler_cache_import_nonce()
     prefix = f".codenib-cache-import-{nonce}"
+    view_destinations = tuple(
+        (view, workspace_root / f"{prefix}-{view}") for view in views
+    )
     return _CompilerCacheImportPaths(
         repo_path=repo_path,
         cache_dir=cache_dir,
         catalog_path=catalog_path,
         cas_root=cas_root,
         workspace_root=workspace_root,
-        bm25_destination=workspace_root / f"{prefix}-bm25",
+        view_destinations=view_destinations,
         context_destination=workspace_root / f"{prefix}-context",
         suggested_materialization=workspace_root / f"{prefix}-materialized",
     )
@@ -1958,7 +1985,7 @@ def _require_compiler_cache_import_topology(
         ]
     ] = []
     for destination in (
-        paths.bm25_destination,
+        *(destination for _view, destination in paths.view_destinations),
         paths.context_destination,
         paths.suggested_materialization,
     ):
@@ -2312,7 +2339,7 @@ def _run_artifact_import_cache(args: argparse.Namespace) -> int:
     from .artifacts.runtime import SourceBindingCleanupOwner
     from .compiler.cache_import import (
         compiler_cache_source_selection,
-        import_compiler_cache_bm25,
+        import_compiler_cache,
     )
     from .source_fingerprint import capture_repository_source
     from .storage import LocalCAS, SQLiteCatalog
@@ -2325,7 +2352,9 @@ def _run_artifact_import_cache(args: argparse.Namespace) -> int:
         ref_name=args.ref,
         expected_generation=args.expected_generation,
     )
-    paths = _compiler_cache_import_paths(args)
+    views = _compiler_cache_import_views(args.view)
+    paths = _compiler_cache_import_paths(args, views=views)
+    view_destinations = paths.destination_map
     try:
         provider = LocalWorkspaceProvider(paths.workspace_root)
         provider.require_support()
@@ -2342,7 +2371,7 @@ def _run_artifact_import_cache(args: argparse.Namespace) -> int:
             (
                 paths.cache_dir,
                 topology.cache_dir,
-                paths.bm25_destination,
+                *view_destinations.values(),
                 paths.context_destination,
                 paths.suggested_materialization,
             )
@@ -2356,7 +2385,7 @@ def _run_artifact_import_cache(args: argparse.Namespace) -> int:
                 topology.catalog_path,
                 topology.cas_root,
                 paths.workspace_root,
-                paths.bm25_destination,
+                *view_destinations.values(),
                 paths.context_destination,
                 paths.suggested_materialization,
             )
@@ -2365,11 +2394,25 @@ def _run_artifact_import_cache(args: argparse.Namespace) -> int:
     summary: tuple[str, str, int] | None = None
     try:
         source_selection = compiler_cache_source_selection(topology.cache_dir)
-        bm25_owner = _new_retained_output_receipt_owner()
+        view_owners = {view: _new_retained_output_receipt_owner() for view in views}
         context_owner = _new_retained_output_receipt_owner()
         source_owner = SourceBindingCleanupOwner()
         object_store_owner = _RetainedMaterializationResourceOwner()
         catalog_owner = _RetainedMaterializationResourceOwner()
+        view_cleanup_actions = tuple(
+            _OrderedAction(
+                label=(
+                    "cache import "
+                    + ("BM25" if view == "bm25" else view.title())
+                    + " receipt cleanup also failed"
+                ),
+                action=owner.close,
+                complete=lambda owner=owner: owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=owner,
+            )
+            for view, owner in reversed(tuple(view_owners.items()))
+        )
         cleanup_actions = (
             _OrderedAction(
                 label="cache import SQLite catalog cleanup also failed",
@@ -2392,13 +2435,7 @@ def _run_artifact_import_cache(args: argparse.Namespace) -> int:
                 retry_incomplete="cancellation",
                 incomplete_owner=context_owner,
             ),
-            _OrderedAction(
-                label="cache import BM25 receipt cleanup also failed",
-                action=bm25_owner.close,
-                complete=lambda: bm25_owner.closed,
-                retry_incomplete="cancellation",
-                incomplete_owner=bm25_owner,
-            ),
+            *view_cleanup_actions,
             _OrderedAction(
                 label="cache import repository source cleanup also failed",
                 action=source_owner.close,
@@ -2432,12 +2469,13 @@ def _run_artifact_import_cache(args: argparse.Namespace) -> int:
                 topology.catalog_path,
                 topology.catalog_identity,
             )
-            result = import_compiler_cache_bm25(
+            result = import_compiler_cache(
                 topology.cache_dir,
+                views=views,
                 repository_source=repository_source,
-                bm25_output_owner=bm25_owner,
+                view_output_owners=view_owners,
                 context_output_owner=context_owner,
-                bm25_destination=paths.bm25_destination,
+                view_destinations=view_destinations,
                 context_destination=paths.context_destination,
                 workspace_provider=provider,
                 repository_key=repository,
@@ -2462,7 +2500,10 @@ def _run_artifact_import_cache(args: argparse.Namespace) -> int:
         print(f"Snapshot:           {snapshot_id}")
         print(f"Ref:                {published_ref}")
         print(f"Generation:         {generation}")
-        print(f"BM25 generation:    {paths.bm25_destination}")
+        print(f"Views:              {','.join(views)}")
+        for view, destination in view_destinations.items():
+            display = "BM25" if view == "bm25" else view.title()
+            print(f"{display + ' generation:':<20}{destination}")
         print(f"Context generation: {paths.context_destination}")
         print(
             "Suggested output:   " f"{paths.suggested_materialization} (not reserved)"
@@ -2494,7 +2535,13 @@ def _run_artifact_import_cache(args: argparse.Namespace) -> int:
         return 0
     except BaseException as primary_error:  # noqa: B036 - preserve cancellation
         for destination, label in (
-            (paths.bm25_destination, "BM25 generation"),
+            *(
+                (
+                    destination,
+                    ("BM25" if view == "bm25" else view.title()) + " generation",
+                )
+                for view, destination in view_destinations.items()
+            ),
             (paths.context_destination, "context generation"),
         ):
             try:
@@ -4433,7 +4480,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     artifact_import_cache_parser = artifact_subparsers.add_parser(
         "import-cache",
-        help="import an existing compiler BM25 cache into retained storage",
+        help="import existing compiler query views into retained storage",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     artifact_import_cache_parser.add_argument(
@@ -4443,7 +4490,16 @@ def build_parser() -> argparse.ArgumentParser:
     artifact_import_cache_parser.add_argument(
         "--cache-dir",
         required=True,
-        help="existing compiler cache containing repo_manifest.json and BM25",
+        help="existing compiler cache containing repo_manifest.json and selected views",
+    )
+    artifact_import_cache_parser.add_argument(
+        "--view",
+        action="append",
+        default=[],
+        help=(
+            "current cache view to import (bm25 or vector); repeat or use a "
+            "comma-separated list; defaults to bm25"
+        ),
     )
     artifact_import_cache_parser.add_argument(
         "--catalog",

--- a/codenib/compiler/__init__.py
+++ b/codenib/compiler/__init__.py
@@ -29,6 +29,9 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
     from codenib.compiler.cache_import import (
         CompilerCacheBm25RecaptureResult,
         CompilerCacheImportResult,
+        CompilerCacheMultiViewImportResult,
+        CompilerCacheViewRecaptureResult,
+        import_compiler_cache,
         import_compiler_cache_bm25,
     )
     from codenib.compiler.index_builders import IndexBuilderRegistry
@@ -80,6 +83,18 @@ _EXPORTS = {
     "CompilerCacheImportResult": (
         "codenib.compiler.cache_import",
         "CompilerCacheImportResult",
+    ),
+    "CompilerCacheMultiViewImportResult": (
+        "codenib.compiler.cache_import",
+        "CompilerCacheMultiViewImportResult",
+    ),
+    "CompilerCacheViewRecaptureResult": (
+        "codenib.compiler.cache_import",
+        "CompilerCacheViewRecaptureResult",
+    ),
+    "import_compiler_cache": (
+        "codenib.compiler.cache_import",
+        "import_compiler_cache",
     ),
     "import_compiler_cache_bm25": (
         "codenib.compiler.cache_import",
@@ -186,6 +201,9 @@ __all__ = [
     # Index compilation
     "CompilerCacheBm25RecaptureResult",
     "CompilerCacheImportResult",
+    "CompilerCacheMultiViewImportResult",
+    "CompilerCacheViewRecaptureResult",
+    "import_compiler_cache",
     "import_compiler_cache_bm25",
     "IndexCompiler",
     "IndexCompilerConfig",

--- a/codenib/compiler/cache_import.py
+++ b/codenib/compiler/cache_import.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Import one compiler-cache BM25 generation through retained authority.
+"""Import compiler-cache query views through retained authority.
 
 The compiler cache is mutable local state, so it is never handed directly to
-the retained importer.  This coordinator holds the compiler cache lock while
-it authenticates the fixed manifest and BM25 tree, plans the exact portable
-manifest, and publishes immutable BM25 and context generations.  Only the
-immutable context receipt crosses the lock boundary into storage import.
+the retained importer.  This coordinator holds one existing compiler cache
+lock while it authenticates the fixed manifest and selected query-view trees,
+plans the exact portable manifest, and publishes immutable view and context
+generations.  Only the immutable context receipt crosses the lock boundary
+into storage import.
 """
 
 from __future__ import annotations
@@ -42,7 +43,12 @@ from ..artifacts.strict_bm25 import (
 from ..artifacts.strict_context import (
     _canonical_json_bytes,
     _portable_capabilities,
-    stage_context_artifact_strict,
+    plan_context_artifact_strict,
+    publish_planned_context_artifact_strict,
+)
+from ..artifacts.strict_vector import (
+    _plan_recaptured_vector_view,
+    _publish_recaptured_vector_view,
 )
 from ..repository_source_selection import (
     DEFAULT_REPOSITORY_SOURCE_SELECTION,
@@ -89,6 +95,7 @@ from .manifest_import import (
     import_retained_repo_manifest,
 )
 from .manifest_storage import (
+    CURRENT_PORTABLE_BUILDER_SCHEMAS,
     DEFAULT_MAX_MANIFEST_BYTES,
     RepoManifestImportPlan,
     _manifest_limit,
@@ -99,6 +106,65 @@ from .manifest_storage import (
 from .snapshot_store import normalize_repo
 
 _COMMIT_RE = re.compile(r"[0-9a-f]{40}\Z", re.ASCII)
+_SUPPORTED_CACHE_VIEWS = ("bm25", "vector")
+
+
+@dataclass(frozen=True, slots=True)
+class CompilerCacheViewRecaptureResult:
+    """Detached evidence for one mutable-to-immutable view recapture."""
+
+    view_type: str
+    source_view: Path
+    output_view: Path
+    source_records: tuple[TreeFileRecord, ...]
+    output_records: tuple[TreeFileRecord, ...]
+
+    def __post_init__(self) -> None:
+        if type(self) is not CompilerCacheViewRecaptureResult:
+            raise TypeError("compiler cache view recapture must use the exact type")
+        if (
+            type(self.view_type) is not str
+            or self.view_type not in _SUPPORTED_CACHE_VIEWS
+        ):
+            raise ValueError("compiler cache view recapture type is unsupported")
+        if type(self.source_view) is not type(Path()) or type(
+            self.output_view
+        ) is not type(Path()):
+            raise TypeError("compiler cache view recapture paths must be exact paths")
+        source_records = tuple(self.source_records)
+        output_records = tuple(self.output_records)
+        for records, label in (
+            (source_records, "source"),
+            (output_records, "output"),
+        ):
+            if not records or any(
+                type(record) is not TreeFileRecord for record in records
+            ):
+                raise TypeError(
+                    f"compiler cache view recapture {label} records are invalid"
+                )
+            if records != tuple(sorted(records, key=lambda item: item.path)):
+                raise ValueError(
+                    f"compiler cache view recapture {label} records are not canonical"
+                )
+            if len({record.path for record in records}) != len(records):
+                raise ValueError(
+                    f"compiler cache view recapture {label} records repeat a path"
+                )
+        if self.view_type == "bm25":
+            expected = {"bm25_metadata.json", "documents.json"}
+            if {record.path for record in source_records} != expected or {
+                record.path for record in output_records
+            } != expected:
+                raise ValueError("compiler cache BM25 recapture records are incomplete")
+        object.__setattr__(self, "source_records", source_records)
+        object.__setattr__(self, "output_records", output_records)
+
+    @property
+    def output_file_fingerprints(self) -> dict[str, dict[str, Any]]:
+        """Return detached output fingerprints keyed by portable path."""
+
+        return _fingerprints_for_records(self.output_records)
 
 
 @dataclass(frozen=True, slots=True)
@@ -184,6 +250,60 @@ class CompilerCacheImportResult:
 
 
 @dataclass(frozen=True, slots=True)
+class CompilerCacheMultiViewImportResult:
+    """Pure-data result of one atomic compiler-cache view-set import."""
+
+    recaptures: tuple[CompilerCacheViewRecaptureResult, ...]
+    canonical_manifest_bytes: bytes
+    import_plan: RepoManifestImportPlan
+    context_artifact: ContextArtifactResult
+    import_result: RepoManifestImportResult
+
+    def __post_init__(self) -> None:
+        if type(self) is not CompilerCacheMultiViewImportResult:
+            raise TypeError(
+                "compiler cache multi-view import must use the exact result type"
+            )
+        recaptures = tuple(self.recaptures)
+        if not recaptures or any(
+            type(item) is not CompilerCacheViewRecaptureResult for item in recaptures
+        ):
+            raise TypeError("compiler cache multi-view recaptures are invalid")
+        views = tuple(item.view_type for item in recaptures)
+        if views != tuple(view for view in _SUPPORTED_CACHE_VIEWS if view in views):
+            raise ValueError("compiler cache multi-view recaptures are not canonical")
+        if len(set(views)) != len(views):
+            raise ValueError("compiler cache multi-view recaptures repeat a view")
+        if type(self.canonical_manifest_bytes) is not bytes:
+            raise TypeError("compiler cache portable manifest must be exact bytes")
+        if type(self.import_plan) is not RepoManifestImportPlan:
+            raise TypeError("compiler cache multi-view import plan is invalid")
+        if type(self.context_artifact) is not ContextArtifactResult:
+            raise TypeError("compiler cache context artifact result is invalid")
+        if type(self.import_result) is not RepoManifestImportResult:
+            raise TypeError("compiler cache retained import result is invalid")
+        if (
+            self.import_plan.selection.selected_views != views
+            or self.context_artifact.views != views
+            or self.import_result.views != views
+            or self.canonical_manifest_bytes
+            != _pretty_manifest_bytes(self.import_plan.manifest)
+        ):
+            raise StorageIntegrityError(
+                "compiler cache multi-view result identities are inconsistent"
+            )
+        object.__setattr__(self, "recaptures", recaptures)
+
+    @property
+    def views(self) -> tuple[str, ...]:
+        return tuple(item.view_type for item in self.recaptures)
+
+    @property
+    def recapture_map(self) -> dict[str, CompilerCacheViewRecaptureResult]:
+        return {item.view_type: item for item in self.recaptures}
+
+
+@dataclass(frozen=True, slots=True)
 class _ImportPreflight:
     repository_key: str
     namespace_name: str
@@ -229,22 +349,55 @@ def _require_missing(path: Path, *, label: str) -> None:
 
 def _preflight_authorities(
     *,
+    views: tuple[str, ...],
     repository_source: RepositorySourceBinding,
-    bm25_output_owner: PublishedWorkspaceReceiptOwner,
+    view_output_owners: dict[str, PublishedWorkspaceReceiptOwner],
+    view_destinations: dict[str, Path],
     context_output_owner: PublishedWorkspaceReceiptOwner,
+    context_destination: Path,
 ) -> None:
+    if type(views) is not tuple:
+        raise TypeError("compiler cache views must be an exact tuple")
+    if not views or any(type(view) is not str for view in views):
+        raise ValueError("compiler cache views must contain exact view names")
+    canonical_views = tuple(
+        view for view in _SUPPORTED_CACHE_VIEWS if view in set(views)
+    )
+    if views != canonical_views:
+        raise ValueError(
+            "compiler cache views must be a non-empty canonical portable subset"
+        )
+    if type(view_output_owners) is not dict:
+        raise TypeError("compiler cache view output owners must be an exact dict")
+    if type(view_destinations) is not dict:
+        raise TypeError("compiler cache view destinations must be an exact dict")
+    if any(type(view) is not str for view in view_output_owners) or any(
+        type(view) is not str for view in view_destinations
+    ):
+        raise TypeError("compiler cache view mapping keys must be exact text")
+    if tuple(view_output_owners) != views or tuple(view_destinations) != views:
+        raise ValueError(
+            "compiler cache view mappings must have the exact selected keys and order"
+        )
     if type(repository_source) is not RepositorySourceBinding:
         raise TypeError("compiler cache source must be an exact source binding")
+    owners = tuple(view_output_owners.values())
     if (
-        type(bm25_output_owner) is not PublishedWorkspaceReceiptOwner
+        any(type(owner) is not PublishedWorkspaceReceiptOwner for owner in owners)
         or type(context_output_owner) is not PublishedWorkspaceReceiptOwner
     ):
         raise TypeError("compiler cache outputs must be exact receipt owners")
-    if bm25_output_owner is context_output_owner:
+    if len({id(owner) for owner in (*owners, context_output_owner)}) != len(owners) + 1:
         raise ValueError("compiler cache outputs must use distinct receipt owners")
+    if any(type(path) is not type(Path()) for path in view_destinations.values()):
+        raise TypeError("compiler cache view destinations must be exact paths")
+    if type(context_destination) is not type(Path()):
+        raise TypeError("compiler cache context destination must be an exact path")
     if not repository_source.usable:
         raise RuntimeError("compiler cache repository source is not usable")
-    if bm25_output_owner.state != "empty" or context_output_owner.state != "empty":
+    if any(owner.state != "empty" for owner in owners) or (
+        context_output_owner.state != "empty"
+    ):
         raise RuntimeError("compiler cache output receipt owners must be empty")
 
 
@@ -380,24 +533,25 @@ def _cache_topology(
 
 
 def _destination_topology(
-    bm25_destination: Path,
+    view_destinations: tuple[Path, ...],
     context_destination: Path,
     *,
     cache: Path,
     repository: Path,
-    source_view: Path,
+    source_views: tuple[Path, ...],
 ) -> None:
-    lexical_boundaries = (cache, repository, source_view)
+    lexical_boundaries = (cache, repository, *source_views)
     physical_boundaries = tuple(
         _resolved_path(path, strict=True, label="compiler cache input")
         for path in lexical_boundaries
     )
+    outputs = (*view_destinations, context_destination)
     physical_destinations = tuple(
         _resolved_path(path, strict=False, label="compiler cache destination")
-        for path in (bm25_destination, context_destination)
+        for path in outputs
     )
     for destination, physical_destination in zip(
-        (bm25_destination, context_destination),
+        outputs,
         physical_destinations,
         strict=True,
     ):
@@ -410,10 +564,18 @@ def _destination_topology(
         ):
             raise ValueError("compiler cache destination overlaps an input authority")
         _require_missing(destination, label="compiler cache destination")
-    if _path_relation(bm25_destination, context_destination) != "disjoint" or (
-        _path_relation(physical_destinations[0], physical_destinations[1]) != "disjoint"
-    ):
-        raise ValueError("compiler cache output destinations overlap")
+    for index, destination in enumerate(outputs):
+        physical_destination = physical_destinations[index]
+        for other, physical_other in zip(
+            outputs[index + 1 :],
+            physical_destinations[index + 1 :],
+            strict=True,
+        ):
+            if (
+                _path_relation(destination, other) != "disjoint"
+                or _path_relation(physical_destination, physical_other) != "disjoint"
+            ):
+                raise ValueError("compiler cache output destinations overlap")
 
 
 def _read_manifest(cache: Path, *, max_manifest_bytes: int) -> bytes:
@@ -447,7 +609,10 @@ def _parse_exact_manifest(payload: bytes, *, max_manifest_bytes: int) -> RepoMan
     except (KeyError, TypeError, ValueError) as exc:
         raise ValueError("compiler cache repository manifest is invalid") from exc
     if exact != data:
-        raise ValueError("compiler cache repository manifest is not exact v1.1 data")
+        raise ValueError(
+            "compiler cache repository manifest is not exact "
+            f"v{manifest.version} data"
+        )
     return manifest
 
 
@@ -499,30 +664,53 @@ def _require_manifest_source(
         raise StorageIntegrityError(
             "compiler cache repository manifest differs from the retained source"
         )
+    selection = manifest.source_selection
+    identity_selection = identity.source_selection
+    if type(selection) is not RepositorySourceSelection:
+        raise ValueError(
+            "compiler cache repository manifest has no exact source selection"
+        )
+    if (
+        type(identity_selection) is not RepositorySourceSelection
+        or identity_selection != selection
+        or identity_selection.digest != selection.digest
+    ):
+        raise StorageIntegrityError(
+            "compiler cache repository source selection differs from the "
+            "retained source"
+        )
 
 
-def _bm25_source(cache: Path, entry: IndexEntry) -> Path:
+def _view_source(cache: Path, entry: IndexEntry, *, view: str) -> Path:
     declared = Path(entry.path).expanduser()
     if not declared.is_absolute():
         declared = cache / declared
     source = lexical_directory_path(declared)
-    expected = lexical_directory_path(cache / "bm25")
+    expected = lexical_directory_path(cache / view)
     if source != expected:
-        raise ValueError("compiler cache BM25 entry does not name its fixed view")
+        raise ValueError(f"compiler cache {view} entry does not name its fixed view")
     return source
 
 
-def _require_current_bm25(manifest: RepoManifest) -> IndexEntry:
-    entry = manifest.indexes.get("bm25")
+def _require_current_view(manifest: RepoManifest, *, view: str) -> IndexEntry:
+    entry = manifest.indexes.get(view)
+    selection_digest = manifest.source_selection_digest
     if (
         type(entry) is not IndexEntry
-        or entry.index_type != "bm25"
+        or entry.index_type != view
         or entry.status != "fresh"
         or entry.commit != manifest.commit
         or entry.source_fingerprint != manifest.source_fingerprint
-        or not manifest.index_is_current("bm25")
+        or not manifest.index_is_current(view)
+        or type(selection_digest) is not str
+        or entry.source_selection_digest != selection_digest
+        or entry.config.get("source_selection_digest") != selection_digest
+        or type(entry.config.get("builder_schema")) is not int
+        or entry.config.get("builder_schema") != CURRENT_PORTABLE_BUILDER_SCHEMAS[view]
     ):
-        raise ValueError("compiler cache repository manifest has no exact current BM25")
+        raise ValueError(
+            f"compiler cache repository manifest has no exact current {view}"
+        )
     return entry
 
 
@@ -549,6 +737,98 @@ def _require_source_fingerprints(
         )
 
 
+def _plan_cache_view(
+    view: str,
+    source: Path,
+    destination: Path,
+    *,
+    repository_source: RepositorySourceBinding,
+    view_config: Mapping[str, Any],
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
+) -> Any:
+    if view == "bm25":
+        return _plan_recaptured_bm25_view(
+            source,
+            destination,
+            repository_source=repository_source,
+            view_config=view_config,
+            forbidden_paths=forbidden_paths,
+            environ=environ,
+        )
+    if view == "vector":
+        return _plan_recaptured_vector_view(
+            source,
+            destination,
+            repository_source=repository_source,
+            view_config=view_config,
+            forbidden_paths=forbidden_paths,
+            environ=environ,
+        )
+    raise AssertionError(f"unsupported compiler cache view: {view}")
+
+
+def _publish_cache_view(
+    view: str,
+    source: Path,
+    destination: Path,
+    *,
+    planned: Any,
+    repository_source: RepositorySourceBinding,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+    view_config: Mapping[str, Any],
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
+) -> dict[str, Any]:
+    if view == "bm25":
+        return _publish_recaptured_bm25_view(
+            source,
+            destination,
+            planned=planned,
+            repository_source=repository_source,
+            workspace_provider=workspace_provider,
+            output_receipt_owner=output_receipt_owner,
+            view_config=view_config,
+            forbidden_paths=forbidden_paths,
+            environ=environ,
+        )
+    if view == "vector":
+        return _publish_recaptured_vector_view(
+            source,
+            destination,
+            planned=planned,
+            repository_source=repository_source,
+            workspace_provider=workspace_provider,
+            output_receipt_owner=output_receipt_owner,
+            view_config=view_config,
+            forbidden_paths=forbidden_paths,
+            environ=environ,
+        )
+    raise AssertionError(f"unsupported compiler cache view: {view}")
+
+
+def _planned_adjustments(view: str, planned: Any) -> dict[str, Any]:
+    adjustments = planned.adjustments
+    if type(adjustments) is not dict:
+        raise TypeError(f"compiler cache {view} plan adjustments are invalid")
+    if view == "bm25" and adjustments != _fingerprints_adjustment(
+        planned.output_records
+    ):
+        raise StorageIntegrityError(
+            "compiler cache BM25 plan adjustments differ from its output records"
+        )
+    if view == "vector" and set(adjustments) != {
+        "artifact_scope",
+        "portable_document_format",
+        "persistence_config_fingerprint",
+    }:
+        raise StorageIntegrityError(
+            "compiler cache vector plan adjustments are incomplete"
+        )
+    return copy.deepcopy(adjustments)
+
+
 def _pretty_manifest_bytes(manifest: RepoManifest) -> bytes:
     return _canonical_json_bytes(
         manifest.to_dict(),
@@ -558,24 +838,29 @@ def _pretty_manifest_bytes(manifest: RepoManifest) -> bytes:
 
 def _portable_manifest(
     manifest: RepoManifest,
-    planned: PlannedBm25View,
+    *,
+    views: tuple[str, ...],
+    planned_views: dict[str, Any],
 ) -> tuple[RepoManifest, bytes]:
     portable = copy.deepcopy(manifest.to_dict())
     portable["repo"]["path"] = "source"
-    entry = copy.deepcopy(portable["indexes"]["bm25"])
-    entry["path"] = "views/bm25"
-    fingerprints = _fingerprints_for_records(planned.output_records)
-    for section_name in ("config", "metadata"):
-        section = entry.get(section_name)
-        if not isinstance(section, dict):
-            raise ValueError(
-                f"compiler cache BM25 {section_name} must be an exact object"
-            )
-        section["artifact_file_fingerprints"] = copy.deepcopy(fingerprints)
-    portable["indexes"] = {"bm25": entry}
+    entries: dict[str, Any] = {}
+    for view in views:
+        entry = copy.deepcopy(portable["indexes"][view])
+        entry["path"] = f"views/{view}"
+        adjustments = _planned_adjustments(view, planned_views[view])
+        for section_name in ("config", "metadata"):
+            section = entry.get(section_name)
+            if type(section) is not dict:
+                raise ValueError(
+                    f"compiler cache {view} {section_name} must be an exact object"
+                )
+            section.update(copy.deepcopy(adjustments))
+        entries[view] = entry
+    portable["indexes"] = entries
     portable["capabilities"] = _portable_capabilities(
         portable["capabilities"],
-        ("bm25",),
+        views,
     )
     try:
         portable_manifest = RepoManifest.from_dict(portable)
@@ -583,6 +868,22 @@ def _portable_manifest(
         raise ValueError("compiler cache portable manifest is invalid") from exc
     if portable_manifest.to_dict() != portable:
         raise ValueError("compiler cache portable manifest is not canonical")
+    selection_digest = manifest.source_selection_digest
+    if (
+        portable_manifest.source_selection != manifest.source_selection
+        or portable_manifest.last_indexed_source_selection_digest
+        != manifest.last_indexed_source_selection_digest
+        or type(selection_digest) is not str
+        or any(
+            portable_manifest.indexes[view].source_selection_digest != selection_digest
+            or portable_manifest.indexes[view].config.get("source_selection_digest")
+            != selection_digest
+            for view in views
+        )
+    ):
+        raise StorageIntegrityError(
+            "compiler cache portable manifest changed its source selection"
+        )
     return portable_manifest, _pretty_manifest_bytes(portable_manifest)
 
 
@@ -611,13 +912,14 @@ def _read_context_manifest(
     return owner.consume(read)
 
 
-def import_compiler_cache_bm25(
+def import_compiler_cache(
     cache_dir: str | Path,
     *,
+    views: tuple[str, ...],
     repository_source: RepositorySourceBinding,
-    bm25_output_owner: PublishedWorkspaceReceiptOwner,
+    view_output_owners: dict[str, PublishedWorkspaceReceiptOwner],
     context_output_owner: PublishedWorkspaceReceiptOwner,
-    bm25_destination: Path,
+    view_destinations: dict[str, Path],
     context_destination: Path,
     workspace_provider: StrictWorkspaceProvider,
     repository_key: str,
@@ -635,22 +937,29 @@ def import_compiler_cache_bm25(
     max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
     forbidden_paths: Iterable[Path] = (),
     environ: Mapping[str, str] | None = None,
-) -> CompilerCacheImportResult:
-    """Recapture and import the exact current BM25 compiler-cache generation.
+) -> CompilerCacheMultiViewImportResult:
+    """Recapture and import one exact current compiler-cache view set.
 
-    Both receipt owners and the retained repository binding are borrowed.  The
-    caller remains responsible for closing them, on both success and failure.
+    All receipt owners and the retained repository binding are borrowed.  The
+    caller remains responsible for closing them on success and failure.
     Published directories are immutable evidence and are never recursively
-    removed by this coordinator when a later stage fails.
+    removed when a later publication or retained import fails.
     """
 
     _preflight_authorities(
+        views=views,
         repository_source=repository_source,
-        bm25_output_owner=bm25_output_owner,
+        view_output_owners=view_output_owners,
+        view_destinations=view_destinations,
         context_output_owner=context_output_owner,
+        context_destination=context_destination,
     )
+    view_owners = dict(view_output_owners)
+    destination_inputs = dict(view_destinations)
     cache = lexical_directory_path(Path(cache_dir))
-    bm25_output = lexical_directory_path(bm25_destination)
+    view_outputs = {
+        view: lexical_directory_path(destination_inputs[view]) for view in views
+    }
     context_output = lexical_directory_path(context_destination)
     inputs = _preflight_import_inputs(
         repository_key=repository_key,
@@ -669,13 +978,13 @@ def import_compiler_cache_bm25(
         forbidden_paths=forbidden_paths,
         environ=environ,
     )
-    fixed_source_view = lexical_directory_path(cache / "bm25")
+    fixed_source_views = {view: lexical_directory_path(cache / view) for view in views}
     policy_forbidden = _snapshot_forbidden_paths(
         (
             *inputs.forbidden_paths,
             cache,
-            fixed_source_view,
-            bm25_output,
+            *fixed_source_views.values(),
+            *view_outputs.values(),
             context_output,
         )
     )
@@ -701,68 +1010,108 @@ def import_compiler_cache_bm25(
             raise TypeError("compiler cache repository identity has an invalid type")
         _cache_topology(cache, identity)
         _require_manifest_source(manifest, identity)
-        bm25_entry = _require_current_bm25(manifest)
-        source_view = _bm25_source(cache, bm25_entry)
+        entries = {view: _require_current_view(manifest, view=view) for view in views}
+        source_views = {
+            view: _view_source(cache, entries[view], view=view) for view in views
+        }
         _destination_topology(
-            bm25_output,
+            tuple(view_outputs.values()),
             context_output,
             cache=cache,
             repository=lexical_directory_path(identity.root),
-            source_view=source_view,
+            source_views=tuple(source_views.values()),
         )
-        if source_view != fixed_source_view:  # pragma: no cover - helper invariant
-            raise AssertionError("compiler cache fixed BM25 source changed")
+        if source_views != fixed_source_views:  # pragma: no cover - helper invariant
+            raise AssertionError("compiler cache fixed view sources changed")
 
-        # This exact plan, portable manifest, and import plan all exist before
-        # the first provider call can mutate either destination.
-        planned_bm25 = _plan_recaptured_bm25_view(
-            source_view,
-            bm25_output,
-            repository_source=repository_source,
-            view_config=bm25_entry.config,
-            forbidden_paths=policy_forbidden,
-            environ=inputs.environment,
-        )
-        _require_source_fingerprints(bm25_entry, planned_bm25)
+        # Every raw-cache recapture plan plus the exact portable manifest and
+        # retained import plan exists before the first provider call can mutate
+        # any workspace destination.  The context plan is authority-dependent:
+        # it is built later from the published view receipts, before context
+        # workspace mutation.
+        planned_views: dict[str, Any] = {}
+        for view in views:
+            planned = _plan_cache_view(
+                view,
+                source_views[view],
+                view_outputs[view],
+                repository_source=repository_source,
+                view_config=entries[view].config,
+                forbidden_paths=policy_forbidden,
+                environ=inputs.environment,
+            )
+            if view == "bm25":
+                _require_source_fingerprints(entries[view], planned)
+            _planned_adjustments(view, planned)
+            planned_views[view] = planned
         portable_manifest, canonical_manifest_bytes = _portable_manifest(
             manifest,
-            planned_bm25,
+            views=views,
+            planned_views=planned_views,
         )
         import_plan = plan_repo_manifest_import_bytes(
             canonical_manifest_bytes,
-            views=("bm25",),
+            views=views,
             max_manifest_bytes=inputs.max_manifest_bytes,
         )
         if (
-            import_plan.selection.selected_views != ("bm25",)
+            import_plan.selection.selected_views != views
             or import_plan.manifest.to_dict() != portable_manifest.to_dict()
         ):
             raise StorageIntegrityError(
                 "compiler cache portable manifest changed during import planning"
             )
 
-        adjustments = _publish_recaptured_bm25_view(
-            source_view,
-            bm25_output,
-            planned=planned_bm25,
-            repository_source=repository_source,
-            workspace_provider=workspace_provider,
-            output_receipt_owner=bm25_output_owner,
-            view_config=bm25_entry.config,
-            forbidden_paths=policy_forbidden,
-            environ=inputs.environment,
-        )
-        if adjustments != _fingerprints_adjustment(planned_bm25.output_records):
-            raise StorageIntegrityError(
-                "compiler cache BM25 publication differs from its exact plan"
+        recaptures: list[CompilerCacheViewRecaptureResult] = []
+        for view in views:
+            planned = planned_views[view]
+            adjustments = _publish_cache_view(
+                view,
+                source_views[view],
+                view_outputs[view],
+                planned=planned,
+                repository_source=repository_source,
+                workspace_provider=workspace_provider,
+                output_receipt_owner=view_owners[view],
+                view_config=entries[view].config,
+                forbidden_paths=policy_forbidden,
+                environ=inputs.environment,
+            )
+            if adjustments != _planned_adjustments(view, planned):
+                raise StorageIntegrityError(
+                    f"compiler cache {view} publication differs from its exact plan"
+                )
+            recaptures.append(
+                CompilerCacheViewRecaptureResult(
+                    view_type=view,
+                    source_view=source_views[view],
+                    output_view=view_outputs[view],
+                    source_records=planned.source_records,
+                    output_records=planned.output_records,
+                )
             )
 
-        context_artifact = stage_context_artifact_strict(
+        planned_context = plan_context_artifact_strict(
+            portable_manifest,
+            repository=inputs.repository_key,
+            repository_source=repository_source,
+            view_generations=view_owners,
+            environ=inputs.environment,
+        )
+        if (
+            planned_context.views != views
+            or planned_context.manifest_payload != canonical_manifest_bytes
+        ):
+            raise StorageIntegrityError(
+                "compiler cache context plan differs from its portable manifest"
+            )
+        context_artifact = publish_planned_context_artifact_strict(
             context_output,
+            planned=planned_context,
             manifest=portable_manifest,
             repository=inputs.repository_key,
             repository_source=repository_source,
-            view_generations={"bm25": bm25_output_owner},
+            view_generations=view_owners,
             workspace_provider=workspace_provider,
             output_receipt_owner=context_output_owner,
             environ=inputs.environment,
@@ -787,14 +1136,6 @@ def import_compiler_cache_bm25(
                 "compiler cache repository manifest changed during recapture"
             )
 
-        recapture = CompilerCacheBm25RecaptureResult(
-            source_view=source_view,
-            output_view=bm25_output,
-            source_records=planned_bm25.source_records,
-            output_records=planned_bm25.output_records,
-            canonical_manifest_bytes=canonical_manifest_bytes,
-        )
-
     # Catalog/CAS publication deliberately occurs after releasing the mutable
     # compiler cache lock.  The context receipt remains the exact authority
     # authenticated above, so the mutable cache is no longer consulted.
@@ -817,11 +1158,81 @@ def import_compiler_cache_bm25(
         forbidden_paths=policy_forbidden,
         environ=inputs.environment,
     )
-    return CompilerCacheImportResult(
-        recapture=recapture,
+    return CompilerCacheMultiViewImportResult(
+        recaptures=tuple(recaptures),
+        canonical_manifest_bytes=canonical_manifest_bytes,
         import_plan=import_plan,
         context_artifact=context_artifact,
         import_result=import_result,
+    )
+
+
+def import_compiler_cache_bm25(
+    cache_dir: str | Path,
+    *,
+    repository_source: RepositorySourceBinding,
+    bm25_output_owner: PublishedWorkspaceReceiptOwner,
+    context_output_owner: PublishedWorkspaceReceiptOwner,
+    bm25_destination: Path,
+    context_destination: Path,
+    workspace_provider: StrictWorkspaceProvider,
+    repository_key: str,
+    catalog: RetainedImportCatalog,
+    object_store: RetainedImportObjectStore,
+    namespace_name: str = DEFAULT_NAMESPACE_NAME,
+    ref_name: str = DEFAULT_REF_NAME,
+    expected_generation: int = 0,
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+    max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
+    max_context_bytes: int = DEFAULT_MAX_CONTEXT_BYTES,
+    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
+    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
+    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> CompilerCacheImportResult:
+    """Compatibility wrapper for one exact current BM25 cache import."""
+
+    result = import_compiler_cache(
+        cache_dir,
+        views=("bm25",),
+        repository_source=repository_source,
+        view_output_owners={"bm25": bm25_output_owner},
+        context_output_owner=context_output_owner,
+        view_destinations={"bm25": bm25_destination},
+        context_destination=context_destination,
+        workspace_provider=workspace_provider,
+        repository_key=repository_key,
+        catalog=catalog,
+        object_store=object_store,
+        namespace_name=namespace_name,
+        ref_name=ref_name,
+        expected_generation=expected_generation,
+        max_manifest_bytes=max_manifest_bytes,
+        max_context_files=max_context_files,
+        max_context_bytes=max_context_bytes,
+        max_bundle_files=max_bundle_files,
+        max_bundle_bytes=max_bundle_bytes,
+        max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        max_projection_bytes=max_projection_bytes,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
+    )
+    recapture = result.recaptures[0]
+    if recapture.view_type != "bm25":  # pragma: no cover - wrapper invariant
+        raise AssertionError("compiler cache BM25 wrapper selected another view")
+    return CompilerCacheImportResult(
+        recapture=CompilerCacheBm25RecaptureResult(
+            source_view=recapture.source_view,
+            output_view=recapture.output_view,
+            source_records=recapture.source_records,
+            output_records=recapture.output_records,
+            canonical_manifest_bytes=result.canonical_manifest_bytes,
+        ),
+        import_plan=result.import_plan,
+        context_artifact=result.context_artifact,
+        import_result=result.import_result,
     )
 
 
@@ -834,5 +1245,8 @@ def _fingerprints_adjustment(
 __all__ = [
     "CompilerCacheBm25RecaptureResult",
     "CompilerCacheImportResult",
+    "CompilerCacheMultiViewImportResult",
+    "CompilerCacheViewRecaptureResult",
+    "import_compiler_cache",
     "import_compiler_cache_bm25",
 ]

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -417,9 +417,11 @@ class VectorIndexBuilder:
     ) -> Dict[str, Any]:
         route = self._embedding_route()
         identity = {
-            # v7 deterministically bounds remote document inputs in addition
-            # to committing vector, chunk, cache, and incremental state.
-            "builder_schema": 7,
+            # v8 commits ordered canonical JSON documents beside each native
+            # index.  Strict cache ingress can therefore authenticate and
+            # publish a portable generation without deserializing pickle or
+            # asking FAISS to parse attacker-controlled bytes.
+            "builder_schema": 8,
             "embedding_model": route.model,
             "embedding_provider": route.provider,
             "embedding_dimension": self.embedding_dimension,
@@ -572,10 +574,37 @@ class VectorIndexBuilder:
                 generation_ownership = build_root.capture_ownership(
                     required_root_file=f"config_{model_suffix}.json",
                 )
+                from ..index.embedding.vector_store import (
+                    _validate_schema_8_native_generation_reader,
+                )
+
+                document_count = status.metadata.get("document_count")
+                if not isinstance(document_count, dict):
+                    raise RuntimeError(
+                        "vector builder returned invalid document counts"
+                    )
+                expected_counts = {
+                    level: document_count.get(level, 0) for level in ("l0", "l2")
+                }
+
+                def validate_and_copy_generation(
+                    reader: PublicationDirectoryReader,
+                ) -> None:
+                    _validate_schema_8_native_generation_reader(
+                        reader,
+                        model_suffix=model_suffix,
+                        artifact_identity=self.artifact_identity(),
+                        expected_dimension=self.embedding_dimension,
+                        expected_metric=self.index_metric,
+                        expected_index_type="flat",
+                        expected_counts=expected_counts,
+                    )
+                    copy_generation(reader)
+
                 reopen_authenticated_directory(
                     build_path,
                     generation_ownership,
-                    copy_generation,
+                    validate_and_copy_generation,
                 )
 
             publication_stage.publish()
@@ -730,6 +759,31 @@ class VectorIndexBuilder:
         )
         with build_root_guard.path_operation("incremental state seed save"):
             inc_state.save(Path(output_dir))
+        from ..index.embedding.artifact_integrity import (
+            validate_vector_generation_artifacts,
+        )
+
+        model_suffix = self._embedding_route().model.replace("/", "__")
+        with build_root_guard.path_operation("schema-8 vector generation validation"):
+            persisted_config = validate_vector_generation_artifacts(
+                output_dir,
+                model_suffix,
+            )
+        if persisted_config.get("artifact") != artifact_identity:
+            raise ValueError(
+                "schema-8 vector generation artifact identity differs from builder"
+            )
+        configured_levels = set(self.build_levels)
+        for level in ("l0", "l2"):
+            expected_count = len(getattr(vs, f"{level}_documents"))
+            if persisted_config.get(f"{level}_documents") != expected_count:
+                raise ValueError(
+                    f"schema-8 vector generation {level} count differs from builder"
+                )
+            if expected_count > 0 and level not in configured_levels:
+                raise ValueError(
+                    f"schema-8 vector generation emitted unconfigured level {level}"
+                )
         with build_root_guard.path_operation("persistence fingerprint read"):
             persistence_config = self._persistence_config_fingerprint(output_dir)
 

--- a/codenib/compiler/manifest_storage.py
+++ b/codenib/compiler/manifest_storage.py
@@ -53,7 +53,14 @@ REPO_MANIFEST_BM25_GENERATION_CONTRACT = "codenib.repo-manifest-bm25-generation.
 REPO_MANIFEST_VECTOR_GENERATION_CONTRACT = "codenib.repo-manifest-vector-generation.v1"
 
 PORTABLE_STORAGE_VIEWS = frozenset({"bm25", "vector"})
-CURRENT_PORTABLE_BUILDER_SCHEMAS = {"bm25": 8, "vector": 7}
+CURRENT_PORTABLE_BUILDER_SCHEMAS = {"bm25": 8, "vector": 8}
+SUPPORTED_PORTABLE_BUILDER_SCHEMAS = {
+    "bm25": frozenset({8}),
+    # Retained schema-7 vector generations remain query-compatible.  Schema 8
+    # is the current producer/strict-ingress contract because it additionally
+    # commits the canonical ordered document-to-row mapping.
+    "vector": frozenset({7, 8}),
+}
 
 DEFAULT_MAX_MANIFEST_BYTES = 16 * 1024 * 1024
 _MAX_JSON_DEPTH = 64
@@ -1667,9 +1674,9 @@ def _profile_config(
     builder_schema = _positive_int(
         config["builder_schema"], f"view {view_type!r} builder_schema"
     )
-    if builder_schema != CURRENT_PORTABLE_BUILDER_SCHEMAS[view_type]:
+    if builder_schema not in SUPPORTED_PORTABLE_BUILDER_SCHEMAS[view_type]:
         raise _IncompleteProfile(
-            f"view {view_type!r} builder_schema is not the current portable schema"
+            f"view {view_type!r} builder_schema is not a supported portable schema"
         )
     _text_list(config["languages"], f"view {view_type!r} languages")
     _positive_int(
@@ -2710,6 +2717,7 @@ def _encode_bounded_manifest_text(value: str, *, limit: int) -> bytes:
 
 __all__ = [
     "BM25_PROFILE_AXES",
+    "CURRENT_PORTABLE_BUILDER_SCHEMAS",
     "DEFAULT_MAX_MANIFEST_BYTES",
     "PORTABLE_STORAGE_VIEWS",
     "REPO_MANIFEST_BM25_GENERATION_CONTRACT",
@@ -2720,6 +2728,7 @@ __all__ = [
     "REPO_MANIFEST_VECTOR_GENERATION_CONTRACT",
     "RepoManifestImportPlan",
     "SourceIntent",
+    "SUPPORTED_PORTABLE_BUILDER_SCHEMAS",
     "VECTOR_PROFILE_AXES",
     "ViewImportIntent",
     "ViewSelection",

--- a/codenib/index/embedding/artifact_integrity.py
+++ b/codenib/index/embedding/artifact_integrity.py
@@ -22,7 +22,7 @@ from ..._atomic_directory import (
     directory_ownership_inventory,
     lexical_directory_path,
 )
-from ..._bounded_json import iter_bounded_json_array
+from ..._bounded_json import canonical_json_array_chunks, iter_bounded_json_array
 from ..._captured_directory import AuthenticatedFile, CapturedDirectoryReader
 from ...native_index_authorization import (
     NativeIndexAuthorization,
@@ -32,6 +32,7 @@ from ...native_index_authorization import (
 )
 
 VECTOR_PERSISTENCE_SCHEMA = 1
+VECTOR_ROW_MAPPING_CONTRACT = "codenib.vector-documents-array-index.v1"
 VECTOR_VIEW_UPDATE_MARKER = ".vector-view.update-in-progress"
 _DIGEST_BYTES = 1024 * 1024
 _MAX_CONFIG_BYTES = 16 * 1024 * 1024
@@ -40,6 +41,21 @@ _MAX_FAISS_BYTES = 8 * 1024 * 1024 * 1024
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _UPDATE_MARKER_PAYLOAD = b'{"schema":"codenib.vector-view-update.v1"}\n'
 _VECTOR_LEVELS = frozenset({"l0", "l2"})
+_VECTOR_DOCUMENT_METADATA_FIELDS = frozenset(
+    {
+        "chunk_id",
+        "chunk_type",
+        "name",
+        "file",
+        "start_line",
+        "end_line",
+        "node_id",
+        "level",
+        "content_hash",
+    }
+)
+_MAX_SOURCE_PATH_BYTES = 4_096
+_MAX_SOURCE_PATH_COMPONENTS = 256
 _MUTABLE_ROOT_FILES = frozenset(
     {
         "chunk_store.json",
@@ -505,6 +521,101 @@ def vector_config_artifact_record(
     return _file_record(Path(root) / f"config_{model_suffix}.json")
 
 
+def validate_schema_8_vector_document_row(
+    document: object,
+    *,
+    row_index: int,
+    level: str,
+) -> tuple[str, dict[str, Any]]:
+    """Validate the source-independent schema-8 document/row contract."""
+
+    if type(row_index) is not int or row_index < 0:
+        raise ValueError("schema-8 vector document row index is invalid")
+    if level not in _VECTOR_LEVELS:
+        raise ValueError("schema-8 vector document level is invalid")
+    if not isinstance(document, dict) or set(document) != {
+        "page_content",
+        "metadata",
+    }:
+        raise ValueError(
+            f"schema-8 vector {level} document {row_index} has an invalid shape"
+        )
+    page_content = document["page_content"]
+    metadata = document["metadata"]
+    if not isinstance(page_content, str) or not isinstance(metadata, dict):
+        raise ValueError(
+            f"schema-8 vector {level} document {row_index} has invalid content"
+        )
+    if set(metadata) != _VECTOR_DOCUMENT_METADATA_FIELDS:
+        raise ValueError(
+            f"schema-8 vector {level} document {row_index} metadata has an "
+            "invalid shape"
+        )
+    if type(metadata["chunk_id"]) is not int or metadata["chunk_id"] != row_index:
+        raise ValueError(
+            f"schema-8 vector {level} document {row_index} has an invalid row"
+        )
+    start_line = metadata["start_line"]
+    end_line = metadata["end_line"]
+    if (
+        type(start_line) is not int
+        or type(end_line) is not int
+        or start_line < 0
+        or end_line < start_line
+    ):
+        raise ValueError(
+            f"schema-8 vector {level} document {row_index} has invalid lines"
+        )
+    for key in ("chunk_type", "name", "node_id"):
+        value = metadata[key]
+        if not isinstance(value, str) or "\x00" in value:
+            raise ValueError(
+                f"schema-8 vector {level} document {row_index} has invalid {key}"
+            )
+    if metadata["level"] != level:
+        raise ValueError(
+            f"schema-8 vector {level} document {row_index} has the wrong level"
+        )
+    expected_hash = hashlib.md5(  # noqa: S324 - producer compatibility only
+        page_content.encode("utf-8", errors="replace"),
+        usedforsecurity=False,
+    ).hexdigest()
+    if metadata["content_hash"] != expected_hash:
+        raise ValueError(
+            f"schema-8 vector {level} document {row_index} has an invalid "
+            "content hash"
+        )
+    source_file = metadata["file"]
+    if not isinstance(source_file, str) or not source_file:
+        raise ValueError(
+            f"schema-8 vector {level} document {row_index} file is invalid"
+        )
+    try:
+        encoded = source_file.encode("utf-8", errors="strict")
+    except UnicodeEncodeError as exc:
+        raise ValueError(
+            f"schema-8 vector {level} document {row_index} file is invalid"
+        ) from exc
+    parts = source_file.split("/")
+    normalized = PurePosixPath(source_file)
+    if (
+        len(encoded) > _MAX_SOURCE_PATH_BYTES
+        or len(normalized.parts) > _MAX_SOURCE_PATH_COMPONENTS
+        or any(
+            ord(character) < 32 or ord(character) == 127 for character in source_file
+        )
+        or source_file.startswith(("/", "~"))
+        or "\\" in source_file
+        or normalized.is_absolute()
+        or any(part in {"", ".", ".."} for part in parts)
+        or normalized.as_posix() != source_file
+    ):
+        raise ValueError(
+            f"schema-8 vector {level} document {row_index} file is invalid"
+        )
+    return page_content, dict(metadata)
+
+
 def require_complete_vector_view(root: str | Path) -> None:
     """Reject a vector view whose multi-artifact update did not finish."""
 
@@ -617,6 +728,49 @@ def validate_vector_level_artifacts(
     return paths["index"], paths["documents"]
 
 
+def _schema_8_document_count(path: Path, *, expected_sha256: str) -> int:
+    """Authenticate canonical ordered JSON and return its array length."""
+
+    descriptor, opened = _open_stable_regular(path)
+    try:
+        if opened.st_size > _MAX_DOCUMENT_BYTES:
+            raise ValueError(
+                f"schema-8 vector documents exceed their byte limit: {path}"
+            )
+        count = 0
+
+        def values():
+            nonlocal count
+            with os.fdopen(os.dup(descriptor), "rb") as source:
+                for document in iter_bounded_json_array(
+                    source,
+                    label=f"schema-8 vector documents {path}",
+                    max_element_bytes=_MAX_DOCUMENT_BYTES,
+                ):
+                    count += 1
+                    yield document
+
+        size = 0
+        digest = hashlib.sha256()
+        for chunk in canonical_json_array_chunks(values()):
+            size += len(chunk)
+            if size > _MAX_DOCUMENT_BYTES:
+                raise ValueError(
+                    f"schema-8 vector documents exceed their byte limit: {path}"
+                )
+            digest.update(chunk)
+        _verify_open_file(descriptor, opened, path)
+        if size != opened.st_size or digest.hexdigest() != expected_sha256:
+            raise ValueError(f"schema-8 vector documents are not canonical: {path}")
+        return count
+    except OSError as exc:
+        raise ValueError(
+            f"schema-8 vector documents could not be read: {path}"
+        ) from exc
+    finally:
+        os.close(descriptor)
+
+
 def validate_vector_generation_artifacts(
     root: str | Path,
     model_suffix: str,
@@ -625,6 +779,16 @@ def validate_vector_generation_artifacts(
 
     config_path = Path(root) / f"config_{model_suffix}.json"
     config = _load_config(config_path)
+
+    artifact = config.get("artifact")
+    builder_schema = (
+        artifact.get("builder_schema") if isinstance(artifact, Mapping) else None
+    )
+    schema_8 = type(builder_schema) is int and builder_schema == 8
+    if schema_8 and config.get("row_mapping") != (VECTOR_ROW_MAPPING_CONTRACT):
+        raise ValueError("schema-8 vector generation has an invalid row mapping")
+    if not schema_8 and config.get("row_mapping") is not None:
+        raise ValueError("legacy vector generation has an unsupported row mapping")
 
     persistence_schema = config.get("persistence_schema")
     committed_levels = config.get("level_artifacts")
@@ -658,17 +822,46 @@ def validate_vector_generation_artifacts(
             raise ValueError(
                 f"vector generation is missing committed artifacts for {level}"
             )
-        validate_vector_level_artifacts(
+        if schema_8:
+            documents = (
+                artifacts.get("documents") if isinstance(artifacts, Mapping) else None
+            )
+            if not isinstance(documents, Mapping) or documents.get("file") != (
+                f"documents_{model_suffix}.json"
+            ):
+                raise ValueError(
+                    f"schema-8 vector generation has invalid {level} documents"
+                )
+        _index_path, documents_path = validate_vector_level_artifacts(
             Path(root) / level,
             model_suffix,
             artifacts,
         )
+        if schema_8:
+            documents_record = artifacts["documents"]
+            if not isinstance(documents_record, Mapping) or not isinstance(
+                documents_record.get("sha256"), str
+            ):
+                raise ValueError(
+                    f"schema-8 vector generation has invalid {level} documents"
+                )
+            if (
+                _schema_8_document_count(
+                    documents_path,
+                    expected_sha256=documents_record["sha256"],
+                )
+                != count
+            ):
+                raise ValueError(
+                    f"schema-8 vector {level} document count does not match its config"
+                )
     return config
 
 
 __all__ = [
     "AuthenticatedVectorView",
     "VECTOR_PERSISTENCE_SCHEMA",
+    "VECTOR_ROW_MAPPING_CONTRACT",
     "VECTOR_VIEW_UPDATE_MARKER",
     "begin_vector_view_update",
     "capture_authenticated_vector_view",
@@ -678,6 +871,7 @@ __all__ = [
     "validate_vector_config_artifact",
     "validate_vector_generation_artifacts",
     "validate_vector_level_artifacts",
+    "validate_schema_8_vector_document_row",
     "vector_config_artifact_record",
     "vector_level_artifact_records",
 ]

--- a/codenib/index/embedding/builders.py
+++ b/codenib/index/embedding/builders.py
@@ -384,6 +384,47 @@ def _require_selected_documents(
         )
 
 
+def _schema_8_repository_chunk(chunk: Any, repo_root: Path) -> Any:
+    """Bind one producer document to a portable repository-relative source."""
+
+    raw_file = getattr(chunk, "file", None)
+    if (
+        not isinstance(raw_file, str)
+        or not raw_file
+        or (os.name != "nt" and "\\" in raw_file)
+    ):
+        raise ValueError("schema-8 vector chunk has an invalid source path")
+    candidate = Path(raw_file)
+    if not candidate.is_absolute():
+        candidate = repo_root / candidate
+    try:
+        if any(part in {"", ".", ".."} for part in candidate.parts):
+            raise ValueError("non-canonical lexical path")
+        lexical = Path(os.path.abspath(os.fspath(candidate)))
+        relative = lexical.relative_to(repo_root)
+        physical = lexical.resolve(strict=True)
+        metadata = lexical.lstat()
+    except (OSError, ValueError) as exc:
+        raise ValueError(
+            "schema-8 vector chunk source is outside its repository"
+        ) from exc
+    if physical != lexical or not stat.S_ISREG(metadata.st_mode):
+        raise ValueError(
+            "schema-8 vector chunk source must be a regular lexical repository file"
+        )
+    relative_text = relative.as_posix()
+    if (
+        not relative.parts
+        or any(part in {"", ".", ".."} for part in relative.parts)
+        or relative_text.startswith(("/", "~"))
+    ):
+        raise ValueError("schema-8 vector chunk has an invalid source path")
+    replace = getattr(chunk, "_replace", None)
+    if not callable(replace):
+        raise TypeError("schema-8 vector chunk has an invalid type")
+    return replace(file=relative_text)
+
+
 def build_hierarchical_vector_store(
     *,
     repo_path: str,
@@ -496,6 +537,12 @@ def build_hierarchical_vector_store(
         )
     languages = languages or ["python"]
     build_levels = normalized_levels
+    repository_root = Path(repo_path).resolve()
+    schema_8_documents = (
+        isinstance(artifact_metadata, dict)
+        and type(artifact_metadata.get("builder_schema")) is int
+        and artifact_metadata.get("builder_schema") == 8
+    )
     repo_cfg = RepoChunkingConfig(
         languages=languages,
         source_selection=selected,
@@ -535,9 +582,14 @@ def build_hierarchical_vector_store(
             f"chunking_{level}",
             {"level": level, "language": languages[0]},
         ):
-            chunks_by_level[level] = chunker.chunk_repository(
+            chunks = chunker.chunk_repository(
                 repo_path=repo_path,
                 strict=strict_chunking,
+            )
+            chunks_by_level[level] = (
+                [_schema_8_repository_chunk(chunk, repository_root) for chunk in chunks]
+                if schema_8_documents
+                else chunks
             )
         _require_selected_paths(
             selected,

--- a/codenib/index/embedding/vector_store.py
+++ b/codenib/index/embedding/vector_store.py
@@ -25,8 +25,11 @@ import faiss
 import numpy as np
 
 from ... import compat_pickle
-from ..._atomic_directory import _annotate_secondary_error
-from ..._bounded_json import iter_bounded_json_array
+from ..._atomic_directory import (
+    PublicationDirectoryReader,
+    _annotate_secondary_error,
+)
+from ..._bounded_json import canonical_json_array_chunks, iter_bounded_json_array
 from ..._captured_directory import AuthenticatedSnapshotReader
 from ...log_utils import get_logger
 from ...native_index_authorization import (
@@ -39,10 +42,12 @@ from ...provider_routes import normalize_provider
 from ...types import NodeInfo
 from .artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
+    VECTOR_ROW_MAPPING_CONTRACT,
     VECTOR_VIEW_UPDATE_MARKER,
     AuthenticatedVectorView,
     _attach_vector_view_cleanup_owner,
     capture_authenticated_vector_view,
+    validate_schema_8_vector_document_row,
     vector_level_artifact_records,
 )
 from .model_policy import (
@@ -57,6 +62,10 @@ from .text_policy import (
 logger = get_logger(__name__)
 
 Level = Literal["l0", "l2"]
+
+_MAX_PORTABLE_DOCUMENTS_JSON_BYTES = 256 * 1024 * 1024
+_MAX_VECTOR_CONFIG_BYTES = 16 * 1024 * 1024
+_MAX_FAISS_INDEX_BYTES = 8 * 1024 * 1024 * 1024
 
 _UNSET = object()
 _MODEL_IDENTITY_KEYS = frozenset({"code_revision", "revision", "trust_remote_code"})
@@ -169,6 +178,34 @@ def _atomic_json_dump(target: Path, value: object) -> None:
         with path.open("w", encoding="utf-8") as handle:
             json.dump(value, handle, indent=2)
             handle.write("\n")
+
+    _atomic_replace(target, _write)
+
+
+def _atomic_canonical_document_dump(
+    target: Path,
+    documents: List["_Document"],
+) -> None:
+    """Atomically stream one bounded canonical document array."""
+
+    def values():
+        for document in documents:
+            yield {
+                "page_content": document.page_content,
+                "metadata": dict(document.metadata),
+            }
+
+    def _write(path: Path) -> None:
+        size = 0
+        with path.open("wb") as handle:
+            for chunk in canonical_json_array_chunks(values()):
+                size += len(chunk)
+                if size > _MAX_PORTABLE_DOCUMENTS_JSON_BYTES:
+                    raise ValueError(
+                        "canonical vector documents exceed their "
+                        f"{_MAX_PORTABLE_DOCUMENTS_JSON_BYTES}-byte limit"
+                    )
+                handle.write(chunk)
 
     _atomic_replace(target, _write)
 
@@ -307,6 +344,356 @@ def _attach_vector_index_cleanup_owner(
         primary.vector_index_cleanup_owner = owner  # type: ignore[attr-defined]
     except BaseException:  # noqa: B036 - traceback still retains cleanup error
         pass
+
+
+def _validate_faiss_row_ids(
+    index: faiss.Index,
+    *,
+    relative: str,
+    document_count: int,
+) -> None:
+    """Require FAISS labels to be the canonical document-array positions."""
+
+    if isinstance(index, faiss.IndexFlat):
+        # A bare IndexFlat has no user-supplied label table. Its labels are
+        # necessarily the insertion positions 0..ntotal-1.
+        return
+    if not isinstance(index, faiss.IndexIVFFlat):
+        raise ValueError(f"FAISS index type cannot bind row IDs at {relative}")
+
+    nlist = int(index.nlist)
+    if nlist <= 0 or (document_count > 0 and nlist > document_count):
+        raise ValueError(f"FAISS IVF list count is invalid at {relative}")
+    if document_count == 0:
+        return
+    seen = bytearray(document_count)
+    observed = 0
+    for list_number in range(nlist):
+        list_size = int(index.invlists.list_size(list_number))
+        if list_size < 0 or list_size > document_count - observed:
+            raise ValueError(f"FAISS IVF row count is invalid at {relative}")
+        if list_size == 0:
+            continue
+        ids = None
+        try:
+            ids = index.invlists.get_ids(list_number)
+            for raw_row_id in faiss.rev_swig_ptr(ids, list_size):
+                row_id = int(raw_row_id)
+                if row_id < 0 or row_id >= document_count or seen[row_id]:
+                    raise ValueError(f"FAISS row IDs are not canonical at {relative}")
+                seen[row_id] = 1
+                observed += 1
+        finally:
+            if ids is not None:
+                index.invlists.release_ids(list_number, ids)
+    if observed != document_count or any(value == 0 for value in seen):
+        raise ValueError(f"FAISS row IDs are not canonical at {relative}")
+
+
+def _validate_faiss_index_contract(
+    index: faiss.Index,
+    *,
+    relative: str,
+    document_count: int,
+    expected_dimension: int,
+    expected_metric: str,
+    expected_index_type: str,
+) -> None:
+    if int(index.d) != expected_dimension:
+        raise ValueError(
+            f"FAISS dimension mismatch at {relative}: expected "
+            f"{expected_dimension}, found {int(index.d)}"
+        )
+    if int(index.ntotal) != document_count:
+        raise ValueError(
+            f"FAISS document count mismatch at {relative}: expected "
+            f"{document_count}, found {int(index.ntotal)}"
+        )
+    expected_metric_type = {
+        "ip": faiss.METRIC_INNER_PRODUCT,
+        "l2": faiss.METRIC_L2,
+    }.get(expected_metric)
+    if expected_metric_type is None:
+        raise ValueError(f"Unsupported index_metric: {expected_metric!r}")
+    if int(index.metric_type) != int(expected_metric_type):
+        raise ValueError(
+            f"FAISS metric mismatch at {relative}: expected "
+            f"{expected_metric}, found {int(index.metric_type)}"
+        )
+    if expected_index_type == "flat":
+        valid_type = isinstance(index, faiss.IndexFlat)
+    elif expected_index_type == "ivf":
+        valid_type = isinstance(index, faiss.IndexIVFFlat)
+    else:
+        raise ValueError(f"Unsupported index_type: {expected_index_type!r}")
+    if not valid_type:
+        raise ValueError(
+            f"FAISS index type mismatch at {relative}: expected {expected_index_type}"
+        )
+    if document_count > 0 and not bool(index.is_trained):
+        raise ValueError(f"FAISS index is not trained at {relative}")
+    _validate_faiss_row_ids(
+        index,
+        relative=relative,
+        document_count=document_count,
+    )
+
+
+def _decode_generation_config(payload: bytes, *, relative: str) -> dict[str, Any]:
+    def reject_duplicate(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        decoded: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in decoded:
+                raise ValueError(f"duplicate JSON object key: {key}")
+            decoded[key] = value
+        return decoded
+
+    def reject_nonfinite(value: str) -> None:
+        raise ValueError(f"non-finite JSON number: {value}")
+
+    try:
+        decoded = json.loads(
+            payload.decode("utf-8", errors="strict"),
+            object_pairs_hook=reject_duplicate,
+            parse_constant=reject_nonfinite,
+        )
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"invalid vector generation config: {relative}") from exc
+    if not isinstance(decoded, dict):
+        raise ValueError(f"vector generation config must be an object: {relative}")
+    return decoded
+
+
+def _require_committed_publication_record(
+    reader: PublicationDirectoryReader,
+    relative: str,
+    expected: object,
+) -> None:
+    if not isinstance(expected, Mapping) or set(expected) != {
+        "file",
+        "size",
+        "sha256",
+    }:
+        raise ValueError(f"invalid committed vector artifact record: {relative}")
+    record = next(
+        (
+            candidate
+            for candidate in reader.file_records()
+            if candidate.path == relative
+        ),
+        None,
+    )
+    if (
+        record is None
+        or expected.get("file") != PurePosixPath(relative).name
+        or (
+            expected.get("size") != record.size
+            or expected.get("sha256") != record.sha256
+        )
+    ):
+        raise ValueError(f"committed vector artifact does not match: {relative}")
+
+
+def _validate_schema_8_native_generation_reader(
+    reader: PublicationDirectoryReader,
+    *,
+    model_suffix: str,
+    artifact_identity: Mapping[str, Any],
+    expected_dimension: int,
+    expected_metric: str,
+    expected_index_type: str,
+    expected_counts: Mapping[str, int],
+) -> None:
+    """Validate the persisted schema-8 receipt inside its publication sandwich."""
+
+    if type(reader) is not PublicationDirectoryReader:
+        raise TypeError("vector producer validation requires its publication reader")
+    config_relative = f"config_{model_suffix}.json"
+    config = _decode_generation_config(
+        reader.read_bytes(config_relative, max_bytes=_MAX_VECTOR_CONFIG_BYTES),
+        relative=config_relative,
+    )
+    expected_root_fields = {
+        "embedding_model",
+        "embedding_provider",
+        "embedding_revision",
+        "dimension",
+        "index_type",
+        "index_metric",
+        "l0_documents",
+        "l2_documents",
+        "persistence_schema",
+        "row_mapping",
+        "level_artifacts",
+        "artifact",
+    }
+    if set(config) != expected_root_fields:
+        raise ValueError("schema-8 vector generation root config shape is invalid")
+    persisted_identity = config.get("artifact")
+    if (
+        not isinstance(persisted_identity, dict)
+        or type(persisted_identity.get("builder_schema")) is not int
+        or persisted_identity.get("builder_schema") != 8
+        or persisted_identity != dict(artifact_identity)
+    ):
+        raise ValueError("schema-8 vector generation artifact identity is invalid")
+    if config.get("row_mapping") != VECTOR_ROW_MAPPING_CONTRACT:
+        raise ValueError("schema-8 vector generation has an invalid row mapping")
+    if config.get("persistence_schema") != VECTOR_PERSISTENCE_SCHEMA:
+        raise ValueError("schema-8 vector generation persistence schema is invalid")
+    if config.get("dimension") != expected_dimension:
+        raise ValueError("schema-8 vector generation dimension is invalid")
+    if config.get("index_metric") != expected_metric:
+        raise ValueError("schema-8 vector generation metric is invalid")
+    if config.get("index_type") != expected_index_type:
+        raise ValueError("schema-8 vector generation index type is invalid")
+    from ...artifacts.portable_views import (
+        validate_portable_vector_persistence_semantics,
+    )
+
+    validate_portable_vector_persistence_semantics(config, artifact_identity)
+    if set(expected_counts) != {"l0", "l2"}:
+        raise ValueError("schema-8 vector producer counts are invalid")
+    if any(
+        type(expected_counts[level]) is not int or expected_counts[level] < 0
+        for level in ("l0", "l2")
+    ):
+        raise ValueError("schema-8 vector producer counts are invalid")
+    committed_levels = config.get("level_artifacts")
+    if not isinstance(committed_levels, dict):
+        raise ValueError("schema-8 vector generation committed levels are invalid")
+    expected_nonempty = {level for level in ("l0", "l2") if expected_counts[level] > 0}
+    if set(committed_levels) != expected_nonempty:
+        raise ValueError("schema-8 vector generation committed levels are invalid")
+
+    for level in ("l0", "l2"):
+        count = expected_counts[level]
+        if (
+            type(count) is not int
+            or count < 0
+            or config.get(f"{level}_documents") != count
+        ):
+            raise ValueError(f"schema-8 vector generation {level} count is invalid")
+        if count == 0:
+            continue
+        artifacts = committed_levels[level]
+        if not isinstance(artifacts, dict) or set(artifacts) != {
+            "index",
+            "documents",
+        }:
+            raise ValueError(
+                f"schema-8 vector generation {level} artifacts are invalid"
+            )
+        documents_relative = f"{level}/documents_{model_suffix}.json"
+        index_relative = f"{level}/index_{model_suffix}.faiss"
+        _require_committed_publication_record(
+            reader,
+            documents_relative,
+            artifacts["documents"],
+        )
+        _require_committed_publication_record(
+            reader,
+            index_relative,
+            artifacts["index"],
+        )
+
+        document_size = 0
+        document_digest = hashlib.sha256()
+        document_count = 0
+        with reader.open_authenticated_file(
+            documents_relative,
+            max_bytes=_MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
+        ) as source:
+            documents = iter_bounded_json_array(
+                source,
+                label=f"schema-8 vector documents {documents_relative}",
+                max_element_bytes=_MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
+            )
+
+            def counted_documents(
+                documents=documents,
+                level=level,
+            ):
+                nonlocal document_count
+                for document in documents:
+                    validate_schema_8_vector_document_row(
+                        document,
+                        row_index=document_count,
+                        level=level,
+                    )
+                    document_count += 1
+                    yield document
+
+            for chunk in canonical_json_array_chunks(counted_documents()):
+                document_size += len(chunk)
+                if document_size > _MAX_PORTABLE_DOCUMENTS_JSON_BYTES:
+                    raise ValueError(
+                        "schema-8 vector documents exceed their byte limit: "
+                        f"{documents_relative}"
+                    )
+                document_digest.update(chunk)
+        documents_record = artifacts["documents"]
+        if (
+            document_count != count
+            or documents_record.get("size") != document_size
+            or documents_record.get("sha256") != document_digest.hexdigest()
+        ):
+            raise ValueError(
+                f"schema-8 vector {level} documents do not bind their rows"
+            )
+
+        level_config_relative = f"{level}/config_{model_suffix}.json"
+        level_config = _decode_generation_config(
+            reader.read_bytes(
+                level_config_relative,
+                max_bytes=_MAX_VECTOR_CONFIG_BYTES,
+            ),
+            relative=level_config_relative,
+        )
+        expected_level_config = {
+            "embedding_model": config["embedding_model"],
+            "embedding_provider": config["embedding_provider"],
+            "embedding_revision": config["embedding_revision"],
+            "dimension": expected_dimension,
+            "index_type": expected_index_type,
+            "index_metric": expected_metric,
+            "level": level,
+            "num_documents": count,
+        }
+        if level_config != expected_level_config:
+            raise ValueError(
+                f"schema-8 vector generation {level} config differs from root"
+            )
+
+        index = None
+        try:
+            with reader.open_authenticated_file(
+                index_relative,
+                max_bytes=_MAX_FAISS_INDEX_BYTES,
+            ) as source:
+                index = faiss.read_index(faiss.PyCallbackIOReader(source.read))
+            _validate_faiss_index_contract(
+                index,
+                relative=index_relative,
+                document_count=count,
+                expected_dimension=expected_dimension,
+                expected_metric=expected_metric,
+                expected_index_type=expected_index_type,
+            )
+        except BaseException as primary_error:
+            if index is not None:
+                try:
+                    _VectorIndexCleanupOwner((index,)).close()
+                except BaseException as cleanup_error:  # noqa: B036
+                    _attach_vector_index_cleanup_owner(primary_error, cleanup_error)
+                    _annotate_secondary_error(
+                        primary_error,
+                        "producer FAISS validation cleanup also failed",
+                        cleanup_error,
+                    )
+            raise
+        else:
+            _VectorIndexCleanupOwner((index,)).close()
 
 
 class _HuggingFaceEmbeddingWrapper:
@@ -1478,13 +1865,18 @@ class CodeVectorStore:
         level_state = {}
         for level in ("l0", "l2"):
             index, documents = self._get_index_and_docs(level)
-            if documents:
-                if index is None or int(index.ntotal) != len(documents):
-                    vector_count = 0 if index is None else int(index.ntotal)
-                    raise ValueError(
-                        f"Cannot save misaligned {level} vector store: "
-                        f"{vector_count} vectors for {len(documents)} documents"
-                    )
+            if documents and (index is None or int(index.ntotal) != len(documents)):
+                vector_count = 0 if index is None else int(index.ntotal)
+                raise ValueError(
+                    f"Cannot save misaligned {level} vector store: "
+                    f"{vector_count} vectors for {len(documents)} documents"
+                )
+            if index is not None:
+                self._validate_loaded_faiss_index(
+                    index,
+                    relative=f"{level}/index_{model_suffix}.faiss",
+                    document_count=len(documents),
+                )
             level_state[level] = (index, documents)
 
         config_path = save_path / f"config_{model_suffix}.json"
@@ -1517,6 +1909,11 @@ class CodeVectorStore:
             }
             if self.artifact_metadata:
                 config["artifact"] = self.artifact_metadata
+            if (
+                type(self.artifact_metadata.get("builder_schema")) is int
+                and self.artifact_metadata.get("builder_schema") == 8
+            ):
+                config["row_mapping"] = VECTOR_ROW_MAPPING_CONTRACT
             # This config is the commit record for both levels. Publishing it
             # last makes an interrupted multi-file save detectable on load.
             _atomic_json_dump(config_path, config)
@@ -1561,9 +1958,21 @@ class CodeVectorStore:
         index_path = level_path / f"{index_name}.faiss"
         _atomic_replace(index_path, lambda path: faiss.write_index(index, str(path)))
 
-        # Save documents (list of _Document)
-        docs_path = level_path / f"documents_{model_suffix}.pkl"
-        _atomic_pickle_dump(docs_path, documents)
+        if (
+            type(self.artifact_metadata.get("builder_schema")) is int
+            and self.artifact_metadata.get("builder_schema") == 8
+        ):
+            # Commit the ordered row-to-document mapping as canonical, inert
+            # JSON.  Its array position is the FAISS row receipt.
+            docs_path = level_path / f"documents_{model_suffix}.json"
+            _atomic_canonical_document_dump(docs_path, documents)
+            (level_path / f"documents_{model_suffix}.pkl").unlink(missing_ok=True)
+        else:
+            # Preserve the legacy local persistence contract for unversioned
+            # and schema-7 callers.  Strict compiler-cache ingress rejects it.
+            docs_path = level_path / f"documents_{model_suffix}.pkl"
+            _atomic_pickle_dump(docs_path, documents)
+            (level_path / f"documents_{model_suffix}.json").unlink(missing_ok=True)
         artifacts = vector_level_artifact_records(
             level_path,
             model_suffix,
@@ -1777,6 +2186,37 @@ class CodeVectorStore:
             elif expected_artifact.get("embedding_fingerprint") is not None:
                 raise ValueError("Vector config is missing embedding artifact identity")
 
+            saved_builder_schema = (
+                saved_artifact.get("builder_schema")
+                if isinstance(saved_artifact, dict)
+                else None
+            )
+            expected_builder_schema = expected_artifact.get("builder_schema")
+            retained_schema_selected = (
+                type(expected_builder_schema) is int and expected_builder_schema >= 7
+            ) or (type(saved_builder_schema) is int and saved_builder_schema >= 7)
+            if retained_schema_selected and not (
+                type(expected_builder_schema) is int
+                and type(saved_builder_schema) is int
+                and saved_builder_schema == expected_builder_schema
+            ):
+                raise ValueError(
+                    "Retained vector authorization and root artifact builder schemas "
+                    "must match exactly"
+                )
+            schema_8_selected = (
+                type(expected_builder_schema) is int
+                and expected_builder_schema == 8
+                and type(saved_builder_schema) is int
+                and saved_builder_schema == 8
+            )
+            if schema_8_selected and config.get("row_mapping") != (
+                VECTOR_ROW_MAPPING_CONTRACT
+            ):
+                raise ValueError("Schema-8 vector config has an invalid row mapping")
+            if not schema_8_selected and config.get("row_mapping") is not None:
+                raise ValueError("Legacy vector config has an unsupported row mapping")
+
             for level in ("l0", "l2"):
                 value = config.get(f"{level}_documents")
                 if value is None:
@@ -1805,6 +2245,21 @@ class CodeVectorStore:
                     raise ValueError(
                         "Vector config with committed artifacts requires level counts"
                     )
+                if schema_8_selected:
+                    for level, records in committed_levels.items():
+                        documents_record = (
+                            records.get("documents")
+                            if isinstance(records, dict)
+                            else None
+                        )
+                        expected_name = f"documents_{model_suffix}.json"
+                        if not isinstance(documents_record, dict) or (
+                            documents_record.get("file") != expected_name
+                        ):
+                            raise ValueError(
+                                "Schema-8 vector config has an invalid canonical "
+                                f"document record for {level}"
+                            )
         elif expected_artifact.get("embedding_fingerprint") is not None:
             raise ValueError("Vector store is missing its top-level configuration")
 
@@ -2109,22 +2564,14 @@ class CodeVectorStore:
         relative: str,
         document_count: int,
     ) -> None:
-        expected_metric = self._faiss_metric()
-        if int(index.metric_type) != int(expected_metric):
-            raise ValueError(
-                f"FAISS metric mismatch at {relative}: expected "
-                f"{self.index_metric}, found {int(index.metric_type)}"
-            )
-        if self.index_type == "flat":
-            valid_type = isinstance(index, faiss.IndexFlat)
-        else:
-            valid_type = isinstance(index, faiss.IndexIVF)
-        if not valid_type:
-            raise ValueError(
-                f"FAISS index type mismatch at {relative}: expected {self.index_type}"
-            )
-        if document_count > 0 and not bool(index.is_trained):
-            raise ValueError(f"FAISS index is not trained at {relative}")
+        _validate_faiss_index_contract(
+            index,
+            relative=relative,
+            document_count=document_count,
+            expected_dimension=self.dimension,
+            expected_metric=self.index_metric,
+            expected_index_type=self.index_type,
+        )
 
     @staticmethod
     def _load_documents_json(

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -17,32 +17,40 @@ missing destination and transfers the generation to a caller-owned
 
 The provider is not part of CodeNib's default compiler, import, or runtime
 path. Two explicit operator bridges use it: `codenib artifact import-cache`
-recaptures one current compiler-cache BM25 view into retained storage, and
-`codenib artifact materialize` publishes a retained catalog ref or immutable
-snapshot to a missing portable-artifact directory. The strict BM25 replacement
-path still requires the unsupported `provider-bound-exact` destination mode.
+recaptures an explicitly selected current compiler-cache BM25/vector view set
+into retained storage, and `codenib artifact materialize` publishes a retained
+catalog ref or immutable snapshot to a missing portable-artifact directory.
+The strict BM25 replacement path still requires the unsupported
+`provider-bound-exact` destination mode.
 
-## Import a compiler BM25 cache
+## Import compiler query views
 
-`codenib artifact import-cache` imports one exact current BM25 view from an
-existing `IndexCompiler` cache as a ready retained snapshot. This is a
-BM25-only bootstrap: it does not change the default `codenib index` route,
-import vector or graph views, run an M2 fenced job, or hot-switch a runtime.
+`codenib artifact import-cache` imports an exact current BM25 view, vector view,
+or both from an existing `IndexCompiler` cache as one ready retained snapshot.
+Omitting `--view` preserves the BM25-only default. Repeat `--view`, or pass a
+comma-separated value such as `--view bm25,vector`, to select views explicitly;
+the CLI canonicalizes the result to BM25 then vector. This remains an offline
+bootstrap: it does not change the default `codenib index` route, import graph or
+Zoekt views, run an M2 fenced job, or hot-switch a runtime.
 
 Prepare these authorities before running it:
 
 - The positional repository must be the source used to build the cache. The
   retained source-fingerprint-v2 identity must match the manifest, whose commit
-  must be a full lowercase 40-character Git SHA. The manifest must contain one
-  exact current BM25 entry and exact fingerprints for
-  `bm25/documents.json` and `bm25/bm25_metadata.json`.
+  must be a full lowercase 40-character Git SHA. The manifest must contain an
+  exact current entry for every selected view. BM25 must have exact
+  fingerprints for `bm25/documents.json` and `bm25/bm25_metadata.json`.
+  Vector ingress requires raw builder schema 8 and the exact schema-8
+  persistence inventory described below. Schema-8 vector documents name
+  regular lexical repository-relative POSIX files; source symlink aliases are
+  rejected instead of being rewritten to a different path identity.
 - `--cache-dir` must be an existing cache produced by the current compiler. It
-  must already contain `repo_manifest.json`, the fixed BM25 tree, and the
-  single-link regular `.index-compiler.lock`. Run or update the cache with the
-  current `IndexCompiler`; do not add a lock file by hand. Import opens the
-  lease existing-only and never creates the cache or lock. The importer owns
-  that lease, so a library caller must not wrap it in another lock for the same
-  cache; same-thread re-entry fails fast. The lock serializes cooperating
+  must already contain `repo_manifest.json`, every selected fixed view tree,
+  and the single-link regular `.index-compiler.lock`. Run or update the cache
+  with the current `IndexCompiler`; do not add a lock file by hand. Import opens
+  the lease existing-only and never creates the cache or lock. The importer
+  owns that lease, so a library caller must not wrap it in another lock for the
+  same cache; same-thread re-entry fails fast. The lock serializes cooperating
   CodeNib compiler and importer processes in a private cache namespace. It is
   not a sandbox against an actor actively replacing cache paths while the lock
   is held.
@@ -67,21 +75,70 @@ codenib artifact import-cache /srv/src/repository \
   --expected-generation 0
 ```
 
-Under the cooperative cache lease, the command authenticates the source,
-manifest, and ordinary BM25 files; completes the canonical BM25-only portable
-manifest and import plan; and publishes fresh missing-only BM25 and context
-generations. It then revalidates those exact bytes and releases the lease
-before retained CAS ingestion or catalog/ref publication begins.
+That command imports only BM25. To import one combined view set into the same
+snapshot, add the explicit selection:
 
-Every invocation allocates random
-`.codenib-cache-import-<nonce>-bm25` and
-`.codenib-cache-import-<nonce>-context` directories below the workspace root.
+```bash
+codenib artifact import-cache /srv/src/repository \
+  --cache-dir /var/lib/codenib/compiler-cache/repository \
+  --view bm25,vector \
+  --catalog /var/lib/codenib/catalog.sqlite3 \
+  --cas-root /var/lib/codenib/cas \
+  --workspace-root /var/lib/codenib/workspaces \
+  --repository owner/repository \
+  --ref main \
+  --expected-generation 0
+```
+
+Under the cooperative cache lease, the command authenticates the source,
+manifest, and every selected raw view. Before the first workspace mutation it
+completes all selected recapture plans, the canonical selected-view portable
+manifest, and the retained import plan. Under that same existing-only lease it
+publishes a fresh missing-only generation for each selected view, then plans
+and publishes one context containing exactly those views. It revalidates the
+source, manifest, and published bytes before releasing the lease; retained CAS
+ingestion and the single atomic snapshot/ref publication happen only afterward.
+
+Current vector producers use builder schema 8. Each non-empty level stores a
+canonical ordered `documents_*.json` array beside its FAISS index, and the root
+config commits both files plus
+`row_mapping = "codenib.vector-documents-array-index.v1"`. Array position is
+the FAISS row. Before publishing a current compiler-cache generation, the
+trusted producer reopens each generated FAISS file and verifies its dimension,
+row count, metric, index type, training state, and canonical row IDs together
+with the exact root, level, and document contract. The later recapture can then
+validate document counts, configuration, and content fingerprints without
+deserializing legacy pickle or parsing FAISS. A raw schema-7 compiler cache must
+be rebuilt before import; already-retained portable schema-7 vector generations
+remain readable for compatibility. FAISS also remains inert during import,
+export, and materialization. Loading it for a native query is a separate,
+explicitly authorized local operation.
+
+The lease and content receipts establish self-consistency, not signed
+provenance. Use a cache namespace private to one trusted OS account and keep
+the source/cache namespace quiescent except for CodeNib processes honoring the
+same lock. An actor that can replace both raw view bytes and the manifest can
+compute matching hashes; neither the cooperative lock nor schema 8 claims to
+sandbox that actor or attest who produced the FAISS bytes.
+
+Every invocation allocates a random
+`.codenib-cache-import-<nonce>-<view>` directory for each selected view and one
+`.codenib-cache-import-<nonce>-context` directory below the workspace root.
 They remain immutable generation evidence after their receipt owners close,
 including when a later stage fails; the command warns instead of deleting
 them. Their future ownership-aware reclamation belongs to M5. On success, the
-CLI prints the snapshot, ref generation, both evidence paths, and a copyable
-`codenib artifact materialize --snapshot ...` command. Its suggested
-`.codenib-cache-import-<nonce>-materialized` output is not created or reserved.
+CLI prints the selected view set, snapshot, ref generation, every evidence
+path, and a copyable `codenib artifact materialize --snapshot ...` command. Its
+suggested `.codenib-cache-import-<nonce>-materialized` output is not created or
+reserved.
+
+Strict ownership capture, semantic validation, workspace replay, bundle/CAS
+ingestion, and receipt revalidation make multiple bounded reads of selected
+payloads. Large FAISS indexes can therefore be read more than once. Treat this
+as an offline maintenance operation and measure representative repositories,
+payload sizes, and storage media before scheduling it at scale. Default or
+latency-sensitive service use requires an end-to-end benchmark gate; do not
+remove an authentication pass merely to improve an unmeasured result.
 
 Use the current ref generation for a changed cache. If a call might have
 committed before its result was observed, retry the exact same source, cache,
@@ -155,10 +212,12 @@ warns that the output now exists, do not assume that the path is disposable or
 retry over it; verify the retained artifact before reuse or reclaim it through
 an ownership-aware workflow.
 
-This retained-read bridge and the BM25 ingress above do not complete the
-hybrid-storage M1 milestone. Default compiler/runtime routing and non-BM25
-cache ingress are still missing, as is a production provider for the strict
-BM25 replacement producer's `provider-bound-exact` destination contract.
+This retained-read bridge and the explicit BM25/vector ingress above do not
+complete the hybrid-storage M1 milestone. Default compiler/runtime routing is
+still missing, as is a production provider for the strict BM25 replacement
+producer's `provider-bound-exact` destination contract. Graph and Zoekt ingress
+remain M2 or later work; fenced jobs and runtime hot switching remain separate
+milestones.
 
 ## Lifecycle
 

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -503,35 +503,76 @@ advancing the ref again. This is the direct M1 bootstrap path, not the M2 fenced
 job-success transaction. Default compiler/import/runtime wiring remains the M1
 gap; production retention and garbage collection remain M5 work.
 
-The first BM25-only compiler-cache ingress now connects current
-`IndexCompiler` output to this executor without treating mutable cache paths as
-retained authority. `recapture_bm25_view_strict` converts the ordinary fixed
-two-file BM25 tree into a missing-only strict workspace generation. The
-`import_compiler_cache_bm25` coordinator takes the existing-only cooperative
-cache lease; validates the retained source-fingerprint-v2 identity, exact
-manifest data, full lowercase 40-character Git commit, current BM25 metadata,
-and both file fingerprints; and completes the canonical portable BM25-only
-manifest and retained import plan before the first workspace mutation. While
-the lock is held, it publishes separate immutable BM25 and whole-context
-evidence generations and repeats the source, manifest, byte, and receipt
-checks. It releases the cache lock before any retained CAS or catalog data
-operation, so only the authenticated context receipt crosses the mutable-cache
-boundary.
+The explicit compiler-cache ingress now connects a selected current BM25,
+vector, or combined BM25/vector `IndexCompiler` view set to this executor
+without treating mutable cache paths as retained authority. The compatibility
+`import_compiler_cache_bm25` wrapper remains, while `import_compiler_cache`
+takes the exact canonical view set and one existing-only cooperative cache
+lease. It validates the retained source-fingerprint-v2 identity, exact manifest
+data, full lowercase 40-character Git commit, and each selected current view.
+Before the first workspace mutation, it completes every raw-view recapture
+plan, the canonical selected-view portable manifest, and the retained import
+plan. While the same lease is held, it publishes one immutable evidence
+generation per selected view, then plans and publishes one whole-context
+generation. All selected generations therefore enter one context and one
+atomic snapshot/ref publication. The coordinator repeats the source, manifest,
+byte, and receipt checks, then releases the cache lease before any retained CAS
+or catalog data operation, so only the authenticated context receipt crosses
+the mutable-cache boundary.
+
+Strict vector ingress requires current raw builder schema 8. Its root commit
+binds each FAISS file to a canonical ordered `documents_*.json` array and the
+`codenib.vector-documents-array-index.v1` row-mapping contract: JSON array
+position is the corresponding FAISS row. Level counts, configuration, and
+content fingerprints must agree before publication. The trusted producer also
+reopens every generated FAISS file before publishing the compiler-cache
+generation and verifies its dimension, row count, metric, index type, training
+state, and canonical row IDs; exact root, level, and document semantics are
+checked in the same authenticated generation sandwich. Raw schema-7 compiler
+caches must be rebuilt; they cannot be recaptured by guessing a row mapping or
+loading their pickle state. This producer gate does not revoke compatibility
+for already-retained portable vector schema 7, which remains readable beside
+schema 8. Portable recapture, retained import, export, and materialization keep
+FAISS bytes inert; native parsing still requires the separate process-local
+authorization described above. Schema-8 source paths are canonical
+repository-relative POSIX paths backed by regular lexical files; contained and
+external symlink aliases both fail closed so document paths, node identities,
+and retained source records cannot silently name different files.
+
+This cache lease and the resulting hashes prove a bounded, self-consistent
+capture, not signed producer provenance. The source and cache namespaces must
+be private, trusted, and quiescent except for CodeNib processes honoring the
+same lease. An actor able to replace both a cache view and its manifest can
+mint matching hashes; strict recapture does not turn that namespace into an
+adversarial sandbox. In particular, inert treatment prevents import-time
+native parsing but does not assert that arbitrary FAISS bytes came from a
+trusted producer.
 
 `codenib artifact import-cache` exposes that coordinator as an explicit local
 bootstrap. It requires an existing initialized SQLite catalog, a fully
 preprovisioned strict `LocalCAS`, an existing private Linux workspace root with
-exact mode `0700`, and a real producer cache with its existing lock. Each call
-chooses fresh missing-only BM25 and context destinations and never recursively
-removes a published directory after a later failure. A changed import
-atomically advances the selected ref and prints an immutable-snapshot
-`artifact materialize` handoff without reserving the suggested output. An
-exact retry uses fresh destinations but the original expected ref generation
-and idempotently returns the already-published snapshot without another ref
-advance. This advances BM25 ingress only. M1 remains in progress: default
-compiler/runtime routing and non-BM25 cache ingress remain. Generic builder
-profiles and fenced job publication remain M2 work, runtime hot switching
-remains M3 work, and evidence retention and reclamation remain M5 work.
+exact mode `0700`, and a real producer cache with its existing lock. With no
+`--view`, it preserves the BM25-only default; repeated or comma-separated
+`--view bm25` and `--view vector` options select either or both current views.
+Each call chooses a fresh missing-only destination for every selected view plus
+one context destination and never recursively removes a published directory
+after a later failure. A changed import atomically advances the selected ref
+and prints an immutable-snapshot `artifact materialize` handoff without
+reserving the suggested output. An exact retry uses fresh destinations but the
+original expected ref generation and idempotently returns the already-published
+snapshot without another ref advance.
+
+This command is an offline bootstrap, not a request-path or worker-path
+primitive. Exact ownership capture, semantic validation, workspace replay,
+bundle/CAS ingestion, and receipt revalidation deliberately make multiple
+bounded passes over large payloads; a selected FAISS file may therefore be
+read more than once. Representative end-to-end corpus, payload-size, and
+storage-media benchmarks are required before this path is enabled by default,
+used as a latency-sensitive service ingress, or has any validation pass
+removed. M1 remains in progress because default compiler/runtime routing is
+still absent. Graph and Zoekt cache ingress, generic builder profiles, and
+fenced job publication remain M2 or later work, runtime hot switching remains
+M3 work, and evidence retention and reclamation remain M5 work.
 
 The first read-only retained `RepoManifest` exporter now closes the data-only
 round trip without introducing path authority. It accepts the additive
@@ -608,10 +649,10 @@ rather than deleting it.
 
 This command does not initialize or populate the control plane, import a legacy
 cache, build views, advance refs, or make retained storage the default. It is
-the retained-read bridge only. Default compiler/runtime routing and non-BM25
-cache ingress remain outstanding M1 work, and strict BM25 replacement still
-lacks the `provider-bound-exact` production provider; fenced job publication
-remains M2 work.
+the retained-read bridge only. Default compiler/runtime routing remains
+outstanding M1 work; graph and Zoekt cache ingress and fenced job publication
+remain M2 or later work. Strict BM25 replacement also still lacks the
+`provider-bound-exact` production provider.
 
 Schema v2 now adds
 canonical idempotent job requests, immutable

--- a/test/artifacts/test_portable_views.py
+++ b/test/artifacts/test_portable_views.py
@@ -2741,6 +2741,40 @@ def test_content_bound_portable_reader_has_stable_public_signature() -> None:
     ]
 
 
+def test_private_framework_sandwich_rejects_reader_without_expected_ownership(
+    tmp_path: Path,
+) -> None:
+    repo, _source = _repository(tmp_path)
+
+    def forbidden_capture(*_args: object, **_kwargs: object) -> object:
+        pytest.fail("framework-sandwiched validation recaptured an unbound reader")
+
+    reader = PublicationDirectoryReader(
+        Path("/__unbound_portable_reader__"),
+        (1,),
+        forbidden_capture,  # type: ignore[arg-type]
+        lambda *_args, **_kwargs: pytest.fail(
+            "unbound framework reader opened a file"
+        ),  # type: ignore[arg-type]
+        None,
+    )
+    try:
+        with capture_repository_source(repo) as repository_source:
+            repository_identity = repository_source.authenticated_identity_snapshot()
+            with pytest.raises(RuntimeError, match="no framework expected ownership"):
+                portable_views_module._validate_content_bound_portable_query_view_reader_with_identity(
+                    reader,
+                    repository_source=repository_source,
+                    repository_identity=repository_identity,
+                    view_type="bm25",
+                    view_config={},
+                    environ={},
+                    _framework_sandwiched=True,
+                )
+    finally:
+        reader._deactivate()
+
+
 def test_content_bound_reader_uses_one_detached_source_identity(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -2912,6 +2946,58 @@ def test_content_bound_portable_reader_validates_vector_without_native_load(
             view_type="vector",
             view_config=view_config,
         )
+
+
+@pytest.mark.parametrize("persisted_schema", [7, 6, None])
+def test_content_bound_vector_binds_retained_v7_label_without_native_load(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    persisted_schema: int | None,
+) -> None:
+    repo, vector, view_config = _production_vector_view(tmp_path)
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["artifact"]["builder_schema"] = 7
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    view_config["builder_schema"] = 7
+    _refresh_view_fingerprint(vector, view_config)
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=view_config,
+    )
+    view_config.update(adjustments)
+    if persisted_schema != 7:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        if persisted_schema is None:
+            config["artifact"].pop("builder_schema")
+        else:
+            config["artifact"]["builder_schema"] = persisted_schema
+        config_path.write_bytes(_canonical_json_bytes(config))
+        _refresh_view_fingerprint(vector, view_config)
+
+    def forbidden_native(*_args: object, **_kwargs: object) -> object:
+        pytest.fail("retained schema label validation invoked native parsing")
+
+    monkeypatch.setattr(portable_views_module, "_faiss_contract", forbidden_native)
+    monkeypatch.setattr(portable_views_module.compat_pickle, "load", forbidden_native)
+    with capture_repository_source(repo) as repository_source:
+        if persisted_schema == 7:
+            _validate_content_bound_view(
+                vector,
+                repository_source=repository_source,
+                view_type="vector",
+                view_config=view_config,
+            )
+        else:
+            with pytest.raises(ValueError, match="builder schema does not match"):
+                _validate_content_bound_view(
+                    vector,
+                    repository_source=repository_source,
+                    view_type="vector",
+                    view_config=view_config,
+                )
 
 
 def test_content_bound_vector_does_not_probe_model_or_source_paths(

--- a/test/artifacts/test_strict_bm25_publication.py
+++ b/test/artifacts/test_strict_bm25_publication.py
@@ -42,6 +42,7 @@ from codenib.artifacts import (
 )
 from codenib.artifacts.strict_bm25 import _record_chunks
 from codenib.index.sparse_idx.bm25_index import BM25CodeIndexer
+from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.source_fingerprint import (
     RepositorySourceBinding,
     RepositorySourceIdentitySnapshot,
@@ -357,6 +358,46 @@ def test_strict_bm25_plans_replays_and_serves_same_query_semantics(
         ]
     finally:
         output_owner.close()
+
+
+@pytest.mark.parametrize(
+    ("view_config", "message"),
+    [
+        ({"builder_schema": 8}, "requires a source selection digest"),
+        (
+            {
+                "builder_schema": 8,
+                "source_selection_digest": RepositorySourceSelection(
+                    ("generated",)
+                ).digest,
+            },
+            "source selection differs",
+        ),
+    ],
+)
+def test_current_bm25_selection_is_bound_before_source_consumption(
+    strict_generation,
+    monkeypatch: pytest.MonkeyPatch,
+    view_config: dict[str, Any],
+    message: str,
+) -> None:
+    fixture = strict_generation
+    monkeypatch.setattr(
+        strict_bm25_module,
+        "_planned_view_from_publication",
+        lambda *_args, **_kwargs: pytest.fail("source generation must not be consumed"),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        plan_bm25_view_strict(
+            fixture.source_owner,
+            repository_source=fixture.repository_source,
+            view_config=view_config,
+            environ={},
+        )
+
+    assert fixture.source_owner.active
+    assert fixture.repository_source.usable
 
 
 def test_strict_bm25_recaptures_raw_directory_with_missing_test_provider(

--- a/test/artifacts/test_strict_vector_publication.py
+++ b/test/artifacts/test_strict_vector_publication.py
@@ -1,0 +1,609 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TypeVar
+
+import numpy as np
+import pytest
+
+import codenib.artifacts.portable_views as portable_views_module
+import codenib.artifacts.strict_vector as strict_vector_module
+import codenib.index.embedding.vector_store as vector_store_module
+from codenib._atomic_directory import PublicationDirectoryReader
+from codenib._captured_directory import (
+    OwnedWorkspaceAuthority,
+    PublishedWorkspaceReceiptOwner,
+)
+from codenib._workspace_provider import (
+    StrictWorkspaceRequest,
+    StrictWorkspaceSession,
+    run_adopted_workspace_operation,
+)
+from codenib.artifacts import (
+    PlannedVectorView,
+    recapture_vector_view_strict,
+    validate_content_bound_portable_query_view_reader,
+)
+from codenib.compiler.index_builders import VectorIndexBuilder
+from codenib.index.embedding.artifact_integrity import (
+    VECTOR_ROW_MAPPING_CONTRACT,
+    capture_authenticated_vector_view,
+    vector_config_artifact_record,
+)
+from codenib.index.embedding.vector_store import CodeVectorStore
+from codenib.native_index_authorization import (
+    _mint_trusted_local_admin_authorization,
+)
+from codenib.repository_source_selection import RepositorySourceSelection
+from codenib.source_fingerprint import capture_repository_source
+
+_Result = TypeVar("_Result")
+_DIMENSION = 4
+_MODEL = "test/model"
+_MODEL_SUFFIX = "test__model"
+
+
+class _DeterministicEmbedding:
+    def _vector(self, text: str) -> list[float]:
+        seed = int.from_bytes(
+            hashlib.sha256(text.encode("utf-8")).digest()[:8],
+            "little",
+        )
+        generator = np.random.default_rng(seed)
+        vector = generator.standard_normal(_DIMENSION).astype(np.float32)
+        vector /= np.linalg.norm(vector) + 1e-12
+        return vector.tolist()
+
+    def embed_query(self, text: str) -> list[float]:
+        return self._vector(text)
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [self._vector(text) for text in texts]
+
+
+class _TestWorkspaceProvider:
+    """Quiescent unit-test provisioner, not a production trust boundary."""
+
+    def __init__(self) -> None:
+        self.support_count = 0
+        self.run_count = 0
+        self.requests: list[StrictWorkspaceRequest] = []
+
+    def require_support(self) -> None:
+        self.support_count += 1
+
+    def run_workspace(
+        self,
+        request: StrictWorkspaceRequest,
+        *,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        operation: Callable[[StrictWorkspaceSession], _Result],
+    ) -> _Result:
+        self.run_count += 1
+        self.requests.append(request)
+        parent = request.destination.parent
+        parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        stage = parent / f".{request.destination.name}.vector-test-{self.run_count}"
+        stage.mkdir(mode=request.plan.root_mode)
+        for directory in request.plan.directories:
+            (stage / directory.path.as_posix()).mkdir(mode=directory.mode)
+
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        flags |= getattr(os, "O_CLOEXEC", 0)
+        parent_descriptor = os.open(parent, flags)
+        root_descriptor = os.open(stage, flags)
+        directory_descriptors = {
+            directory.path.as_posix(): os.open(
+                stage / directory.path.as_posix(),
+                flags,
+            )
+            for directory in request.plan.directories
+        }
+        workspace = OwnedWorkspaceAuthority()
+        try:
+            workspace.adopt(
+                destination=request.destination,
+                stage_name=stage.name,
+                parent_descriptor=parent_descriptor,
+                root_descriptor=root_descriptor,
+                directory_descriptors=directory_descriptors,
+                plan=request.plan,
+                expected_destination=None,
+            )
+            try:
+                return run_adopted_workspace_operation(
+                    request,
+                    workspace=workspace,
+                    receipt_owner=receipt_owner,
+                    operation=operation,
+                )
+            except BaseException:
+                if receipt_owner.state == "empty":
+                    workspace.close()
+                raise
+        finally:
+            for descriptor in directory_descriptors.values():
+                os.close(descriptor)
+            os.close(root_descriptor)
+            os.close(parent_descriptor)
+
+
+def _write_current_mutable_state(source: Path) -> None:
+    payloads = {
+        "chunk_store.json": b"{}\n",
+        "chunk_store.pkl": b"opaque legacy chunk state",
+        "embeddings_cache.json": b"[]\n",
+        "embeddings_cache.npz": b"opaque numeric cache",
+        "embeddings_cache.pkl": b"opaque legacy embedding state",
+        "incremental_state.json": b"{}\n",
+    }
+    for name, payload in payloads.items():
+        (source / name).write_bytes(payload)
+
+
+def _generation(tmp_path: Path) -> SimpleNamespace:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    contents = {
+        "alpha.py": "def alpha(value):\n    return value + 1\n",
+        "beta.py": "def beta(value):\n    return value * 2\n",
+        "gamma.py": "def gamma(value):\n    return value - 3\n",
+    }
+    for relative, content in contents.items():
+        (repository / relative).write_text(content, encoding="utf-8")
+
+    identity = VectorIndexBuilder(
+        languages=["python"],
+        embedding_model=_MODEL,
+        embedding_dimension=_DIMENSION,
+        build_levels=["l2"],
+    ).artifact_identity()
+    source = tmp_path / "raw-vector"
+    store = CodeVectorStore(
+        embedding_model=_MODEL,
+        embedding_provider="huggingface",
+        dimension=_DIMENSION,
+        embedding=_DeterministicEmbedding(),
+        artifact_metadata=identity,
+    )
+    store.add_code_chunks(
+        [
+            {
+                "content": content,
+                "chunk_type": "function",
+                "name": Path(relative).stem,
+                "file": relative,
+                "start_line": 0,
+                "end_line": 1,
+                "node_id": f"{Path(relative).stem}.function",
+            }
+            for relative, content in contents.items()
+        ],
+        level="l2",
+    )
+    store.save(str(source))
+    _write_current_mutable_state(source)
+    view_config = {
+        **identity,
+        "persistence_config_fingerprint": vector_config_artifact_record(
+            source,
+            _MODEL_SUFFIX,
+        ),
+        "document_count": {"l2": len(contents)},
+    }
+    return SimpleNamespace(
+        repository=repository,
+        source=source,
+        view_config=view_config,
+        query=contents["beta.py"],
+    )
+
+
+def _load_for_native_parity(path: Path, view_config: dict) -> CodeVectorStore:
+    store = CodeVectorStore(
+        embedding_model=_MODEL,
+        embedding_provider="huggingface",
+        dimension=_DIMENSION,
+        store_path=str(path),
+        embedding=_DeterministicEmbedding(),
+        artifact_metadata=view_config,
+    )
+    with capture_authenticated_vector_view(path) as captured:
+        authorization = _mint_trusted_local_admin_authorization(
+            captured.ownership,
+            view_type="vector",
+            semantic_contract=store.artifact_metadata,
+            evidence=(
+                "strict-vector-test-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
+    store.load(native_index_authorization=authorization)
+    return store
+
+
+def test_schema_8_recapture_is_inert_and_preserves_native_top_k(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _generation(tmp_path)
+    destination = tmp_path / "workspace" / "vector"
+    repository_source = capture_repository_source(fixture.repository)
+    provider = _TestWorkspaceProvider()
+    output_owner = PublishedWorkspaceReceiptOwner()
+    candidate_capture_callers: list[str] = []
+    faiss_stream_opens: list[str] = []
+    original_capture = PublicationDirectoryReader.capture_ownership
+    original_open = PublicationDirectoryReader.open_authenticated_file
+
+    def track_capture(self, *args, **kwargs):
+        caller = sys._getframe(1).f_code.co_name
+        if caller in {"_candidate_records", "verify_root"}:
+            candidate_capture_callers.append(caller)
+        return original_capture(self, *args, **kwargs)
+
+    def track_open(self, relative, *, max_bytes):
+        if str(relative).endswith(".faiss"):
+            faiss_stream_opens.append(str(relative))
+        return original_open(self, relative, max_bytes=max_bytes)
+
+    try:
+        with monkeypatch.context() as patcher:
+            patcher.setattr(
+                PublicationDirectoryReader,
+                "capture_ownership",
+                track_capture,
+            )
+            patcher.setattr(
+                PublicationDirectoryReader,
+                "open_authenticated_file",
+                track_open,
+            )
+            patcher.setattr(
+                vector_store_module.faiss,
+                "read_index",
+                lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                    AssertionError("strict recapture parsed FAISS")
+                ),
+            )
+            patcher.setattr(
+                vector_store_module.compat_pickle,
+                "load",
+                lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                    AssertionError("strict recapture parsed pickle")
+                ),
+            )
+            adjustments = recapture_vector_view_strict(
+                fixture.source,
+                destination,
+                repository_source=repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_config=fixture.view_config,
+                environ={},
+            )
+
+        assert provider.support_count == 1
+        assert provider.run_count == 1
+        assert provider.requests[0].destination_expectation == "missing"
+        assert candidate_capture_callers == []
+        assert faiss_stream_opens == [f"l2/index_{_MODEL_SUFFIX}.faiss"]
+        assert output_owner.active
+        assert output_owner.receipt.path == destination
+        assert output_owner.receipt.plan == provider.requests[0].plan
+        assert adjustments == {
+            "artifact_scope": "query-serving",
+            "portable_document_format": "codenib.vector-documents.v1",
+            "persistence_config_fingerprint": vector_config_artifact_record(
+                destination,
+                _MODEL_SUFFIX,
+            ),
+        }
+        assert sorted(
+            path.relative_to(destination).as_posix() for path in destination.rglob("*")
+        ) == [
+            f"config_{_MODEL_SUFFIX}.json",
+            "l2",
+            f"l2/config_{_MODEL_SUFFIX}.json",
+            f"l2/documents_{_MODEL_SUFFIX}.json",
+            f"l2/index_{_MODEL_SUFFIX}.faiss",
+        ]
+        assert not list(destination.rglob("*.pkl"))
+        assert (destination / f"l2/index_{_MODEL_SUFFIX}.faiss").read_bytes() == (
+            fixture.source / f"l2/index_{_MODEL_SUFFIX}.faiss"
+        ).read_bytes()
+
+        raw = _load_for_native_parity(fixture.source, fixture.view_config)
+        recaptured = _load_for_native_parity(
+            destination,
+            {**fixture.view_config, **adjustments},
+        )
+        raw_results = raw.search(fixture.query, top_k=3, level="l2")
+        recaptured_results = recaptured.search(
+            fixture.query,
+            top_k=3,
+            level="l2",
+        )
+        assert [result.node_id for result in recaptured_results] == [
+            result.node_id for result in raw_results
+        ]
+        assert [result.score for result in recaptured_results] == pytest.approx(
+            [result.score for result in raw_results],
+            abs=1e-7,
+        )
+    finally:
+        output_owner.close()
+        repository_source.close()
+
+
+def test_real_chunker_builder_generation_recaptures_with_relative_sources(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    source_file = repository / "pkg" / "sample.py"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text(
+        "def sample(value):\n    return value + 1\n",
+        encoding="utf-8",
+    )
+    raw_generation = tmp_path / "raw-vector"
+    monkeypatch.setattr(
+        CodeVectorStore,
+        "_initialize_embedding_model",
+        lambda _self, **_kwargs: _DeterministicEmbedding(),
+    )
+    builder = VectorIndexBuilder(
+        languages=["python"],
+        embedding_model=_MODEL,
+        embedding_dimension=_DIMENSION,
+        build_levels=["l2"],
+    )
+
+    status = builder.build(
+        scope="current_repo",
+        repo_path=str(repository),
+        output_dir=str(raw_generation),
+    )
+
+    raw_documents = json.loads(
+        (raw_generation / f"l2/documents_{_MODEL_SUFFIX}.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert raw_documents
+    assert {document["metadata"]["file"] for document in raw_documents} == {
+        "pkg/sample.py"
+    }
+    destination = tmp_path / "workspace" / "vector"
+    provider = _TestWorkspaceProvider()
+    output_owner = PublishedWorkspaceReceiptOwner()
+    try:
+        with capture_repository_source(repository) as repository_source:
+            recapture_vector_view_strict(
+                raw_generation,
+                destination,
+                repository_source=repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_config=status.metadata,
+                environ={},
+            )
+        portable_documents = json.loads(
+            (destination / f"l2/documents_{_MODEL_SUFFIX}.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert portable_documents == raw_documents
+    finally:
+        output_owner.close()
+
+
+def test_schema_7_is_rejected_before_provider_or_destination(
+    tmp_path: Path,
+) -> None:
+    fixture = _generation(tmp_path)
+    destination = tmp_path / "workspace" / "vector"
+    repository_source = capture_repository_source(fixture.repository)
+    provider = _TestWorkspaceProvider()
+    output_owner = PublishedWorkspaceReceiptOwner()
+    try:
+        with pytest.raises(ValueError, match="schema 8.*rebuild older"):
+            recapture_vector_view_strict(
+                fixture.source,
+                destination,
+                repository_source=repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_config={**fixture.view_config, "builder_schema": 7},
+                environ={},
+            )
+        assert provider.support_count == 0
+        assert provider.run_count == 0
+        assert output_owner.state == "empty"
+        assert not destination.exists()
+    finally:
+        output_owner.close()
+        repository_source.close()
+
+
+def test_source_selection_mismatch_is_rejected_before_cache_capture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _generation(tmp_path)
+    destination = tmp_path / "workspace" / "vector"
+    repository_source = capture_repository_source(
+        fixture.repository,
+        selection=RepositorySourceSelection(("generated",)),
+    )
+    provider = _TestWorkspaceProvider()
+    output_owner = PublishedWorkspaceReceiptOwner()
+    monkeypatch.setattr(
+        strict_vector_module,
+        "capture_directory_ownership",
+        lambda *_args, **_kwargs: pytest.fail("raw cache must not be captured"),
+    )
+    try:
+        with pytest.raises(ValueError, match="source selection differs"):
+            recapture_vector_view_strict(
+                fixture.source,
+                destination,
+                repository_source=repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_config=fixture.view_config,
+                environ={},
+            )
+        assert provider.support_count == 0
+        assert provider.run_count == 0
+        assert output_owner.state == "empty"
+        assert not destination.exists()
+    finally:
+        output_owner.close()
+        repository_source.close()
+
+
+def test_content_validator_rejects_oversized_inert_faiss_without_opening_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _generation(tmp_path)
+    destination = tmp_path / "workspace" / "vector"
+    repository_source = capture_repository_source(fixture.repository)
+    provider = _TestWorkspaceProvider()
+    output_owner = PublishedWorkspaceReceiptOwner()
+    faiss_opens: list[str] = []
+    try:
+        adjustments = recapture_vector_view_strict(
+            fixture.source,
+            destination,
+            repository_source=repository_source,
+            workspace_provider=provider,
+            output_receipt_owner=output_owner,
+            view_config=fixture.view_config,
+            environ={},
+        )
+        index_path = destination / f"l2/index_{_MODEL_SUFFIX}.faiss"
+        original_open = PublicationDirectoryReader.open_authenticated_file
+
+        def track_open(self, relative, *, max_bytes):
+            if str(relative).endswith(".faiss"):
+                faiss_opens.append(str(relative))
+            return original_open(self, relative, max_bytes=max_bytes)
+
+        monkeypatch.setattr(
+            portable_views_module,
+            "MAX_PORTABLE_FAISS_INDEX_BYTES",
+            index_path.stat().st_size - 1,
+        )
+        monkeypatch.setattr(
+            PublicationDirectoryReader,
+            "open_authenticated_file",
+            track_open,
+        )
+
+        def validate(_receipt, publication):
+            with pytest.raises(ValueError, match="byte limit"):
+                validate_content_bound_portable_query_view_reader(
+                    publication,
+                    repository_source=repository_source,
+                    view_type="vector",
+                    view_config={**fixture.view_config, **adjustments},
+                    environ={},
+                )
+
+        output_owner.consume(validate)
+        assert faiss_opens == []
+        assert output_owner.active
+    finally:
+        output_owner.close()
+        repository_source.close()
+
+
+@pytest.mark.parametrize("tamper", ["row-mapping", "documents"])
+def test_tampered_schema_8_receipts_fail_before_provider(
+    tmp_path: Path,
+    tamper: str,
+) -> None:
+    fixture = _generation(tmp_path)
+    if tamper == "row-mapping":
+        config_path = fixture.source / f"config_{_MODEL_SUFFIX}.json"
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        assert config["row_mapping"] == VECTOR_ROW_MAPPING_CONTRACT
+        config["row_mapping"] = "attacker-controlled-row-order"
+        config_path.write_text(json.dumps(config), encoding="utf-8")
+    else:
+        documents = fixture.source / f"l2/documents_{_MODEL_SUFFIX}.json"
+        documents.write_bytes(documents.read_bytes() + b" ")
+
+    destination = tmp_path / "workspace" / "vector"
+    repository_source = capture_repository_source(fixture.repository)
+    provider = _TestWorkspaceProvider()
+    output_owner = PublishedWorkspaceReceiptOwner()
+    try:
+        with pytest.raises(ValueError, match="row mapping|fingerprint"):
+            recapture_vector_view_strict(
+                fixture.source,
+                destination,
+                repository_source=repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_config=fixture.view_config,
+                environ={},
+            )
+        assert provider.run_count == 0
+        assert output_owner.state == "empty"
+        assert not destination.exists()
+    finally:
+        output_owner.close()
+        repository_source.close()
+
+
+def test_source_change_after_plan_is_rejected_before_provider(
+    tmp_path: Path,
+) -> None:
+    fixture = _generation(tmp_path)
+    destination = tmp_path / "workspace" / "vector"
+    repository_source = capture_repository_source(fixture.repository)
+    provider = _TestWorkspaceProvider()
+    output_owner = PublishedWorkspaceReceiptOwner()
+    try:
+        planned = strict_vector_module._plan_recaptured_vector_view(
+            fixture.source,
+            destination,
+            repository_source=repository_source,
+            view_config=fixture.view_config,
+            environ={},
+        )
+        assert isinstance(planned, PlannedVectorView)
+        documents = fixture.source / f"l2/documents_{_MODEL_SUFFIX}.json"
+        documents.write_bytes(documents.read_bytes() + b" ")
+
+        with pytest.raises(ValueError, match="another source generation"):
+            strict_vector_module._publish_recaptured_vector_view(
+                fixture.source,
+                destination,
+                planned=planned,
+                repository_source=repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_config=fixture.view_config,
+                environ={},
+            )
+        assert provider.run_count == 0
+        assert output_owner.state == "empty"
+        assert not destination.exists()
+    finally:
+        output_owner.close()
+        repository_source.close()

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -36,16 +36,25 @@ from codenib.artifacts import query_context_artifact
 from codenib.compiler.cache_import import (
     CompilerCacheBm25RecaptureResult,
     CompilerCacheImportResult,
+    CompilerCacheMultiViewImportResult,
+    CompilerCacheViewRecaptureResult,
     compiler_cache_source_selection,
+    import_compiler_cache,
     import_compiler_cache_bm25,
 )
-from codenib.compiler.index_builders import BM25IndexBuilder, IndexBuilderRegistry
+from codenib.compiler.index_builders import (
+    BM25IndexBuilder,
+    IndexBuilderRegistry,
+    VectorIndexBuilder,
+)
 from codenib.compiler.index_compiler import IndexCompiler, IndexCompilerConfig
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.compiler.manifest_import import RepoManifestImportResult
 from codenib.compiler.manifest_materialization import (
     materialize_retained_repo_manifest_ref,
 )
+from codenib.compiler.retained_manifest_contract import REPO_MANIFEST_PROJECTION_VIEW
+from codenib.index.embedding.vector_store import CodeVectorStore
 from codenib.mcp.context import ServerContext
 from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.source_fingerprint import (
@@ -64,6 +73,22 @@ from codenib.storage import (
 _Result = TypeVar("_Result")
 _COMMIT = "a" * 40
 _REPOSITORY_KEY = "owner/repo"
+
+
+class _DeterministicEmbedding:
+    """Small local embedding used to produce real schema-8 vector bytes."""
+
+    def __init__(self, dimension: int) -> None:
+        self.dimension = dimension
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [
+            [float((index + offset) % 7 + 1) for offset in range(self.dimension)]
+            for index, _text in enumerate(texts)
+        ]
+
+    def embed_query(self, text: str) -> list[float]:
+        return self.embed_documents([text])[0]
 
 
 class _BackendTripwire:
@@ -223,6 +248,7 @@ class _LockAwareCAS(LocalCAS):
 class _LockAwareCatalog(SQLiteCatalog):
     def __init__(self, path: Path, state: dict[str, object]) -> None:
         self._test_state = state
+        self.publications: list[dict[str, object]] = []
         super().__init__(path)
 
     def retained_import_contract(self) -> str:
@@ -232,23 +258,62 @@ class _LockAwareCatalog(SQLiteCatalog):
         )
         return super().retained_import_contract()
 
-    def create_namespace(self, name: str) -> str:
+    def _record_data(self, name: str) -> None:
         assert self._test_state["phase"] == "released"
         self._test_state["events"].append(  # type: ignore[union-attr]
-            ("catalog.create_namespace", self._test_state["phase"])
+            (f"catalog.data.{name}", self._test_state["phase"])
         )
-        return super().create_namespace(name)
+
+    def create_namespace(self, *args, **kwargs):
+        self._record_data("create_namespace")
+        return super().create_namespace(*args, **kwargs)
+
+    def create_repository(self, *args, **kwargs):
+        self._record_data("create_repository")
+        return super().create_repository(*args, **kwargs)
+
+    def create_source_revision(self, *args, **kwargs):
+        self._record_data("create_source_revision")
+        return super().create_source_revision(*args, **kwargs)
+
+    def create_view_profile(self, *args, **kwargs):
+        self._record_data("create_view_profile")
+        return super().create_view_profile(*args, **kwargs)
+
+    def register_object(self, *args, **kwargs):
+        self._record_data("register_object")
+        return super().register_object(*args, **kwargs)
+
+    def stage_view_generation(self, *args, **kwargs):
+        self._record_data("stage_view_generation")
+        return super().stage_view_generation(*args, **kwargs)
+
+    def publish_snapshot(self, *args, **kwargs):
+        self._record_data("publish_snapshot")
+        publication = super().publish_snapshot(*args, **kwargs)
+        self.publications.append(copy.deepcopy(publication))
+        return publication
+
+    def resolve_ref(self, *args, **kwargs):
+        self._record_data("resolve_ref")
+        return super().resolve_ref(*args, **kwargs)
+
+    def get_manifest_summary(self, *args, **kwargs):
+        self._record_data("get_manifest_summary")
+        return super().get_manifest_summary(*args, **kwargs)
 
 
 class _PostCommitInterruptCatalog(SQLiteCatalog):
     def __init__(self, path: Path) -> None:
         self._interrupt_after_first_publish = True
+        self.interrupted_publication: dict[str, object] | None = None
         super().__init__(path)
 
     def publish_snapshot(self, *args, **kwargs):
         publication = super().publish_snapshot(*args, **kwargs)
         if self._interrupt_after_first_publish:
             self._interrupt_after_first_publish = False
+            self.interrupted_publication = copy.deepcopy(publication)
             raise RuntimeError("postcommit interruption")
         return publication
 
@@ -437,13 +502,63 @@ def _call(
     return import_compiler_cache_bm25(fixture.cache, **arguments)  # type: ignore[arg-type]
 
 
+def _call_generic(
+    fixture: _CacheFixture,
+    *,
+    catalog: object | None = None,
+    object_store: object | None = None,
+    **overrides,
+) -> CompilerCacheMultiViewImportResult:
+    if catalog is None:
+        catalog = _BackendTripwire()
+    if object_store is None:
+        object_store = catalog
+    arguments = {
+        "views": ("bm25",),
+        "repository_source": fixture.source,
+        "view_output_owners": {"bm25": fixture.bm25_owner},
+        "context_output_owner": fixture.context_owner,
+        "view_destinations": {"bm25": fixture.bm25_destination},
+        "context_destination": fixture.context_destination,
+        "workspace_provider": fixture.provider,
+        "repository_key": _REPOSITORY_KEY,
+        "catalog": catalog,
+        "object_store": object_store,
+        "environ": {},
+    }
+    arguments.update(overrides)
+    return import_compiler_cache(fixture.cache, **arguments)  # type: ignore[arg-type]
+
+
 def test_compiler_cache_import_is_a_lazy_public_export() -> None:
     assert compiler_module.CompilerCacheImportResult is CompilerCacheImportResult
+    assert (
+        compiler_module.CompilerCacheMultiViewImportResult
+        is CompilerCacheMultiViewImportResult
+    )
+    assert (
+        compiler_module.CompilerCacheViewRecaptureResult
+        is CompilerCacheViewRecaptureResult
+    )
     assert (
         compiler_module.CompilerCacheBm25RecaptureResult
         is CompilerCacheBm25RecaptureResult
     )
+    assert compiler_module.import_compiler_cache is import_compiler_cache
     assert compiler_module.import_compiler_cache_bm25 is import_compiler_cache_bm25
+    assert list(inspect.signature(import_compiler_cache).parameters)[:11] == [
+        "cache_dir",
+        "views",
+        "repository_source",
+        "view_output_owners",
+        "context_output_owner",
+        "view_destinations",
+        "context_destination",
+        "workspace_provider",
+        "repository_key",
+        "catalog",
+        "object_store",
+    ]
     assert list(inspect.signature(import_compiler_cache_bm25).parameters)[:10] == [
         "cache_dir",
         "repository_source",
@@ -458,11 +573,10 @@ def test_compiler_cache_import_is_a_lazy_public_export() -> None:
     ]
 
 
-def test_compiler_cache_source_selection_reads_exact_persisted_policy(
-    tmp_path: Path,
-) -> None:
-    fixture = _cache_fixture(tmp_path)
-    selection = RepositorySourceSelection(("generated",))
+def _persist_fixture_source_selection(
+    fixture: _CacheFixture,
+    selection: RepositorySourceSelection,
+):
     identity = fingerprint_repository(
         fixture.repository,
         exclude_roots=(fixture.cache,),
@@ -478,12 +592,238 @@ def test_compiler_cache_source_selection_reads_exact_persisted_policy(
     entry = manifest.indexes["bm25"]
     entry.source_selection_digest = selection.digest
     entry.source_fingerprint = identity.value
+    entry.config["source_selection_digest"] = selection.digest
+    entry.metadata["source_selection_digest"] = selection.digest
     manifest.save(manifest_path)
+    manifest_path.chmod(0o600)
+    return identity
+
+
+def test_compiler_cache_source_selection_reads_exact_persisted_policy(
+    tmp_path: Path,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    selection = RepositorySourceSelection(("generated",))
+    _persist_fixture_source_selection(fixture, selection)
 
     observed = compiler_cache_source_selection(fixture.cache)
 
     assert observed == selection
     assert observed is not selection
+
+
+def test_nondefault_source_selection_survives_portable_multiview_planning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    selection = RepositorySourceSelection(("generated",))
+    persisted_identity = _persist_fixture_source_selection(fixture, selection)
+    fixture.source.close()
+    fixture.source = capture_repository_source(
+        fixture.repository,
+        exclude_roots=(fixture.cache,),
+        selection=selection,
+    )
+    monkeypatch.setattr(
+        cache_import_module,
+        "import_retained_repo_manifest",
+        lambda *args, **kwargs: _fake_import_result(),
+    )
+
+    try:
+        result = _call_generic(fixture)
+
+        assert fixture.source.fingerprint == persisted_identity.value
+        assert result.import_plan.manifest.source_selection == selection
+        assert result.import_plan.source.source_selection == selection
+        entry = result.import_plan.manifest.indexes["bm25"]
+        assert entry.source_selection_digest == selection.digest
+        assert entry.config["source_selection_digest"] == selection.digest
+        assert (
+            RepoManifest.load(result.context_artifact.manifest_path).source_selection
+            == selection
+        )
+    finally:
+        fixture.close()
+
+
+@pytest.mark.parametrize(
+    ("mismatch", "error_type", "message"),
+    [
+        ("binding", StorageIntegrityError, "source selection differs"),
+        ("config", ValueError, "no exact current bm25"),
+    ],
+)
+def test_source_selection_mismatch_fails_before_workspace_or_storage_io(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mismatch: str,
+    error_type: type[Exception],
+    message: str,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    selection = RepositorySourceSelection(("generated",))
+    if mismatch == "binding":
+        # Exercise the independent identity axis after the byte fingerprint was
+        # captured; the coordinator must not authorize a selection mismatch
+        # merely because the retained bytes still match the manifest.
+        fixture.source._source_selection_identity = selection  # type: ignore[attr-defined]
+    else:
+        manifest_path = fixture.cache / "repo_manifest.json"
+        manifest = RepoManifest.load(manifest_path)
+        manifest.indexes["bm25"].config["source_selection_digest"] = selection.digest
+        manifest.save(manifest_path)
+        manifest_path.chmod(0o600)
+
+    backend = _BackendTripwire()
+    planned = False
+
+    def unexpected_plan(*args, **kwargs):
+        nonlocal planned
+        planned = True
+        raise AssertionError("cache view planning must not run")
+
+    monkeypatch.setattr(cache_import_module, "_plan_cache_view", unexpected_plan)
+    monkeypatch.setattr(
+        cache_import_module,
+        "import_retained_repo_manifest",
+        lambda *args, **kwargs: pytest.fail("storage import must not run"),
+    )
+    try:
+        with pytest.raises(error_type, match=message):
+            _call_generic(fixture, catalog=backend, object_store=backend)
+        assert not planned
+        assert backend.calls == ["contract"]
+        assert fixture.provider.support_count == 1
+        assert fixture.provider.run_count == 0
+        assert fixture.bm25_owner.state == "empty"
+        assert fixture.context_owner.state == "empty"
+    finally:
+        fixture.close()
+
+
+def test_generic_bm25_import_returns_ordered_detached_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    monkeypatch.setattr(
+        cache_import_module,
+        "import_retained_repo_manifest",
+        lambda *args, **kwargs: _fake_import_result(),
+    )
+    try:
+        result = _call_generic(fixture)
+
+        assert type(result) is CompilerCacheMultiViewImportResult
+        assert result.views == ("bm25",)
+        assert tuple(result.recapture_map) == ("bm25",)
+        recapture = result.recaptures[0]
+        assert type(recapture) is CompilerCacheViewRecaptureResult
+        assert recapture.view_type == "bm25"
+        assert recapture.source_view == fixture.cache / "bm25"
+        assert recapture.output_view == fixture.bm25_destination
+        assert recapture.output_file_fingerprints == {
+            record.path: {"size": record.size, "sha256": record.sha256}
+            for record in recapture.output_records
+        }
+        assert result.context_artifact.manifest_path.read_bytes() == (
+            result.canonical_manifest_bytes
+        )
+        assert result.import_plan.selection.selected_views == ("bm25",)
+        assert result.import_result == _fake_import_result()
+    finally:
+        fixture.close()
+
+
+def test_generic_import_rejects_nonexact_or_misaligned_view_mappings(
+    tmp_path: Path,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    backend = _BackendTripwire()
+
+    class DictSubclass(dict):
+        pass
+
+    extra_owner = PublishedWorkspaceReceiptOwner()
+    cases = (
+        (
+            {"views": ["bm25"]},
+            (TypeError, "exact tuple"),
+        ),
+        (
+            {"views": ("vector", "bm25")},
+            (ValueError, "canonical portable subset"),
+        ),
+        (
+            {"view_output_owners": DictSubclass({"bm25": fixture.bm25_owner})},
+            (TypeError, "exact dict"),
+        ),
+        (
+            {
+                "view_destinations": {
+                    "bm25": fixture.bm25_destination,
+                    "vector": fixture.workspace / "vector",
+                }
+            },
+            (ValueError, "exact selected keys and order"),
+        ),
+        (
+            {
+                "views": ("bm25", "vector"),
+                "view_output_owners": {
+                    "vector": extra_owner,
+                    "bm25": fixture.bm25_owner,
+                },
+                "view_destinations": {
+                    "bm25": fixture.bm25_destination,
+                    "vector": fixture.workspace / "vector",
+                },
+            },
+            (ValueError, "exact selected keys and order"),
+        ),
+        (
+            {
+                "views": ("bm25", "vector"),
+                "view_output_owners": {
+                    "bm25": fixture.bm25_owner,
+                    "vector": fixture.bm25_owner,
+                },
+                "view_destinations": {
+                    "bm25": fixture.bm25_destination,
+                    "vector": fixture.workspace / "vector",
+                },
+            },
+            (ValueError, "distinct receipt owners"),
+        ),
+        (
+            {"view_output_owners": {"bm25": fixture.context_owner}},
+            (ValueError, "distinct receipt owners"),
+        ),
+        (
+            {"view_destinations": {"bm25": str(fixture.bm25_destination)}},
+            (TypeError, "exact paths"),
+        ),
+    )
+    try:
+        for overrides, (error_type, message) in cases:
+            with pytest.raises(error_type, match=message):
+                _call_generic(
+                    fixture,
+                    catalog=backend,
+                    object_store=backend,
+                    **overrides,
+                )
+        assert backend.calls == []
+        assert fixture.provider.support_count == 0
+        assert fixture.provider.run_count == 0
+        assert fixture.bm25_owner.state == "empty"
+        assert fixture.context_owner.state == "empty"
+        assert extra_owner.state == "empty"
+    finally:
+        extra_owner.close()
+        fixture.close()
 
 
 def test_import_recaptures_inside_cache_lock_and_imports_after_release(
@@ -512,10 +852,25 @@ def test_import_recaptures_inside_cache_lock_and_imports_after_release(
         return real_plan(*args, **kwargs)
 
     real_publish = cache_import_module._publish_recaptured_bm25_view
+    real_context_plan = cache_import_module.plan_context_artifact_strict
+    real_context_publish = cache_import_module.publish_planned_context_artifact_strict
+    context_planned = {"value": False}
 
     def tracked_publish(*args, **kwargs):
         assert planned_before_publish["value"]
         return real_publish(*args, **kwargs)
+
+    def tracked_context_plan(*args, **kwargs):
+        assert lock_state["held"]
+        assert fixture.bm25_owner.active
+        assert fixture.context_owner.state == "empty"
+        context_planned["value"] = True
+        return real_context_plan(*args, **kwargs)
+
+    def tracked_context_publish(*args, **kwargs):
+        assert lock_state["held"]
+        assert context_planned["value"]
+        return real_context_publish(*args, **kwargs)
 
     def imported(plan, **kwargs):
         assert not lock_state["held"]
@@ -534,6 +889,16 @@ def test_import_recaptures_inside_cache_lock_and_imports_after_release(
         cache_import_module,
         "_publish_recaptured_bm25_view",
         tracked_publish,
+    )
+    monkeypatch.setattr(
+        cache_import_module,
+        "plan_context_artifact_strict",
+        tracked_context_plan,
+    )
+    monkeypatch.setattr(
+        cache_import_module,
+        "publish_planned_context_artifact_strict",
+        tracked_context_publish,
     )
     monkeypatch.setattr(
         cache_import_module,
@@ -883,9 +1248,18 @@ def test_postcommit_interruption_retries_as_exact_unchanged_import(
             fixture.context_owner = PublishedWorkspaceReceiptOwner()
             retry = _call(fixture, catalog=catalog, object_store=cas)
 
+            assert catalog.interrupted_publication is not None
+            assert catalog.interrupted_publication["changed"] is True
             assert retry.import_result.generation == 1
             assert retry.import_result.changed is False
-            assert retry.import_result.snapshot_id
+            assert (
+                retry.import_result.snapshot_id
+                == catalog.interrupted_publication["snapshot_id"]
+            )
+            assert (
+                retry.import_result.generation
+                == catalog.interrupted_publication["generation"]
+            )
             assert fixture.provider.support_count == 6
             assert fixture.provider.run_count == 4
             assert first_bm25_owner.active
@@ -908,6 +1282,112 @@ def _git_commit(repository: Path, message: str) -> str:
         capture_output=True,
         text=True,
     ).stdout.strip()
+
+
+@dataclass(frozen=True)
+class _MultiViewCompilerFixture:
+    repository: Path
+    source_file: Path
+    cache: Path
+    compiler: IndexCompiler
+    commit: str
+
+
+def _multiview_compiler_fixture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    marker: str,
+) -> _MultiViewCompilerFixture:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    subprocess.run(["git", "init", "-q", str(repository)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repository), "config", "user.email", "test@example.test"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repository), "config", "user.name", "CodeNib Test"],
+        check=True,
+    )
+    source_file = repository / "sample.py"
+    source_file.write_text(
+        f"MULTIVIEW_CACHE_MARKER = {marker!r}\n",
+        encoding="utf-8",
+    )
+    commit = _git_commit(repository, f"multiview-{marker.lower()}")
+
+    vector_builder = VectorIndexBuilder(
+        languages=["python"],
+        embedding_model="test/model",
+        embedding_dimension=4,
+        build_levels=["l2"],
+    )
+
+    def build_vector(**kwargs):
+        assert kwargs["artifact_metadata"]["builder_schema"] == 8
+        assert kwargs["_atomic_publish"] is False
+        store = CodeVectorStore(
+            embedding_model=kwargs["embedding_model"],
+            embedding_provider=kwargs["embedding_provider"],
+            dimension=kwargs["embedding_dimension"],
+            index_metric=kwargs["index_metric"],
+            store_path=kwargs["index_path"],
+            embedding=_DeterministicEmbedding(kwargs["embedding_dimension"]),
+            artifact_metadata=kwargs["artifact_metadata"],
+            **kwargs["embedding_kwargs"],
+        )
+        store.add_code_chunks(
+            [
+                {
+                    "content": source_file.read_text(encoding="utf-8"),
+                    "chunk_type": "file",
+                    "name": "sample",
+                    "file": "sample.py",
+                    "start_line": 0,
+                    "end_line": 0,
+                    "node_id": "sample.py",
+                }
+            ],
+            level="l2",
+        )
+        store.save(kwargs["index_path"])
+        return store
+
+    monkeypatch.setattr(
+        "codenib.index.embedding.builders.build_hierarchical_vector_store",
+        build_vector,
+    )
+    registry = IndexBuilderRegistry()
+    registry.register(
+        "bm25",
+        BM25IndexBuilder(languages=["python"], max_k=17),
+    )
+    registry.register("vector", vector_builder)
+    compiler = IndexCompiler(
+        registry,
+        IndexCompilerConfig(
+            index_types=["bm25", "vector"],
+            languages=["python"],
+        ),
+    )
+    cache = repository / ".codenib_cache"
+    manifest = compiler.compile_repo(
+        str(repository),
+        index_types=["bm25", "vector"],
+        cache_dir=str(cache),
+    )
+    assert manifest.commit == commit
+    assert manifest.indexes["vector"].config["builder_schema"] == 8
+    assert (cache / "vector/l2/documents_test__model.json").is_file()
+    assert not (cache / "vector/l2/documents_test__model.pkl").exists()
+    return _MultiViewCompilerFixture(
+        repository=repository,
+        source_file=source_file,
+        cache=cache,
+        compiler=compiler,
+        commit=commit,
+    )
 
 
 def test_real_compiler_cache_import_retry_update_and_latest_query(
@@ -1029,7 +1509,7 @@ def test_real_compiler_cache_import_retry_update_and_latest_query(
             assert all(
                 phase == "released"
                 for event, phase in state["events"]  # type: ignore[union-attr]
-                if event in {"cas.put_chunks", "catalog.create_namespace"}
+                if event.startswith(("cas.", "catalog.data."))
             )
 
             retry = import_generation(
@@ -1118,6 +1598,540 @@ def test_real_compiler_cache_import_retry_update_and_latest_query(
         source_a.close()
 
 
+def test_real_multiview_compiler_cache_imports_one_context_and_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    compiled = _multiview_compiler_fixture(
+        tmp_path,
+        monkeypatch,
+        marker="GENERATION_A_ONLY",
+    )
+    repository = compiled.repository
+    source_file = compiled.source_file
+    cache = compiled.cache
+    compiler = compiled.compiler
+    commit_a = compiled.commit
+    source_a = capture_repository_source(repository, exclude_roots=(cache,))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    provider = _TestWorkspaceProvider()
+    retained_owners: list[PublishedWorkspaceReceiptOwner] = []
+    materialized_owner = PublishedWorkspaceReceiptOwner()
+    source_b: RepositorySourceBinding | None = None
+    state: dict[str, object] = {"phase": "before", "events": []}
+    real_lock = cache_import_module.compiler_cache_lock
+
+    @contextmanager
+    def tracked_lock(cache_path: Path, *, create: bool = True):
+        assert create is False
+        with real_lock(cache_path, create=create):
+            state["phase"] = "locked"
+            state["events"].append(  # type: ignore[union-attr]
+                ("cache.lock.acquired", state["phase"])
+            )
+            try:
+                yield
+            finally:
+                state["phase"] = "released"
+                state["events"].append(  # type: ignore[union-attr]
+                    ("cache.lock.released", state["phase"])
+                )
+
+    monkeypatch.setattr(cache_import_module, "compiler_cache_lock", tracked_lock)
+    events: list[str] = []
+    real_plan_view = cache_import_module._plan_cache_view
+    real_import_plan = cache_import_module.plan_repo_manifest_import_bytes
+    real_publish_view = cache_import_module._publish_cache_view
+    real_context_plan = cache_import_module.plan_context_artifact_strict
+    real_context_publish = cache_import_module.publish_planned_context_artifact_strict
+
+    def tracked_plan_view(view, *args, **kwargs):
+        events.append(f"plan:{view}")
+        return real_plan_view(view, *args, **kwargs)
+
+    def tracked_import_plan(*args, **kwargs):
+        events.append("plan:retained")
+        return real_import_plan(*args, **kwargs)
+
+    def tracked_publish_view(view, *args, **kwargs):
+        expected = ["plan:bm25", "plan:vector", "plan:retained"]
+        if view == "vector":
+            expected.append("publish:bm25")
+        assert events == expected
+        events.append(f"publish:{view}")
+        return real_publish_view(view, *args, **kwargs)
+
+    def tracked_context_plan(*args, **kwargs):
+        assert events == [
+            "plan:bm25",
+            "plan:vector",
+            "plan:retained",
+            "publish:bm25",
+            "publish:vector",
+        ]
+        events.append("plan:context")
+        return real_context_plan(*args, **kwargs)
+
+    def tracked_context_publish(*args, **kwargs):
+        assert events[-1] == "plan:context"
+        events.append("publish:context")
+        return real_context_publish(*args, **kwargs)
+
+    monkeypatch.setattr(cache_import_module, "_plan_cache_view", tracked_plan_view)
+    monkeypatch.setattr(
+        cache_import_module,
+        "plan_repo_manifest_import_bytes",
+        tracked_import_plan,
+    )
+    monkeypatch.setattr(
+        cache_import_module,
+        "_publish_cache_view",
+        tracked_publish_view,
+    )
+    monkeypatch.setattr(
+        cache_import_module,
+        "plan_context_artifact_strict",
+        tracked_context_plan,
+    )
+    monkeypatch.setattr(
+        cache_import_module,
+        "publish_planned_context_artifact_strict",
+        tracked_context_publish,
+    )
+
+    expected_events = [
+        "plan:bm25",
+        "plan:vector",
+        "plan:retained",
+        "publish:bm25",
+        "publish:vector",
+        "plan:context",
+        "publish:context",
+    ]
+
+    def import_generation(
+        name: str,
+        source: RepositorySourceBinding,
+        *,
+        expected_generation: int,
+        catalog: SQLiteCatalog,
+        cas: LocalCAS,
+    ) -> CompilerCacheMultiViewImportResult:
+        view_owners = {
+            "bm25": PublishedWorkspaceReceiptOwner(),
+            "vector": PublishedWorkspaceReceiptOwner(),
+        }
+        context_owner = PublishedWorkspaceReceiptOwner()
+        retained_owners.extend((*view_owners.values(), context_owner))
+        events.clear()
+        result = import_compiler_cache(
+            cache,
+            views=("bm25", "vector"),
+            repository_source=source,
+            view_output_owners=view_owners,
+            context_output_owner=context_owner,
+            view_destinations={
+                "bm25": workspace / f"{name}-bm25",
+                "vector": workspace / f"{name}-vector",
+            },
+            context_destination=workspace / f"{name}-context",
+            workspace_provider=provider,
+            repository_key=_REPOSITORY_KEY,
+            catalog=catalog,
+            object_store=cas,
+            expected_generation=expected_generation,
+            environ={},
+        )
+        assert events == expected_events
+        return result
+
+    binding = None
+    context: ServerContext | None = None
+    try:
+        with (
+            _LockAwareCAS(tmp_path / "cas", state) as cas,
+            _LockAwareCatalog(tmp_path / "catalog.sqlite", state) as catalog,
+        ):
+            first = import_generation(
+                "a-first",
+                source_a,
+                expected_generation=0,
+                catalog=catalog,
+                cas=cas,
+            )
+            assert first.views == ("bm25", "vector")
+            assert tuple(first.recapture_map) == ("bm25", "vector")
+            assert first.import_plan.selection.selected_views == (
+                "bm25",
+                "vector",
+            )
+            assert first.context_artifact.views == ("bm25", "vector")
+            assert first.import_result.views == ("bm25", "vector")
+            assert first.import_result.generation == 1
+            assert first.import_result.changed is True
+            assert tuple(
+                view for view, _generation in first.import_result.view_generation_items
+            ) == ("bm25", REPO_MANIFEST_PROJECTION_VIEW, "vector")
+            assert provider.support_count == 4
+            assert provider.run_count == 3
+            first_view_generations = {
+                view: generation
+                for view, generation in first.import_result.view_generation_items
+                if view in first.views
+            }
+
+            retry = import_generation(
+                "a-retry",
+                source_a,
+                expected_generation=0,
+                catalog=catalog,
+                cas=cas,
+            )
+            assert retry.import_plan.plan_digest == first.import_plan.plan_digest
+            assert retry.import_result.snapshot_id == first.import_result.snapshot_id
+            assert retry.import_result.generation == 1
+            assert retry.import_result.changed is False
+            assert {
+                view: generation
+                for view, generation in retry.import_result.view_generation_items
+                if view in retry.views
+            } == first_view_generations
+
+            source_a.close()
+            source_file.write_text(
+                'MULTIVIEW_CACHE_MARKER = "GENERATION_B_ONLY"\n',
+                encoding="utf-8",
+            )
+            commit_b = _git_commit(repository, "multiview-generation-b")
+            manifest_b = compiler.update_repo(
+                str(repository),
+                index_types=["bm25", "vector"],
+                cache_dir=str(cache),
+            )
+            assert commit_b != commit_a
+            assert manifest_b.commit == commit_b
+            assert manifest_b.indexes["vector"].config["builder_schema"] == 8
+            source_b = capture_repository_source(
+                repository,
+                exclude_roots=(cache,),
+            )
+
+            updated = import_generation(
+                "b-updated",
+                source_b,
+                expected_generation=1,
+                catalog=catalog,
+                cas=cas,
+            )
+            assert updated.import_result.generation == 2
+            assert updated.import_result.changed is True
+            assert updated.import_result.snapshot_id != first.import_result.snapshot_id
+            updated_view_generations = {
+                view: generation
+                for view, generation in updated.import_result.view_generation_items
+                if view in updated.views
+            }
+            assert tuple(updated_view_generations) == ("bm25", "vector")
+            assert all(
+                updated_view_generations[view] != first_view_generations[view]
+                for view in ("bm25", "vector")
+            )
+            assert [
+                (publication["generation"], publication["changed"])
+                for publication in catalog.publications
+            ] == [(1, True), (1, False), (2, True)]
+            assert provider.support_count == 12
+            assert provider.run_count == 9
+            lock_events = [
+                event
+                for event, _phase in state["events"]  # type: ignore[union-attr]
+                if event.startswith("cache.lock.")
+            ]
+            assert (
+                lock_events
+                == [
+                    "cache.lock.acquired",
+                    "cache.lock.released",
+                ]
+                * 3
+            )
+            assert all(
+                phase == "released"
+                for event, phase in state["events"]  # type: ignore[union-attr]
+                if event.startswith(("cas.", "catalog.data."))
+            )
+
+            materialized = materialize_retained_repo_manifest_ref(
+                _REPOSITORY_KEY,
+                workspace / "latest-materialized",
+                catalog=catalog,
+                object_store=cas,
+                workspace_provider=provider,
+                output_receipt_owner=materialized_owner,
+                expected_generation=2,
+                environ={},
+            )
+            assert materialized.export_receipt.ref_generation == 2
+            assert materialized.artifact.commit == commit_b
+            assert materialized.artifact.views == ("bm25", "vector")
+            binding = query_context_artifact(
+                materialized.artifact.output_dir,
+                expected_repository=_REPOSITORY_KEY,
+                expected_commit=commit_b,
+            )
+            assert tuple(sorted(binding.manifest.indexes)) == ("bm25", "vector")
+            context = ServerContext.load(
+                binding.manifest,
+                views=("bm25",),
+                artifact_binding=binding,
+            )
+            assert context.errors == {}
+            assert context.bm25 is not None
+            assert any(
+                "generation b only" in document.page_content
+                for document in context.bm25.documents
+            )
+            assert all(
+                "generation a only" not in document.page_content
+                for document in context.bm25.documents
+            )
+            assert context.bm25.search("GENERATION_B_ONLY", top_k=5)
+    finally:
+        if context is not None:
+            context.close()
+        if binding is not None:
+            binding.close()
+        materialized_owner.close()
+        for owner in reversed(retained_owners):
+            owner.close()
+        if source_b is not None:
+            source_b.close()
+        source_a.close()
+
+
+def test_real_vector_only_cache_import_materializes_exact_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    compiled = _multiview_compiler_fixture(
+        tmp_path,
+        monkeypatch,
+        marker="VECTOR_ONLY",
+    )
+    source = capture_repository_source(
+        compiled.repository,
+        exclude_roots=(compiled.cache,),
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    provider = _TestWorkspaceProvider()
+    vector_owner = PublishedWorkspaceReceiptOwner()
+    context_owner = PublishedWorkspaceReceiptOwner()
+    materialized_owner = PublishedWorkspaceReceiptOwner()
+    binding = None
+    vector_destination = workspace / "vector-only-vector"
+    context_destination = workspace / "vector-only-context"
+    materialized_destination = workspace / "vector-only-materialized"
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            result = import_compiler_cache(
+                compiled.cache,
+                views=("vector",),
+                repository_source=source,
+                view_output_owners={"vector": vector_owner},
+                context_output_owner=context_owner,
+                view_destinations={"vector": vector_destination},
+                context_destination=context_destination,
+                workspace_provider=provider,
+                repository_key=_REPOSITORY_KEY,
+                catalog=catalog,
+                object_store=cas,
+                expected_generation=0,
+                environ={},
+            )
+
+            assert result.views == ("vector",)
+            assert tuple(result.recapture_map) == ("vector",)
+            assert tuple(result.import_plan.manifest.indexes) == ("vector",)
+            assert result.import_plan.manifest.capabilities == {
+                "sparse_search": False,
+                "dense_search": True,
+                "hybrid_search": False,
+                "symbol_navigation": False,
+            }
+            assert result.context_artifact.views == ("vector",)
+            assert result.context_artifact.output_dir == context_destination
+            assert result.import_result.views == ("vector",)
+            assert result.import_result.generation == 1
+            assert result.import_result.changed is True
+            assert tuple(
+                view for view, _generation in result.import_result.view_generation_items
+            ) == (REPO_MANIFEST_PROJECTION_VIEW, "vector")
+            resolved = catalog.resolve_ref(result.import_result.repository_id)
+            assert resolved["ref_name"] == "main"
+            assert resolved["snapshot_id"] == result.import_result.snapshot_id
+            assert resolved["generation"] == 1
+            assert vector_destination.is_dir()
+            assert context_destination.is_dir()
+            assert not (workspace / "vector-only-bm25").exists()
+
+            materialized = materialize_retained_repo_manifest_ref(
+                _REPOSITORY_KEY,
+                materialized_destination,
+                catalog=catalog,
+                object_store=cas,
+                workspace_provider=provider,
+                output_receipt_owner=materialized_owner,
+                expected_generation=1,
+                environ={},
+            )
+            assert materialized.export_receipt.snapshot_id == (
+                result.import_result.snapshot_id
+            )
+            assert materialized.artifact.views == ("vector",)
+            assert (materialized_destination / "views/vector").is_dir()
+            assert not (materialized_destination / "views/bm25").exists()
+            binding = query_context_artifact(
+                materialized_destination,
+                expected_repository=_REPOSITORY_KEY,
+                expected_commit=compiled.commit,
+            )
+            assert tuple(binding.manifest.indexes) == ("vector",)
+            assert binding.manifest.capabilities == {
+                "sparse_search": False,
+                "dense_search": True,
+                "hybrid_search": False,
+                "symbol_navigation": False,
+            }
+            assert provider.run_count == 3
+    finally:
+        if binding is not None:
+            binding.close()
+        materialized_owner.close()
+        context_owner.close()
+        vector_owner.close()
+        source.close()
+
+
+def test_multiview_postcommit_interruption_retries_with_fresh_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    compiled = _multiview_compiler_fixture(
+        tmp_path,
+        monkeypatch,
+        marker="POSTCOMMIT",
+    )
+    source = capture_repository_source(
+        compiled.repository,
+        exclude_roots=(compiled.cache,),
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    provider = _TestWorkspaceProvider()
+    first_owners = {
+        "bm25": PublishedWorkspaceReceiptOwner(),
+        "vector": PublishedWorkspaceReceiptOwner(),
+    }
+    first_context_owner = PublishedWorkspaceReceiptOwner()
+    retry_owners = {
+        "bm25": PublishedWorkspaceReceiptOwner(),
+        "vector": PublishedWorkspaceReceiptOwner(),
+    }
+    retry_context_owner = PublishedWorkspaceReceiptOwner()
+    first_destinations = {
+        "bm25": workspace / "first-bm25",
+        "vector": workspace / "first-vector",
+    }
+    first_context_destination = workspace / "first-context"
+    retry_destinations = {
+        "bm25": workspace / "retry-bm25",
+        "vector": workspace / "retry-vector",
+    }
+    retry_context_destination = workspace / "retry-context"
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            _PostCommitInterruptCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            with pytest.raises(RuntimeError, match="postcommit interruption"):
+                import_compiler_cache(
+                    compiled.cache,
+                    views=("bm25", "vector"),
+                    repository_source=source,
+                    view_output_owners=first_owners,
+                    context_output_owner=first_context_owner,
+                    view_destinations=first_destinations,
+                    context_destination=first_context_destination,
+                    workspace_provider=provider,
+                    repository_key=_REPOSITORY_KEY,
+                    catalog=catalog,
+                    object_store=cas,
+                    expected_generation=0,
+                    environ={},
+                )
+
+            assert all(path.is_dir() for path in first_destinations.values())
+            assert first_context_destination.is_dir()
+            assert all(owner.active for owner in first_owners.values())
+            assert first_context_owner.active
+            assert all(not path.exists() for path in retry_destinations.values())
+            assert not retry_context_destination.exists()
+
+            retry = import_compiler_cache(
+                compiled.cache,
+                views=("bm25", "vector"),
+                repository_source=source,
+                view_output_owners=retry_owners,
+                context_output_owner=retry_context_owner,
+                view_destinations=retry_destinations,
+                context_destination=retry_context_destination,
+                workspace_provider=provider,
+                repository_key=_REPOSITORY_KEY,
+                catalog=catalog,
+                object_store=cas,
+                expected_generation=0,
+                environ={},
+            )
+
+            assert catalog.interrupted_publication is not None
+            assert catalog.interrupted_publication["changed"] is True
+            assert retry.import_result.generation == 1
+            assert retry.import_result.changed is False
+            assert (
+                retry.import_result.snapshot_id
+                == catalog.interrupted_publication["snapshot_id"]
+            )
+            assert (
+                retry.import_result.generation
+                == catalog.interrupted_publication["generation"]
+            )
+            assert retry.import_result.views == ("bm25", "vector")
+            assert tuple(
+                view for view, _generation in retry.import_result.view_generation_items
+            ) == ("bm25", REPO_MANIFEST_PROJECTION_VIEW, "vector")
+            assert all(path.is_dir() for path in retry_destinations.values())
+            assert retry_context_destination.is_dir()
+            assert all(owner.active for owner in retry_owners.values())
+            assert retry_context_owner.active
+            assert all(owner.active for owner in first_owners.values())
+            assert first_context_owner.active
+            assert provider.support_count == 8
+            assert provider.run_count == 6
+    finally:
+        retry_context_owner.close()
+        for owner in reversed(tuple(retry_owners.values())):
+            owner.close()
+        first_context_owner.close()
+        for owner in reversed(tuple(first_owners.values())):
+            owner.close()
+        source.close()
+
+
 def test_real_cli_import_cache_materialize_snapshot_and_query(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1132,40 +2146,14 @@ def test_real_cli_import_cache_materialize_snapshot_and_query(
     except UnsupportedWorkspaceCreation as error:
         pytest.skip(f"native local workspace provider is unavailable: {error}")
 
-    repository = tmp_path / "repository"
-    repository.mkdir(mode=0o700)
-    subprocess.run(["git", "init", "-q", str(repository)], check=True)
-    subprocess.run(
-        ["git", "-C", str(repository), "config", "user.email", "test@example.test"],
-        check=True,
+    compiled = _multiview_compiler_fixture(
+        tmp_path,
+        monkeypatch,
+        marker="PRODUCTION_SHAPED_CACHE_IMPORT",
     )
-    subprocess.run(
-        ["git", "-C", str(repository), "config", "user.name", "CodeNib Test"],
-        check=True,
-    )
-    source_file = repository / "sample.py"
-    source_file.write_text(
-        'CLI_E2E_MARKER = "PRODUCTION_SHAPED_CACHE_IMPORT"\n',
-        encoding="utf-8",
-    )
-    commit = _git_commit(repository, "cli-cache-import")
-
-    registry = IndexBuilderRegistry()
-    registry.register(
-        "bm25",
-        BM25IndexBuilder(languages=["python"], max_k=17),
-    )
-    compiler = IndexCompiler(
-        registry,
-        IndexCompilerConfig(index_types=["bm25"], languages=["python"]),
-    )
-    cache = repository / ".codenib_cache"
-    manifest = compiler.compile_repo(
-        str(repository),
-        index_types=["bm25"],
-        cache_dir=str(cache),
-    )
-    assert manifest.commit == commit
+    repository = compiled.repository
+    cache = compiled.cache
+    commit = compiled.commit
 
     catalog_path = tmp_path / "catalog.sqlite"
     with SQLiteCatalog(catalog_path):
@@ -1192,6 +2180,8 @@ def test_real_cli_import_cache_materialize_snapshot_and_query(
             os.fspath(workspace),
             "--repository",
             _REPOSITORY_KEY,
+            "--view",
+            "vector,bm25",
         ]
     )
     assert import_args.handler is cli_module._run_artifact_import_cache
@@ -1205,13 +2195,18 @@ def test_real_cli_import_cache_materialize_snapshot_and_query(
     )
     assert snapshot_id
     assert "Generation:         1" in import_output
+    assert "Views:              bm25,vector" in import_output
 
     prefix = f".codenib-cache-import-{nonce}"
     bm25_generation = workspace / f"{prefix}-bm25"
+    vector_generation = workspace / f"{prefix}-vector"
     context_generation = workspace / f"{prefix}-context"
     suggested_output = workspace / f"{prefix}-materialized"
     materialized_output = workspace / "materialized"
     assert bm25_generation.is_dir()
+    assert vector_generation.is_dir()
+    assert (vector_generation / "l2/documents_test__model.json").is_file()
+    assert not (vector_generation / "l2/documents_test__model.pkl").exists()
     assert context_generation.is_dir()
     assert not suggested_output.exists()
     assert not materialized_output.exists()
@@ -1239,8 +2234,12 @@ def test_real_cli_import_cache_materialize_snapshot_and_query(
 
     materialize_output = capsys.readouterr().out
     assert f"Snapshot:         {snapshot_id}" in materialize_output
+    assert "Views:            bm25, vector" in materialize_output
     assert materialized_output.is_dir()
+    assert (materialized_output / "views/bm25").is_dir()
+    assert (materialized_output / "views/vector").is_dir()
     assert bm25_generation.is_dir()
+    assert vector_generation.is_dir()
     assert context_generation.is_dir()
 
     binding = query_context_artifact(
@@ -1250,6 +2249,7 @@ def test_real_cli_import_cache_materialize_snapshot_and_query(
     )
     context: ServerContext | None = None
     try:
+        assert tuple(sorted(binding.manifest.indexes)) == ("bm25", "vector")
         context = ServerContext.load(
             binding.manifest,
             views=("bm25",),

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -19,6 +19,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import ANY, MagicMock, patch
 
+import faiss
+import numpy as np
 import pytest
 
 import codenib.compiler.index_compiler as index_compiler_module
@@ -27,6 +29,7 @@ from codenib._atomic_directory import (
     directory_ownership_digest,
     directory_ownership_root_identity,
 )
+from codenib._bounded_json import canonical_json_array_chunks
 from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
 from codenib.compiler.index_builders import (
     BM25IndexBuilder,
@@ -50,8 +53,16 @@ from codenib.compiler.resources import (
     IndexStatus,
     ResourceResolver,
 )
-from codenib.index.embedding.artifact_integrity import VECTOR_VIEW_UPDATE_MARKER
-from codenib.index.embedding.model_policy import DEFAULT_EMBEDDING_REVISION
+from codenib.index.embedding.artifact_integrity import (
+    VECTOR_PERSISTENCE_SCHEMA,
+    VECTOR_ROW_MAPPING_CONTRACT,
+    VECTOR_VIEW_UPDATE_MARKER,
+    vector_level_artifact_records,
+)
+from codenib.index.embedding.model_policy import (
+    DEFAULT_EMBEDDING_REVISION,
+    resolve_embedding_artifact_load_policy_from_options,
+)
 from codenib.index.incremental import IncrementalState
 from codenib.ls_router import GraphBuildResult
 from codenib.native_index_authorization import (
@@ -361,17 +372,125 @@ class TestBM25IndexBuilder:
 # ---------------------------------------------------------------------------
 
 
-def _write_mock_vector_generation(root: Path, model_suffix: str) -> None:
+def _write_mock_vector_generation(
+    root: Path,
+    model_suffix: str,
+    *,
+    artifact_metadata: dict | None = None,
+    l0_count: int = 0,
+    l2_count: int = 1,
+    dimension: int = 384,
+    index_metric: str = "ip",
+) -> None:
     root.mkdir(parents=True, exist_ok=True)
+    if artifact_metadata is None:
+        (root / f"config_{model_suffix}.json").write_text(
+            '{"level_artifacts": {}}',
+            encoding="utf-8",
+        )
+        level = root / "l2"
+        level.mkdir()
+        (level / f"config_{model_suffix}.json").write_text("{}", encoding="utf-8")
+        (level / f"index_{model_suffix}.faiss").write_bytes(b"new-vector")
+        (level / f"documents_{model_suffix}.pkl").write_bytes(b"new-documents")
+        return
+
+    level_artifacts = {}
+    embedding_model = artifact_metadata["embedding_model"]
+    embedding_provider = artifact_metadata["embedding_provider"]
+    embedding_revision = (
+        resolve_embedding_artifact_load_policy_from_options(
+            embedding_model,
+            artifact_metadata["embedding_kwargs"],
+        ).revision
+        if embedding_provider == "huggingface"
+        else None
+    )
+    for level, count in (("l0", l0_count), ("l2", l2_count)):
+        if count == 0:
+            continue
+        level_path = root / level
+        level_path.mkdir()
+        (level_path / f"config_{model_suffix}.json").write_text(
+            json.dumps(
+                {
+                    "embedding_model": embedding_model,
+                    "embedding_provider": embedding_provider,
+                    "embedding_revision": embedding_revision,
+                    "dimension": dimension,
+                    "index_type": "flat",
+                    "index_metric": index_metric,
+                    "level": level,
+                    "num_documents": count,
+                }
+            ),
+            encoding="utf-8",
+        )
+        if index_metric == "ip":
+            index = faiss.IndexFlatIP(dimension)
+        else:
+            index = faiss.IndexFlatL2(dimension)
+        vectors = np.zeros((count, dimension), dtype=np.float32)
+        vectors[:, 0] = np.arange(1, count + 1, dtype=np.float32)
+        index.add(vectors)
+        faiss.write_index(
+            index,
+            str(level_path / f"index_{model_suffix}.faiss"),
+        )
+        documents_file = f"documents_{model_suffix}.json"
+
+        def documents(
+            count=count,
+            level=level,
+        ):
+            for index in range(count):
+                content = f"{level}-document-{index}"
+                yield {
+                    "page_content": content,
+                    "metadata": {
+                        "chunk_id": index,
+                        "chunk_type": "function",
+                        "name": f"document_{index}",
+                        "file": f"source_{index}.py",
+                        "start_line": index,
+                        "end_line": index,
+                        "node_id": f"source_{index}.py::document_{index}",
+                        "level": level,
+                        "content_hash": hashlib.md5(  # noqa: S324
+                            content.encode("utf-8"),
+                            usedforsecurity=False,
+                        ).hexdigest(),
+                    },
+                }
+
+        (level_path / documents_file).write_bytes(
+            b"".join(canonical_json_array_chunks(documents()))
+        )
+        level_artifacts[level] = vector_level_artifact_records(
+            level_path,
+            model_suffix,
+            documents_file=documents_file,
+        )
+
     (root / f"config_{model_suffix}.json").write_text(
-        '{"level_artifacts": {}}',
+        json.dumps(
+            {
+                "artifact": artifact_metadata,
+                "dimension": dimension,
+                "embedding_model": artifact_metadata["embedding_model"],
+                "embedding_provider": artifact_metadata["embedding_provider"],
+                "embedding_revision": embedding_revision,
+                "index_metric": index_metric,
+                "index_type": "flat",
+                "l0_documents": l0_count,
+                "l2_documents": l2_count,
+                "level_artifacts": level_artifacts,
+                "persistence_schema": VECTOR_PERSISTENCE_SCHEMA,
+                "row_mapping": VECTOR_ROW_MAPPING_CONTRACT,
+            }
+        ),
         encoding="utf-8",
     )
-    level = root / "l2"
-    level.mkdir()
-    (level / f"config_{model_suffix}.json").write_text("{}", encoding="utf-8")
-    (level / f"index_{model_suffix}.faiss").write_bytes(b"new-vector")
-    (level / f"documents_{model_suffix}.pkl").write_bytes(b"new-documents")
 
 
 def _tree_file_bytes(root: Path) -> dict[str, bytes]:
@@ -445,7 +564,13 @@ class TestVectorIndexBuilder:
 
         def build_vector(**kwargs):
             build_path = Path(kwargs["index_path"])
-            _write_mock_vector_generation(build_path, "test-model")
+            _write_mock_vector_generation(
+                build_path,
+                "test-model",
+                artifact_metadata=kwargs["artifact_metadata"],
+                l0_count=2,
+                l2_count=3,
+            )
             return mock_vs
 
         mock_build_fn.side_effect = build_vector
@@ -563,6 +688,174 @@ class TestVectorIndexBuilder:
                 output_dir=str(tmp_path / "vector"),
             )
 
+    @patch("codenib.index.embedding.builders.build_hierarchical_vector_store")
+    def test_build_rejects_unreceipted_schema_8_generation(
+        self,
+        mock_build_fn,
+        tmp_path,
+    ):
+        mock_vs = MagicMock(
+            l0_documents=[],
+            l2_documents=[SimpleNamespace(metadata={"file": "source_0.py"})],
+        )
+
+        def build_vector(**kwargs):
+            build_path = Path(kwargs["index_path"])
+            _write_mock_vector_generation(build_path, "test-model")
+            level_artifacts = {
+                "l2": vector_level_artifact_records(
+                    build_path / "l2",
+                    "test-model",
+                    documents_file="documents_test-model.pkl",
+                )
+            }
+            (build_path / "config_test-model.json").write_text(
+                json.dumps(
+                    {
+                        "artifact": kwargs["artifact_metadata"],
+                        "l0_documents": 0,
+                        "l2_documents": 1,
+                        "level_artifacts": level_artifacts,
+                        "persistence_schema": VECTOR_PERSISTENCE_SCHEMA,
+                        "row_mapping": VECTOR_ROW_MAPPING_CONTRACT,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            return mock_vs
+
+        mock_build_fn.side_effect = build_vector
+        output_path = tmp_path / "vector"
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+
+        with pytest.raises(ValueError, match="invalid l2 documents"):
+            builder.build(
+                scope="current_repo",
+                repo_path="/fake/repo",
+                output_dir=str(output_path),
+            )
+
+        assert not output_path.exists()
+
+    @pytest.mark.parametrize("mutation", ["corrupt", "wrong-count"])
+    @patch("codenib.index.embedding.builders.build_hierarchical_vector_store")
+    def test_build_rejects_invalid_persisted_faiss_receipt(
+        self,
+        mock_build_fn,
+        tmp_path,
+        mutation,
+    ):
+        mock_vs = MagicMock(
+            l0_documents=[],
+            l2_documents=[SimpleNamespace(metadata={"file": "source_0.py"})],
+        )
+
+        def build_vector(**kwargs):
+            build_path = Path(kwargs["index_path"])
+            _write_mock_vector_generation(
+                build_path,
+                "test-model",
+                artifact_metadata=kwargs["artifact_metadata"],
+            )
+            index_path = build_path / "l2/index_test-model.faiss"
+            if mutation == "corrupt":
+                index_path.write_bytes(b"not-a-faiss-index")
+            else:
+                index = faiss.IndexFlatIP(384)
+                index.add(np.zeros((2, 384), dtype=np.float32))
+                faiss.write_index(index, str(index_path))
+            config_path = build_path / "config_test-model.json"
+            config = json.loads(config_path.read_text(encoding="utf-8"))
+            config["level_artifacts"]["l2"] = vector_level_artifact_records(
+                build_path / "l2",
+                "test-model",
+                documents_file="documents_test-model.json",
+            )
+            config_path.write_text(json.dumps(config), encoding="utf-8")
+            return mock_vs
+
+        mock_build_fn.side_effect = build_vector
+        output_path = tmp_path / "vector"
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+        expected_error = RuntimeError if mutation == "corrupt" else ValueError
+
+        with pytest.raises(expected_error):
+            builder.build(
+                scope="current_repo",
+                repo_path="/fake/repo",
+                output_dir=str(output_path),
+            )
+
+        assert not output_path.exists()
+
+    @pytest.mark.parametrize("mutation", ["root", "level", "metadata"])
+    @patch("codenib.index.embedding.builders.build_hierarchical_vector_store")
+    def test_build_rejects_incomplete_schema_8_structural_contract(
+        self,
+        mock_build_fn,
+        tmp_path,
+        mutation,
+    ):
+        mock_vs = MagicMock(
+            l0_documents=[],
+            l2_documents=[SimpleNamespace(metadata={"file": "source_0.py"})],
+        )
+
+        def build_vector(**kwargs):
+            build_path = Path(kwargs["index_path"])
+            _write_mock_vector_generation(
+                build_path,
+                "test-model",
+                artifact_metadata=kwargs["artifact_metadata"],
+            )
+            config_path = build_path / "config_test-model.json"
+            if mutation == "root":
+                config = json.loads(config_path.read_text(encoding="utf-8"))
+                config.pop("embedding_model")
+                config_path.write_text(json.dumps(config), encoding="utf-8")
+            elif mutation == "level":
+                (build_path / "l2/config_test-model.json").write_text(
+                    "{}",
+                    encoding="utf-8",
+                )
+            else:
+                documents_path = build_path / "l2/documents_test-model.json"
+                documents = json.loads(documents_path.read_text(encoding="utf-8"))
+                documents[0]["metadata"].pop("content_hash")
+                documents_path.write_bytes(
+                    b"".join(canonical_json_array_chunks(documents))
+                )
+                config = json.loads(config_path.read_text(encoding="utf-8"))
+                config["level_artifacts"]["l2"] = vector_level_artifact_records(
+                    build_path / "l2",
+                    "test-model",
+                    documents_file="documents_test-model.json",
+                )
+                config_path.write_text(json.dumps(config), encoding="utf-8")
+            return mock_vs
+
+        mock_build_fn.side_effect = build_vector
+        output_path = tmp_path / "vector"
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+
+        with pytest.raises(ValueError):
+            builder.build(
+                scope="current_repo",
+                repo_path="/fake/repo",
+                output_dir=str(output_path),
+            )
+
+        assert not output_path.exists()
+
     def test_build_publishes_one_complete_generation_without_stale_state(
         self,
         monkeypatch,
@@ -601,7 +894,11 @@ class TestVectorIndexBuilder:
             calls.append(kwargs)
             build_path = Path(kwargs["index_path"])
             assert (build_path / VECTOR_VIEW_UPDATE_MARKER).is_file()
-            _write_mock_vector_generation(build_path, "test-model")
+            _write_mock_vector_generation(
+                build_path,
+                "test-model",
+                artifact_metadata=kwargs["artifact_metadata"],
+            )
             return vector_store
 
         monkeypatch.setattr(
@@ -629,7 +926,7 @@ class TestVectorIndexBuilder:
             "embeddings_cache.pkl",
             "incremental_state.json",
             "l2/config_test-model.json",
-            "l2/documents_test-model.pkl",
+            "l2/documents_test-model.json",
             "l2/index_test-model.faiss",
         }
         assert files["config_test-model.json"] != b"old-config"
@@ -770,7 +1067,11 @@ class TestVectorIndexBuilder:
             raise exception_type(f"interrupt during {phase}")
 
         def build_vector(**kwargs):
-            _write_mock_vector_generation(Path(kwargs["index_path"]), "test-model")
+            _write_mock_vector_generation(
+                Path(kwargs["index_path"]),
+                "test-model",
+                artifact_metadata=kwargs["artifact_metadata"],
+            )
             if phase == "vector_save":
                 interrupt()
             return vector_store
@@ -1300,7 +1601,7 @@ class TestVectorIndexBuilder:
 
         identity = builder.artifact_identity()
         assert identity == {
-            "builder_schema": 7,
+            "builder_schema": 8,
             "embedding_model": "test-model",
             "embedding_provider": "huggingface",
             "embedding_dimension": 384,
@@ -1386,6 +1687,8 @@ class TestVectorIndexBuilder:
             _write_mock_vector_generation(
                 build_path,
                 "text-embedding-3-small",
+                artifact_metadata=kwargs["artifact_metadata"],
+                dimension=1536,
             )
             return mock_vs
 

--- a/test/compiler/test_manifest_import.py
+++ b/test/compiler/test_manifest_import.py
@@ -250,6 +250,10 @@ def _vector_identity(
     if manifest_version == LEGACY_MANIFEST_VERSION:
         identity.pop("source_selection_digest")
         identity["repository_filter_policy"] = 3
+    # This fixture deliberately exercises compatibility with an already-retained
+    # schema-7 portable generation.  Current raw compiler caches use schema 8 and
+    # must carry the ordered JSON row-mapping receipt.
+    identity["builder_schema"] = 7
     return identity
 
 

--- a/test/compiler/test_manifest_storage.py
+++ b/test/compiler/test_manifest_storage.py
@@ -600,7 +600,7 @@ def test_unknown_builder_schemas_fail_closed(view_type: str) -> None:
     manifest = _manifest()
     _set_entry_field(manifest.indexes[view_type], "builder_schema", 999)
 
-    with pytest.raises(StorageValidationError, match="current portable schema"):
+    with pytest.raises(StorageValidationError, match="supported portable schema"):
         plan_repo_manifest_import(manifest, views=[view_type])
 
     optional = plan_repo_manifest_import(
@@ -609,6 +609,18 @@ def test_unknown_builder_schemas_fail_closed(view_type: str) -> None:
         optional_views=[view_type],
     )
     assert optional.selection.skipped_views[view_type] == "incomplete_profile"
+
+
+@pytest.mark.parametrize("builder_schema", [7, 8])
+def test_retained_vector_schema_7_and_current_schema_8_are_supported(
+    builder_schema: int,
+) -> None:
+    manifest = _manifest()
+    _set_entry_field(manifest.indexes["vector"], "builder_schema", builder_schema)
+
+    plan = plan_repo_manifest_import(manifest, views=["vector"])
+
+    assert plan.view_map["vector"].profile.config["builder_schema"] == builder_schema
 
 
 @pytest.mark.parametrize("view_type", ["bm25", "vector"])

--- a/test/index/test_embedding_builders.py
+++ b/test/index/test_embedding_builders.py
@@ -2,12 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 import codenib._atomic_directory as atomic_directory
+from codenib.code_chunking.base import CodeChunk
 from codenib.index.embedding import builders
 from codenib.index.embedding.artifact_integrity import VECTOR_VIEW_UPDATE_MARKER
 from codenib.native_index_authorization import (
@@ -48,6 +50,67 @@ def _record_fake_documents(store, chunks, level):
         else:
             source_path = getattr(chunk, "file", None)
         documents.append(SimpleNamespace(metadata={"file": source_path}))
+
+
+def test_schema_8_chunk_source_is_repository_relative_posix(tmp_path):
+    repository = tmp_path / "repository"
+    source = repository / "pkg" / "source.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("VALUE = 1\n", encoding="utf-8")
+    chunk = CodeChunk(
+        content="VALUE = 1",
+        start_line=0,
+        end_line=0,
+        chunk_type="module",
+        name="source",
+        file=str(source),
+        node_id="pkg/source.py",
+    )
+
+    normalized = builders._schema_8_repository_chunk(
+        chunk,
+        repository.resolve(strict=True),
+    )
+
+    assert normalized.file == "pkg/source.py"
+    if os.name != "nt":
+        with pytest.raises(ValueError, match="invalid source path"):
+            builders._schema_8_repository_chunk(
+                chunk._replace(file=r"pkg\source.py"),
+                repository.resolve(strict=True),
+            )
+
+
+@pytest.mark.parametrize("target_location", ["inside", "outside"])
+def test_schema_8_chunk_source_rejects_symlink_alias(
+    tmp_path,
+    target_location,
+):
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    target = (
+        repository / "target.py"
+        if target_location == "inside"
+        else tmp_path / "outside.py"
+    )
+    target.write_text("VALUE = 1\n", encoding="utf-8")
+    alias = repository / "alias.py"
+    alias.symlink_to(target)
+    chunk = CodeChunk(
+        content="VALUE = 1",
+        start_line=0,
+        end_line=0,
+        chunk_type="module",
+        name="alias",
+        file=str(alias),
+        node_id="alias.py",
+    )
+
+    with pytest.raises(ValueError, match="regular lexical repository file"):
+        builders._schema_8_repository_chunk(
+            chunk,
+            repository.resolve(strict=True),
+        )
 
 
 def test_cached_builder_closes_store_when_load_fails(monkeypatch, tmp_path):

--- a/test/index/test_vector_store_ivf.py
+++ b/test/index/test_vector_store_ivf.py
@@ -23,10 +23,14 @@ import faiss
 import numpy as np
 import pytest
 
+import codenib.index.embedding.vector_store as vector_store_module
+from codenib._bounded_json import canonical_json_array_chunks
 from codenib.index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
+    VECTOR_ROW_MAPPING_CONTRACT,
     VECTOR_VIEW_UPDATE_MARKER,
     capture_authenticated_vector_view,
+    validate_vector_generation_artifacts,
     vector_config_artifact_record,
     vector_level_artifact_records,
 )
@@ -220,6 +224,183 @@ def test_ivf_save_load_roundtrip(tmp_path):
     assert res and res[0].node_name == chunks[1]["name"]
 
 
+def test_schema_8_save_commits_bounded_canonical_json_row_mapping(tmp_path):
+    path = tmp_path / "vs"
+    store = _make_store(
+        embedding_model="test/model",
+        artifact_metadata={"builder_schema": 8},
+    )
+    store.add_code_chunks(_chunks(2))
+    store.save(str(path))
+
+    config = json.loads((path / "config_test__model.json").read_text())
+    documents_path = path / "l2/documents_test__model.json"
+    payload = documents_path.read_bytes()
+    assert config["row_mapping"] == VECTOR_ROW_MAPPING_CONTRACT
+    assert config["level_artifacts"]["l2"]["documents"]["file"] == (documents_path.name)
+    assert payload == b"".join(canonical_json_array_chunks(json.loads(payload)))
+    assert not (path / "l2/documents_test__model.pkl").exists()
+    assert not (path / "l0").exists()
+    validate_vector_generation_artifacts(path, "test__model")
+
+
+def test_schema_8_save_enforces_canonical_document_byte_cap(
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "vs"
+    store = _make_store(
+        embedding_model="test/model",
+        artifact_metadata={"builder_schema": 8},
+    )
+    store.add_code_chunks(_chunks(1))
+    monkeypatch.setattr(
+        vector_store_module,
+        "_MAX_PORTABLE_DOCUMENTS_JSON_BYTES",
+        64,
+    )
+
+    with pytest.raises(ValueError, match="canonical vector documents exceed"):
+        store.save(str(path))
+
+    assert (path / ".config_test__model.json.save-in-progress").is_file()
+    assert not (path / "config_test__model.json").exists()
+
+
+@pytest.mark.parametrize(
+    ("saved_schema", "expected_schema"),
+    [(8, 7), (7, 8)],
+)
+def test_schema_8_loader_rejects_cross_labeled_identity_before_native_parse(
+    tmp_path,
+    monkeypatch,
+    saved_schema,
+    expected_schema,
+):
+    path = tmp_path / "vs"
+    saved = _make_store(
+        embedding_model="test/model",
+        artifact_metadata={"builder_schema": saved_schema},
+    )
+    saved.add_code_chunks(_chunks(1))
+    saved.save(str(path))
+    loaded = _make_store(
+        embedding_model="test/model",
+        store_path=str(path),
+        artifact_metadata={"builder_schema": expected_schema},
+    )
+    monkeypatch.setattr(
+        vector_store_module.faiss,
+        "read_index",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("cross-labeled schema reached FAISS")
+        ),
+    )
+    monkeypatch.setattr(
+        vector_store_module.compat_pickle,
+        "load",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("cross-labeled schema reached pickle")
+        ),
+    )
+
+    with pytest.raises(ValueError, match="builder schemas must match exactly"):
+        _load_trusted(loaded)
+
+
+@pytest.mark.parametrize("saved_schema", [6, None])
+def test_schema_7_loader_rejects_downgraded_or_missing_root_label_before_parse(
+    tmp_path,
+    monkeypatch,
+    saved_schema,
+):
+    path = tmp_path / "vs"
+    saved = _make_store(
+        embedding_model="test/model",
+        artifact_metadata={"builder_schema": 7},
+    )
+    saved.add_code_chunks(_chunks(1))
+    saved.save(str(path))
+    config_path = path / "config_test__model.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    if saved_schema is None:
+        config.pop("artifact")
+    else:
+        config["artifact"]["builder_schema"] = saved_schema
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    loaded = _make_store(
+        embedding_model="test/model",
+        store_path=str(path),
+        artifact_metadata={"builder_schema": 7},
+    )
+    monkeypatch.setattr(
+        vector_store_module.faiss,
+        "read_index",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("downgraded schema reached FAISS")
+        ),
+    )
+    monkeypatch.setattr(
+        vector_store_module.compat_pickle,
+        "load",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("downgraded schema reached pickle")
+        ),
+    )
+
+    with pytest.raises(ValueError, match="builder schemas must match exactly"):
+        _load_trusted(loaded)
+
+
+@pytest.mark.parametrize("mutation", ["missing-row-mapping", "pickle-record"])
+def test_schema_8_loader_rejects_invalid_contract_before_native_parse(
+    tmp_path,
+    monkeypatch,
+    mutation,
+):
+    path = tmp_path / "vs"
+    identity = {"builder_schema": 8}
+    saved = _make_store(
+        embedding_model="test/model",
+        artifact_metadata=identity,
+    )
+    saved.add_code_chunks(_chunks(1))
+    saved.save(str(path))
+    config_path = path / "config_test__model.json"
+    config = json.loads(config_path.read_text())
+    if mutation == "missing-row-mapping":
+        config.pop("row_mapping")
+        expected = "row mapping"
+    else:
+        config["level_artifacts"]["l2"]["documents"][
+            "file"
+        ] = "documents_test__model.pkl"
+        expected = "canonical document record"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    loaded = _make_store(
+        embedding_model="test/model",
+        store_path=str(path),
+        artifact_metadata=identity,
+    )
+    monkeypatch.setattr(
+        vector_store_module.faiss,
+        "read_index",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("invalid schema-8 contract reached FAISS")
+        ),
+    )
+    monkeypatch.setattr(
+        vector_store_module.compat_pickle,
+        "load",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("invalid schema-8 contract reached pickle")
+        ),
+    )
+
+    with pytest.raises(ValueError, match=expected):
+        _load_trusted(loaded)
+
+
 def test_save_removes_persisted_level_after_last_document_is_deleted(tmp_path):
     path = tmp_path / "vs"
     store = _make_store(embedding_model="test/model")
@@ -246,6 +427,32 @@ def test_save_rejects_misaligned_vectors_and_documents(tmp_path):
     store.l2_documents.pop()
 
     with pytest.raises(ValueError, match="2 vectors for 1 documents"):
+        store.save(str(tmp_path / "vs"))
+
+
+def test_save_rejects_noncanonical_ivf_row_ids(tmp_path):
+    store = _make_store(
+        embedding_model="test/model",
+        index_type="ivf",
+        ivf_nlist=1,
+    )
+    chunks = _chunks(2)
+    store.add_code_chunks(chunks)
+    vectors = np.asarray(
+        store.embedding.embed_documents([chunk["content"] for chunk in chunks]),
+        dtype=np.float32,
+    )
+    index = faiss.IndexIVFFlat(
+        faiss.IndexFlatIP(_DIM),
+        _DIM,
+        1,
+        faiss.METRIC_INNER_PRODUCT,
+    )
+    index.train(vectors)
+    index.add_with_ids(vectors, np.asarray([0, 2], dtype=np.int64))
+    store.l2_index = index
+
+    with pytest.raises(ValueError, match="row IDs are not canonical"):
         store.save(str(tmp_path / "vs"))
 
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -305,6 +305,8 @@ def test_artifact_import_cache_parser_exposes_existing_storage_inputs() -> None:
             "release",
             "--expected-generation",
             "0",
+            "--view",
+            "vector,bm25",
         ]
     )
     defaults = cli.build_parser().parse_args(base)
@@ -316,9 +318,15 @@ def test_artifact_import_cache_parser_exposes_existing_storage_inputs() -> None:
     assert args.namespace == "production"
     assert args.ref == "release"
     assert args.expected_generation == 0
+    assert args.view == ["vector,bm25"]
     assert defaults.namespace == "default"
     assert defaults.ref == "main"
     assert defaults.expected_generation == 0
+    assert defaults.view == []
+    assert cli._compiler_cache_import_views(defaults.view) == ("bm25",)
+    assert cli._compiler_cache_import_views(args.view) == ("bm25", "vector")
+    with pytest.raises(cli.CLIError, match="unsupported compiler cache view"):
+        cli._compiler_cache_import_views(["graph"])
     assert cli._compiler_cache_import_selection(
         ref_name=None,
         expected_generation=None,
@@ -362,7 +370,7 @@ def test_artifact_import_cache_freezes_missing_disjoint_topology(
     assert topology.cache_dir == cache.resolve(strict=True)
     assert topology.catalog_path == catalog.resolve(strict=True)
     assert topology.cas_root == cas_root.resolve(strict=True)
-    assert paths.bm25_destination == workspace_root / f"{prefix}-bm25"
+    assert paths.view_destinations == (("bm25", workspace_root / f"{prefix}-bm25"),)
     assert paths.context_destination == workspace_root / f"{prefix}-context"
     assert paths.suggested_materialization == (
         workspace_root / f"{prefix}-materialized"
@@ -442,6 +450,7 @@ def _cache_import_cli_test_args(tmp_path: Path) -> SimpleNamespace:
         namespace="default",
         ref="main",
         expected_generation=0,
+        view=[],
     )
 
 
@@ -521,6 +530,7 @@ def test_artifact_import_cache_uses_frozen_authorities_and_closes_before_output(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     args = _cache_import_cli_test_args(tmp_path)
+    args.view = ["vector,bm25"]
     nonce = "b" * 32
     monkeypatch.setattr(cli, "_new_compiler_cache_import_nonce", lambda: nonce)
     workspace_root = Path(args.workspace_root)
@@ -528,6 +538,7 @@ def test_artifact_import_cache_uses_frozen_authorities_and_closes_before_output(
     catalog_path = Path(args.catalog)
     cas_root = Path(args.cas_root)
     bm25_destination = workspace_root / f".codenib-cache-import-{nonce}-bm25"
+    vector_destination = workspace_root / f".codenib-cache-import-{nonce}-vector"
     context_destination = workspace_root / f".codenib-cache-import-{nonce}-context"
     suggested = workspace_root / f".codenib-cache-import-{nonce}-materialized"
     events: list[str] = []
@@ -553,11 +564,12 @@ def test_artifact_import_cache_uses_frozen_authorities_and_closes_before_output(
             self.closed = True
 
     bm25_owner = Closeable("bm25")
+    vector_owner = Closeable("vector")
     context_owner = Closeable("context")
     source = Closeable("source")
     store = Closeable("cas")
     catalog = Closeable("catalog")
-    receipt_owners = iter((bm25_owner, context_owner))
+    receipt_owners = iter((bm25_owner, vector_owner, context_owner))
     catalog_identity = cli._retained_catalog_file_identity(catalog_path)
 
     def capture(
@@ -591,6 +603,7 @@ def test_artifact_import_cache_uses_frozen_authorities_and_closes_before_output(
         events.append("bridge")
         bridge_calls.append((cache_dir, kwargs))
         bm25_destination.mkdir()
+        vector_destination.mkdir()
         context_destination.mkdir()
         return SimpleNamespace(
             import_result=SimpleNamespace(
@@ -611,7 +624,7 @@ def test_artifact_import_cache_uses_frozen_authorities_and_closes_before_output(
     monkeypatch.setattr(storage_module, "SQLiteCatalog", open_catalog)
     monkeypatch.setattr(
         cache_import_module,
-        "import_compiler_cache_bm25",
+        "import_compiler_cache",
         import_cache,
     )
     monkeypatch.setattr(
@@ -623,6 +636,7 @@ def test_artifact_import_cache_uses_frozen_authorities_and_closes_before_output(
 
     def print_after_cleanup(*values: object, **kwargs: object) -> None:
         assert bm25_owner.closed
+        assert vector_owner.closed
         assert context_owner.closed
         assert source.closed
         assert store.closed
@@ -636,17 +650,30 @@ def test_artifact_import_cache_uses_frozen_authorities_and_closes_before_output(
     assert capture_calls == [
         (
             Path(args.repo),
-            (cache, bm25_destination, context_destination, suggested),
+            (
+                cache,
+                bm25_destination,
+                vector_destination,
+                context_destination,
+                suggested,
+            ),
             source_selection,
         )
     ]
     assert len(bridge_calls) == 1
     passed_cache, passed = bridge_calls[0]
     assert passed_cache == cache.resolve(strict=True)
+    assert passed["views"] == ("bm25", "vector")
     assert passed["repository_source"] is source
-    assert passed["bm25_output_owner"] is bm25_owner
+    assert passed["view_output_owners"] == {
+        "bm25": bm25_owner,
+        "vector": vector_owner,
+    }
     assert passed["context_output_owner"] is context_owner
-    assert passed["bm25_destination"] == bm25_destination
+    assert passed["view_destinations"] == {
+        "bm25": bm25_destination,
+        "vector": vector_destination,
+    }
     assert passed["context_destination"] == context_destination
     assert passed["repository_key"] == "owner/repo"
     assert passed["namespace_name"] == "default"
@@ -654,26 +681,31 @@ def test_artifact_import_cache_uses_frozen_authorities_and_closes_before_output(
     assert passed["expected_generation"] == 0
     forbidden = passed["forbidden_paths"]
     assert bm25_destination in forbidden
+    assert vector_destination in forbidden
     assert context_destination in forbidden
     assert events.index("provider-support") < events.index("capture")
     assert events.index("capture") < events.index("cas-open")
     assert events.index("cas-open") < events.index("catalog-open")
     assert events.index("catalog-open") < events.index("bridge")
-    assert events[-5:] == [
+    assert events[-6:] == [
         "catalog-close",
         "cas-close",
         "context-close",
+        "vector-close",
         "bm25-close",
         "source-close",
     ]
     assert bm25_destination.is_dir()
+    assert vector_destination.is_dir()
     assert context_destination.is_dir()
     assert not suggested.exists()
     output = capsys.readouterr().out
     assert "Snapshot:           snapshot-id" in output
     assert "Ref:                main" in output
     assert "Generation:         1" in output
+    assert "Views:              bm25,vector" in output
     assert f"BM25 generation:    {bm25_destination}" in output
+    assert f"Vector generation:  {vector_destination}" in output
     assert f"Context generation: {context_destination}" in output
     assert f"Suggested output:   {suggested} (not reserved)" in output
     assert "codenib artifact materialize" in output
@@ -686,10 +718,12 @@ def test_artifact_import_cache_failure_preserves_primary_and_published_outputs(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     args = _cache_import_cli_test_args(tmp_path)
+    args.view = ["bm25,vector"]
     nonce = "c" * 32
     monkeypatch.setattr(cli, "_new_compiler_cache_import_nonce", lambda: nonce)
     workspace_root = Path(args.workspace_root)
     bm25_destination = workspace_root / f".codenib-cache-import-{nonce}-bm25"
+    vector_destination = workspace_root / f".codenib-cache-import-{nonce}-vector"
     context_destination = workspace_root / f".codenib-cache-import-{nonce}-context"
     primary = KeyboardInterrupt("import interrupted after publication")
 
@@ -713,11 +747,12 @@ def test_artifact_import_cache_failure_preserves_primary_and_published_outputs(
             self.closed = True
 
     bm25_owner = RetryableCloseable()
+    vector_owner = RetryableCloseable()
     context_owner = RetryableCloseable()
     source = RetryableCloseable()
     store = RetryableCloseable()
     catalog = RetryableCloseable()
-    receipt_owners = iter((bm25_owner, context_owner))
+    receipt_owners = iter((bm25_owner, vector_owner, context_owner))
 
     def capture(
         *_args: object,
@@ -729,6 +764,7 @@ def test_artifact_import_cache_failure_preserves_primary_and_published_outputs(
 
     def fail_after_publication(*_args: object, **_kwargs: object) -> None:
         bm25_destination.mkdir()
+        vector_destination.mkdir()
         context_destination.mkdir()
         raise primary
 
@@ -747,7 +783,7 @@ def test_artifact_import_cache_failure_preserves_primary_and_published_outputs(
     )
     monkeypatch.setattr(
         cache_import_module,
-        "import_compiler_cache_bm25",
+        "import_compiler_cache",
         fail_after_publication,
     )
     monkeypatch.setattr(
@@ -761,11 +797,13 @@ def test_artifact_import_cache_failure_preserves_primary_and_published_outputs(
 
     assert raised.value is primary
     assert not bm25_owner.closed
+    assert not vector_owner.closed
     assert not context_owner.closed
     assert not source.closed
     assert not store.closed
     assert not catalog.closed
     assert bm25_owner.close_calls == 1
+    assert vector_owner.close_calls == 1
     assert context_owner.close_calls == 1
     assert source.close_calls == 1
     assert store.close_calls == 1
@@ -775,22 +813,33 @@ def test_artifact_import_cache_failure_preserves_primary_and_published_outputs(
     assert any("local CAS cleanup" in note for note in notes)
     assert any("context receipt cleanup" in note for note in notes)
     assert any("BM25 receipt cleanup" in note for note in notes)
+    assert any("Vector receipt cleanup" in note for note in notes)
     assert any("repository source cleanup" in note for note in notes)
     assert bm25_destination.is_dir()
+    assert vector_destination.is_dir()
     assert context_destination.is_dir()
     warnings = capsys.readouterr().err
     assert "cache import BM25 generation now exists" in warnings
+    assert "cache import Vector generation now exists" in warnings
     assert "cache import context generation now exists" in warnings
 
     retained = primary.publication_cleanup_owners  # type: ignore[attr-defined]
     assert type(retained) is tuple
-    assert len(retained) == 5
-    for resource in (bm25_owner, context_owner, source, store, catalog):
+    assert len(retained) == 6
+    for resource in (
+        bm25_owner,
+        vector_owner,
+        context_owner,
+        source,
+        store,
+        catalog,
+    ):
         resource.allow_close = True
     for cleanup_owner in retained:
         cleanup_owner.close()
         assert cleanup_owner.closed
     assert bm25_owner.closed
+    assert vector_owner.closed
     assert context_owner.closed
     assert source.closed
     assert store.closed


### PR DESCRIPTION
## Summary

Add an explicit offline bridge from current compiler BM25/vector caches into retained storage. Vector generations now carry a schema-8 canonical document-to-FAISS row receipt, while strict recapture and import keep native bytes inert and bind every selected view to the authenticated repository source selection.

## Changes

- Upgrade current vector compiler generations to schema 8 with canonical ordered JSON documents, an explicit FAISS row-mapping contract, and trusted producer-side structural/native validation. Already-retained portable schema 7 remains readable; raw schema-7 caches must be rebuilt.
- Add missing-only strict vector recapture with source-selection binding, bounded authenticated replay, inert FAISS handling, and native top-k parity coverage.
- Generalize compiler-cache import to exact BM25, vector, or combined view sets under one existing cache lease, then publish one strict context and one atomic snapshot/ref update after releasing the mutable cache lock.
- Extend `codenib artifact import-cache` with canonical `--view` selection, per-view evidence ownership, source-selection-aware capture, ordered cleanup, and snapshot materialization handoff.
- Bind current-schema standalone BM25 recapture configs to the authenticated source selection while preserving legacy generic inputs.
- Document the trust, compatibility, cleanup, and offline multi-pass I/O boundaries. M1 remains in progress; default compiler/runtime routing is unchanged.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Unit tier: `6706 passed, 71 skipped, 190 deselected`
- Extended artifact/vector/compiler matrix: `728 passed`
- Cache import, CLI, materialization, storage, and native workspace matrix: `646 passed`
- Post-final-rebase strict vector/BM25, cache import, and CLI smoke: `192 passed`
- Black 24.8.0, isort 5.13.2 with the repository profile, flake8 7.1.1 + bugbear, py_compile, and `git diff --check`
- `mkdocs build --strict` and `scripts/check_public_docs.py`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
