### PR TITLE
feat(storage): publish index builds to retained storage

### DIFF
--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -538,13 +538,12 @@ def _selected_views_for_args(args: argparse.Namespace) -> list[str]:
     return list(_PRESET_VIEWS[resolved])
 
 
-def index_repository(
+def _prepare_index_compiler(
     repo_path: Path,
     *,
     languages: Sequence[str],
     views: Sequence[str],
     source_selection: RepositorySourceSelection = (DEFAULT_REPOSITORY_SOURCE_SELECTION),
-    rebuild: bool = False,
     embedding_provider: str = "huggingface",
     embedding_model: str | None = None,
     embedding_dimension: int | None = None,
@@ -552,14 +551,13 @@ def index_repository(
     embedding_credential_env: str | None = None,
     allow_graph_project_preparation: bool = True,
     allow_partial_graph_languages: bool = True,
-):
-    """Build or update the requested repository views."""
+) -> tuple[object, Path]:
+    """Construct the shared compiler configuration and canonical cache path."""
     from .toolchains import activate_managed_toolchain
 
     activate_managed_toolchain()
     from .compiler.index_builders import IndexBuilderRegistry, register_default_builders
     from .compiler.index_compiler import IndexCompiler, IndexCompilerConfig
-    from .compiler.manifest import MANIFEST_FILENAME
     from .index.embedding.model_policy import (
         DEFAULT_EMBEDDING_DIMENSION,
         DEFAULT_EMBEDDING_MODEL,
@@ -592,6 +590,40 @@ def index_repository(
         ),
     )
     cache_dir = repo_index_dir(repo_path)
+    return compiler, cache_dir
+
+
+def index_repository(
+    repo_path: Path,
+    *,
+    languages: Sequence[str],
+    views: Sequence[str],
+    source_selection: RepositorySourceSelection = (DEFAULT_REPOSITORY_SOURCE_SELECTION),
+    rebuild: bool = False,
+    embedding_provider: str = "huggingface",
+    embedding_model: str | None = None,
+    embedding_dimension: int | None = None,
+    embedding_endpoint: str | None = None,
+    embedding_credential_env: str | None = None,
+    allow_graph_project_preparation: bool = True,
+    allow_partial_graph_languages: bool = True,
+):
+    """Build or update the requested repository views."""
+    from .compiler.manifest import MANIFEST_FILENAME
+
+    compiler, cache_dir = _prepare_index_compiler(
+        repo_path,
+        languages=languages,
+        views=views,
+        source_selection=source_selection,
+        embedding_provider=embedding_provider,
+        embedding_model=embedding_model,
+        embedding_dimension=embedding_dimension,
+        embedding_endpoint=embedding_endpoint,
+        embedding_credential_env=embedding_credential_env,
+        allow_graph_project_preparation=allow_graph_project_preparation,
+        allow_partial_graph_languages=allow_partial_graph_languages,
+    )
     manifest_path = cache_dir / MANIFEST_FILENAME
     if manifest_path.is_file() and not rebuild:
         manifest = compiler.update_repo(
@@ -641,11 +673,88 @@ def _print_index_summary(manifest, views: Sequence[str]) -> None:
         print(f"  {view:<14} {entry.status}{suffix}")
 
 
+@dataclass(frozen=True, slots=True)
+class _RetainedIndexSelection:
+    repository: str
+    namespace: str
+    ref_name: str
+    expected_generation: int
+
+
+def _retained_index_selection(
+    args: argparse.Namespace,
+) -> _RetainedIndexSelection | None:
+    """Validate the all-or-none retained publication option group."""
+
+    if not hasattr(args, "publish_retained"):
+        return None
+    publish = bool(getattr(args, "publish_retained", False))
+    retained_options = {
+        "catalog": getattr(args, "catalog", None),
+        "cas_root": getattr(args, "cas_root", None),
+        "workspace_root": getattr(args, "workspace_root", None),
+        "repository": getattr(args, "repository", None),
+        "namespace": getattr(args, "namespace", None),
+        "ref": getattr(args, "ref", None),
+        "expected_generation": getattr(args, "expected_generation", None),
+    }
+    if not publish:
+        selected = [
+            name for name, value in retained_options.items() if value is not None
+        ]
+        if selected:
+            rendered = ", ".join("--" + name.replace("_", "-") for name in selected)
+            raise CLIError(f"{rendered} require --publish-retained")
+        return None
+
+    if bool(getattr(args, "rebuild", False)):
+        raise CLIError("--rebuild is not supported with --publish-retained")
+    required = ("catalog", "cas_root", "workspace_root", "repository")
+    missing = [name for name in required if retained_options[name] is None]
+    if missing:
+        rendered = ", ".join("--" + name.replace("_", "-") for name in missing)
+        raise CLIError(f"--publish-retained requires {rendered}")
+
+    repository, namespace = _retained_materialization_identity(
+        retained_options["repository"],
+        retained_options["namespace"] or "default",
+    )
+    ref_name, expected_generation = _compiler_cache_import_selection(
+        ref_name=retained_options["ref"],
+        expected_generation=retained_options["expected_generation"],
+    )
+    return _RetainedIndexSelection(
+        repository=repository,
+        namespace=namespace,
+        ref_name=ref_name,
+        expected_generation=expected_generation,
+    )
+
+
+def _require_retained_index_views(views: Sequence[str]) -> tuple[str, ...]:
+    selected = tuple(views)
+    unsupported = sorted(set(selected) - set(_COMPILER_CACHE_IMPORT_VIEWS))
+    if unsupported:
+        raise CLIError(
+            "--publish-retained supports only compiler cache views: "
+            + ", ".join(unsupported)
+        )
+    return tuple(view for view in _COMPILER_CACHE_IMPORT_VIEWS if view in set(selected))
+
+
 def _run_index(
     args: argparse.Namespace,
     *,
     selected_views: Sequence[str] | None = None,
 ) -> int:
+    retained_selection = _retained_index_selection(args)
+    retained_views = None
+    if retained_selection is not None:
+        retained_views = _require_retained_index_views(
+            list(selected_views)
+            if selected_views is not None
+            else _selected_views_for_args(args)
+        )
     repo_path = resolve_repo_path(args.repo)
     resolved_selection = _resolve_repository_source_selection(repo_path, args)
     languages = _selected_languages(
@@ -654,9 +763,13 @@ def _run_index(
         source_selection=resolved_selection.selection,
     )
     views = (
-        list(selected_views)
-        if selected_views is not None
-        else _selected_views_for_args(args)
+        list(retained_views)
+        if retained_views is not None
+        else (
+            list(selected_views)
+            if selected_views is not None
+            else _selected_views_for_args(args)
+        )
     )
     embedding_route = None
     if "vector" in views:
@@ -681,6 +794,15 @@ def _run_index(
             embedding_dimension=embedding_route.dimension,
             embedding_endpoint=embedding_route.endpoint,
             embedding_credential_env=embedding_route.credential_env,
+        )
+    if retained_selection is not None:
+        return _run_index_retained(
+            args,
+            repo_path=repo_path,
+            selection=retained_selection,
+            compiler_kwargs={
+                key: value for key, value in index_kwargs.items() if key != "rebuild"
+            },
         )
     manifest, failed = index_repository(repo_path, **index_kwargs)
     _print_index_summary(manifest, views)
@@ -1916,11 +2038,17 @@ def _compiler_cache_import_paths(
     args: argparse.Namespace,
     *,
     views: tuple[str, ...] = ("bm25",),
+    repo_path: Path | None = None,
+    cache_dir: Path | None = None,
 ) -> _CompilerCacheImportPaths:
     """Freeze all user paths and allocate missing-only generation names."""
 
-    repo_path = resolve_repo_path(args.repo)
-    cache_dir = _lexical_cli_path(args.cache_dir, label="cache directory")
+    selected_repo = resolve_repo_path(args.repo) if repo_path is None else repo_path
+    selected_cache = (
+        _lexical_cli_path(args.cache_dir, label="cache directory")
+        if cache_dir is None
+        else Path(os.path.abspath(os.fspath(cache_dir)))
+    )
     catalog_path = _lexical_cli_path(args.catalog, label="catalog")
     cas_root = _lexical_cli_path(args.cas_root, label="CAS root")
     workspace_root = _lexical_cli_path(args.workspace_root, label="workspace root")
@@ -1928,16 +2056,16 @@ def _compiler_cache_import_paths(
         (catalog_path, "catalog", cas_root, "CAS root"),
         (catalog_path, "catalog", workspace_root, "workspace root"),
         (cas_root, "CAS root", workspace_root, "workspace root"),
-        (repo_path, "repository", catalog_path, "catalog"),
-        (repo_path, "repository", cas_root, "CAS root"),
-        (repo_path, "repository", workspace_root, "workspace root"),
-        (cache_dir, "cache directory", catalog_path, "catalog"),
-        (cache_dir, "cache directory", cas_root, "CAS root"),
-        (cache_dir, "cache directory", workspace_root, "workspace root"),
+        (selected_repo, "repository", catalog_path, "catalog"),
+        (selected_repo, "repository", cas_root, "CAS root"),
+        (selected_repo, "repository", workspace_root, "workspace root"),
+        (selected_cache, "cache directory", catalog_path, "catalog"),
+        (selected_cache, "cache directory", cas_root, "CAS root"),
+        (selected_cache, "cache directory", workspace_root, "workspace root"),
     ):
         if _paths_overlap(first, second):
             raise CLIError(f"{first_label} must not overlap the {second_label}")
-    if cache_dir == repo_path or cache_dir in repo_path.parents:
+    if selected_cache == selected_repo or selected_cache in selected_repo.parents:
         raise CLIError("cache directory must not contain the repository")
 
     nonce = _new_compiler_cache_import_nonce()
@@ -1946,8 +2074,8 @@ def _compiler_cache_import_paths(
         (view, workspace_root / f"{prefix}-{view}") for view in views
     )
     return _CompilerCacheImportPaths(
-        repo_path=repo_path,
-        cache_dir=cache_dir,
+        repo_path=selected_repo,
+        cache_dir=selected_cache,
         catalog_path=catalog_path,
         cas_root=cas_root,
         workspace_root=workspace_root,
@@ -1960,15 +2088,129 @@ def _compiler_cache_import_paths(
 @dataclass(frozen=True, slots=True)
 class _CompilerCacheImportTopology:
     cache_dir: Path
+    cache_identity: tuple[int, int]
     catalog_path: Path
     catalog_identity: tuple[int, int, int]
     cas_root: Path
+    cas_identity: tuple[int, ...]
+    workspace_root: Path
+    workspace_identity: tuple[int, ...]
 
 
-def _require_compiler_cache_import_topology(
+@dataclass(frozen=True, slots=True)
+class _CompilerRetainedStorageTopology:
+    repo_path: Path
+    repository_identity: tuple[int, int]
+    planned_cache_path: Path
+    cache_parent_path: Path
+    cache_parent_identity: tuple[int, int]
+    catalog_path: Path
+    catalog_identity: tuple[int, int, int]
+    cas_root: Path
+    cas_identity: tuple[int, ...]
+    workspace_root: Path
+    workspace_identity: tuple[int, ...]
+
+
+@dataclass(slots=True)
+class _CompilerRetainedCacheTopologyGuard:
+    """Sandwich one exact cache/storage topology inside the compiler lease."""
+
+    paths: _CompilerCacheImportPaths
+    storage: _CompilerRetainedStorageTopology
+    _captured: _CompilerCacheImportTopology | None = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
+    _verify_count: int = field(default=0, init=False, repr=False)
+
+    def _observe(
+        self,
+        cache: Path,
+        *,
+        allow_published_outputs: bool,
+    ) -> _CompilerCacheImportTopology:
+        lexical_cache = Path(os.path.abspath(os.fspath(cache)))
+        if lexical_cache != self.paths.cache_dir:
+            raise CLIError("compiler cache lease did not bind the canonical cache")
+        observed = _require_compiler_cache_import_topology(
+            self.paths,
+            allow_published_outputs=allow_published_outputs,
+        )
+        if (
+            observed.cache_dir != self.storage.planned_cache_path
+            or observed.catalog_path != self.storage.catalog_path
+            or observed.catalog_identity != self.storage.catalog_identity
+            or observed.cas_root != self.storage.cas_root
+            or observed.cas_identity != self.storage.cas_identity
+            or observed.workspace_root != self.storage.workspace_root
+            or observed.workspace_identity != self.storage.workspace_identity
+        ):
+            raise CLIError("retained storage topology changed during compilation")
+        if (
+            _resolved_retained_materialization_path(
+                self.storage.cache_parent_path,
+                label="cache parent",
+                strict=True,
+            )
+            != self.storage.cache_parent_path
+            or _retained_real_directory_identity(
+                self.storage.cache_parent_path,
+                label="cache parent",
+            )
+            != self.storage.cache_parent_identity
+        ):
+            raise CLIError("cache parent topology changed during compilation")
+        if (
+            _resolved_retained_materialization_path(
+                self.paths.repo_path,
+                label="repository",
+                strict=True,
+            )
+            != self.storage.repo_path
+            or _retained_real_directory_identity(
+                self.storage.repo_path,
+                label="repository",
+            )
+            != self.storage.repository_identity
+        ):
+            raise CLIError("repository topology changed during compilation")
+        return observed
+
+    def capture(self, cache: Path) -> None:
+        if self._captured is not None:
+            raise CLIError("compiler cache topology was already captured")
+        self._captured = self._observe(cache, allow_published_outputs=False)
+
+    def verify(self, cache: Path) -> None:
+        captured = self._captured
+        if captured is None:
+            raise CLIError("compiler cache topology was not captured")
+        observed = self._observe(
+            cache,
+            allow_published_outputs=self._verify_count > 0,
+        )
+        if observed != captured:
+            raise CLIError("compiler cache topology changed during compilation")
+        self._verify_count += 1
+
+
+def _compiler_cache_import_materialization_snapshot(
     paths: _CompilerCacheImportPaths,
-) -> _CompilerCacheImportTopology:
-    """Freeze existing inputs and deny physical storage/source aliases."""
+    *,
+    allow_published_outputs: bool = False,
+) -> tuple[
+    Path,
+    tuple[int, int, int],
+    Path,
+    Path,
+    Path,
+    tuple[int, ...],
+    tuple[int, ...],
+    tuple[int, ...],
+]:
+    """Bind every retained output to one unchanged storage topology."""
 
     from ._atomic_directory import _OrderedAction, _run_context_with_cleanup_actions
 
@@ -1984,11 +2226,16 @@ def _require_compiler_cache_import_topology(
             tuple[int, ...],
         ]
     ] = []
-    for destination in (
-        *(destination for _view, destination in paths.view_destinations),
-        paths.context_destination,
-        paths.suggested_materialization,
-    ):
+    destinations = (
+        (paths.suggested_materialization,)
+        if allow_published_outputs
+        else (
+            *(destination for _view, destination in paths.view_destinations),
+            paths.context_destination,
+            paths.suggested_materialization,
+        )
+    )
+    for destination in destinations:
         topology_owner = _RetainedMaterializationResourceOwner()
         cleanup_action = _OrderedAction(
             label="cache import path authority cleanup also failed",
@@ -2026,16 +2273,198 @@ def _require_compiler_cache_import_topology(
     first = materialization_snapshots[0]
     if any(candidate != first for candidate in materialization_snapshots[1:]):
         raise CLIError("storage topology changed while allocating import outputs")
+    return first
+
+
+def _compiler_retained_cache_creation_topology(
+    cache_dir: Path,
+) -> tuple[Path, Path, tuple[int, int], tuple[tuple[Path, tuple[int, int]], ...]]:
+    """Bind the nearest existing real parent of a possibly missing cache."""
+
+    current = cache_dir
+    while True:
+        try:
+            metadata = current.lstat()
+        except FileNotFoundError:
+            parent = current.parent
+            if parent == current:
+                raise CLIError("cache directory has no existing parent") from None
+            current = parent
+            continue
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise CLIError("cache parent cannot be inspected safely") from exc
+        if not stat.S_ISDIR(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+            raise CLIError("cache path must contain only existing real directories")
+        break
+
+    # This also inspects every lexical ancestor without following a symlink.
+    ancestry = _retained_directory_ancestry(current, label="cache parent")
+    resolved_parent = _resolved_retained_materialization_path(
+        current,
+        label="cache parent",
+        strict=True,
+    )
+    try:
+        suffix = cache_dir.relative_to(current)
+    except ValueError as exc:  # pragma: no cover - upward walk proves containment
+        raise CLIError("cache path escaped its existing parent") from exc
+    planned_cache = resolved_parent.joinpath(*suffix.parts)
+    return (
+        planned_cache,
+        resolved_parent,
+        _retained_real_directory_identity(resolved_parent, label="cache parent"),
+        ancestry,
+    )
+
+
+def _require_compiler_retained_storage_topology(
+    paths: _CompilerCacheImportPaths,
+) -> _CompilerRetainedStorageTopology:
+    """Freeze storage and repository authorities before a cache is created."""
+
     (
         frozen_catalog_path,
         frozen_catalog_identity,
         frozen_cas_root,
-        _frozen_workspace_root,
+        frozen_workspace_root,
         _frozen_output_parent,
-        _frozen_cas_identity,
-        _frozen_workspace_identity,
+        frozen_cas_identity,
+        frozen_workspace_identity,
         _frozen_output_parent_identity,
-    ) = first
+    ) = _compiler_cache_import_materialization_snapshot(paths)
+
+    resolved_repo = _resolved_retained_materialization_path(
+        paths.repo_path,
+        label="repository",
+        strict=True,
+    )
+    repository_identity = _retained_real_directory_identity(
+        resolved_repo,
+        label="repository",
+    )
+    repository_ancestry = _retained_directory_ancestry(
+        resolved_repo,
+        label="repository",
+    )
+    (
+        planned_cache,
+        cache_parent,
+        cache_parent_identity,
+        cache_parent_ancestry,
+    ) = _compiler_retained_cache_creation_topology(paths.cache_dir)
+    catalog_ancestry = _retained_directory_ancestry(
+        frozen_catalog_path.parent,
+        label="catalog parent",
+    )
+    cas_ancestry = _retained_directory_ancestry(
+        frozen_cas_root,
+        label="CAS root",
+    )
+    workspace_ancestry = _retained_directory_ancestry(
+        frozen_workspace_root,
+        label="workspace root",
+    )
+    for storage, storage_label in (
+        (frozen_catalog_path, "catalog"),
+        (frozen_cas_root, "CAS root"),
+        (frozen_workspace_root, "workspace root"),
+    ):
+        if _paths_overlap(resolved_repo, storage):
+            raise CLIError(
+                f"repository must not physically overlap the {storage_label}"
+            )
+        if _paths_overlap(planned_cache, storage):
+            raise CLIError(
+                f"cache directory must not physically overlap the {storage_label}"
+            )
+    for first_ancestry, first_label, second_ancestry, second_label in (
+        (
+            cache_parent_ancestry,
+            "cache parent",
+            repository_ancestry,
+            "repository",
+        ),
+        (cache_parent_ancestry, "cache parent", catalog_ancestry, "catalog"),
+        (cache_parent_ancestry, "cache parent", cas_ancestry, "CAS root"),
+        (
+            cache_parent_ancestry,
+            "cache parent",
+            workspace_ancestry,
+            "workspace root",
+        ),
+        (repository_ancestry, "repository", catalog_ancestry, "catalog"),
+        (repository_ancestry, "repository", cas_ancestry, "CAS root"),
+        (
+            repository_ancestry,
+            "repository",
+            workspace_ancestry,
+            "workspace root",
+        ),
+        (catalog_ancestry, "catalog", cas_ancestry, "CAS root"),
+        (catalog_ancestry, "catalog", workspace_ancestry, "workspace root"),
+        (cas_ancestry, "CAS root", workspace_ancestry, "workspace root"),
+    ):
+        _require_distinct_directory_ancestry(
+            first_ancestry,
+            first_label,
+            second_ancestry,
+            second_label,
+        )
+    mappings = _retained_linux_mount_mappings()
+    planned_physical = _retained_linux_physical_path(planned_cache, mappings)
+    for storage, storage_label in (
+        (resolved_repo, "repository"),
+        (frozen_catalog_path, "catalog"),
+        (frozen_cas_root, "CAS root"),
+        (frozen_workspace_root, "workspace root"),
+    ):
+        storage_physical = _retained_linux_physical_path(storage, mappings)
+        if (
+            planned_physical is not None
+            and storage_physical is not None
+            and _retained_physical_paths_overlap(
+                planned_physical,
+                storage_physical,
+            )
+        ):
+            raise CLIError(
+                f"cache directory must not traverse a physical {storage_label} alias"
+            )
+    return _CompilerRetainedStorageTopology(
+        repo_path=resolved_repo,
+        repository_identity=repository_identity,
+        planned_cache_path=planned_cache,
+        cache_parent_path=cache_parent,
+        cache_parent_identity=cache_parent_identity,
+        catalog_path=frozen_catalog_path,
+        catalog_identity=frozen_catalog_identity,
+        cas_root=frozen_cas_root,
+        cas_identity=frozen_cas_identity,
+        workspace_root=frozen_workspace_root,
+        workspace_identity=frozen_workspace_identity,
+    )
+
+
+def _require_compiler_cache_import_topology(
+    paths: _CompilerCacheImportPaths,
+    *,
+    allow_published_outputs: bool = False,
+) -> _CompilerCacheImportTopology:
+    """Freeze existing inputs and deny physical storage/source aliases."""
+
+    (
+        frozen_catalog_path,
+        frozen_catalog_identity,
+        frozen_cas_root,
+        frozen_workspace_root,
+        _frozen_output_parent,
+        frozen_cas_identity,
+        frozen_workspace_identity,
+        _frozen_output_parent_identity,
+    ) = _compiler_cache_import_materialization_snapshot(
+        paths,
+        allow_published_outputs=allow_published_outputs,
+    )
 
     resolved_repo = _resolved_retained_materialization_path(
         paths.repo_path,
@@ -2046,6 +2475,10 @@ def _require_compiler_cache_import_topology(
         paths.cache_dir,
         label="cache directory",
         strict=True,
+    )
+    cache_identity = _retained_real_directory_identity(
+        resolved_cache,
+        label="cache directory",
     )
     repository_ancestry = _retained_directory_ancestry(
         resolved_repo,
@@ -2058,11 +2491,7 @@ def _require_compiler_cache_import_topology(
     if resolved_cache == resolved_repo or resolved_cache in resolved_repo.parents:
         raise CLIError("cache directory must not physically contain the repository")
 
-    resolved_workspace = _resolved_retained_materialization_path(
-        paths.workspace_root,
-        label="workspace root",
-        strict=True,
-    )
+    resolved_workspace = frozen_workspace_root
     catalog_ancestry = _retained_directory_ancestry(
         frozen_catalog_path.parent,
         label="catalog parent",
@@ -2118,10 +2547,260 @@ def _require_compiler_cache_import_topology(
         )
     return _CompilerCacheImportTopology(
         cache_dir=resolved_cache,
+        cache_identity=cache_identity,
         catalog_path=frozen_catalog_path,
         catalog_identity=frozen_catalog_identity,
         cas_root=frozen_cas_root,
+        cas_identity=frozen_cas_identity,
+        workspace_root=resolved_workspace,
+        workspace_identity=frozen_workspace_identity,
     )
+
+
+def _run_index_retained(
+    args: argparse.Namespace,
+    *,
+    repo_path: Path,
+    selection: _RetainedIndexSelection,
+    compiler_kwargs: dict[str, object],
+) -> int:
+    """Compile and retain selected views through one cache lease."""
+
+    from . import LocalWorkspaceProvider
+    from ._atomic_directory import (
+        _annotate_secondary_error,
+        _OrderedAction,
+        _run_context_with_cleanup_actions,
+    )
+    from .artifacts.runtime import SourceBindingCleanupOwner
+    from .compiler.cache_import import compile_and_import_repo
+    from .paths import repo_index_dir
+    from .source_fingerprint import capture_repository_source
+    from .storage import LocalCAS, SQLiteCatalog
+
+    views = tuple(compiler_kwargs["views"])  # type: ignore[arg-type]
+    canonical_cache = Path(os.path.abspath(os.fspath(repo_index_dir(repo_path))))
+    paths = _compiler_cache_import_paths(
+        args,
+        views=views,
+        repo_path=repo_path,
+        cache_dir=canonical_cache,
+    )
+    view_destinations = paths.destination_map
+    try:
+        provider = LocalWorkspaceProvider(paths.workspace_root)
+        provider.require_support()
+        storage_topology = _require_compiler_retained_storage_topology(paths)
+    except CLIError:
+        raise
+    except (OSError, RuntimeError, ValueError, sqlite3.Error) as exc:
+        wrapped = CLIError(str(exc))
+        _inherit_publication_cleanup_owners(wrapped, exc)
+        raise wrapped from exc
+
+    source_exclusions = tuple(
+        dict.fromkeys(
+            (
+                paths.cache_dir,
+                *view_destinations.values(),
+                paths.context_destination,
+                paths.suggested_materialization,
+            )
+        )
+    )
+    publication_forbidden_paths = tuple(
+        dict.fromkeys(
+            (
+                paths.cache_dir,
+                storage_topology.catalog_path,
+                storage_topology.cas_root,
+                storage_topology.workspace_root,
+                *view_destinations.values(),
+                paths.context_destination,
+                paths.suggested_materialization,
+            )
+        )
+    )
+    try:
+        view_owners = {view: _new_retained_output_receipt_owner() for view in views}
+        context_owner = _new_retained_output_receipt_owner()
+        source_owner = SourceBindingCleanupOwner()
+        object_store_owner = _RetainedMaterializationResourceOwner()
+        catalog_owner = _RetainedMaterializationResourceOwner()
+        view_cleanup_actions = tuple(
+            _OrderedAction(
+                label=(
+                    "retained index "
+                    + ("BM25" if view == "bm25" else view.title())
+                    + " receipt cleanup also failed"
+                ),
+                action=owner.close,
+                complete=lambda owner=owner: owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=owner,
+            )
+            for view, owner in reversed(tuple(view_owners.items()))
+        )
+        cleanup_actions = (
+            _OrderedAction(
+                label="retained index SQLite catalog cleanup also failed",
+                action=catalog_owner.close,
+                complete=lambda: catalog_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=catalog_owner,
+            ),
+            _OrderedAction(
+                label="retained index local CAS cleanup also failed",
+                action=object_store_owner.close,
+                complete=lambda: object_store_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=object_store_owner,
+            ),
+            _OrderedAction(
+                label="retained index context receipt cleanup also failed",
+                action=context_owner.close,
+                complete=lambda: context_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=context_owner,
+            ),
+            *view_cleanup_actions,
+            _OrderedAction(
+                label="retained index repository source cleanup also failed",
+                action=source_owner.close,
+                complete=lambda: source_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=source_owner,
+            ),
+        )
+        result = None
+        with _run_context_with_cleanup_actions(cleanup_actions):
+            object_store = object_store_owner.acquire(
+                lambda: LocalCAS(
+                    storage_topology.cas_root,
+                    require_preprovisioned=True,
+                )
+            )
+            _require_retained_catalog_binding(
+                storage_topology.catalog_path,
+                storage_topology.catalog_identity,
+            )
+            catalog = catalog_owner.acquire(
+                lambda: SQLiteCatalog(
+                    storage_topology.catalog_path,
+                    create=False,
+                    expected_file_identity=storage_topology.catalog_identity,
+                )
+            )
+            _require_retained_catalog_binding(
+                storage_topology.catalog_path,
+                storage_topology.catalog_identity,
+            )
+            repository_source = capture_repository_source(
+                repo_path,
+                exclude_roots=source_exclusions,
+                selection=compiler_kwargs["source_selection"],
+                _source_owner=source_owner.retain,
+            )
+            compiler, prepared_cache = _prepare_index_compiler(
+                repo_path,
+                **compiler_kwargs,  # type: ignore[arg-type]
+            )
+            if Path(os.path.abspath(os.fspath(prepared_cache))) != paths.cache_dir:
+                raise CLIError("compiler did not select the canonical cache directory")
+            cache_guard = _CompilerRetainedCacheTopologyGuard(
+                paths,
+                storage_topology,
+            )
+            result = compile_and_import_repo(
+                compiler,
+                repo_path,
+                cache_dir=paths.cache_dir,
+                views=views,
+                repository_source=repository_source,
+                view_output_owners=view_owners,
+                context_output_owner=context_owner,
+                view_destinations=view_destinations,
+                context_destination=paths.context_destination,
+                workspace_provider=provider,
+                repository_key=selection.repository,
+                catalog=catalog,
+                object_store=object_store,
+                namespace_name=selection.namespace,
+                ref_name=selection.ref_name,
+                expected_generation=selection.expected_generation,
+                forbidden_paths=publication_forbidden_paths,
+                environ=_publication_environment(),
+                cache_topology_guard=cache_guard,
+            )
+        if result is None:  # pragma: no cover - successful producer always sets it
+            raise RuntimeError("retained compiler publication returned no summary")
+
+        retained = result.retained_import.import_result
+        _print_index_summary(result.manifest, views)
+        print(f"Retained Snapshot:   {retained.snapshot_id}")
+        print(f"Retained Ref:        {retained.ref_name}")
+        print(f"Retained Generation: {retained.generation}")
+        print(f"Retained Views:      {','.join(views)}")
+        for view, destination in view_destinations.items():
+            display = "BM25" if view == "bm25" else view.title()
+            print(f"{display + ' evidence:':<21}{destination}")
+        print(f"Context evidence:    {paths.context_destination}")
+        print(
+            "Materialize snapshot: "
+            + shlex.join(
+                [
+                    "codenib",
+                    "artifact",
+                    "materialize",
+                    "--catalog",
+                    os.fspath(storage_topology.catalog_path),
+                    "--cas-root",
+                    os.fspath(storage_topology.cas_root),
+                    "--workspace-root",
+                    os.fspath(storage_topology.workspace_root),
+                    "--repository",
+                    selection.repository,
+                    "--namespace",
+                    selection.namespace,
+                    "--snapshot",
+                    retained.snapshot_id,
+                    "--output",
+                    os.fspath(paths.suggested_materialization),
+                ]
+            )
+        )
+        return 0
+    except BaseException as primary_error:  # noqa: B036 - preserve cancellation
+        for destination, label in (
+            *(
+                (
+                    destination,
+                    ("BM25" if view == "bm25" else view.title()) + " evidence",
+                )
+                for view, destination in view_destinations.items()
+            ),
+            (paths.context_destination, "context evidence"),
+        ):
+            try:
+                _warn_possible_compiler_cache_import_publication(
+                    destination,
+                    label=label,
+                )
+            except BaseException as warning_error:  # noqa: B036 - diagnostic only
+                _annotate_secondary_error(
+                    primary_error,
+                    f"retained index {label} warning also failed",
+                    warning_error,
+                )
+        if isinstance(primary_error, CLIError):
+            raise
+        if isinstance(
+            primary_error, (OSError, RuntimeError, ValueError, sqlite3.Error)
+        ):
+            wrapped = CLIError(str(primary_error))
+            _inherit_publication_cleanup_owners(wrapped, primary_error)
+            raise wrapped from primary_error
+        raise
 
 
 def _warn_possible_compiler_cache_import_publication(
@@ -4344,6 +5023,47 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_source_selection_arguments(index_parser)
     _add_embedding_route_arguments(index_parser)
+    index_parser.add_argument(
+        "--publish-retained",
+        action="store_true",
+        help="atomically publish BM25/vector results to retained storage",
+    )
+    index_parser.add_argument(
+        "--catalog",
+        default=None,
+        help="existing initialized SQLite catalog used with --publish-retained",
+    )
+    index_parser.add_argument(
+        "--cas-root",
+        default=None,
+        help="existing fully preprovisioned local CAS root",
+    )
+    index_parser.add_argument(
+        "--workspace-root",
+        default=None,
+        help="existing private owner-only LocalWorkspaceProvider root",
+    )
+    index_parser.add_argument(
+        "--repository",
+        default=None,
+        help="canonical owner/repository key for retained publication",
+    )
+    index_parser.add_argument(
+        "--namespace",
+        default=None,
+        help="logical catalog namespace; defaults to default when publishing",
+    )
+    index_parser.add_argument(
+        "--ref",
+        default=None,
+        help="repository ref advanced by retained publication; defaults to main",
+    )
+    index_parser.add_argument(
+        "--expected-generation",
+        type=_argparse_nonnegative_int,
+        default=None,
+        help="required current generation for optimistic retained publication",
+    )
     index_parser.set_defaults(handler=_run_index)
 
     wiki_parser = subparsers.add_parser(

--- a/codenib/compiler/__init__.py
+++ b/codenib/compiler/__init__.py
@@ -30,7 +30,10 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
         CompilerCacheBm25RecaptureResult,
         CompilerCacheImportResult,
         CompilerCacheMultiViewImportResult,
+        CompilerCacheTopologyGuard,
         CompilerCacheViewRecaptureResult,
+        CompilerRetainedPublicationResult,
+        compile_and_import_repo,
         import_compiler_cache,
         import_compiler_cache_bm25,
     )
@@ -88,9 +91,21 @@ _EXPORTS = {
         "codenib.compiler.cache_import",
         "CompilerCacheMultiViewImportResult",
     ),
+    "CompilerCacheTopologyGuard": (
+        "codenib.compiler.cache_import",
+        "CompilerCacheTopologyGuard",
+    ),
     "CompilerCacheViewRecaptureResult": (
         "codenib.compiler.cache_import",
         "CompilerCacheViewRecaptureResult",
+    ),
+    "CompilerRetainedPublicationResult": (
+        "codenib.compiler.cache_import",
+        "CompilerRetainedPublicationResult",
+    ),
+    "compile_and_import_repo": (
+        "codenib.compiler.cache_import",
+        "compile_and_import_repo",
     ),
     "import_compiler_cache": (
         "codenib.compiler.cache_import",
@@ -202,7 +217,10 @@ __all__ = [
     "CompilerCacheBm25RecaptureResult",
     "CompilerCacheImportResult",
     "CompilerCacheMultiViewImportResult",
+    "CompilerCacheTopologyGuard",
     "CompilerCacheViewRecaptureResult",
+    "CompilerRetainedPublicationResult",
+    "compile_and_import_repo",
     "import_compiler_cache",
     "import_compiler_cache_bm25",
     "IndexCompiler",

--- a/codenib/compiler/cache_import.py
+++ b/codenib/compiler/cache_import.py
@@ -18,10 +18,11 @@ import copy
 import hashlib
 import inspect
 import re
+import stat
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 from .._atomic_directory import (
     PublicationDirectoryReader,
@@ -76,6 +77,7 @@ from ..storage.view_bundle import (
     DEFAULT_MAX_BUNDLE_METADATA_BYTES,
 )
 from .cache_lock import compiler_cache_lock
+from .index_compiler import IndexCompiler
 from .manifest import MANIFEST_FILENAME, MANIFEST_VERSION, IndexEntry, RepoManifest
 from .manifest_import import (
     _CATALOG_METHODS,
@@ -107,6 +109,16 @@ from .snapshot_store import normalize_repo
 
 _COMMIT_RE = re.compile(r"[0-9a-f]{40}\Z", re.ASCII)
 _SUPPORTED_CACHE_VIEWS = ("bm25", "vector")
+
+
+class CompilerCacheTopologyGuard(Protocol):
+    """Trusted application-level checks around one compiler-cache mutation."""
+
+    def capture(self, cache: Path) -> None:
+        """Capture topology after the cache lease binds its directory."""
+
+    def verify(self, cache: Path) -> None:
+        """Reject topology drift while the same cache lease remains held."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -304,6 +316,48 @@ class CompilerCacheMultiViewImportResult:
 
 
 @dataclass(frozen=True, slots=True)
+class CompilerRetainedPublicationResult:
+    """Result of updating compiler views and atomically retaining them."""
+
+    manifest: RepoManifest
+    retained_import: CompilerCacheMultiViewImportResult
+
+    def __post_init__(self) -> None:
+        if type(self) is not CompilerRetainedPublicationResult:
+            raise TypeError("compiler retained publication must use the exact type")
+        if type(self.manifest) is not RepoManifest:
+            raise TypeError("compiler retained publication manifest is invalid")
+        if type(self.retained_import) is not CompilerCacheMultiViewImportResult:
+            raise TypeError("compiler retained publication import result is invalid")
+        views = self.retained_import.views
+        for view in views:
+            _require_current_view(self.manifest, view=view)
+        portable = self.retained_import.import_plan.manifest
+        if (
+            portable.commit != self.manifest.commit
+            or portable.source_fingerprint != self.manifest.source_fingerprint
+            or portable.file_count != self.manifest.file_count
+            or portable.source_selection != self.manifest.source_selection
+            or portable.last_indexed_commit != self.manifest.last_indexed_commit
+            or portable.last_indexed_source_fingerprint
+            != self.manifest.last_indexed_source_fingerprint
+            or portable.last_indexed_source_selection_digest
+            != self.manifest.last_indexed_source_selection_digest
+        ):
+            raise StorageIntegrityError(
+                "compiler retained publication identities are inconsistent"
+            )
+
+    @property
+    def views(self) -> tuple[str, ...]:
+        return self.retained_import.views
+
+    @property
+    def import_result(self) -> RepoManifestImportResult:
+        return self.retained_import.import_result
+
+
+@dataclass(frozen=True, slots=True)
 class _ImportPreflight:
     repository_key: str
     namespace_name: str
@@ -318,6 +372,26 @@ class _ImportPreflight:
     max_projection_bytes: int
     forbidden_paths: tuple[Path, ...]
     environment: Mapping[str, str]
+
+
+@dataclass(slots=True)
+class _ImportOperation:
+    cache: Path
+    view_owners: dict[str, PublishedWorkspaceReceiptOwner]
+    view_outputs: dict[str, Path]
+    context_output: Path
+    inputs: _ImportPreflight
+    fixed_source_views: dict[str, Path]
+    policy_forbidden: tuple[Path, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedCompilerCacheImport:
+    manifest: RepoManifest
+    recaptures: tuple[CompilerCacheViewRecaptureResult, ...]
+    canonical_manifest_bytes: bytes
+    import_plan: RepoManifestImportPlan
+    context_artifact: ContextArtifactResult
 
 
 def _path_relation(path: Path, boundary: Path) -> str:
@@ -416,6 +490,46 @@ def _preflight_workspace_provider(
         if not callable(candidate):
             raise TypeError("compiler cache workspace provider has an invalid contract")
     workspace_provider.require_support()
+
+
+def _preflight_cache_topology_guard(
+    guard: CompilerCacheTopologyGuard | None,
+) -> None:
+    if guard is None:
+        return
+    for member in ("capture", "verify"):
+        try:
+            candidate = inspect.getattr_static(guard, member)
+        except AttributeError as exc:
+            raise TypeError(
+                "compiler cache topology guard has an invalid contract"
+            ) from exc
+        if isinstance(candidate, (classmethod, staticmethod)):
+            candidate = candidate.__func__
+        if not callable(candidate):
+            raise TypeError("compiler cache topology guard has an invalid contract")
+
+
+def _cache_directory_identity(cache: Path) -> tuple[int, int]:
+    try:
+        metadata = cache.lstat()
+    except OSError as exc:
+        raise RuntimeError("compiler cache directory cannot be authenticated") from exc
+    if not stat.S_ISDIR(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+        raise RuntimeError("compiler cache path is not a real directory")
+    return (metadata.st_dev, metadata.st_ino)
+
+
+def _run_cache_topology_guard(
+    guard: CompilerCacheTopologyGuard | None,
+    member: str,
+    cache: Path,
+) -> None:
+    if guard is None:
+        return
+    result = getattr(guard, member)(cache)
+    if result is not None:
+        raise TypeError(f"compiler cache topology guard {member} must return None")
 
 
 def _preflight_import_inputs(
@@ -912,7 +1026,7 @@ def _read_context_manifest(
     return owner.consume(read)
 
 
-def import_compiler_cache(
+def _preflight_cache_import_operation(
     cache_dir: str | Path,
     *,
     views: tuple[str, ...],
@@ -925,26 +1039,20 @@ def import_compiler_cache(
     repository_key: str,
     catalog: RetainedImportCatalog,
     object_store: RetainedImportObjectStore,
-    namespace_name: str = DEFAULT_NAMESPACE_NAME,
-    ref_name: str = DEFAULT_REF_NAME,
-    expected_generation: int = 0,
-    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
-    max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
-    max_context_bytes: int = DEFAULT_MAX_CONTEXT_BYTES,
-    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
-    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
-    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
-    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
-    forbidden_paths: Iterable[Path] = (),
-    environ: Mapping[str, str] | None = None,
-) -> CompilerCacheMultiViewImportResult:
-    """Recapture and import one exact current compiler-cache view set.
-
-    All receipt owners and the retained repository binding are borrowed.  The
-    caller remains responsible for closing them on success and failure.
-    Published directories are immutable evidence and are never recursively
-    removed when a later publication or retained import fails.
-    """
+    namespace_name: str,
+    ref_name: str,
+    expected_generation: int,
+    max_manifest_bytes: int,
+    max_context_files: int,
+    max_context_bytes: int,
+    max_bundle_files: int,
+    max_bundle_bytes: int,
+    max_bundle_metadata_bytes: int,
+    max_projection_bytes: int,
+    forbidden_paths: Iterable[Path],
+    environ: Mapping[str, str] | None,
+) -> _ImportOperation:
+    """Validate borrowed authorities without touching the compiler cache."""
 
     _preflight_authorities(
         views=views,
@@ -990,157 +1098,203 @@ def import_compiler_cache(
     )
     _preflight_workspace_provider(workspace_provider)
     _preflight_catalog_contract(catalog)
+    return _ImportOperation(
+        cache=cache,
+        view_owners=view_owners,
+        view_outputs=view_outputs,
+        context_output=context_output,
+        inputs=inputs,
+        fixed_source_views=fixed_source_views,
+        policy_forbidden=policy_forbidden,
+    )
 
-    with compiler_cache_lock(cache, create=False):
-        source_manifest_bytes = _read_manifest(
-            cache,
-            max_manifest_bytes=inputs.max_manifest_bytes,
-        )
-        manifest = _parse_exact_manifest(
-            source_manifest_bytes,
-            max_manifest_bytes=inputs.max_manifest_bytes,
-        )
-        if _COMMIT_RE.fullmatch(manifest.commit) is None:
-            raise ValueError(
-                "compiler cache repository manifest commit must be a full "
-                "lowercase Git SHA"
-            )
-        identity = repository_source.authenticated_identity_snapshot()
-        if type(identity) is not RepositorySourceIdentitySnapshot:
-            raise TypeError("compiler cache repository identity has an invalid type")
-        _cache_topology(cache, identity)
-        _require_manifest_source(manifest, identity)
-        entries = {view: _require_current_view(manifest, view=view) for view in views}
-        source_views = {
-            view: _view_source(cache, entries[view], view=view) for view in views
-        }
-        _destination_topology(
-            tuple(view_outputs.values()),
-            context_output,
-            cache=cache,
-            repository=lexical_directory_path(identity.root),
-            source_views=tuple(source_views.values()),
-        )
-        if source_views != fixed_source_views:  # pragma: no cover - helper invariant
-            raise AssertionError("compiler cache fixed view sources changed")
 
-        # Every raw-cache recapture plan plus the exact portable manifest and
-        # retained import plan exists before the first provider call can mutate
-        # any workspace destination.  The context plan is authority-dependent:
-        # it is built later from the published view receipts, before context
-        # workspace mutation.
-        planned_views: dict[str, Any] = {}
-        for view in views:
-            planned = _plan_cache_view(
-                view,
-                source_views[view],
-                view_outputs[view],
-                repository_source=repository_source,
-                view_config=entries[view].config,
-                forbidden_paths=policy_forbidden,
-                environ=inputs.environment,
-            )
-            if view == "bm25":
-                _require_source_fingerprints(entries[view], planned)
-            _planned_adjustments(view, planned)
-            planned_views[view] = planned
-        portable_manifest, canonical_manifest_bytes = _portable_manifest(
-            manifest,
-            views=views,
-            planned_views=planned_views,
-        )
-        import_plan = plan_repo_manifest_import_bytes(
-            canonical_manifest_bytes,
-            views=views,
-            max_manifest_bytes=inputs.max_manifest_bytes,
-        )
-        if (
-            import_plan.selection.selected_views != views
-            or import_plan.manifest.to_dict() != portable_manifest.to_dict()
-        ):
+def _prepare_compiler_cache_import_locked(
+    operation: _ImportOperation,
+    *,
+    views: tuple[str, ...],
+    repository_source: RepositorySourceBinding,
+    context_output_owner: PublishedWorkspaceReceiptOwner,
+    workspace_provider: StrictWorkspaceProvider,
+    expected_manifest: RepoManifest | None = None,
+) -> _PreparedCompilerCacheImport:
+    """Recapture selected views while the caller holds the cache lease."""
+
+    cache = operation.cache
+    inputs = operation.inputs
+    source_manifest_bytes = _read_manifest(
+        cache,
+        max_manifest_bytes=inputs.max_manifest_bytes,
+    )
+    manifest = _parse_exact_manifest(
+        source_manifest_bytes,
+        max_manifest_bytes=inputs.max_manifest_bytes,
+    )
+    if expected_manifest is not None:
+        if type(expected_manifest) is not RepoManifest:
+            raise TypeError("compiler update returned an invalid repository manifest")
+        if expected_manifest.to_dict() != manifest.to_dict():
             raise StorageIntegrityError(
-                "compiler cache portable manifest changed during import planning"
+                "compiler update result differs from its exact serialized manifest"
             )
+    if _COMMIT_RE.fullmatch(manifest.commit) is None:
+        raise ValueError(
+            "compiler cache repository manifest commit must be a full "
+            "lowercase Git SHA"
+        )
+    identity = repository_source.authenticated_identity_snapshot()
+    if type(identity) is not RepositorySourceIdentitySnapshot:
+        raise TypeError("compiler cache repository identity has an invalid type")
+    _cache_topology(cache, identity)
+    _require_manifest_source(manifest, identity)
+    entries = {view: _require_current_view(manifest, view=view) for view in views}
+    source_views = {
+        view: _view_source(cache, entries[view], view=view) for view in views
+    }
+    _destination_topology(
+        tuple(operation.view_outputs.values()),
+        operation.context_output,
+        cache=cache,
+        repository=lexical_directory_path(identity.root),
+        source_views=tuple(source_views.values()),
+    )
+    if source_views != operation.fixed_source_views:  # pragma: no cover
+        raise AssertionError("compiler cache fixed view sources changed")
 
-        recaptures: list[CompilerCacheViewRecaptureResult] = []
-        for view in views:
-            planned = planned_views[view]
-            adjustments = _publish_cache_view(
-                view,
-                source_views[view],
-                view_outputs[view],
-                planned=planned,
-                repository_source=repository_source,
-                workspace_provider=workspace_provider,
-                output_receipt_owner=view_owners[view],
-                view_config=entries[view].config,
-                forbidden_paths=policy_forbidden,
-                environ=inputs.environment,
-            )
-            if adjustments != _planned_adjustments(view, planned):
-                raise StorageIntegrityError(
-                    f"compiler cache {view} publication differs from its exact plan"
-                )
-            recaptures.append(
-                CompilerCacheViewRecaptureResult(
-                    view_type=view,
-                    source_view=source_views[view],
-                    output_view=view_outputs[view],
-                    source_records=planned.source_records,
-                    output_records=planned.output_records,
-                )
-            )
-
-        planned_context = plan_context_artifact_strict(
-            portable_manifest,
-            repository=inputs.repository_key,
+    # Every raw-cache recapture plan plus the exact portable manifest and
+    # retained import plan exists before the first provider call can mutate
+    # any workspace destination.  The context plan is authority-dependent:
+    # it is built later from the published view receipts, before context
+    # workspace mutation.
+    planned_views: dict[str, Any] = {}
+    for view in views:
+        planned = _plan_cache_view(
+            view,
+            source_views[view],
+            operation.view_outputs[view],
             repository_source=repository_source,
-            view_generations=view_owners,
+            view_config=entries[view].config,
+            forbidden_paths=operation.policy_forbidden,
             environ=inputs.environment,
         )
-        if (
-            planned_context.views != views
-            or planned_context.manifest_payload != canonical_manifest_bytes
-        ):
-            raise StorageIntegrityError(
-                "compiler cache context plan differs from its portable manifest"
-            )
-        context_artifact = publish_planned_context_artifact_strict(
-            context_output,
-            planned=planned_context,
-            manifest=portable_manifest,
-            repository=inputs.repository_key,
+        if view == "bm25":
+            _require_source_fingerprints(entries[view], planned)
+        _planned_adjustments(view, planned)
+        planned_views[view] = planned
+    portable_manifest, canonical_manifest_bytes = _portable_manifest(
+        manifest,
+        views=views,
+        planned_views=planned_views,
+    )
+    import_plan = plan_repo_manifest_import_bytes(
+        canonical_manifest_bytes,
+        views=views,
+        max_manifest_bytes=inputs.max_manifest_bytes,
+    )
+    if (
+        import_plan.selection.selected_views != views
+        or import_plan.manifest.to_dict() != portable_manifest.to_dict()
+    ):
+        raise StorageIntegrityError(
+            "compiler cache portable manifest changed during import planning"
+        )
+
+    recaptures: list[CompilerCacheViewRecaptureResult] = []
+    for view in views:
+        planned = planned_views[view]
+        adjustments = _publish_cache_view(
+            view,
+            source_views[view],
+            operation.view_outputs[view],
+            planned=planned,
             repository_source=repository_source,
-            view_generations=view_owners,
             workspace_provider=workspace_provider,
-            output_receipt_owner=context_output_owner,
+            output_receipt_owner=operation.view_owners[view],
+            view_config=entries[view].config,
+            forbidden_paths=operation.policy_forbidden,
             environ=inputs.environment,
         )
-        observed_manifest_bytes = _read_context_manifest(
-            context_output_owner,
-            max_manifest_bytes=inputs.max_manifest_bytes,
+        if adjustments != _planned_adjustments(view, planned):
+            raise StorageIntegrityError(
+                f"compiler cache {view} publication differs from its exact plan"
+            )
+        recaptures.append(
+            CompilerCacheViewRecaptureResult(
+                view_type=view,
+                source_view=source_views[view],
+                output_view=operation.view_outputs[view],
+                source_records=planned.source_records,
+                output_records=planned.output_records,
+            )
         )
-        if observed_manifest_bytes != canonical_manifest_bytes:
-            raise StorageIntegrityError(
-                "compiler cache context manifest differs from its preplanned bytes"
-            )
-        if repository_source.authenticated_identity_snapshot() != identity:
-            raise StorageIntegrityError(
-                "compiler cache repository source changed during recapture"
-            )
-        if (
-            _read_manifest(cache, max_manifest_bytes=inputs.max_manifest_bytes)
-            != source_manifest_bytes
-        ):
-            raise StorageIntegrityError(
-                "compiler cache repository manifest changed during recapture"
-            )
 
-    # Catalog/CAS publication deliberately occurs after releasing the mutable
-    # compiler cache lock.  The context receipt remains the exact authority
-    # authenticated above, so the mutable cache is no longer consulted.
+    planned_context = plan_context_artifact_strict(
+        portable_manifest,
+        repository=inputs.repository_key,
+        repository_source=repository_source,
+        view_generations=operation.view_owners,
+        environ=inputs.environment,
+    )
+    if (
+        planned_context.views != views
+        or planned_context.manifest_payload != canonical_manifest_bytes
+    ):
+        raise StorageIntegrityError(
+            "compiler cache context plan differs from its portable manifest"
+        )
+    context_artifact = publish_planned_context_artifact_strict(
+        operation.context_output,
+        planned=planned_context,
+        manifest=portable_manifest,
+        repository=inputs.repository_key,
+        repository_source=repository_source,
+        view_generations=operation.view_owners,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=context_output_owner,
+        environ=inputs.environment,
+    )
+    observed_manifest_bytes = _read_context_manifest(
+        context_output_owner,
+        max_manifest_bytes=inputs.max_manifest_bytes,
+    )
+    if observed_manifest_bytes != canonical_manifest_bytes:
+        raise StorageIntegrityError(
+            "compiler cache context manifest differs from its preplanned bytes"
+        )
+    if repository_source.authenticated_identity_snapshot() != identity:
+        raise StorageIntegrityError(
+            "compiler cache repository source changed during recapture"
+        )
+    if (
+        _read_manifest(cache, max_manifest_bytes=inputs.max_manifest_bytes)
+        != source_manifest_bytes
+    ):
+        raise StorageIntegrityError(
+            "compiler cache repository manifest changed during recapture"
+        )
+    return _PreparedCompilerCacheImport(
+        manifest=manifest,
+        recaptures=tuple(recaptures),
+        canonical_manifest_bytes=canonical_manifest_bytes,
+        import_plan=import_plan,
+        context_artifact=context_artifact,
+    )
+
+
+def _commit_prepared_compiler_cache_import(
+    preparation: _PreparedCompilerCacheImport,
+    operation: _ImportOperation,
+    *,
+    repository_source: RepositorySourceBinding,
+    context_output_owner: PublishedWorkspaceReceiptOwner,
+    catalog: RetainedImportCatalog,
+    object_store: RetainedImportObjectStore,
+) -> CompilerCacheMultiViewImportResult:
+    """Commit immutable evidence after the mutable cache lease is released."""
+
+    inputs = operation.inputs
     import_result = import_retained_repo_manifest(
-        import_plan,
+        preparation.import_plan,
         artifact_owner=context_output_owner,
         repository_source=repository_source,
         repository_key=inputs.repository_key,
@@ -1155,15 +1309,241 @@ def import_compiler_cache(
         max_bundle_bytes=inputs.max_bundle_bytes,
         max_bundle_metadata_bytes=inputs.max_bundle_metadata_bytes,
         max_projection_bytes=inputs.max_projection_bytes,
-        forbidden_paths=policy_forbidden,
+        forbidden_paths=operation.policy_forbidden,
         environ=inputs.environment,
     )
     return CompilerCacheMultiViewImportResult(
-        recaptures=tuple(recaptures),
-        canonical_manifest_bytes=canonical_manifest_bytes,
-        import_plan=import_plan,
-        context_artifact=context_artifact,
+        recaptures=preparation.recaptures,
+        canonical_manifest_bytes=preparation.canonical_manifest_bytes,
+        import_plan=preparation.import_plan,
+        context_artifact=preparation.context_artifact,
         import_result=import_result,
+    )
+
+
+def import_compiler_cache(
+    cache_dir: str | Path,
+    *,
+    views: tuple[str, ...],
+    repository_source: RepositorySourceBinding,
+    view_output_owners: dict[str, PublishedWorkspaceReceiptOwner],
+    context_output_owner: PublishedWorkspaceReceiptOwner,
+    view_destinations: dict[str, Path],
+    context_destination: Path,
+    workspace_provider: StrictWorkspaceProvider,
+    repository_key: str,
+    catalog: RetainedImportCatalog,
+    object_store: RetainedImportObjectStore,
+    namespace_name: str = DEFAULT_NAMESPACE_NAME,
+    ref_name: str = DEFAULT_REF_NAME,
+    expected_generation: int = 0,
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+    max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
+    max_context_bytes: int = DEFAULT_MAX_CONTEXT_BYTES,
+    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
+    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
+    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> CompilerCacheMultiViewImportResult:
+    """Recapture and import one exact current compiler-cache view set.
+
+    All receipt owners and the retained repository binding are borrowed.  The
+    caller remains responsible for closing them on success and failure.
+    Published directories are immutable evidence and are never recursively
+    removed when a later publication or retained import fails.
+    """
+
+    operation = _preflight_cache_import_operation(
+        cache_dir,
+        views=views,
+        repository_source=repository_source,
+        view_output_owners=view_output_owners,
+        context_output_owner=context_output_owner,
+        view_destinations=view_destinations,
+        context_destination=context_destination,
+        workspace_provider=workspace_provider,
+        repository_key=repository_key,
+        catalog=catalog,
+        object_store=object_store,
+        namespace_name=namespace_name,
+        ref_name=ref_name,
+        expected_generation=expected_generation,
+        max_manifest_bytes=max_manifest_bytes,
+        max_context_files=max_context_files,
+        max_context_bytes=max_context_bytes,
+        max_bundle_files=max_bundle_files,
+        max_bundle_bytes=max_bundle_bytes,
+        max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        max_projection_bytes=max_projection_bytes,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
+    )
+    with compiler_cache_lock(operation.cache, create=False):
+        preparation = _prepare_compiler_cache_import_locked(
+            operation,
+            views=views,
+            repository_source=repository_source,
+            context_output_owner=context_output_owner,
+            workspace_provider=workspace_provider,
+        )
+
+    # Catalog/CAS publication deliberately occurs after releasing the mutable
+    # compiler cache lock.  The context receipt remains the exact authority
+    # authenticated above, so the mutable cache is no longer consulted.
+    return _commit_prepared_compiler_cache_import(
+        preparation,
+        operation,
+        repository_source=repository_source,
+        context_output_owner=context_output_owner,
+        catalog=catalog,
+        object_store=object_store,
+    )
+
+
+def compile_and_import_repo(
+    compiler: IndexCompiler,
+    repo_path: str | Path,
+    *,
+    cache_dir: str | Path,
+    views: tuple[str, ...],
+    repository_source: RepositorySourceBinding,
+    view_output_owners: dict[str, PublishedWorkspaceReceiptOwner],
+    context_output_owner: PublishedWorkspaceReceiptOwner,
+    view_destinations: dict[str, Path],
+    context_destination: Path,
+    workspace_provider: StrictWorkspaceProvider,
+    repository_key: str,
+    catalog: RetainedImportCatalog,
+    object_store: RetainedImportObjectStore,
+    namespace_name: str = DEFAULT_NAMESPACE_NAME,
+    ref_name: str = DEFAULT_REF_NAME,
+    expected_generation: int = 0,
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+    max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
+    max_context_bytes: int = DEFAULT_MAX_CONTEXT_BYTES,
+    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
+    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
+    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+    cache_topology_guard: CompilerCacheTopologyGuard | None = None,
+) -> CompilerRetainedPublicationResult:
+    """Update-or-create selected compiler views and retain one snapshot.
+
+    The mutable compiler update and strict immutable recapture share one cache
+    lease.  The lease is released before the retained importer invokes any
+    CAS or catalog data-plane method; static contract probes may run earlier.
+    ``cache_topology_guard`` is a trusted application-level denial check for
+    topology that needs the newly created, lease-bound cache directory.  It is
+    not an authority token: ``capture`` runs before compiler mutation and
+    ``verify`` runs before retained workspace mutation and again before lease
+    release.
+
+    All source and receipt authorities are borrowed.  The caller owns their
+    cleanup, including immutable evidence left by a later storage failure.
+    There is intentionally no force-rebuild option: this route only performs
+    the compiler's ordinary update-or-create policy.
+    """
+
+    if type(compiler) is not IndexCompiler:
+        raise TypeError("compiler retained publication requires an IndexCompiler")
+    _preflight_cache_topology_guard(cache_topology_guard)
+    repository = lexical_directory_path(Path(repo_path))
+    operation = _preflight_cache_import_operation(
+        cache_dir,
+        views=views,
+        repository_source=repository_source,
+        view_output_owners=view_output_owners,
+        context_output_owner=context_output_owner,
+        view_destinations=view_destinations,
+        context_destination=context_destination,
+        workspace_provider=workspace_provider,
+        repository_key=repository_key,
+        catalog=catalog,
+        object_store=object_store,
+        namespace_name=namespace_name,
+        ref_name=ref_name,
+        expected_generation=expected_generation,
+        max_manifest_bytes=max_manifest_bytes,
+        max_context_files=max_context_files,
+        max_context_bytes=max_context_bytes,
+        max_bundle_files=max_bundle_files,
+        max_bundle_bytes=max_bundle_bytes,
+        max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        max_projection_bytes=max_projection_bytes,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
+    )
+
+    with compiler_cache_lock(operation.cache):
+        cache_identity = _cache_directory_identity(operation.cache)
+        identity = repository_source.authenticated_identity_snapshot()
+        if type(identity) is not RepositorySourceIdentitySnapshot:
+            raise TypeError("compiler cache repository identity has an invalid type")
+        if lexical_directory_path(identity.root) != repository:
+            raise StorageIntegrityError(
+                "compiler retained publication source belongs to another repository"
+            )
+        _cache_topology(operation.cache, identity)
+        _run_cache_topology_guard(
+            cache_topology_guard,
+            "capture",
+            operation.cache,
+        )
+        if _cache_directory_identity(operation.cache) != cache_identity:
+            raise RuntimeError(
+                "compiler cache directory changed during topology capture"
+            )
+        compiled_manifest = compiler._update_repo_locked(
+            str(repository),
+            index_types=list(views),
+            cache=str(operation.cache),
+        )
+        if _cache_directory_identity(operation.cache) != cache_identity:
+            raise RuntimeError("compiler cache directory changed during compilation")
+        _run_cache_topology_guard(
+            cache_topology_guard,
+            "verify",
+            operation.cache,
+        )
+        if _cache_directory_identity(operation.cache) != cache_identity:
+            raise RuntimeError(
+                "compiler cache directory changed during topology verify"
+            )
+        preparation = _prepare_compiler_cache_import_locked(
+            operation,
+            views=views,
+            repository_source=repository_source,
+            context_output_owner=context_output_owner,
+            workspace_provider=workspace_provider,
+            expected_manifest=compiled_manifest,
+        )
+        if _cache_directory_identity(operation.cache) != cache_identity:
+            raise RuntimeError("compiler cache directory changed during recapture")
+        _run_cache_topology_guard(
+            cache_topology_guard,
+            "verify",
+            operation.cache,
+        )
+        if _cache_directory_identity(operation.cache) != cache_identity:
+            raise RuntimeError(
+                "compiler cache directory changed during topology verify"
+            )
+
+    retained_import = _commit_prepared_compiler_cache_import(
+        preparation,
+        operation,
+        repository_source=repository_source,
+        context_output_owner=context_output_owner,
+        catalog=catalog,
+        object_store=object_store,
+    )
+    return CompilerRetainedPublicationResult(
+        manifest=compiled_manifest,
+        retained_import=retained_import,
     )
 
 
@@ -1246,7 +1626,10 @@ __all__ = [
     "CompilerCacheBm25RecaptureResult",
     "CompilerCacheImportResult",
     "CompilerCacheMultiViewImportResult",
+    "CompilerCacheTopologyGuard",
     "CompilerCacheViewRecaptureResult",
+    "CompilerRetainedPublicationResult",
+    "compile_and_import_repo",
     "import_compiler_cache",
     "import_compiler_cache_bm25",
 ]

--- a/codenib/compiler/index_compiler.py
+++ b/codenib/compiler/index_compiler.py
@@ -169,7 +169,12 @@ class IndexCompiler:
         index_types: Optional[List[str]],
         cache: str,
     ) -> RepoManifest:
-        """Update a repository while holding its cache-level compiler lock."""
+        """Update or create a repository while the caller holds its cache lock.
+
+        This method deliberately does not acquire another lease.  It is the
+        composition boundary used by retained publication so compilation and
+        immutable recapture share one cache generation.
+        """
         manifest_path = os.path.join(cache, MANIFEST_FILENAME)
 
         if not os.path.isfile(manifest_path):

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -15,13 +15,73 @@ strict workspace contract. It publishes one fully validated directory into a
 missing destination and transfers the generation to a caller-owned
 `PublishedWorkspaceReceiptOwner`.
 
-The provider is not part of CodeNib's default compiler, import, or runtime
-path. Two explicit operator bridges use it: `codenib artifact import-cache`
-recaptures an explicitly selected current compiler-cache BM25/vector view set
-into retained storage, and `codenib artifact materialize` publishes a retained
-catalog ref or immutable snapshot to a missing portable-artifact directory.
-The strict BM25 replacement path still requires the unsupported
-`provider-bound-exact` destination mode.
+The provider is not enabled by CodeNib's default compiler or runtime path.
+Three explicit routes use it: `codenib index --publish-retained` builds and
+publishes current BM25/vector views in one compiler-cache lease,
+`codenib artifact import-cache` recaptures an already existing selected cache,
+and `codenib artifact materialize` publishes a retained catalog ref or
+immutable snapshot to a missing portable-artifact directory. The strict BM25
+replacement path still requires the unsupported `provider-bound-exact`
+destination mode.
+
+## Publish a normal index build
+
+Use `--publish-retained` on the normal `codenib index` command to build or
+update BM25, vector, or both and publish the exact compiler result as one ready
+snapshot. This is the first production compiler-to-retained route; without the
+flag, `codenib index` keeps its existing local-cache behavior and output.
+
+The route requires the same existing initialized SQLite catalog, fully
+preprovisioned strict `LocalCAS`, and private owner-only Linux workspace root
+described below. It never provisions those authorities. It uses CodeNib's
+canonical per-repository compiler cache; a first invocation may create that
+cache, but the cache's nearest existing real ancestor and physical storage
+topology are checked before creation. Inside the single compiler lease, the
+route freezes the newly created cache identity before the build, verifies it
+before publication and again after recapture, and rejects a changed or aliased
+cache instead of importing a different generation.
+
+All retained options are opt-in as one group. `--rebuild` is intentionally
+incompatible because a post-commit retry must reuse the current compiler
+generation rather than force new bytes. Selected views must be exactly BM25,
+vector, or BM25 plus vector; graph and Zoekt publication remain later
+milestones. For a first BM25-only publication:
+
+```bash
+codenib index /srv/src/repository \
+  --preset fast \
+  --publish-retained \
+  --catalog /var/lib/codenib/catalog.sqlite3 \
+  --cas-root /var/lib/codenib/cas \
+  --workspace-root /var/lib/codenib/workspaces \
+  --repository owner/repository \
+  --ref main \
+  --expected-generation 0
+```
+
+Use `--preset semantic` or `--view bm25,vector` with a configured embedding
+route for the combined portable view set. The command captures the retained
+source before compilation, then performs update-or-create, exact serialized
+manifest binding, all selected view plans and publications, and one context
+publication under the same cache lease. The retained importer performs no CAS
+or catalog data-plane operation until that lease is released; support,
+existing-storage open, and static contract probes may run earlier. A failed or
+stale selected view stops before retained publication.
+
+Each invocation uses fresh missing-only evidence destinations. Published
+evidence is warned about rather than deleted if a later step fails. On success,
+the normal index summary is followed by the snapshot, ref generation, evidence
+paths, and an immutable-snapshot `artifact materialize` command. If a result
+might have committed before it was observed, retry without `--rebuild`, with
+the original `--expected-generation`; unchanged source and compiler
+configuration resolve to the same snapshot with `changed=False` rather than
+advancing the ref again.
+
+This remains explicit offline dual-write. Keep the source/cache and storage
+namespaces trusted and quiescent, and apply the payload-size and storage-media
+benchmark gate described below before enabling it by default or treating it as
+a latency-sensitive worker path. Catalog-selected MCP cold start is still a
+separate M1 route; runtime hot switching remains M3.
 
 ## Import compiler query views
 
@@ -30,8 +90,9 @@ or both from an existing `IndexCompiler` cache as one ready retained snapshot.
 Omitting `--view` preserves the BM25-only default. Repeat `--view`, or pass a
 comma-separated value such as `--view bm25,vector`, to select views explicitly;
 the CLI canonicalizes the result to BM25 then vector. This remains an offline
-bootstrap: it does not change the default `codenib index` route, import graph or
-Zoekt views, run an M2 fenced job, or hot-switch a runtime.
+bootstrap for an already existing cache: it does not enable retained
+publication for an `index` invocation that lacks `--publish-retained`, import
+graph or Zoekt views, run an M2 fenced job, or hot-switch a runtime.
 
 Prepare these authorities before running it:
 
@@ -213,10 +274,11 @@ retry over it; verify the retained artifact before reuse or reclaim it through
 an ownership-aware workflow.
 
 This retained-read bridge and the explicit BM25/vector ingress above do not
-complete the hybrid-storage M1 milestone. Default compiler/runtime routing is
-still missing, as is a production provider for the strict BM25 replacement
-producer's `provider-bound-exact` destination contract. Graph and Zoekt ingress
-remain M2 or later work; fenced jobs and runtime hot switching remain separate
+complete the hybrid-storage M1 milestone. Catalog-selected cold-start runtime
+and benchmark-backed promotion of the opt-in compiler route are still missing,
+as is a production provider for the strict BM25 replacement producer's
+`provider-bound-exact` destination contract. Graph and Zoekt ingress remain M2
+or later work; fenced jobs and runtime hot switching remain separate
 milestones.
 
 ## Lifecycle

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -562,14 +562,33 @@ reserving the suggested output. An exact retry uses fresh destinations but the
 original expected ref generation and idempotently returns the already-published
 snapshot without another ref advance.
 
-This command is an offline bootstrap, not a request-path or worker-path
-primitive. Exact ownership capture, semantic validation, workspace replay,
-bundle/CAS ingestion, and receipt revalidation deliberately make multiple
-bounded passes over large payloads; a selected FAISS file may therefore be
-read more than once. Representative end-to-end corpus, payload-size, and
-storage-media benchmarks are required before this path is enabled by default,
-used as a latency-sensitive service ingress, or has any validation pass
-removed. M1 remains in progress because default compiler/runtime routing is
+The same coordinator now has a normal compiler composition boundary.
+`compile_and_import_repo` performs update-or-create and immutable recapture in
+one compiler-cache lease, binds the exact serialized manifest to the returned
+compiler result, and releases the lease before the retained importer invokes
+CAS/catalog data-plane methods. Support, existing-storage open, and static
+contract probes may run before the lease.
+The existing `codenib index` command exposes it only when
+`--publish-retained` is present with an existing catalog, preprovisioned strict
+CAS, private `0700` workspace root, canonical repository key, and optimistic
+ref generation. A first build may create the canonical compiler cache. Before
+that creation, the CLI authenticates its nearest existing real ancestor and
+denies physical storage aliases; inside the sole semantic lease it freezes the
+created cache identity, repeats the storage-topology gate before publication,
+and verifies it again after recapture. `--rebuild` is incompatible with this
+route so an at-least-once retry can reuse the same compiler generation and
+resolve to the same snapshot rather than manufacture new bytes. Default index
+behavior remains unchanged when the flag is absent.
+
+Both compiler-cache ingress routes are offline publication paths, not
+request-path or worker-path primitives. Exact ownership capture, semantic
+validation, workspace replay, bundle/CAS ingestion, and receipt revalidation
+deliberately make multiple bounded passes over large payloads; a selected FAISS
+file may therefore be read more than once. Representative end-to-end corpus,
+payload-size, and storage-media benchmarks are required before either path is
+enabled by default, used as a latency-sensitive service ingress, or has any
+validation pass removed. M1 remains in progress because catalog-selected
+cold-start runtime routing and benchmark-backed default compiler promotion are
 still absent. Graph and Zoekt cache ingress, generic builder profiles, and
 fenced job publication remain M2 or later work, runtime hot switching remains
 M3 work, and evidence retention and reclamation remain M5 work.
@@ -649,9 +668,10 @@ rather than deleting it.
 
 This command does not initialize or populate the control plane, import a legacy
 cache, build views, advance refs, or make retained storage the default. It is
-the retained-read bridge only. Default compiler/runtime routing remains
-outstanding M1 work; graph and Zoekt cache ingress and fenced job publication
-remain M2 or later work. Strict BM25 replacement also still lacks the
+the retained-read bridge only. Catalog-selected cold-start runtime and
+benchmark-backed promotion of the explicit compiler route remain outstanding
+M1 work; graph and Zoekt cache ingress and fenced job publication remain M2 or
+later work. Strict BM25 replacement also still lacks the
 `provider-bound-exact` production provider.
 
 Schema v2 now adds
@@ -661,9 +681,9 @@ per-ref leases.  Catalog reads revalidate the normalized view rows against the
 canonical request; the M2 publication transaction must repeat that gate before
 associating outputs.  An explicit acquire may atomically retire an expired
 holder while taking over its slot; this slice adds no background reaper and is
-not wired to the compiler or Web workers. Default compiler/import/runtime
-wiring remains the outstanding M1 deliverable; fenced job publication remains
-M2 work.
+not wired to the compiler or Web workers. Catalog-selected cold-start runtime
+and benchmark-backed default compiler promotion remain outstanding M1
+deliverables; fenced job publication remains M2 work.
 
 The shared compiler-cache lock is a cooperative serialization boundary for
 compiler and importer processes using a cache namespace private to one OS

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -37,7 +37,10 @@ from codenib.compiler.cache_import import (
     CompilerCacheBm25RecaptureResult,
     CompilerCacheImportResult,
     CompilerCacheMultiViewImportResult,
+    CompilerCacheTopologyGuard,
     CompilerCacheViewRecaptureResult,
+    CompilerRetainedPublicationResult,
+    compile_and_import_repo,
     compiler_cache_source_selection,
     import_compiler_cache,
     import_compiler_cache_bm25,
@@ -58,6 +61,7 @@ from codenib.index.embedding.vector_store import CodeVectorStore
 from codenib.mcp.context import ServerContext
 from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.source_fingerprint import (
+    RepositoryChangedError,
     RepositorySourceBinding,
     capture_repository_source,
     fingerprint_repository,
@@ -531,6 +535,12 @@ def _call_generic(
 
 
 def test_compiler_cache_import_is_a_lazy_public_export() -> None:
+    assert (
+        compiler_module.CompilerRetainedPublicationResult
+        is CompilerRetainedPublicationResult
+    )
+    assert compiler_module.CompilerCacheTopologyGuard is CompilerCacheTopologyGuard
+    assert compiler_module.compile_and_import_repo is compile_and_import_repo
     assert compiler_module.CompilerCacheImportResult is CompilerCacheImportResult
     assert (
         compiler_module.CompilerCacheMultiViewImportResult
@@ -571,6 +581,419 @@ def test_compiler_cache_import_is_a_lazy_public_export() -> None:
         "catalog",
         "object_store",
     ]
+    compile_signature = inspect.signature(compile_and_import_repo)
+    assert list(compile_signature.parameters)[:4] == [
+        "compiler",
+        "repo_path",
+        "cache_dir",
+        "views",
+    ]
+    assert compile_signature.parameters["cache_dir"].kind is (
+        inspect.Parameter.KEYWORD_ONLY
+    )
+    assert compile_signature.parameters["cache_dir"].default is inspect.Parameter.empty
+    assert "rebuild" not in compile_signature.parameters
+
+
+def test_compile_and_import_fresh_cache_uses_one_lease_and_storage_after_release(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    subprocess.run(["git", "init", "-q", str(repository)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repository), "config", "user.email", "test@example.test"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repository), "config", "user.name", "CodeNib Test"],
+        check=True,
+    )
+    (repository / "sample.py").write_text("VALUE = 1\n", encoding="utf-8")
+    commit = _git_commit(repository, "fresh-retained-route")
+    cache = tmp_path / "cache"
+    source = capture_repository_source(repository, exclude_roots=(cache,))
+    registry = IndexBuilderRegistry()
+    registry.register("bm25", BM25IndexBuilder(languages=["python"], max_k=17))
+    compiler = IndexCompiler(
+        registry,
+        IndexCompilerConfig(index_types=["bm25"], languages=["python"]),
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    provider = _TestWorkspaceProvider()
+    view_owner = PublishedWorkspaceReceiptOwner()
+    context_owner = PublishedWorkspaceReceiptOwner()
+    state: dict[str, object] = {
+        "phase": "before",
+        "events": [],
+        "lock_count": 0,
+    }
+    real_lock = cache_import_module.compiler_cache_lock
+
+    @contextmanager
+    def tracked_lock(cache_path: Path, *, create: bool = True):
+        assert create is True
+        state["lock_count"] = int(state["lock_count"]) + 1
+        with real_lock(cache_path, create=create):
+            state["phase"] = "locked"
+            state["events"].append("lock:acquired")  # type: ignore[union-attr]
+            try:
+                yield
+            finally:
+                state["phase"] = "released"
+                state["events"].append("lock:released")  # type: ignore[union-attr]
+
+    monkeypatch.setattr(cache_import_module, "compiler_cache_lock", tracked_lock)
+    real_update = compiler._update_repo_locked
+
+    def tracked_update(*args, **kwargs):
+        assert state["phase"] == "locked"
+        state["events"].append("compile")  # type: ignore[union-attr]
+        return real_update(*args, **kwargs)
+
+    monkeypatch.setattr(compiler, "_update_repo_locked", tracked_update)
+
+    class Guard:
+        def __init__(self) -> None:
+            self.identity: tuple[int, int] | None = None
+            self.verify_count = 0
+
+        def capture(self, observed_cache: Path) -> None:
+            assert state["phase"] == "locked"
+            assert observed_cache == cache
+            metadata = observed_cache.lstat()
+            self.identity = (metadata.st_dev, metadata.st_ino)
+            state["events"].append("guard:capture")  # type: ignore[union-attr]
+
+        def verify(self, observed_cache: Path) -> None:
+            assert state["phase"] == "locked"
+            metadata = observed_cache.lstat()
+            assert (metadata.st_dev, metadata.st_ino) == self.identity
+            self.verify_count += 1
+            state["events"].append("guard:verify")  # type: ignore[union-attr]
+
+    guard = Guard()
+    try:
+        with (
+            _LockAwareCAS(tmp_path / "cas", state) as cas,
+            _LockAwareCatalog(tmp_path / "catalog.sqlite", state) as catalog,
+        ):
+            result = compile_and_import_repo(
+                compiler,
+                repository,
+                cache_dir=cache,
+                views=("bm25",),
+                repository_source=source,
+                view_output_owners={"bm25": view_owner},
+                context_output_owner=context_owner,
+                view_destinations={"bm25": workspace / "published-bm25"},
+                context_destination=workspace / "published-context",
+                workspace_provider=provider,
+                repository_key=_REPOSITORY_KEY,
+                catalog=catalog,
+                object_store=cas,
+                cache_topology_guard=guard,
+                environ={},
+            )
+
+        assert type(result) is CompilerRetainedPublicationResult
+        assert result.manifest.commit == commit
+        assert result.views == ("bm25",)
+        assert result.import_result.generation == 1
+        assert result.import_result.changed is True
+        assert state["lock_count"] == 1
+        assert guard.verify_count == 2
+        events = state["events"]
+        assert [event for event in events if isinstance(event, str)] == [
+            "lock:acquired",
+            "guard:capture",
+            "compile",
+            "guard:verify",
+            "guard:verify",
+            "lock:released",
+        ]
+        storage_events = [
+            event
+            for event in events
+            if isinstance(event, tuple)
+            and len(event) == 2
+            and isinstance(event[0], str)
+            and (event[0].startswith("cas.") or event[0].startswith("catalog.data."))
+        ]
+        assert storage_events
+        assert all(event[1] == "released" for event in storage_events)
+    finally:
+        context_owner.close()
+        view_owner.close()
+        source.close()
+
+
+def test_compile_and_import_fresh_nested_cache_fails_before_workspace_or_data_io(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    (repository / "sample.py").write_text("VALUE = 1\n", encoding="utf-8")
+    cache = repository / ".codenib_cache"
+    source = capture_repository_source(repository, exclude_roots=(cache,))
+    compiler = IndexCompiler(IndexBuilderRegistry())
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    provider = _TestWorkspaceProvider()
+    view_owner = PublishedWorkspaceReceiptOwner()
+    context_owner = PublishedWorkspaceReceiptOwner()
+    backend = _BackendTripwire()
+    try:
+        # Creating a previously absent child changes the retained repository
+        # root.  The low-level route must fail closed before compiler or
+        # workspace mutation; CLI topology preflight prevents this layout.
+        with pytest.raises(
+            RepositoryChangedError,
+            match="repository source changed after it was authenticated",
+        ):
+            compile_and_import_repo(
+                compiler,
+                repository,
+                cache_dir=cache,
+                views=("bm25",),
+                repository_source=source,
+                view_output_owners={"bm25": view_owner},
+                context_output_owner=context_owner,
+                view_destinations={"bm25": workspace / "published-bm25"},
+                context_destination=workspace / "published-context",
+                workspace_provider=provider,
+                repository_key=_REPOSITORY_KEY,
+                catalog=backend,
+                object_store=backend,
+                environ={},
+            )
+
+        assert cache.is_dir()
+        assert not (cache / "repo_manifest.json").exists()
+        assert not (cache / "bm25").exists()
+        assert not (workspace / "published-bm25").exists()
+        assert not (workspace / "published-context").exists()
+        assert backend.calls == ["contract"]
+        assert provider.support_count == 1
+        assert provider.run_count == 0
+        assert view_owner.state == "empty"
+        assert context_owner.state == "empty"
+    finally:
+        context_owner.close()
+        view_owner.close()
+        source.close()
+
+
+@pytest.mark.parametrize("failure", ["source", "config", "failed-view"])
+def test_compile_and_import_rejects_drift_or_failed_view_before_data_io(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    compiler = IndexCompiler(IndexBuilderRegistry())
+    manifest_path = fixture.cache / "repo_manifest.json"
+    manifest = RepoManifest.load(manifest_path)
+    if failure == "source":
+        returned_manifest = manifest
+        expected_error = RepositoryChangedError
+        expected_message = "repository source inventory changed"
+    elif failure == "config":
+        returned_manifest = copy.deepcopy(manifest)
+        returned_manifest.indexes["bm25"].config["max_k"] = 23
+        expected_error = StorageIntegrityError
+        expected_message = "differs from its exact serialized manifest"
+    else:
+        manifest.indexes["bm25"].status = "failed"
+        manifest.save(manifest_path)
+        manifest_path.chmod(0o600)
+        returned_manifest = manifest
+        expected_error = ValueError
+        expected_message = "no exact current bm25"
+
+    def fake_update(*args, **kwargs):
+        if failure == "source":
+            (fixture.repository / "sample.py").write_text(
+                "VALUE = 2\n",
+                encoding="utf-8",
+            )
+        return returned_manifest
+
+    monkeypatch.setattr(compiler, "_update_repo_locked", fake_update)
+    monkeypatch.setattr(
+        cache_import_module,
+        "_plan_cache_view",
+        lambda *args, **kwargs: pytest.fail("view planning must not run"),
+    )
+    backend = _BackendTripwire()
+    try:
+        with pytest.raises(expected_error, match=expected_message):
+            compile_and_import_repo(
+                compiler,
+                fixture.repository,
+                cache_dir=fixture.cache,
+                views=("bm25",),
+                repository_source=fixture.source,
+                view_output_owners={"bm25": fixture.bm25_owner},
+                context_output_owner=fixture.context_owner,
+                view_destinations={"bm25": fixture.bm25_destination},
+                context_destination=fixture.context_destination,
+                workspace_provider=fixture.provider,
+                repository_key=_REPOSITORY_KEY,
+                catalog=backend,
+                object_store=backend,
+                environ={},
+            )
+        assert backend.calls == ["contract"]
+        assert fixture.provider.support_count == 1
+        assert fixture.provider.run_count == 0
+        assert fixture.bm25_owner.state == "empty"
+        assert fixture.context_owner.state == "empty"
+        assert not fixture.bm25_destination.exists()
+        assert not fixture.context_destination.exists()
+    finally:
+        fixture.close()
+
+
+def test_compile_and_import_postcommit_retry_reuses_exact_current_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    subprocess.run(["git", "init", "-q", str(repository)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repository), "config", "user.email", "test@example.test"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repository), "config", "user.name", "CodeNib Test"],
+        check=True,
+    )
+    (repository / "sample.py").write_text("VALUE = 1\n", encoding="utf-8")
+    commit = _git_commit(repository, "retained-postcommit-retry")
+    cache = tmp_path / "cache"
+    source = capture_repository_source(repository, exclude_roots=(cache,))
+    builder = BM25IndexBuilder(languages=["python"], max_k=17)
+    registry = IndexBuilderRegistry()
+    registry.register("bm25", builder)
+    compiler = IndexCompiler(
+        registry,
+        IndexCompilerConfig(index_types=["bm25"], languages=["python"]),
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    provider = _TestWorkspaceProvider()
+    first_owner = PublishedWorkspaceReceiptOwner()
+    first_context_owner = PublishedWorkspaceReceiptOwner()
+    retry_owner = PublishedWorkspaceReceiptOwner()
+    retry_context_owner = PublishedWorkspaceReceiptOwner()
+    first_destination = workspace / "first-bm25"
+    first_context_destination = workspace / "first-context"
+    retry_destination = workspace / "retry-bm25"
+    retry_context_destination = workspace / "retry-context"
+
+    def publish(
+        *,
+        view_owner: PublishedWorkspaceReceiptOwner,
+        context_owner: PublishedWorkspaceReceiptOwner,
+        view_destination: Path,
+        context_destination: Path,
+        catalog: SQLiteCatalog,
+        object_store: LocalCAS,
+    ) -> CompilerRetainedPublicationResult:
+        return compile_and_import_repo(
+            compiler,
+            repository,
+            cache_dir=cache,
+            views=("bm25",),
+            repository_source=source,
+            view_output_owners={"bm25": view_owner},
+            context_output_owner=context_owner,
+            view_destinations={"bm25": view_destination},
+            context_destination=context_destination,
+            workspace_provider=provider,
+            repository_key=_REPOSITORY_KEY,
+            catalog=catalog,
+            object_store=object_store,
+            expected_generation=0,
+            environ={},
+        )
+
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            _PostCommitInterruptCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            with pytest.raises(RuntimeError, match="postcommit interruption"):
+                publish(
+                    view_owner=first_owner,
+                    context_owner=first_context_owner,
+                    view_destination=first_destination,
+                    context_destination=first_context_destination,
+                    catalog=catalog,
+                    object_store=cas,
+                )
+
+            manifest_path = cache / "repo_manifest.json"
+            manifest_bytes = manifest_path.read_bytes()
+            metadata = manifest_path.stat()
+            manifest_identity = (
+                metadata.st_dev,
+                metadata.st_ino,
+                metadata.st_size,
+                metadata.st_mtime_ns,
+            )
+
+            def unexpected_build(*args, **kwargs):
+                pytest.fail("an exact current-cache retry must not call the builder")
+
+            monkeypatch.setattr(builder, "build", unexpected_build)
+            retry = publish(
+                view_owner=retry_owner,
+                context_owner=retry_context_owner,
+                view_destination=retry_destination,
+                context_destination=retry_context_destination,
+                catalog=catalog,
+                object_store=cas,
+            )
+
+            assert catalog.interrupted_publication is not None
+            assert catalog.interrupted_publication["changed"] is True
+            assert retry.manifest.commit == commit
+            assert retry.import_result.snapshot_id == (
+                catalog.interrupted_publication["snapshot_id"]
+            )
+            assert retry.import_result.generation == (
+                catalog.interrupted_publication["generation"]
+            )
+            assert retry.import_result.generation == 1
+            assert retry.import_result.changed is False
+            assert manifest_path.read_bytes() == manifest_bytes
+            retry_metadata = manifest_path.stat()
+            assert (
+                retry_metadata.st_dev,
+                retry_metadata.st_ino,
+                retry_metadata.st_size,
+                retry_metadata.st_mtime_ns,
+            ) == manifest_identity
+            assert first_destination.is_dir()
+            assert first_context_destination.is_dir()
+            assert retry_destination.is_dir()
+            assert retry_context_destination.is_dir()
+            assert first_owner.active
+            assert first_context_owner.active
+            assert retry_owner.active
+            assert retry_context_owner.active
+            assert source.usable
+    finally:
+        retry_context_owner.close()
+        retry_owner.close()
+        first_context_owner.close()
+        first_owner.close()
+        source.close()
 
 
 def _persist_fixture_source_selection(
@@ -832,13 +1255,14 @@ def test_import_recaptures_inside_cache_lock_and_imports_after_release(
 ) -> None:
     fixture = _cache_fixture(tmp_path)
     lock_state = {"held": False}
+    lock_calls: list[tuple[Path, bool]] = []
     real_lock = cache_import_module.compiler_cache_lock
     real_plan = cache_import_module.plan_repo_manifest_import_bytes
     planned_before_publish = {"value": False}
 
     @contextmanager
     def tracked_lock(cache: Path, *, create: bool = True):
-        assert create is False
+        lock_calls.append((cache, create))
         with real_lock(cache, create=create):
             lock_state["held"] = True
             try:
@@ -915,6 +1339,7 @@ def test_import_recaptures_inside_cache_lock_and_imports_after_release(
             result.recapture.canonical_manifest_bytes
         )
         assert result.recapture.output_view == fixture.bm25_destination
+        assert lock_calls == [(fixture.cache, False)]
         assert fixture.provider.support_count == 3
         assert fixture.provider.run_count == 2
         assert fixture.bm25_owner.active

--- a/test/compiler/test_retained_index_cli_e2e.py
+++ b/test/compiler/test_retained_index_cli_e2e.py
@@ -1,0 +1,280 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import codenib.storage as storage_module
+from codenib import LocalWorkspaceProvider
+from codenib import cli as cli_module
+from codenib._captured_directory import (
+    PublishedWorkspaceReceiptOwner,
+    UnsupportedWorkspaceCreation,
+)
+from codenib.artifacts import query_context_artifact
+from codenib.compiler.manifest import MANIFEST_FILENAME
+from codenib.mcp.context import ServerContext
+from codenib.paths import repo_index_dir
+from codenib.storage import LocalCAS, SQLiteCatalog, StorageIntegrityError
+
+_REPOSITORY_KEY = "owner/retained-index-route"
+_MARKER = "PRODUCTION_RETAINED_INDEX_ROUTE"
+
+
+def _git_commit(repository: Path) -> str:
+    subprocess.run(["git", "init", "-q", os.fspath(repository)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            os.fspath(repository),
+            "config",
+            "user.email",
+            "test@example.test",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            os.fspath(repository),
+            "config",
+            "user.name",
+            "CodeNib Test",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", os.fspath(repository), "add", "sample.py"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", os.fspath(repository), "commit", "-qm", "fixture"],
+        check=True,
+    )
+    return subprocess.run(
+        ["git", "-C", os.fspath(repository), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def test_index_publish_retained_materialize_snapshot_and_query_real_bm25(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    (repository / "sample.py").write_text(
+        f"def retained_index_marker():\n    return {_MARKER!r}\n",
+        encoding="utf-8",
+    )
+    commit = _git_commit(repository)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    workspace.chmod(0o700)
+    provider = LocalWorkspaceProvider(workspace)
+    try:
+        provider.require_support()
+    except UnsupportedWorkspaceCreation as error:
+        pytest.skip(f"native local workspace provider is unavailable: {error}")
+
+    catalog_path = tmp_path / "catalog.sqlite"
+    with SQLiteCatalog(catalog_path):
+        pass
+    cas_root = tmp_path / "cas"
+    with LocalCAS.provision(cas_root):
+        pass
+    codenib_home = tmp_path / "codenib-home"
+    codenib_home.mkdir(mode=0o700)
+    monkeypatch.setenv("CODENIB_HOME", os.fspath(codenib_home))
+
+    nonce = "0123456789abcdef0123456789abcdef"
+    monkeypatch.setattr(cli_module, "_new_compiler_cache_import_nonce", lambda: nonce)
+
+    owners: list[PublishedWorkspaceReceiptOwner] = []
+    stores: list[LocalCAS] = []
+    catalogs: list[SQLiteCatalog] = []
+    real_owner = PublishedWorkspaceReceiptOwner
+    real_store = LocalCAS
+    real_catalog = SQLiteCatalog
+
+    def owner_factory() -> PublishedWorkspaceReceiptOwner:
+        owner = real_owner()
+        owners.append(owner)
+        return owner
+
+    def store_factory(
+        root: str | Path,
+        *,
+        require_preprovisioned: bool = False,
+    ) -> LocalCAS:
+        assert require_preprovisioned is True
+        store = real_store(root, require_preprovisioned=True)
+        stores.append(store)
+        return store
+
+    def catalog_factory(
+        path: str | Path,
+        *,
+        create: bool = True,
+        expected_file_identity: tuple[int, int, int] | None = None,
+    ) -> SQLiteCatalog:
+        assert create is False
+        assert type(expected_file_identity) is tuple
+        opened = real_catalog(
+            path,
+            create=False,
+            expected_file_identity=expected_file_identity,
+        )
+        catalogs.append(opened)
+        return opened
+
+    monkeypatch.setattr(
+        cli_module,
+        "_new_retained_output_receipt_owner",
+        owner_factory,
+    )
+    monkeypatch.setattr(storage_module, "LocalCAS", store_factory)
+    monkeypatch.setattr(storage_module, "SQLiteCatalog", catalog_factory)
+
+    parser = cli_module.build_parser()
+    index_args = parser.parse_args(
+        [
+            "index",
+            os.fspath(repository),
+            "--preset",
+            "fast",
+            "--publish-retained",
+            "--catalog",
+            os.fspath(catalog_path),
+            "--cas-root",
+            os.fspath(cas_root),
+            "--workspace-root",
+            os.fspath(workspace),
+            "--repository",
+            _REPOSITORY_KEY,
+        ]
+    )
+    assert index_args.handler is cli_module._run_index
+    assert index_args.handler(index_args) == 0
+
+    index_output = capsys.readouterr().out
+    snapshot_id = next(
+        line.partition(":")[2].strip()
+        for line in index_output.splitlines()
+        if line.startswith("Retained Snapshot:")
+    )
+    assert snapshot_id
+    assert "Retained Generation: 1" in index_output
+    assert "Retained Views:      bm25" in index_output
+
+    prefix = f".codenib-cache-import-{nonce}"
+    bm25_evidence = workspace / f"{prefix}-bm25"
+    context_evidence = workspace / f"{prefix}-context"
+    suggested_output = workspace / f"{prefix}-materialized"
+    materialized_output = workspace / "materialized"
+    cache = repo_index_dir(repository)
+    assert (cache / MANIFEST_FILENAME).is_file()
+    assert (cache / "bm25").is_dir()
+    assert bm25_evidence.is_dir()
+    assert context_evidence.is_dir()
+    assert not suggested_output.exists()
+    assert not materialized_output.exists()
+
+    assert len(owners) == 2
+    assert all(owner.closed for owner in owners)
+    assert len(stores) == 1
+    with pytest.raises(StorageIntegrityError, match="closed"):
+        stores[0].has("0" * 64)
+    assert len(catalogs) == 1
+    with pytest.raises(sqlite3.ProgrammingError):
+        catalogs[0]._connection.execute("SELECT 1")
+
+    materialize_args = parser.parse_args(
+        [
+            "artifact",
+            "materialize",
+            "--catalog",
+            os.fspath(catalog_path),
+            "--cas-root",
+            os.fspath(cas_root),
+            "--workspace-root",
+            os.fspath(workspace),
+            "--repository",
+            _REPOSITORY_KEY,
+            "--snapshot",
+            snapshot_id,
+            "--output",
+            os.fspath(materialized_output),
+        ]
+    )
+    assert materialize_args.handler is cli_module._run_artifact_materialize
+    assert materialize_args.handler(materialize_args) == 0
+
+    materialize_output = capsys.readouterr().out
+    assert f"Snapshot:         {snapshot_id}" in materialize_output
+    assert "Views:            bm25" in materialize_output
+    assert materialized_output.is_dir()
+    assert (materialized_output / "views/bm25").is_dir()
+    assert bm25_evidence.is_dir()
+    assert context_evidence.is_dir()
+
+    assert len(owners) == 3
+    assert all(owner.closed for owner in owners)
+    assert len(stores) == 2
+    for store in stores:
+        with pytest.raises(StorageIntegrityError, match="closed"):
+            store.has("0" * 64)
+    assert len(catalogs) == 2
+    for catalog in catalogs:
+        with pytest.raises(sqlite3.ProgrammingError):
+            catalog._connection.execute("SELECT 1")
+
+    binding = query_context_artifact(
+        materialized_output,
+        expected_repository=_REPOSITORY_KEY,
+        expected_commit=commit,
+    )
+    context: ServerContext | None = None
+    try:
+        assert tuple(binding.manifest.indexes) == ("bm25",)
+        context = ServerContext.load(
+            binding.manifest,
+            views=("bm25",),
+            artifact_binding=binding,
+        )
+        assert context.errors == {}
+        assert context.loaded_views == frozenset({"bm25"})
+        assert context.bm25 is not None
+        hits = context.bm25.search(
+            _MARKER,
+            top_k=5,
+            return_code_content=True,
+        )
+        assert hits
+        assert hits[0].file == "sample.py"
+        normalized_marker = _MARKER.lower().replace("_", " ")
+        assert any(
+            normalized_marker in document.page_content
+            for document in context.bm25.documents
+        )
+    finally:
+        if context is not None:
+            context.close()
+        binding.close()
+
+    assert materialized_output.is_dir()
+    assert bm25_evidence.is_dir()
+    assert context_evidence.is_dir()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -97,6 +97,201 @@ def test_index_parser_accepts_exact_source_exclusions() -> None:
     assert args.clear_exclude_dirs is False
 
 
+def test_index_parser_exposes_retained_publication_as_an_explicit_group() -> None:
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "index",
+            "/src/repo",
+            "--preset",
+            "fast",
+            "--publish-retained",
+            "--catalog",
+            "/state/catalog.sqlite3",
+            "--cas-root",
+            "/state/cas",
+            "--workspace-root",
+            "/state/workspaces",
+            "--repository",
+            "owner/repo",
+            "--namespace",
+            "production",
+            "--ref",
+            "release",
+            "--expected-generation",
+            "7",
+        ]
+    )
+    defaults = parser.parse_args(["index", "/src/repo", "--preset", "fast"])
+
+    assert args.publish_retained is True
+    assert args.catalog == "/state/catalog.sqlite3"
+    assert args.cas_root == "/state/cas"
+    assert args.workspace_root == "/state/workspaces"
+    assert args.repository == "owner/repo"
+    assert args.namespace == "production"
+    assert args.ref == "release"
+    assert args.expected_generation == 7
+    assert defaults.publish_retained is False
+    assert defaults.catalog is None
+    assert defaults.cas_root is None
+    assert defaults.workspace_root is None
+    assert defaults.repository is None
+    assert defaults.namespace is None
+    assert defaults.ref is None
+    assert defaults.expected_generation is None
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["index", ".", "--catalog", "/state/catalog.sqlite3"],
+        ["index", ".", "--publish-retained", "--catalog", "/state/catalog.sqlite3"],
+    ],
+)
+def test_index_retained_arguments_are_all_or_none_before_repository_work(
+    argv: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = cli.build_parser().parse_args(argv)
+    monkeypatch.setattr(
+        cli,
+        "resolve_repo_path",
+        lambda _value: pytest.fail("retained option validation must run first"),
+    )
+
+    with pytest.raises(cli.CLIError, match="--publish-retained"):
+        cli._run_index(args)
+
+
+def test_publish_repository_identity_does_not_enable_retained_index(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib import artifacts as artifacts_module
+    from codenib.compiler import manifest as manifest_module
+    from codenib.web import static_export as static_export_module
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    args = cli.build_parser().parse_args(
+        [
+            "publish",
+            str(repo),
+            "--preset",
+            "fast",
+            "--repository",
+            "owner/repo",
+        ]
+    )
+    selection = RepositorySourceSelection()
+    manifest = SimpleNamespace(
+        repo_path=str(repo),
+        languages=["python"],
+        source_selection=selection,
+        indexes={"bm25": SimpleNamespace(status="fresh", metadata={})},
+        commit="a" * 40,
+    )
+    indexed: list[dict[str, object]] = []
+
+    monkeypatch.setattr(cli, "resolve_repo_path", lambda _value: repo)
+    monkeypatch.setattr(
+        cli, "_validate_publish_outputs", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        cli,
+        "_resolve_repository_source_selection",
+        lambda *_args, **_kwargs: SimpleNamespace(selection=selection),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_require_clean_artifact_checkout",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(cli, "_selected_views_for_args", lambda _args: ["bm25"])
+    monkeypatch.setattr(
+        cli, "_selected_languages", lambda *_args, **_kwargs: ["python"]
+    )
+    monkeypatch.setattr(cli, "_check_view_dependencies", lambda *_args, **_kwargs: None)
+
+    def index_repository(_repo: Path, **kwargs: object):
+        indexed.append(kwargs)
+        return manifest, []
+
+    monkeypatch.setattr(cli, "index_repository", index_repository)
+    monkeypatch.setattr(
+        cli,
+        "resolve_manifest_path",
+        lambda _value: tmp_path / "repo_manifest.json",
+    )
+
+    class FakeRepoManifest:
+        @staticmethod
+        def load(_path: Path) -> object:
+            return manifest
+
+    monkeypatch.setattr(manifest_module, "RepoManifest", FakeRepoManifest)
+    monkeypatch.setattr(
+        static_export_module,
+        "export_static_wiki",
+        lambda *_args, **_kwargs: SimpleNamespace(output_dir=tmp_path / "wiki"),
+    )
+    monkeypatch.setattr(
+        artifacts_module,
+        "stage_context_artifact",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            output_dir=tmp_path / "context",
+            repository="owner/repo",
+            commit=manifest.commit,
+            views=("bm25",),
+        ),
+    )
+    monkeypatch.setattr(cli, "_publication_environment", lambda *_args: {})
+
+    assert args.handler is cli._run_publish
+    assert args.handler(args) == 0
+    assert len(indexed) == 1
+    assert indexed[0]["views"] == ["bm25"]
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        ["--rebuild"],
+        ["--view", "symbol_graph"],
+        ["--view", "zoekt"],
+    ],
+)
+def test_index_retained_rejects_unsupported_build_modes_before_repository_work(
+    extra: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = cli.build_parser().parse_args(
+        [
+            "index",
+            ".",
+            "--publish-retained",
+            "--catalog",
+            "/state/catalog.sqlite3",
+            "--cas-root",
+            "/state/cas",
+            "--workspace-root",
+            "/state/workspaces",
+            "--repository",
+            "owner/repo",
+            *extra,
+        ]
+    )
+    monkeypatch.setattr(
+        cli,
+        "resolve_repo_path",
+        lambda _value: pytest.fail("unsupported retained mode must fail first"),
+    )
+
+    with pytest.raises(cli.CLIError, match="not supported|supports only"):
+        cli._run_index(args)
+
+
 def test_source_selection_flags_are_mutually_exclusive() -> None:
     with pytest.raises(SystemExit) as exc_info:
         cli.build_parser().parse_args(
@@ -452,6 +647,320 @@ def _cache_import_cli_test_args(tmp_path: Path) -> SimpleNamespace:
         expected_generation=0,
         view=[],
     )
+
+
+def _retained_index_cli_test_args(tmp_path: Path) -> SimpleNamespace:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.py").write_text("VALUE = 1\n")
+    catalog = tmp_path / "catalog.sqlite3"
+    catalog.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir(mode=0o700)
+    return SimpleNamespace(
+        repo=str(repo),
+        preset="fast",
+        language=[],
+        view=[],
+        rebuild=False,
+        exclude_dir=None,
+        clear_exclude_dirs=False,
+        publish_retained=True,
+        catalog=str(catalog),
+        cas_root=str(cas_root),
+        workspace_root=str(workspace_root),
+        repository="owner/repo",
+        namespace=None,
+        ref=None,
+        expected_generation=None,
+    )
+
+
+def test_index_retained_uses_one_core_route_and_ordered_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from codenib.paths import repo_index_dir
+
+    args = _retained_index_cli_test_args(tmp_path)
+    repo = Path(args.repo)
+    catalog_path = Path(args.catalog).resolve(strict=True)
+    cas_root = Path(args.cas_root).resolve(strict=True)
+    workspace_root = Path(args.workspace_root).resolve(strict=True)
+    monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "state"))
+    canonical_cache = Path(os.path.abspath(os.fspath(repo_index_dir(repo))))
+    canonical_cache.parent.mkdir(parents=True)
+    nonce = "1" * 32
+    monkeypatch.setattr(cli, "_new_compiler_cache_import_nonce", lambda: nonce)
+    bm25_destination = workspace_root / f".codenib-cache-import-{nonce}-bm25"
+    vector_destination = workspace_root / f".codenib-cache-import-{nonce}-vector"
+    context_destination = workspace_root / f".codenib-cache-import-{nonce}-context"
+    suggested = workspace_root / f".codenib-cache-import-{nonce}-materialized"
+    events: list[str] = []
+    topology_modes: list[bool] = []
+
+    class Provider:
+        def __init__(self, root: Path) -> None:
+            assert root == workspace_root
+            events.append("provider")
+
+        def require_support(self) -> None:
+            events.append("provider-support")
+
+    class Closeable:
+        def __init__(self, label: str) -> None:
+            self.label = label
+            self.closed = False
+
+        def close(self) -> None:
+            events.append(f"{self.label}-close")
+            self.closed = True
+
+    bm25_owner = Closeable("bm25")
+    vector_owner = Closeable("vector")
+    context_owner = Closeable("context")
+    source = Closeable("source")
+    store = Closeable("cas")
+    catalog = Closeable("catalog")
+    receipt_owners = iter((bm25_owner, vector_owner, context_owner))
+    catalog_identity = cli._retained_catalog_file_identity(catalog_path)
+    storage_topology = cli._CompilerRetainedStorageTopology(
+        repo_path=repo.resolve(strict=True),
+        repository_identity=cli._retained_real_directory_identity(
+            repo.resolve(strict=True),
+            label="repository",
+        ),
+        planned_cache_path=canonical_cache,
+        cache_parent_path=canonical_cache.parent,
+        cache_parent_identity=cli._retained_real_directory_identity(
+            canonical_cache.parent,
+            label="cache parent",
+        ),
+        catalog_path=catalog_path,
+        catalog_identity=catalog_identity,
+        cas_root=cas_root,
+        cas_identity=(1, 20),
+        workspace_root=workspace_root,
+        workspace_identity=(1, 30),
+    )
+    cache_topology = cli._CompilerCacheImportTopology(
+        cache_dir=canonical_cache,
+        cache_identity=(1, 10),
+        catalog_path=catalog_path,
+        catalog_identity=catalog_identity,
+        cas_root=cas_root,
+        cas_identity=(1, 20),
+        workspace_root=workspace_root,
+        workspace_identity=(1, 30),
+    )
+
+    def capture(
+        root: Path,
+        *,
+        exclude_roots: tuple[Path, ...],
+        selection: RepositorySourceSelection,
+        _source_owner,
+    ) -> Closeable:
+        events.append("capture")
+        assert root == repo
+        assert canonical_cache in exclude_roots
+        assert selection == RepositorySourceSelection()
+        _source_owner(source)
+        return source
+
+    def prepare(root: Path, **kwargs: object) -> tuple[object, Path]:
+        events.append("prepare")
+        assert root == repo
+        assert kwargs["views"] == ["bm25", "vector"]
+        return object(), canonical_cache
+
+    def observe_topology(
+        _paths: object,
+        *,
+        allow_published_outputs: bool = False,
+    ) -> object:
+        topology_modes.append(allow_published_outputs)
+        return cache_topology
+
+    def compile_and_import(
+        _compiler: object,
+        root: Path,
+        *,
+        cache_dir: Path,
+        cache_topology_guard: object,
+        **kwargs: object,
+    ) -> SimpleNamespace:
+        events.append("core")
+        assert root == repo
+        assert cache_dir == canonical_cache
+        assert kwargs["views"] == ("bm25", "vector")
+        assert kwargs["repository_source"] is source
+        assert kwargs["view_output_owners"] == {
+            "bm25": bm25_owner,
+            "vector": vector_owner,
+        }
+        assert kwargs["context_output_owner"] is context_owner
+        assert kwargs["repository_key"] == "owner/repo"
+        assert kwargs["namespace_name"] == "default"
+        assert kwargs["ref_name"] == "main"
+        assert kwargs["expected_generation"] == 0
+        canonical_cache.mkdir()
+        cache_topology_guard.capture(canonical_cache)
+        cache_topology_guard.verify(canonical_cache)
+        bm25_destination.mkdir()
+        vector_destination.mkdir()
+        context_destination.mkdir()
+        cache_topology_guard.verify(canonical_cache)
+        entry = SimpleNamespace(status="fresh", metadata={})
+        return SimpleNamespace(
+            manifest=SimpleNamespace(
+                repo_path=str(repo),
+                languages=["python"],
+                source_selection=RepositorySourceSelection(),
+                indexes={"bm25": entry, "vector": entry},
+            ),
+            retained_import=SimpleNamespace(
+                import_result=SimpleNamespace(
+                    snapshot_id="snapshot-id",
+                    ref_name="main",
+                    generation=1,
+                )
+            ),
+        )
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(
+        cli,
+        "_require_compiler_retained_storage_topology",
+        lambda _paths: storage_topology,
+    )
+    monkeypatch.setattr(
+        cli,
+        "_require_compiler_cache_import_topology",
+        observe_topology,
+    )
+    monkeypatch.setattr(
+        cli,
+        "_new_retained_output_receipt_owner",
+        lambda: next(receipt_owners),
+    )
+    monkeypatch.setattr(source_fingerprint_module, "capture_repository_source", capture)
+    monkeypatch.setattr(cli, "_prepare_index_compiler", prepare)
+    monkeypatch.setattr(
+        storage_module,
+        "LocalCAS",
+        lambda *_args, **_kwargs: events.append("cas-open") or store,
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "SQLiteCatalog",
+        lambda *_args, **_kwargs: events.append("catalog-open") or catalog,
+    )
+    monkeypatch.setattr(
+        cache_import_module,
+        "compile_and_import_repo",
+        compile_and_import,
+    )
+
+    result = cli._run_index_retained(
+        args,
+        repo_path=repo,
+        selection=cli._RetainedIndexSelection("owner/repo", "default", "main", 0),
+        compiler_kwargs={
+            "languages": ["python"],
+            "views": ["bm25", "vector"],
+            "source_selection": RepositorySourceSelection(),
+        },
+    )
+
+    assert result == 0
+    assert topology_modes == [False, False, True]
+    assert events.index("cas-open") < events.index("catalog-open")
+    assert events.index("catalog-open") < events.index("capture")
+    assert events.index("capture") < events.index("prepare") < events.index("core")
+    assert events[-6:] == [
+        "catalog-close",
+        "cas-close",
+        "context-close",
+        "vector-close",
+        "bm25-close",
+        "source-close",
+    ]
+    assert not suggested.exists()
+    output = capsys.readouterr().out
+    assert "Retained Snapshot:   snapshot-id" in output
+    assert "Retained Ref:        main" in output
+    assert "Retained Generation: 1" in output
+    assert "Retained Views:      bm25,vector" in output
+    assert f"BM25 evidence:       {bm25_destination}" in output
+    assert f"Vector evidence:     {vector_destination}" in output
+    assert f"Context evidence:    {context_destination}" in output
+    assert "Materialize snapshot: codenib artifact materialize" in output
+    assert "--snapshot snapshot-id" in output
+
+
+def test_index_retained_rejects_missing_cache_parent_symlink_before_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.paths import repo_index_dir
+
+    args = _retained_index_cli_test_args(tmp_path)
+    repo = Path(args.repo)
+    cas_root = Path(args.cas_root)
+    aliased_home = tmp_path / "aliased-state"
+    aliased_home.symlink_to(cas_root, target_is_directory=True)
+    monkeypatch.setenv("CODENIB_HOME", str(aliased_home))
+    canonical_cache = Path(os.path.abspath(os.fspath(repo_index_dir(repo))))
+    assert not canonical_cache.exists()
+    before = tuple(cas_root.iterdir())
+    monkeypatch.setattr(cli, "_new_compiler_cache_import_nonce", lambda: "2" * 32)
+    monkeypatch.setattr(
+        cli,
+        "_prepare_index_compiler",
+        lambda *_args, **_kwargs: pytest.fail("compiler must not be prepared"),
+    )
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "capture_repository_source",
+        lambda *_args, **_kwargs: pytest.fail("source must not be captured"),
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "LocalCAS",
+        lambda *_args, **_kwargs: pytest.fail("CAS must not be opened"),
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "SQLiteCatalog",
+        lambda *_args, **_kwargs: pytest.fail("catalog must not be opened"),
+    )
+
+    with pytest.raises(
+        cli.CLIError,
+        match="cache path must contain only existing real directories",
+    ):
+        cli._run_index_retained(
+            args,
+            repo_path=repo,
+            selection=cli._RetainedIndexSelection(
+                "owner/repo",
+                "default",
+                "main",
+                0,
+            ),
+            compiler_kwargs={
+                "languages": ["python"],
+                "views": ["bm25"],
+                "source_selection": RepositorySourceSelection(),
+            },
+        )
+
+    assert tuple(cas_root.iterdir()) == before
+    assert not canonical_cache.exists()
 
 
 def test_artifact_import_cache_retains_failed_topology_cleanup_for_retry(


### PR DESCRIPTION
## Summary

Add an explicit offline dual-write route from normal `codenib index` builds
into retained SQLite/LocalCAS storage. Legacy index behavior remains unchanged
unless `--publish-retained` is selected.

Related to #199. M1 remains in progress: catalog-selected cold-start runtime
routing and benchmark-backed default promotion are still outstanding.

## Changes

- Add `compile_and_import_repo`, keeping update-or-create, exact persisted
  manifest binding, selected BM25/vector recapture, and context publication
  under one compiler-cache lease.
- Release the compiler lease before retained CAS/catalog data-plane operations,
  while allowing support checks, existing-storage opens, and static contract
  probes beforehand.
- Add explicit `codenib index --publish-retained` storage identity, ref CAS,
  topology, ownership, cleanup, and immutable snapshot handoff behavior.
- Reject rebuilds, unsupported views, cache/storage aliases, and identity or
  topology drift; preserve exact postcommit retry with fresh evidence and the
  original expected ref generation.
- Cover lease ordering, fail-closed drift, cleanup retention, exact retry,
  unchanged legacy routes, and a real Git → BM25 index → retained snapshot →
  materialization → `ServerContext` query round trip.
- Document the offline benchmark gate, trust boundary, retry contract, and
  remaining M1/M2/M3 work.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Unit tier: `6722 passed, 71 skipped, 190 deselected`
- Final route-focused matrix: `22 passed`
- Complete compiler-cache importer module: `34 passed`
- Complete CLI module: `126 passed`
- Related retained/compiler/artifact matrix: `893 passed`
- Real BM25 retained-index, snapshot materialization, and query round trip
- Black, isort, flake8, and `git diff --check`
- `mkdocs build --strict` and `scripts/check_public_docs.py`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
