### PR TITLE
docs(news): add standalone project updates page

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ SPDX-License-Identifier: Apache-2.0
     &nbsp;&middot;&nbsp;
     <a href="https://docs.codenib.ai/">Documentation</a>
     &nbsp;&middot;&nbsp;
+    <a href="https://docs.codenib.ai/news/">News</a>
+    &nbsp;&middot;&nbsp;
     <a href="https://docs.codenib.ai/codegraph/">CodeGraph</a>
     &nbsp;&middot;&nbsp;
     <a href="https://docs.codenib.ai/mcp/">MCP</a>

--- a/docs/news.md
+++ b/docs/news.md
@@ -1,0 +1,75 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# News
+
+Product releases, integration updates, and notable additions to CodeNib. For
+the complete version history, see
+[GitHub Releases](https://github.com/sysevol-ai/CodeNib/releases) and the
+[changelog](https://github.com/sysevol-ai/CodeNib/blob/main/CHANGELOG.md).
+
+## 2026-08-21 — Repository source authority
+
+CodeNib 0.2.2 admits absolute symlinks through authenticated indexing only
+when they remain inside the same pinned checkout. Exact root-relative source
+exclusions now persist across indexing, CodeGraph, MCP, Wiki, and Web runtimes.
+
+[Read the 0.2.2 release notes](releases/0.2.2.md)
+
+## 2026-08-13 — Agent-ready CodeGraph onboarding
+
+One command prepares a repository graph and connects it to Codex and Claude
+Code. The workflow includes idempotent status, safe uninstall, and
+installed-wheel MCP graph verification.
+
+[Open the CodeGraph guide](codegraph.md)
+
+## 2026-08-08 — RepoNavigator Jump adapter
+
+The published single-tool
+[RepoNavigator](https://arxiv.org/abs/2512.20957v6) contract resolves symbol
+definitions through a persisted SCIP occurrence or injected LSP signal, with
+graph-only resolution disclosed as a degraded fallback.
+
+[Review the support boundary](agent_integrations.md#reponavigator)
+
+## 2026-08-05 — Static Wiki and reusable context artifacts
+
+CodeNib 0.2.0 introduced a build-once path for static Wikis and reusable
+context artifacts, serving them through GitHub Pages or the official MCP
+package alongside hybrid retrieval and managed SCIP/LSP providers.
+
+[Read the 0.2.0 release notes](releases/0.2.0.md)
+
+## 2026-08-05 — SweRank retrieval and reranking
+
+The SweRank recipe runs
+[SweRank](https://github.com/SalesforceAIResearch/SweRank) retrieval and
+reranking over a local checkout.
+
+[Open the example](https://github.com/sysevol-ai/CodeNib/blob/main/examples/swerank_retrieve_rerank.py)
+
+## 2026-08-04 — Native repository explorer
+
+CodeNib's planner targets the
+[SWE-Explore](https://github.com/Qiushao-E/SWE-Explore-Bench) source-region
+protocol for native repository exploration.
+
+[Review the validation](evaluation/swe_explore.md)
+
+## 2026-08-03 — Native LocAgent policy
+
+[LocAgent](https://github.com/gersteinlab/LocAgent) runs directly on CodeNib
+views without LocAgent, LiteLLM, or LlamaIndex dependencies.
+
+[Open the agent support matrix](agent_integrations.md)
+
+## 2026-08-02 — OrcaLoca SearchAgent
+
+[OrcaLoca](https://github.com/fishmingyu/OrcaLoca)'s six-tool search loop
+reuses CodeNib's symbol graph.
+
+[Open the agent support matrix](agent_integrations.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -163,6 +163,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - News: news.md
   - Blog:
       - blog/index.md
       - One Repository Index for Humans and Agents: blog/local-code-intelligence-dgx-spark.md

--- a/test/scripts/test_check_public_docs.py
+++ b/test/scripts/test_check_public_docs.py
@@ -32,6 +32,7 @@ def test_mkdocs_navigation_tabs_contract():
     titles = [item if isinstance(item, str) else next(iter(item)) for item in nav]
     assert titles == [
         "Home",
+        "News",
         "Blog",
         "Get Started",
         "Guides",
@@ -45,6 +46,7 @@ def test_mkdocs_navigation_tabs_contract():
         for item in nav
         if isinstance(item, dict)
     }
+    assert sections["News"] == "news.md"
     assert sections["Blog"][0] == "blog/index.md"
     assert sections["Get Started"][0] == "get-started/index.md"
     assert sections["Guides"][0] == "guides/index.md"


### PR DESCRIPTION
## Summary
Move dated project updates into a standalone, searchable News page while keeping the README evergreen.

## Changes
- add `docs/news.md` with the product and ecosystem updates previously removed from the README
- publish News as a top-level MkDocs navigation item
- add one News link to the README header
- keep images and other static media under `assets/` rather than storing documentation there

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

`mkdocs build --strict`

`pytest -q test/test_release_artifacts.py --tb=short` (28 passed)

`pre-commit run --files README.md mkdocs.yml docs/news.md` (all hooks passed)

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published