### PR TITLE
feat(wiki): add server-side media evidence packs

### DIFF
--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -451,7 +451,7 @@ async def wiki_page(
                 "relation_count": 0,
             },
         }
-    return page
+    return redact_media_evidence_packs(page)
 
 
 @app.get("/api/repos/{repo_id}/wiki-media/{page_id}/{filename:path}")

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -21,6 +21,7 @@ import argparse
 import asyncio
 import hashlib
 import os
+from collections.abc import Mapping
 from contextlib import asynccontextmanager
 from functools import partial
 from pathlib import Path, PurePosixPath
@@ -37,6 +38,7 @@ from ..log_utils import get_logger
 from ..repository_filters import repository_path_is_visible
 from ..repository_source_selection import RepositorySourceSelection
 from ..wiki import WikiBuilder
+from ..wiki.media_evidence import build_media_evidence_pack
 from ..wiki.media_generation import (
     image_generator_from_config,
     materialize_media_slots,
@@ -253,6 +255,38 @@ def _wiki_media_dir(config, repo_id: str, page_id: str) -> Path:
     return root / repo_key / page_key
 
 
+def _wiki_media_source_snippet(source_reader, citation: Mapping) -> str | None:
+    source = bound_source_slice(
+        source_reader,
+        str(citation.get("file") or ""),
+        citation.get("start_line"),
+        citation.get("end_line"),
+    )
+    if not isinstance(source, Mapping):
+        return None
+    return str(source.get("content") or "") or None
+
+
+def _wiki_media_evidence_builder(bundle, page: Mapping):
+    evidence = page.get("evidence")
+    relations = evidence.get("relations") or () if isinstance(evidence, Mapping) else ()
+    source_reader = getattr(bundle, "source_reader", None)
+    source_loader = (
+        partial(_wiki_media_source_snippet, source_reader)
+        if source_reader is not None
+        else None
+    )
+    return partial(
+        build_media_evidence_pack,
+        page_id=str(page.get("id") or ""),
+        page_title=str(page.get("title") or ""),
+        page_markdown=str(page.get("markdown") or ""),
+        citations=page.get("citations") or (),
+        relations=relations,
+        source_reader=source_loader,
+    )
+
+
 def _materialize_wiki_media(repo_id: str, page_id: str, page: dict) -> dict:
     """Attach generated media assets when a wiki media provider is configured."""
 
@@ -271,6 +305,7 @@ def _materialize_wiki_media(repo_id: str, page_id: str, page: dict) -> dict:
             generator=generator,
             output_dir=_wiki_media_dir(config, repo_id, page_id),
             asset_base_path=asset_base,
+            evidence_builder=_wiki_media_evidence_builder(_bundle(repo_id), page),
         )
     except MemoryError:
         raise

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -41,6 +41,7 @@ from ..wiki.media_generation import (
     image_generator_from_config,
     materialize_media_slots,
     read_generated_media_asset,
+    redact_media_evidence_packs,
 )
 from ..wiki.narrator import Narrator
 from .config import load_config
@@ -255,10 +256,11 @@ def _wiki_media_dir(config, repo_id: str, page_id: str) -> Path:
 def _materialize_wiki_media(repo_id: str, page_id: str, page: dict) -> dict:
     """Attach generated media assets when a wiki media provider is configured."""
 
+    public_page = redact_media_evidence_packs(page)
     config = load_config()
     generator = image_generator_from_config(config)
     if generator is None:
-        return page
+        return public_page
     try:
         asset_base = (
             f"api/repos/{quote(repo_id, safe='')}/wiki-media/"
@@ -280,7 +282,7 @@ def _materialize_wiki_media(repo_id: str, page_id: str, page: dict) -> dict:
             exc,
             exc_info=True,
         )
-        return page
+        return public_page
 
 
 def _safe_media_filename(value: str) -> str:

--- a/codenib/wiki/media_evidence.py
+++ b/codenib/wiki/media_evidence.py
@@ -1,0 +1,266 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Server-side evidence packs for VLM-ready wiki media generation."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable, Iterable, Mapping
+
+_MAX_TEXT_BYTES = 4096
+_MAX_PAGE_SUMMARY_BYTES = 1024
+_DEFAULT_MAX_SOURCES = 6
+_DEFAULT_MAX_RELATIONS = 12
+_DEFAULT_MAX_SNIPPET_BYTES = 1200
+
+SourceReader = Callable[[Mapping[str, Any]], str | None]
+
+
+@dataclass(frozen=True)
+class WikiMediaSourceEvidence:
+    """One bounded source citation made available to a media generator."""
+
+    file: str
+    symbol: str = ""
+    start_line: int | None = None
+    end_line: int | None = None
+    snippet: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class WikiMediaRelationEvidence:
+    """One compact graph/fact relation made available to a media generator."""
+
+    source: str
+    target: str
+    relation: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class WikiMediaEvidencePack:
+    """Structured, source-grounded VLM input for one planned media slot."""
+
+    slot_id: str
+    kind: str
+    title: str
+    purpose: str
+    page: dict[str, str]
+    sources: tuple[WikiMediaSourceEvidence, ...] = ()
+    relations: tuple[WikiMediaRelationEvidence, ...] = ()
+    human_prior: dict[str, Any] = field(default_factory=dict)
+    output_requirements: tuple[str, ...] = (
+        "Use only the provided source citations and relation evidence.",
+        "Prefer a deterministic teaching structure over decorative imagery.",
+        "Keep labels grounded in source files, symbols, routes, or relations.",
+        "Preserve provenance so the generated asset can be audited later.",
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["sources"] = [source.to_dict() for source in self.sources]
+        data["relations"] = [relation.to_dict() for relation in self.relations]
+        data["output_requirements"] = list(self.output_requirements)
+        return data
+
+
+def build_media_evidence_pack(
+    slot: Mapping[str, Any],
+    *,
+    page_id: str = "",
+    page_title: str = "",
+    page_markdown: str = "",
+    citations: Iterable[Mapping[str, Any]] = (),
+    relations: Iterable[Mapping[str, Any]] = (),
+    source_reader: SourceReader | None = None,
+    max_sources: int = _DEFAULT_MAX_SOURCES,
+    max_relations: int = _DEFAULT_MAX_RELATIONS,
+    max_snippet_bytes: int = _DEFAULT_MAX_SNIPPET_BYTES,
+) -> dict[str, Any]:
+    """Build a bounded, provider-neutral evidence pack for one media slot.
+
+    This helper does not read repository files by itself. Callers may pass a
+    ``source_reader`` that returns small snippets for already-selected
+    citations, which keeps source exposure explicitly server-side and bounded.
+    """
+
+    pack = WikiMediaEvidencePack(
+        slot_id=_safe_text(slot.get("id")),
+        kind=_safe_text(slot.get("kind")),
+        title=_safe_text(slot.get("title")),
+        purpose=_safe_text(slot.get("purpose")),
+        page={
+            "id": _safe_text(page_id),
+            "title": _safe_text(page_title),
+            "summary": _page_summary(page_markdown),
+        },
+        sources=_source_evidence(
+            slot,
+            citations,
+            source_reader=source_reader,
+            max_sources=max_sources,
+            max_snippet_bytes=max_snippet_bytes,
+        ),
+        relations=_relation_evidence(relations, max_relations=max_relations),
+        human_prior=_human_prior(slot.get("human_prior")),
+    )
+    return pack.to_dict()
+
+
+def _source_evidence(
+    slot: Mapping[str, Any],
+    citations: Iterable[Mapping[str, Any]],
+    *,
+    source_reader: SourceReader | None,
+    max_sources: int,
+    max_snippet_bytes: int,
+) -> tuple[WikiMediaSourceEvidence, ...]:
+    allowed_files = {
+        file
+        for file in (_safe_file(value) for value in slot.get("source_citations") or ())
+        if file
+    }
+    evidence: list[WikiMediaSourceEvidence] = []
+    seen: set[tuple[str, str, int | None, int | None]] = set()
+    for citation in citations or ():
+        if not isinstance(citation, Mapping):
+            continue
+        file = _safe_file(citation.get("file"))
+        if not file or (allowed_files and file not in allowed_files):
+            continue
+        symbol = _safe_text(citation.get("symbol") or citation.get("name"))
+        start_line = _positive_int(citation.get("start_line") or citation.get("line"))
+        end_line = _positive_int(citation.get("end_line"))
+        key = (file, symbol, start_line, end_line)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        snippet = _safe_text(citation.get("snippet"), max_bytes=max_snippet_bytes)
+        if source_reader is not None and not snippet:
+            snippet = _safe_text(source_reader(citation), max_bytes=max_snippet_bytes)
+        evidence.append(
+            WikiMediaSourceEvidence(
+                file=file,
+                symbol=symbol,
+                start_line=start_line,
+                end_line=end_line,
+                snippet=snippet,
+            )
+        )
+        if len(evidence) >= max(0, max_sources):
+            break
+    return tuple(evidence)
+
+
+def _relation_evidence(
+    relations: Iterable[Mapping[str, Any]],
+    *,
+    max_relations: int,
+) -> tuple[WikiMediaRelationEvidence, ...]:
+    evidence: list[WikiMediaRelationEvidence] = []
+    seen: set[tuple[str, str, str]] = set()
+    for relation in relations or ():
+        if not isinstance(relation, Mapping):
+            continue
+        source = _safe_text(
+            relation.get("source")
+            or relation.get("source_symbol")
+            or relation.get("from")
+        )
+        target = _safe_text(
+            relation.get("target")
+            or relation.get("target_symbol")
+            or relation.get("to")
+        )
+        kind = _safe_text(relation.get("relation") or relation.get("kind") or "related")
+        if not source or not target:
+            continue
+        key = (source, target, kind)
+        if key in seen:
+            continue
+        seen.add(key)
+        evidence.append(WikiMediaRelationEvidence(source, target, kind))
+        if len(evidence) >= max(0, max_relations):
+            break
+    return tuple(evidence)
+
+
+def _page_summary(markdown: str) -> str:
+    lines = []
+    for raw_line in str(markdown or "").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        lines.append(line)
+        if len(" ".join(lines).encode("utf-8")) >= _MAX_PAGE_SUMMARY_BYTES:
+            break
+    return _safe_text(" ".join(lines), max_bytes=_MAX_PAGE_SUMMARY_BYTES)
+
+
+def _human_prior(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {"editable": True, "notes": []}
+    result: dict[str, Any] = {}
+    for key, item in value.items():
+        safe_key = _safe_text(key, max_bytes=128)
+        if safe_key:
+            result[safe_key] = _bounded_json_value(item)
+    return result
+
+
+def _bounded_json_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            key: _bounded_json_value(item)
+            for raw_key, item in value.items()
+            if (key := _safe_text(raw_key, max_bytes=128))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_bounded_json_value(item) for item in value[:16]]
+    if isinstance(value, str):
+        return _safe_text(value)
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    return _safe_text(value)
+
+
+def _safe_file(value: Any) -> str:
+    file = _safe_text(value)
+    if not file or any(ord(character) < 0x20 for character in file):
+        return ""
+    return file
+
+
+def _safe_text(value: Any, *, max_bytes: int = _MAX_TEXT_BYTES) -> str:
+    text = str(value or "").strip()
+    if len(text.encode("utf-8")) <= max_bytes:
+        return text
+    encoded = text.encode("utf-8")[: max(0, max_bytes - 1)]
+    return encoded.decode("utf-8", errors="ignore").rstrip() + "…"
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    return number if number > 0 else None
+
+
+__all__ = [
+    "SourceReader",
+    "WikiMediaEvidencePack",
+    "WikiMediaRelationEvidence",
+    "WikiMediaSourceEvidence",
+    "build_media_evidence_pack",
+]

--- a/codenib/wiki/media_evidence.py
+++ b/codenib/wiki/media_evidence.py
@@ -6,7 +6,11 @@
 
 from __future__ import annotations
 
+import json
+import math
 from dataclasses import asdict, dataclass, field
+from itertools import islice
+from pathlib import PurePosixPath, PureWindowsPath
 from typing import Any, Callable, Iterable, Mapping
 
 _MAX_TEXT_BYTES = 4096
@@ -14,6 +18,10 @@ _MAX_PAGE_SUMMARY_BYTES = 1024
 _DEFAULT_MAX_SOURCES = 6
 _DEFAULT_MAX_RELATIONS = 12
 _DEFAULT_MAX_SNIPPET_BYTES = 1200
+_MAX_INPUT_CANDIDATES = 256
+_MAX_HUMAN_PRIOR_DEPTH = 4
+_MAX_HUMAN_PRIOR_ITEMS = 16
+MAX_MEDIA_EVIDENCE_PACK_BYTES = 24 * 1024
 
 SourceReader = Callable[[Mapping[str, Any]], str | None]
 
@@ -91,6 +99,17 @@ def build_media_evidence_pack(
     citations, which keeps source exposure explicitly server-side and bounded.
     """
 
+    max_sources = _validated_limit(
+        max_sources, name="max_sources", maximum=_DEFAULT_MAX_SOURCES
+    )
+    max_relations = _validated_limit(
+        max_relations, name="max_relations", maximum=_DEFAULT_MAX_RELATIONS
+    )
+    max_snippet_bytes = _validated_limit(
+        max_snippet_bytes,
+        name="max_snippet_bytes",
+        maximum=_DEFAULT_MAX_SNIPPET_BYTES,
+    )
     pack = WikiMediaEvidencePack(
         slot_id=_safe_text(slot.get("id")),
         kind=_safe_text(slot.get("kind")),
@@ -111,7 +130,20 @@ def build_media_evidence_pack(
         relations=_relation_evidence(relations, max_relations=max_relations),
         human_prior=_human_prior(slot.get("human_prior")),
     )
-    return pack.to_dict()
+    data = pack.to_dict()
+    try:
+        encoded = json.dumps(
+            data,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    except (RecursionError, TypeError, ValueError) as exc:
+        raise ValueError("wiki media evidence pack must contain bounded JSON") from exc
+    if len(encoded) > MAX_MEDIA_EVIDENCE_PACK_BYTES:
+        raise ValueError("wiki media evidence pack exceeds the byte limit")
+    return data
 
 
 def _source_evidence(
@@ -122,30 +154,40 @@ def _source_evidence(
     max_sources: int,
     max_snippet_bytes: int,
 ) -> tuple[WikiMediaSourceEvidence, ...]:
+    if max_sources == 0:
+        return ()
+    selected_files = _slot_source_citations(slot)
+    restrict_to_selected_files = bool(selected_files)
     allowed_files = {
-        file
-        for file in (_safe_file(value) for value in slot.get("source_citations") or ())
-        if file
+        file for file in (_safe_file(value) for value in selected_files) if file
     }
     evidence: list[WikiMediaSourceEvidence] = []
     seen: set[tuple[str, str, int | None, int | None]] = set()
-    for citation in citations or ():
-        if not isinstance(citation, Mapping):
-            continue
+    for citation in _mapping_candidates(citations, label="citations"):
         file = _safe_file(citation.get("file"))
-        if not file or (allowed_files and file not in allowed_files):
+        if not file or (restrict_to_selected_files and file not in allowed_files):
             continue
         symbol = _safe_text(citation.get("symbol") or citation.get("name"))
         start_line = _positive_int(citation.get("start_line") or citation.get("line"))
         end_line = _positive_int(citation.get("end_line"))
+        if end_line is not None and (start_line is None or end_line < start_line):
+            continue
         key = (file, symbol, start_line, end_line)
         if key in seen:
             continue
         seen.add(key)
 
         snippet = _safe_text(citation.get("snippet"), max_bytes=max_snippet_bytes)
-        if source_reader is not None and not snippet:
-            snippet = _safe_text(source_reader(citation), max_bytes=max_snippet_bytes)
+        if source_reader is not None and max_snippet_bytes and not snippet:
+            reader_citation = {
+                "file": file,
+                "symbol": symbol,
+                "start_line": start_line,
+                "end_line": end_line,
+            }
+            snippet = _safe_text(
+                source_reader(reader_citation), max_bytes=max_snippet_bytes
+            )
         evidence.append(
             WikiMediaSourceEvidence(
                 file=file,
@@ -165,11 +207,11 @@ def _relation_evidence(
     *,
     max_relations: int,
 ) -> tuple[WikiMediaRelationEvidence, ...]:
+    if max_relations == 0:
+        return ()
     evidence: list[WikiMediaRelationEvidence] = []
     seen: set[tuple[str, str, str]] = set()
-    for relation in relations or ():
-        if not isinstance(relation, Mapping):
-            continue
+    for relation in _mapping_candidates(relations, label="relations"):
         source = _safe_text(
             relation.get("source")
             or relation.get("source_symbol")
@@ -180,7 +222,7 @@ def _relation_evidence(
             or relation.get("target_symbol")
             or relation.get("to")
         )
-        kind = _safe_text(relation.get("relation") or relation.get("kind") or "related")
+        kind = _safe_text(relation.get("relation") or relation.get("kind")) or "related"
         if not source or not target:
             continue
         key = (source, target, kind)
@@ -208,24 +250,27 @@ def _page_summary(markdown: str) -> str:
 def _human_prior(value: Any) -> dict[str, Any]:
     if not isinstance(value, Mapping):
         return {"editable": True, "notes": []}
-    result: dict[str, Any] = {}
-    for key, item in value.items():
-        safe_key = _safe_text(key, max_bytes=128)
-        if safe_key:
-            result[safe_key] = _bounded_json_value(item)
-    return result
+    bounded = _bounded_json_value(value)
+    return bounded if isinstance(bounded, dict) else {}
 
 
-def _bounded_json_value(value: Any) -> Any:
+def _bounded_json_value(value: Any, *, depth: int = 0) -> Any:
+    if depth >= _MAX_HUMAN_PRIOR_DEPTH:
+        return "[truncated]"
     if isinstance(value, Mapping):
         return {
-            key: _bounded_json_value(item)
-            for raw_key, item in value.items()
+            key: _bounded_json_value(item, depth=depth + 1)
+            for raw_key, item in islice(value.items(), _MAX_HUMAN_PRIOR_ITEMS)
             if (key := _safe_text(raw_key, max_bytes=128))
         }
     if isinstance(value, (list, tuple)):
-        return [_bounded_json_value(item) for item in value[:16]]
+        return [
+            _bounded_json_value(item, depth=depth + 1)
+            for item in islice(iter(value), _MAX_HUMAN_PRIOR_ITEMS)
+        ]
     if isinstance(value, str):
+        return _safe_text(value)
+    if isinstance(value, float) and not math.isfinite(value):
         return _safe_text(value)
     if isinstance(value, (int, float, bool)) or value is None:
         return value
@@ -234,17 +279,77 @@ def _bounded_json_value(value: Any) -> Any:
 
 def _safe_file(value: Any) -> str:
     file = _safe_text(value)
-    if not file or any(ord(character) < 0x20 for character in file):
+    if (
+        not file
+        or "\\" in file
+        or PureWindowsPath(file).drive
+        or any(ord(character) < 0x20 or ord(character) == 0x7F for character in file)
+    ):
+        return ""
+    relative = PurePosixPath(file)
+    if (
+        not relative.parts
+        or relative.is_absolute()
+        or relative.as_posix() != file
+        or any(part in {"", ".", ".."} for part in relative.parts)
+    ):
         return ""
     return file
 
 
 def _safe_text(value: Any, *, max_bytes: int = _MAX_TEXT_BYTES) -> str:
+    if isinstance(max_bytes, bool) or not isinstance(max_bytes, int) or max_bytes < 0:
+        raise ValueError("text byte limit must be a non-negative integer")
     text = str(value or "").strip()
-    if len(text.encode("utf-8")) <= max_bytes:
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
         return text
-    encoded = text.encode("utf-8")[: max(0, max_bytes - 1)]
-    return encoded.decode("utf-8", errors="ignore").rstrip() + "…"
+    if max_bytes == 0:
+        return ""
+    ellipsis = "…"
+    ellipsis_bytes = ellipsis.encode("utf-8")
+    if max_bytes < len(ellipsis_bytes):
+        return encoded[:max_bytes].decode("utf-8", errors="ignore").rstrip()
+    prefix = encoded[: max_bytes - len(ellipsis_bytes)]
+    return prefix.decode("utf-8", errors="ignore").rstrip() + ellipsis
+
+
+def _slot_source_citations(slot: Mapping[str, Any]) -> tuple[Any, ...]:
+    values = slot.get("source_citations") or ()
+    if isinstance(values, (str, bytes, bytearray, Mapping)):
+        raise ValueError("wiki media source citations must be an iterable of paths")
+    try:
+        return tuple(islice(iter(values), _DEFAULT_MAX_SOURCES))
+    except TypeError as exc:
+        raise ValueError(
+            "wiki media source citations must be an iterable of paths"
+        ) from exc
+
+
+def _mapping_candidates(
+    values: Iterable[Mapping[str, Any]], *, label: str
+) -> Iterable[Mapping[str, Any]]:
+    if isinstance(values, (str, bytes, bytearray, Mapping)):
+        raise ValueError(f"wiki media {label} must be an iterable of objects")
+    try:
+        candidates = iter(values or ())
+    except TypeError as exc:
+        raise ValueError(f"wiki media {label} must be an iterable of objects") from exc
+    return (
+        value
+        for value in islice(candidates, _MAX_INPUT_CANDIDATES)
+        if isinstance(value, Mapping)
+    )
+
+
+def _validated_limit(value: Any, *, name: str, maximum: int) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value <= maximum
+    ):
+        raise ValueError(f"{name} must be an integer between 0 and {maximum}")
+    return value
 
 
 def _positive_int(value: Any) -> int | None:
@@ -258,6 +363,7 @@ def _positive_int(value: Any) -> int | None:
 
 
 __all__ = [
+    "MAX_MEDIA_EVIDENCE_PACK_BYTES",
     "SourceReader",
     "WikiMediaEvidencePack",
     "WikiMediaRelationEvidence",

--- a/codenib/wiki/media_evidence.py
+++ b/codenib/wiki/media_evidence.py
@@ -146,6 +146,46 @@ def build_media_evidence_pack(
     return data
 
 
+def normalize_media_evidence_pack(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Return one caller-supplied pack in the bounded canonical schema."""
+
+    if not isinstance(value, Mapping):
+        raise ValueError("wiki media evidence pack must be a mapping")
+    page = value.get("page")
+    if not isinstance(page, Mapping):
+        page = {}
+    source_candidates = tuple(
+        _mapping_candidates(value.get("sources") or (), label="evidence sources")
+    )
+    relation_candidates = tuple(
+        _mapping_candidates(value.get("relations") or (), label="evidence relations")
+    )
+    selected_files = tuple(
+        dict.fromkeys(
+            file
+            for file in (
+                _safe_file(candidate.get("file")) for candidate in source_candidates
+            )
+            if file
+        )
+    )
+    return build_media_evidence_pack(
+        {
+            "id": value.get("slot_id") or value.get("id"),
+            "kind": value.get("kind"),
+            "title": value.get("title"),
+            "purpose": value.get("purpose"),
+            "source_citations": selected_files,
+            "human_prior": value.get("human_prior"),
+        },
+        page_id=_safe_text(page.get("id")),
+        page_title=_safe_text(page.get("title")),
+        page_markdown=_safe_text(page.get("summary")),
+        citations=source_candidates,
+        relations=relation_candidates,
+    )
+
+
 def _source_evidence(
     slot: Mapping[str, Any],
     citations: Iterable[Mapping[str, Any]],
@@ -167,7 +207,9 @@ def _source_evidence(
         file = _safe_file(citation.get("file"))
         if not file or (restrict_to_selected_files and file not in allowed_files):
             continue
-        symbol = _safe_text(citation.get("symbol") or citation.get("name"))
+        symbol = _safe_text(
+            citation.get("symbol") or citation.get("name") or citation.get("node_name")
+        )
         start_line = _positive_int(citation.get("start_line") or citation.get("line"))
         end_line = _positive_int(citation.get("end_line"))
         if end_line is not None and (start_line is None or end_line < start_line):
@@ -177,7 +219,10 @@ def _source_evidence(
             continue
         seen.add(key)
 
-        snippet = _safe_text(citation.get("snippet"), max_bytes=max_snippet_bytes)
+        snippet = _safe_text(
+            citation.get("snippet") or citation.get("content"),
+            max_bytes=max_snippet_bytes,
+        )
         if source_reader is not None and max_snippet_bytes and not snippet:
             reader_citation = {
                 "file": file,
@@ -369,4 +414,5 @@ __all__ = [
     "WikiMediaRelationEvidence",
     "WikiMediaSourceEvidence",
     "build_media_evidence_pack",
+    "normalize_media_evidence_pack",
 ]

--- a/codenib/wiki/media_generation.py
+++ b/codenib/wiki/media_generation.py
@@ -27,6 +27,7 @@ from urllib.parse import urlsplit
 _GENERATABLE_IMAGE_KINDS = frozenset({"diagram", "image", "storyboard"})
 _MAX_MEDIA_SLOTS = 12
 _MAX_PROMPT_BYTES = 32 * 1024
+_MAX_EVIDENCE_PACK_BYTES = 24 * 1024
 _MAX_IMAGE_RESPONSE_BYTES = 32 * 1024 * 1024
 _MAX_IMAGE_BYTES = 16 * 1024 * 1024
 _MAX_MANIFEST_BYTES = 256 * 1024
@@ -42,9 +43,10 @@ _WINDOWS_RESERVED_NAMES = frozenset(
     | {f"LPT{index}" for index in range(1, 10)}
 )
 _ASSET_LOCKS_GUARD = threading.Lock()
-_ASSET_LOCKS: weakref.WeakValueDictionary[str, threading.Lock] = (
-    weakref.WeakValueDictionary()
-)
+_ASSET_LOCKS: weakref.WeakValueDictionary[
+    str, threading.Lock
+] = weakref.WeakValueDictionary()
+MediaEvidenceBuilder = Callable[[Mapping[str, Any]], Mapping[str, Any] | None]
 
 
 @dataclass(frozen=True)
@@ -125,6 +127,8 @@ class OpenAICompatibleImageGenerator:
             raise ValueError("output_dir is required for image generation")
 
         prompt = _generation_prompt(slot)
+        public_prompt = _generation_prompt(slot, include_evidence_pack=False)
+        prompt_sha256 = _sha256_text(prompt)
         render_sha256 = _slot_render_sha256(slot)
         filename = f"{_safe_filename(slot_id)}.png"
         with _asset_lock(output_dir, filename):
@@ -135,7 +139,7 @@ class OpenAICompatibleImageGenerator:
                     "slot_id": slot_id,
                     "model": self.model,
                     "provider": self.provider,
-                    "prompt_sha256": _sha256_text(prompt),
+                    "prompt_sha256": prompt_sha256,
                     "render_sha256": render_sha256,
                     "size": self.size,
                 },
@@ -184,15 +188,15 @@ class OpenAICompatibleImageGenerator:
                 mime_type=mime_type,
                 model=self.model,
                 provider=self.provider,
-                prompt=prompt,
+                prompt=public_prompt,
                 source_citations=citations,
-                metadata={"size": self.size},
+                metadata=_asset_metadata(slot, size=self.size),
             ).to_dict()
             _write_asset_manifest(
                 output_dir,
                 filename,
                 asset,
-                prompt_sha256=_sha256_text(prompt),
+                prompt_sha256=prompt_sha256,
                 render_sha256=render_sha256,
                 content_sha256=content_sha256,
             )
@@ -249,6 +253,8 @@ class DeterministicSvgMediaGenerator:
             raise ValueError("output_dir is required for local SVG generation")
 
         prompt = _generation_prompt(slot)
+        public_prompt = _generation_prompt(slot, include_evidence_pack=False)
+        prompt_sha256 = _sha256_text(prompt)
         render_sha256 = _slot_render_sha256(slot)
         filename = f"{_safe_filename(slot_id)}.svg"
         with _asset_lock(output_dir, filename):
@@ -259,7 +265,7 @@ class DeterministicSvgMediaGenerator:
                     "slot_id": slot_id,
                     "model": self.model,
                     "provider": self.provider,
-                    "prompt_sha256": _sha256_text(prompt),
+                    "prompt_sha256": prompt_sha256,
                     "render_sha256": render_sha256,
                 },
             )
@@ -281,15 +287,15 @@ class DeterministicSvgMediaGenerator:
                 mime_type="image/svg+xml",
                 model=self.model,
                 provider=self.provider,
-                prompt=prompt,
+                prompt=public_prompt,
                 source_citations=citations,
-                metadata={"deterministic": True},
+                metadata=_asset_metadata(slot, deterministic=True),
             ).to_dict()
             _write_asset_manifest(
                 output_dir,
                 filename,
                 asset,
-                prompt_sha256=_sha256_text(prompt),
+                prompt_sha256=prompt_sha256,
                 render_sha256=render_sha256,
                 content_sha256=hashlib.sha256(svg).hexdigest(),
             )
@@ -302,6 +308,7 @@ def materialize_media_slots(
     generator: Any,
     output_dir: str | Path,
     asset_base_path: str = "assets/wiki-media",
+    evidence_builder: MediaEvidenceBuilder | None = None,
 ) -> dict[str, Any]:
     """Generate assets for supported slots and attach them to a page payload."""
 
@@ -322,8 +329,13 @@ def materialize_media_slots(
         if "asset" not in updated:
             kind = str(updated.get("kind") or "")
             if kind in _GENERATABLE_IMAGE_KINDS:
+                generation_slot = updated
+                if evidence_builder is not None and "evidence_pack" not in updated:
+                    evidence_pack = evidence_builder(updated)
+                    if evidence_pack:
+                        generation_slot = {**updated, "evidence_pack": evidence_pack}
                 updated["asset"] = generator.generate(
-                    updated,
+                    generation_slot,
                     output_dir=output_dir,
                     asset_base_path=asset_base_path,
                 )
@@ -362,7 +374,9 @@ def read_generated_media_asset(output_dir: str | Path, filename: str) -> bytes |
     return _read_regular_bytes(Path(output_dir) / filename, max_bytes=_MAX_IMAGE_BYTES)
 
 
-def _generation_prompt(slot: Mapping[str, Any]) -> str:
+def _generation_prompt(
+    slot: Mapping[str, Any], *, include_evidence_pack: bool = True
+) -> str:
     parts = [str(slot.get("prompt") or "").strip()]
     purpose = str(slot.get("purpose") or "").strip()
     if purpose:
@@ -370,10 +384,42 @@ def _generation_prompt(slot: Mapping[str, Any]) -> str:
     citations = _source_citations(slot)
     if citations:
         parts.append("Source citations: " + ", ".join(citations))
+    if include_evidence_pack:
+        evidence_pack = _evidence_pack_prompt(slot.get("evidence_pack"))
+        if evidence_pack:
+            parts.append(evidence_pack)
     prompt = "\n\n".join(part for part in parts if part)
     if len(prompt.encode("utf-8")) > _MAX_PROMPT_BYTES:
         raise ValueError("wiki media prompt exceeds the byte limit")
     return prompt
+
+
+def _evidence_pack_prompt(value: Any) -> str:
+    if not isinstance(value, Mapping):
+        return ""
+    evidence = json.dumps(
+        value,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    if len(evidence.encode("utf-8")) > _MAX_EVIDENCE_PACK_BYTES:
+        raise ValueError("wiki media evidence pack exceeds the byte limit")
+    return "Source-grounded media evidence pack:\n" + evidence
+
+
+def _asset_metadata(slot: Mapping[str, Any], **values: Any) -> dict[str, Any]:
+    metadata = dict(values)
+    if isinstance(slot.get("evidence_pack"), Mapping):
+        metadata["evidence_pack_sha256"] = _sha256_text(
+            json.dumps(
+                slot["evidence_pack"],
+                ensure_ascii=True,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        )
+    return metadata
 
 
 def _source_citations(slot: Mapping[str, Any]) -> tuple[str, ...]:

--- a/codenib/wiki/media_generation.py
+++ b/codenib/wiki/media_generation.py
@@ -24,10 +24,11 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 from urllib.parse import urlsplit
 
+from .media_evidence import MAX_MEDIA_EVIDENCE_PACK_BYTES
+
 _GENERATABLE_IMAGE_KINDS = frozenset({"diagram", "image", "storyboard"})
 _MAX_MEDIA_SLOTS = 12
 _MAX_PROMPT_BYTES = 32 * 1024
-_MAX_EVIDENCE_PACK_BYTES = 24 * 1024
 _MAX_IMAGE_RESPONSE_BYTES = 32 * 1024 * 1024
 _MAX_IMAGE_BYTES = 16 * 1024 * 1024
 _MAX_MANIFEST_BYTES = 256 * 1024
@@ -43,9 +44,9 @@ _WINDOWS_RESERVED_NAMES = frozenset(
     | {f"LPT{index}" for index in range(1, 10)}
 )
 _ASSET_LOCKS_GUARD = threading.Lock()
-_ASSET_LOCKS: weakref.WeakValueDictionary[
-    str, threading.Lock
-] = weakref.WeakValueDictionary()
+_ASSET_LOCKS: weakref.WeakValueDictionary[str, threading.Lock] = (
+    weakref.WeakValueDictionary()
+)
 MediaEvidenceBuilder = Callable[[Mapping[str, Any]], Mapping[str, Any] | None]
 
 
@@ -326,13 +327,21 @@ def materialize_media_slots(
         if not isinstance(slot, Mapping):
             continue
         updated = _normalized_slot(slot)
+        generation_slot = dict(updated)
+        updated.pop("evidence_pack", None)
         if "asset" not in updated:
             kind = str(updated.get("kind") or "")
             if kind in _GENERATABLE_IMAGE_KINDS:
-                generation_slot = updated
-                if evidence_builder is not None and "evidence_pack" not in updated:
-                    evidence_pack = evidence_builder(updated)
-                    if evidence_pack:
+                if (
+                    evidence_builder is not None
+                    and "evidence_pack" not in generation_slot
+                ):
+                    evidence_pack = evidence_builder(dict(updated))
+                    if evidence_pack is not None:
+                        if not isinstance(evidence_pack, Mapping):
+                            raise ValueError(
+                                "wiki media evidence builder must return a mapping or None"
+                            )
                         generation_slot = {**updated, "evidence_pack": evidence_pack}
                 updated["asset"] = generator.generate(
                     generation_slot,
@@ -397,14 +406,7 @@ def _generation_prompt(
 def _evidence_pack_prompt(value: Any) -> str:
     if not isinstance(value, Mapping):
         return ""
-    evidence = json.dumps(
-        value,
-        ensure_ascii=True,
-        separators=(",", ":"),
-        sort_keys=True,
-    )
-    if len(evidence.encode("utf-8")) > _MAX_EVIDENCE_PACK_BYTES:
-        raise ValueError("wiki media evidence pack exceeds the byte limit")
+    evidence = _serialized_evidence_pack(value)
     return "Source-grounded media evidence pack:\n" + evidence
 
 
@@ -412,14 +414,25 @@ def _asset_metadata(slot: Mapping[str, Any], **values: Any) -> dict[str, Any]:
     metadata = dict(values)
     if isinstance(slot.get("evidence_pack"), Mapping):
         metadata["evidence_pack_sha256"] = _sha256_text(
-            json.dumps(
-                slot["evidence_pack"],
-                ensure_ascii=True,
-                separators=(",", ":"),
-                sort_keys=True,
-            )
+            _serialized_evidence_pack(slot["evidence_pack"])
         )
     return metadata
+
+
+def _serialized_evidence_pack(value: Mapping[str, Any]) -> str:
+    try:
+        evidence = json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (RecursionError, TypeError, ValueError) as exc:
+        raise ValueError("wiki media evidence pack must contain bounded JSON") from exc
+    if len(evidence.encode("utf-8")) > MAX_MEDIA_EVIDENCE_PACK_BYTES:
+        raise ValueError("wiki media evidence pack exceeds the byte limit")
+    return evidence
 
 
 def _source_citations(slot: Mapping[str, Any]) -> tuple[str, ...]:

--- a/codenib/wiki/media_generation.py
+++ b/codenib/wiki/media_generation.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 from urllib.parse import urlsplit
 
-from .media_evidence import MAX_MEDIA_EVIDENCE_PACK_BYTES
+from .media_evidence import MAX_MEDIA_EVIDENCE_PACK_BYTES, normalize_media_evidence_pack
 
 _GENERATABLE_IMAGE_KINDS = frozenset({"diagram", "image", "storyboard"})
 _MAX_MEDIA_SLOTS = 12
@@ -342,7 +342,9 @@ def materialize_media_slots(
                             raise ValueError(
                                 "wiki media evidence builder must return a mapping or None"
                             )
-                        generation_slot = {**updated, "evidence_pack": evidence_pack}
+                        generation_slot = _normalized_slot(
+                            {**updated, "evidence_pack": evidence_pack}
+                        )
                 updated["asset"] = generator.generate(
                     generation_slot,
                     output_dir=output_dir,
@@ -350,6 +352,29 @@ def materialize_media_slots(
                 )
         slots.append(updated)
     return {**dict(page), "media_slots": slots}
+
+
+def redact_media_evidence_packs(page: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a public page payload without server-only media evidence."""
+
+    public_page = dict(page)
+    raw_slots = public_page.get("media_slots")
+    if raw_slots is None:
+        return public_page
+    if not isinstance(raw_slots, (list, tuple)):
+        public_page["media_slots"] = []
+        return public_page
+
+    public_slots = []
+    for slot in raw_slots:
+        if isinstance(slot, Mapping):
+            public_slot = dict(slot)
+            public_slot.pop("evidence_pack", None)
+            public_slots.append(public_slot)
+        else:
+            public_slots.append(slot)
+    public_page["media_slots"] = public_slots
+    return public_page
 
 
 def image_generator_from_config(
@@ -453,6 +478,25 @@ def _source_citations(slot: Mapping[str, Any]) -> tuple[str, ...]:
 def _normalized_slot(slot: Mapping[str, Any]) -> dict[str, Any]:
     normalized = dict(slot)
     normalized["source_citations"] = list(_source_citations(slot))
+    if "evidence_pack" in normalized:
+        raw_evidence = normalized["evidence_pack"]
+        if raw_evidence is None:
+            normalized.pop("evidence_pack")
+        elif not isinstance(raw_evidence, Mapping):
+            raise ValueError("wiki media evidence pack must be a mapping")
+        else:
+            evidence_pack = normalize_media_evidence_pack(raw_evidence)
+            slot_id = str(normalized.get("id") or "").strip()
+            kind = str(normalized.get("kind") or "").strip()
+            if evidence_pack["slot_id"] != slot_id:
+                raise ValueError(
+                    "wiki media evidence pack slot_id does not match the slot"
+                )
+            if evidence_pack["kind"] != kind:
+                raise ValueError(
+                    "wiki media evidence pack kind does not match the slot"
+                )
+            normalized["evidence_pack"] = evidence_pack
     return normalized
 
 

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -359,6 +359,7 @@ def test_wiki_page_can_skip_media_materialization_for_preload(monkeypatch):
         "id": "overview-concept-illustration",
         "kind": "image",
         "prompt": "Draw the runtime.",
+        "evidence_pack": {"snippet": "server-only preload evidence"},
     }
 
     class Builder:
@@ -381,8 +382,16 @@ def test_wiki_page_can_skip_media_materialization_for_preload(monkeypatch):
 
     page = asyncio.run(web_app.wiki_page("demo", "overview", materialize_media=False))
 
-    assert page["media_slots"] == [slot]
+    assert page["media_slots"] == [
+        {
+            "id": "overview-concept-illustration",
+            "kind": "image",
+            "prompt": "Draw the runtime.",
+        }
+    ]
     assert "asset" not in page["media_slots"][0]
+    assert "server-only preload evidence" not in str(page)
+    assert slot["evidence_pack"]["snippet"] == "server-only preload evidence"
 
 
 def test_wiki_media_storage_keys_cannot_traverse_data_root(tmp_path):

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -341,6 +341,7 @@ def test_wiki_page_materializes_local_svg_media(tmp_path, monkeypatch):
     ) or asset["uri"].endswith(
         "api/repos/demo/wiki-media/overview/overview-concept-illustration.svg"
     )
+    assert asset["metadata"]["evidence_pack_sha256"]
     asset_response = asyncio.run(
         web_app.wiki_media_asset(
             "demo",
@@ -352,6 +353,83 @@ def test_wiki_page_materializes_local_svg_media(tmp_path, monkeypatch):
     assert asset_response.media_type == "image/svg+xml"
     assert asset_response.headers["x-content-type-options"] == "nosniff"
     assert "sandbox" in asset_response.headers["content-security-policy"]
+
+
+def test_wiki_media_materialization_builds_page_evidence(tmp_path, monkeypatch):
+    captured = {}
+
+    class SourceReader:
+        def captured_relative_path(self, path):
+            return path if path == "src/runtime.py" else None
+
+        def read_line_range(self, relative, *, start_line, end_line, max_bytes):
+            captured["source_read"] = (
+                relative,
+                start_line,
+                end_line,
+                max_bytes,
+            )
+            return b"def run(): return 'grounded'\n"
+
+    class Generator:
+        def generate(self, slot, **_kwargs):
+            captured["generation_slot"] = slot
+            return {"slot_id": slot["id"], "provider": "capture"}
+
+    config = SimpleNamespace(data_dir=str(tmp_path))
+    monkeypatch.setattr(web_app, "load_config", lambda: config)
+    monkeypatch.setattr(
+        web_app, "image_generator_from_config", lambda _config: Generator()
+    )
+    monkeypatch.setattr(
+        web_app,
+        "_bundle",
+        lambda _repo_id: SimpleNamespace(source_reader=SourceReader()),
+    )
+    page = {
+        "id": "overview",
+        "title": "Overview",
+        "markdown": "# Overview\n\nRuntime flow.",
+        "citations": [
+            {
+                "file": "src/runtime.py",
+                "start_line": 7,
+                "end_line": 9,
+                "node_name": "run",
+                "content": None,
+            }
+        ],
+        "evidence": {
+            "relations": [{"source": "run", "target": "render", "relation": "calls"}]
+        },
+        "media_slots": [
+            {
+                "id": "overview-image",
+                "kind": "image",
+                "prompt": "Draw the runtime.",
+                "source_citations": ["src/runtime.py"],
+            }
+        ],
+    }
+
+    materialized = web_app._materialize_wiki_media("demo", "overview", page)
+
+    evidence_pack = captured["generation_slot"]["evidence_pack"]
+    assert evidence_pack["page"]["summary"] == "Runtime flow."
+    assert evidence_pack["sources"] == [
+        {
+            "file": "src/runtime.py",
+            "symbol": "run",
+            "start_line": 7,
+            "end_line": 9,
+            "snippet": "def run(): return 'grounded'",
+        }
+    ]
+    assert evidence_pack["relations"] == [
+        {"source": "run", "target": "render", "relation": "calls"}
+    ]
+    assert captured["source_read"][:3] == ("src/runtime.py", 7, 9)
+    assert "evidence_pack" not in materialized["media_slots"][0]
 
 
 def test_wiki_page_can_skip_media_materialization_for_preload(monkeypatch):
@@ -441,6 +519,9 @@ def test_wiki_media_materialization_does_not_swallow_memory_error(
     monkeypatch.setattr(
         web_app, "image_generator_from_config", lambda _config: object()
     )
+    monkeypatch.setattr(
+        web_app, "_bundle", lambda _repo_id: SimpleNamespace(source_reader=None)
+    )
 
     def fail_materialization(*_args, **_kwargs):
         raise MemoryError("out of memory")
@@ -474,6 +555,9 @@ def test_wiki_media_redacts_evidence_after_generation_failure(tmp_path, monkeypa
     monkeypatch.setattr(web_app, "load_config", lambda: config)
     monkeypatch.setattr(
         web_app, "image_generator_from_config", lambda _config: object()
+    )
+    monkeypatch.setattr(
+        web_app, "_bundle", lambda _repo_id: SimpleNamespace(source_reader=None)
     )
     monkeypatch.setattr(
         web_app,

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -444,6 +444,45 @@ def test_wiki_media_materialization_does_not_swallow_memory_error(
         )
 
 
+def test_wiki_media_redacts_evidence_when_generation_is_disabled(tmp_path, monkeypatch):
+    config = SimpleNamespace(data_dir=str(tmp_path))
+    monkeypatch.setattr(web_app, "load_config", lambda: config)
+    monkeypatch.setattr(web_app, "image_generator_from_config", lambda _config: None)
+    page = {
+        "media_slots": [
+            {"id": "asset", "evidence_pack": {"snippet": "server-only secret"}}
+        ]
+    }
+
+    public_page = web_app._materialize_wiki_media("demo", "overview", page)
+
+    assert "evidence_pack" not in public_page["media_slots"][0]
+    assert page["media_slots"][0]["evidence_pack"]["snippet"] == "server-only secret"
+
+
+def test_wiki_media_redacts_evidence_after_generation_failure(tmp_path, monkeypatch):
+    config = SimpleNamespace(data_dir=str(tmp_path))
+    monkeypatch.setattr(web_app, "load_config", lambda: config)
+    monkeypatch.setattr(
+        web_app, "image_generator_from_config", lambda _config: object()
+    )
+    monkeypatch.setattr(
+        web_app,
+        "materialize_media_slots",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("failed")),
+    )
+    page = {
+        "media_slots": [
+            {"id": "asset", "evidence_pack": {"snippet": "server-only secret"}}
+        ]
+    }
+
+    public_page = web_app._materialize_wiki_media("demo", "overview", page)
+
+    assert "evidence_pack" not in public_page["media_slots"][0]
+    assert "server-only secret" not in str(public_page)
+
+
 def test_wiki_page_graph_reports_why_the_graph_is_unavailable(monkeypatch):
     class Builder:
         def page_citations(self, page_id):

--- a/test/wiki/test_media_evidence.py
+++ b/test/wiki/test_media_evidence.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from codenib.wiki.media_evidence import build_media_evidence_pack
+
+
+def test_build_media_evidence_pack_filters_to_slot_citations():
+    slot = {
+        "id": "overview-flow-storyboard",
+        "kind": "storyboard",
+        "title": "Overview flow",
+        "purpose": "Explain how wiki media is generated.",
+        "source_citations": ["codenib/wiki/media_generation.py"],
+        "human_prior": {"style": "teaching-blog", "avoid": ["decorative images"]},
+    }
+    pack = build_media_evidence_pack(
+        slot,
+        page_id="overview",
+        page_title="Overview",
+        page_markdown="# Overview\n\nMedia slots become assets.",
+        citations=[
+            {
+                "file": "codenib/wiki/media_generation.py",
+                "symbol": "materialize_media_slots",
+                "start_line": 281,
+                "end_line": 312,
+                "snippet": "def materialize_media_slots(...):",
+            },
+            {
+                "file": "unrelated.py",
+                "symbol": "ignored",
+                "snippet": "not relevant",
+            },
+        ],
+        relations=[
+            {
+                "source": "plan_media_slots",
+                "target": "materialize_media_slots",
+                "relation": "feeds",
+            }
+        ],
+    )
+
+    assert pack["slot_id"] == "overview-flow-storyboard"
+    assert pack["page"] == {
+        "id": "overview",
+        "title": "Overview",
+        "summary": "Media slots become assets.",
+    }
+    assert pack["sources"] == [
+        {
+            "file": "codenib/wiki/media_generation.py",
+            "symbol": "materialize_media_slots",
+            "start_line": 281,
+            "end_line": 312,
+            "snippet": "def materialize_media_slots(...):",
+        }
+    ]
+    assert pack["relations"] == [
+        {
+            "source": "plan_media_slots",
+            "target": "materialize_media_slots",
+            "relation": "feeds",
+        }
+    ]
+    assert pack["human_prior"]["style"] == "teaching-blog"
+    assert "decorative" in pack["output_requirements"][1]
+
+
+def test_build_media_evidence_pack_reads_bounded_snippets():
+    long_source = "x" * 200
+
+    def source_reader(_citation):
+        return long_source
+
+    pack = build_media_evidence_pack(
+        {"id": "slot", "kind": "image", "source_citations": ["src/app.py"]},
+        citations=[{"file": "src/app.py", "line": 7}],
+        source_reader=source_reader,
+        max_snippet_bytes=12,
+    )
+
+    assert pack["sources"][0]["snippet"] == "xxxxxxxxxxx…"
+    assert pack["sources"][0]["start_line"] == 7
+
+
+def test_build_media_evidence_pack_deduplicates_relations_and_sources():
+    slot = {"id": "slot", "kind": "diagram", "source_citations": ["src/app.py"]}
+    pack = build_media_evidence_pack(
+        slot,
+        citations=[
+            {"file": "src/app.py", "symbol": "app", "start_line": 1},
+            {"file": "src/app.py", "symbol": "app", "start_line": 1},
+        ],
+        relations=[
+            {"from": "app", "to": "view", "kind": "calls"},
+            {"from": "app", "to": "view", "kind": "calls"},
+        ],
+    )
+
+    assert len(pack["sources"]) == 1
+    assert pack["relations"] == [
+        {"source": "app", "target": "view", "relation": "calls"}
+    ]

--- a/test/wiki/test_media_evidence.py
+++ b/test/wiki/test_media_evidence.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from codenib.wiki.media_evidence import build_media_evidence_pack
 
 
@@ -83,7 +85,8 @@ def test_build_media_evidence_pack_reads_bounded_snippets():
         max_snippet_bytes=12,
     )
 
-    assert pack["sources"][0]["snippet"] == "xxxxxxxxxxx…"
+    assert pack["sources"][0]["snippet"] == "xxxxxxxxx…"
+    assert len(pack["sources"][0]["snippet"].encode("utf-8")) <= 12
     assert pack["sources"][0]["start_line"] == 7
 
 
@@ -105,3 +108,43 @@ def test_build_media_evidence_pack_deduplicates_relations_and_sources():
     assert pack["relations"] == [
         {"source": "app", "target": "view", "relation": "calls"}
     ]
+
+
+def test_build_media_evidence_pack_zero_limits_do_not_consume_inputs():
+    def unexpected_values():
+        raise AssertionError("zero limits must not consume evidence iterables")
+        yield {}
+
+    pack = build_media_evidence_pack(
+        {"id": "slot", "kind": "diagram", "source_citations": ["src/app.py"]},
+        citations=unexpected_values(),
+        relations=unexpected_values(),
+        source_reader=lambda _citation: (_ for _ in ()).throw(AssertionError()),
+        max_sources=0,
+        max_relations=0,
+        max_snippet_bytes=0,
+    )
+
+    assert pack["sources"] == []
+    assert pack["relations"] == []
+
+
+def test_build_media_evidence_pack_does_not_broaden_unsafe_file_selectors():
+    reader_calls = []
+    pack = build_media_evidence_pack(
+        {"id": "slot", "kind": "image", "source_citations": ["../secret.py"]},
+        citations=[{"file": "src/app.py", "start_line": 1}],
+        source_reader=lambda citation: reader_calls.append(citation) or "source",
+    )
+
+    assert pack["sources"] == []
+    assert reader_calls == []
+
+
+def test_build_media_evidence_pack_rejects_oversized_total_payload():
+    human_prior = {f"key-{index}": "x" * 4096 for index in range(16)}
+
+    with pytest.raises(ValueError, match="evidence pack exceeds"):
+        build_media_evidence_pack(
+            {"id": "slot", "kind": "image", "human_prior": human_prior}
+        )

--- a/test/wiki/test_media_evidence.py
+++ b/test/wiki/test_media_evidence.py
@@ -90,6 +90,31 @@ def test_build_media_evidence_pack_reads_bounded_snippets():
     assert pack["sources"][0]["start_line"] == 7
 
 
+def test_build_media_evidence_pack_accepts_native_citation_fields():
+    pack = build_media_evidence_pack(
+        {"id": "slot", "kind": "image", "source_citations": ["src/app.py"]},
+        citations=[
+            {
+                "file": "src/app.py",
+                "node_name": "create_app",
+                "start_line": 7,
+                "end_line": 12,
+                "content": "def create_app(): ...",
+            }
+        ],
+    )
+
+    assert pack["sources"] == [
+        {
+            "file": "src/app.py",
+            "symbol": "create_app",
+            "start_line": 7,
+            "end_line": 12,
+            "snippet": "def create_app(): ...",
+        }
+    ]
+
+
 def test_build_media_evidence_pack_deduplicates_relations_and_sources():
     slot = {"id": "slot", "kind": "diagram", "source_citations": ["src/app.py"]}
     pack = build_media_evidence_pack(

--- a/test/wiki/test_media_generation.py
+++ b/test/wiki/test_media_generation.py
@@ -14,6 +14,7 @@ import time
 import pytest
 
 import codenib.wiki.media_generation as media_generation
+from codenib.wiki.media_evidence import build_media_evidence_pack
 from codenib.wiki.media_generation import (
     DeterministicSvgMediaGenerator,
     OpenAICompatibleImageGenerator,
@@ -111,6 +112,66 @@ def test_materialize_media_slots_skips_unsupported_video_slots(tmp_path):
     assert "asset" not in materialized["media_slots"][1]
 
 
+def test_materialize_media_slots_uses_server_side_evidence_without_exposing_it(
+    tmp_path,
+):
+    requests = []
+    png = base64.b64encode(_PNG).decode("ascii")
+
+    def fake_urlopen(request, timeout):
+        requests.append(request)
+        return _Response({"data": [{"b64_json": png}]})
+
+    generator = OpenAICompatibleImageGenerator(
+        model="openai/gpt-image-1",
+        api_base="https://api.example/v1",
+        urlopen=fake_urlopen,
+    )
+    page = {
+        "id": "overview",
+        "title": "Overview",
+        "content": "This page explains wiki media generation.",
+        "media_slots": [
+            {
+                "id": "overview-image",
+                "kind": "image",
+                "prompt": "Draw a grounded concept.",
+                "source_citations": ["src/app.py"],
+            }
+        ],
+    }
+
+    def evidence_builder(slot):
+        return build_media_evidence_pack(
+            slot,
+            page_id=page["id"],
+            page_title=page["title"],
+            page_markdown=page["content"],
+            citations=[
+                {
+                    "file": "src/app.py",
+                    "symbol": "build_page",
+                    "snippet": "secret server-side source snippet",
+                }
+            ],
+            relations=[{"from": "build_page", "to": "render_media", "kind": "calls"}],
+        )
+
+    materialized = materialize_media_slots(
+        page,
+        generator=generator,
+        output_dir=tmp_path,
+        evidence_builder=evidence_builder,
+    )
+
+    body = json.loads(requests[0].data.decode("utf-8"))
+    assert "secret server-side source snippet" in body["prompt"]
+    slot = materialized["media_slots"][0]
+    assert "evidence_pack" not in slot
+    assert "secret server-side source snippet" not in json.dumps(slot)
+    assert "evidence_pack_sha256" in slot["asset"]["metadata"]
+
+
 def test_deterministic_svg_generator_writes_visible_asset(tmp_path):
     generator = DeterministicSvgMediaGenerator()
 
@@ -179,6 +240,46 @@ def test_media_generation_reuses_cached_asset(tmp_path):
 
     assert first == second
     assert len(calls) == 2
+
+
+def test_asset_prompt_redacts_evidence_pack_contents(tmp_path):
+    generator = DeterministicSvgMediaGenerator()
+    slot = {
+        "id": "overview-image",
+        "kind": "image",
+        "prompt": "Draw it.",
+        "source_citations": ["src/app.py"],
+        "evidence_pack": {
+            "slot_id": "overview-image",
+            "sources": [
+                {"file": "src/app.py", "snippet": "private code snippet"},
+            ],
+        },
+    }
+
+    asset = generator.generate(slot, output_dir=tmp_path)
+
+    assert "private code snippet" not in asset["prompt"]
+    assert asset["metadata"]["evidence_pack_sha256"]
+
+
+def test_generation_prompt_rejects_oversized_evidence_pack(tmp_path):
+    generator = DeterministicSvgMediaGenerator()
+    oversized = {
+        "slot_id": "overview-image",
+        "sources": [{"file": "src/app.py", "snippet": "x" * (25 * 1024)}],
+    }
+
+    with pytest.raises(ValueError, match="evidence pack exceeds"):
+        generator.generate(
+            {
+                "id": "overview-image",
+                "kind": "image",
+                "prompt": "Draw it.",
+                "evidence_pack": oversized,
+            },
+            output_dir=tmp_path,
+        )
 
 
 def test_hosted_image_url_is_validated_and_cached(tmp_path):

--- a/test/wiki/test_media_generation.py
+++ b/test/wiki/test_media_generation.py
@@ -263,6 +263,47 @@ def test_asset_prompt_redacts_evidence_pack_contents(tmp_path):
     assert asset["metadata"]["evidence_pack_sha256"]
 
 
+def test_materialize_media_slots_redacts_input_evidence_pack(tmp_path):
+    page = {
+        "id": "overview",
+        "media_slots": [
+            {
+                "id": "overview-image",
+                "kind": "image",
+                "prompt": "Draw it.",
+                "evidence_pack": {
+                    "sources": [{"file": "src/app.py", "snippet": "server-only source"}]
+                },
+            }
+        ],
+    }
+
+    materialized = materialize_media_slots(
+        page,
+        generator=DeterministicSvgMediaGenerator(),
+        output_dir=tmp_path,
+    )
+
+    slot = materialized["media_slots"][0]
+    assert "evidence_pack" not in slot
+    assert "server-only source" not in json.dumps(materialized)
+    assert slot["asset"]["metadata"]["evidence_pack_sha256"]
+
+
+def test_materialize_media_slots_rejects_non_mapping_evidence(tmp_path):
+    page = {
+        "media_slots": [{"id": "overview-image", "kind": "image", "prompt": "Draw it."}]
+    }
+
+    with pytest.raises(ValueError, match="must return a mapping or None"):
+        materialize_media_slots(
+            page,
+            generator=DeterministicSvgMediaGenerator(),
+            output_dir=tmp_path,
+            evidence_builder=lambda _slot: ["not", "a", "mapping"],
+        )
+
+
 def test_generation_prompt_rejects_oversized_evidence_pack(tmp_path):
     generator = DeterministicSvgMediaGenerator()
     oversized = {

--- a/test/wiki/test_media_generation.py
+++ b/test/wiki/test_media_generation.py
@@ -251,6 +251,7 @@ def test_asset_prompt_redacts_evidence_pack_contents(tmp_path):
         "source_citations": ["src/app.py"],
         "evidence_pack": {
             "slot_id": "overview-image",
+            "kind": "image",
             "sources": [
                 {"file": "src/app.py", "snippet": "private code snippet"},
             ],
@@ -272,7 +273,11 @@ def test_materialize_media_slots_redacts_input_evidence_pack(tmp_path):
                 "kind": "image",
                 "prompt": "Draw it.",
                 "evidence_pack": {
-                    "sources": [{"file": "src/app.py", "snippet": "server-only source"}]
+                    "slot_id": "overview-image",
+                    "kind": "image",
+                    "sources": [
+                        {"file": "src/app.py", "snippet": "server-only source"}
+                    ],
                 },
             }
         ],
@@ -304,23 +309,53 @@ def test_materialize_media_slots_rejects_non_mapping_evidence(tmp_path):
         )
 
 
-def test_generation_prompt_rejects_oversized_evidence_pack(tmp_path):
-    generator = DeterministicSvgMediaGenerator()
-    oversized = {
-        "slot_id": "overview-image",
-        "sources": [{"file": "src/app.py", "snippet": "x" * (25 * 1024)}],
-    }
+def test_generation_normalizes_caller_supplied_evidence_pack(tmp_path):
+    requests = []
+    png = base64.b64encode(_PNG).decode("ascii")
 
-    with pytest.raises(ValueError, match="evidence pack exceeds"):
-        generator.generate(
-            {
-                "id": "overview-image",
+    def fake_urlopen(request, timeout):
+        requests.append(request)
+        assert timeout == 120.0
+        return _Response({"data": [{"b64_json": png}]})
+
+    generator = OpenAICompatibleImageGenerator(
+        model="image-model",
+        api_base="https://api.example/v1",
+        urlopen=fake_urlopen,
+    )
+    generator.generate(
+        {
+            "id": "overview-image",
+            "kind": "image",
+            "prompt": "Draw it.",
+            "evidence_pack": {
+                "slot_id": "overview-image",
                 "kind": "image",
-                "prompt": "Draw it.",
-                "evidence_pack": oversized,
+                "unknown": "must not reach the provider",
+                "sources": [
+                    {"file": "../secret.py", "snippet": "server-only secret"},
+                    {
+                        "file": "src/app.py",
+                        "node_name": "create_app",
+                        "content": "safe source",
+                    },
+                ],
             },
-            output_dir=tmp_path,
-        )
+        },
+        output_dir=tmp_path,
+    )
+
+    prompt = json.loads(requests[0].data.decode("utf-8"))["prompt"]
+    assert "safe source" in prompt
+    assert "create_app" in prompt
+    assert "server-only secret" not in prompt
+    assert "../secret.py" not in prompt
+    assert "must not reach the provider" not in prompt
+
+
+def test_evidence_serialization_rejects_oversized_noncanonical_payload():
+    with pytest.raises(ValueError, match="evidence pack exceeds"):
+        media_generation._serialized_evidence_pack({"raw": "x" * (25 * 1024)})
 
 
 def test_hosted_image_url_is_validated_and_cached(tmp_path):


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Part 1 of the proposed multimodal CodeWiki work from #655.

This PR adds server-side evidence packs for planned wiki media slots. Media generation receives bounded, source-grounded context while raw source snippets and provider prompts stay out of frontend-visible wiki payloads. This slice intentionally introduces the provider-neutral evidence contract without adding VLM/provider configuration.

## Changes

- Add `WikiMediaEvidencePack` and `build_media_evidence_pack` for source-grounded wiki media planning.
- Include bounded source snippets, graph/fact-style relations, human priors, and output requirements as transient server-side generation inputs.
- Accept the native `node_name` and `content` fields emitted by both wiki implementations.
- Pass evidence packs into `materialize_media_slots` through an optional `evidence_builder` hook.
- Wire the public wiki materialization path to page citations, AgentWiki relation metadata, and authenticated bounded source reads.
- Normalize builder- and caller-supplied packs through the same canonical path, count, depth, JSON, and UTF-8 byte constraints before provider dispatch.
- Keep evidence packs out of returned page payloads, including read-only preload, disabled-provider, and failed-materialization paths.
- Store `evidence_pack_sha256` in generated asset metadata for auditability.
- Redact source snippets from the public asset prompt while preserving safe citations and provenance.
- Add regression tests for evidence-pack construction, native citations, privacy fallbacks, bounds, and media materialization behavior.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

Commands run against the latest `main` integration tree:

```text
pytest -q test/wiki/test_media_evidence.py test/wiki/test_media_generation.py test/web/test_app_runtime.py --tb=short --deselect=test/web/test_app_runtime.py::test_request_timing_header_and_slow_log_exclude_query
pytest -q test/web/test_app_runtime.py --tb=short --deselect=test/web/test_app_runtime.py::test_request_timing_header_and_slow_log_exclude_query
pytest -q test/web test/wiki --tb=short --deselect=test/web/test_app_runtime.py::test_request_timing_header_and_slow_log_exclude_query
pytest -q test/wiki --tb=short
pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short --deselect=test/web/test_app_runtime.py::test_request_timing_header_and_slow_log_exclude_query
pre-commit run --files codenib/wiki/media_evidence.py codenib/wiki/media_generation.py codenib/web/app.py test/wiki/test_media_evidence.py test/wiki/test_media_generation.py test/web/test_app_runtime.py
```

Latest local results:

```text
68 focused tests passed, 1 known caplog baseline test deselected
29 web runtime tests passed, 1 known caplog baseline test deselected
685 web and wiki tests passed, 1 known caplog baseline test deselected
353 wiki tests passed
6745 unit tests passed, 71 skipped, 191 deselected
all pre-commit hooks passed
```

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented code where needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
