### PR TITLE
feat(storage): serve retained catalog contexts

### DIFF
--- a/codenib/artifacts/__init__.py
+++ b/codenib/artifacts/__init__.py
@@ -30,6 +30,7 @@ from .runtime import (
     VerifiedContextArtifact,
     bind_context_artifact,
     query_context_artifact,
+    query_context_artifact_reader,
     verify_context_artifact,
 )
 from .strict_bm25 import (
@@ -73,6 +74,7 @@ __all__ = [
     "publish_planned_bm25_view_strict",
     "publish_planned_context_artifact_strict",
     "query_context_artifact",
+    "query_context_artifact_reader",
     "recapture_bm25_view_strict",
     "recapture_vector_view_strict",
     "validate_portable_query_view",

--- a/codenib/artifacts/runtime.py
+++ b/codenib/artifacts/runtime.py
@@ -12,6 +12,7 @@ import re
 from contextlib import contextmanager
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
+from dataclasses import replace
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Iterator, Mapping, NoReturn
 
@@ -25,6 +26,7 @@ from .._atomic_directory import (
     reopen_authenticated_directory,
 )
 from .._bounded_json import iter_bounded_json_array
+from .._captured_directory import PublishedWorkspaceReceipt
 from .._contained_source import _attach_source_cleanup_owner
 from ..compiler.checkout_identity import checkout_commit
 from ..compiler.manifest import (
@@ -36,7 +38,9 @@ from ..compiler.manifest import (
 from ..compiler.manifest_source import (
     capture_repository_source_for_manifest as capture_repository_source,
 )
-from ..compiler.manifest_source import require_manifest_source_identity
+from ..compiler.manifest_source import (
+    require_manifest_source_identity,
+)
 from ..compiler.snapshot_store import normalize_repo
 from ..repository_filters import (
     REPOSITORY_FILTER_POLICY_VERSION,
@@ -217,6 +221,11 @@ class ContextArtifactBinding:
     repo_path: Path | None
     manifest: RepoManifest
     checkout_commit_observed: str | None = None
+    _requires_authenticated_reader: bool = dataclass_field(
+        default=False,
+        repr=False,
+        compare=False,
+    )
     _source_binding: RepositorySourceBinding | None = dataclass_field(
         default=None,
         repr=False,
@@ -1291,12 +1300,77 @@ def query_context_artifact(
     )
 
 
+def query_context_artifact_reader(
+    receipt: PublishedWorkspaceReceipt,
+    publication: PublicationDirectoryReader,
+    *,
+    expected_root: str | Path,
+    expected_ownership: object,
+    expected_repository: str | None = None,
+    expected_commit: str | None = None,
+) -> ContextArtifactBinding:
+    """Create a query binding inside one exact workspace-receipt callback."""
+
+    if type(receipt) is not PublishedWorkspaceReceipt:
+        raise TypeError("context artifact receipt has an invalid type")
+    if type(publication) is not PublicationDirectoryReader:
+        raise TypeError("context artifact publication reader has an invalid type")
+
+    real_root = lexical_directory_path(Path(expected_root))
+    if receipt.path != real_root:
+        raise RuntimeError(
+            "context artifact receipt path differs from its expected root"
+        )
+    if receipt.ownership != expected_ownership:
+        raise RuntimeError("context artifact receipt ownership changed")
+    if publication._require_expected_ownership_token() != expected_ownership:
+        raise RuntimeError("context artifact publication ownership changed")
+
+    artifact = verify_context_artifact_reader(
+        publication,
+        expected_repository=expected_repository,
+        expected_commit=expected_commit,
+        expected_manifest_version=None,
+    )
+    if artifact.ownership != expected_ownership:
+        raise RuntimeError("context artifact verified ownership changed")
+
+    try:
+        metadata_relative = artifact.metadata_path.relative_to(artifact.root)
+        manifest_relative = artifact.manifest_path.relative_to(artifact.root)
+    except ValueError as exc:
+        raise RuntimeError(
+            "context artifact verification paths are not contained"
+        ) from exc
+    if (metadata_relative, manifest_relative) != (
+        Path(CONTEXT_ARTIFACT_MANIFEST),
+        Path(MANIFEST_FILENAME),
+    ):
+        raise RuntimeError("context artifact verification paths are not canonical")
+
+    relocated = replace(
+        artifact,
+        root=real_root,
+        metadata_path=real_root / metadata_relative,
+        manifest_path=real_root / manifest_relative,
+    )
+    return ContextArtifactBinding(
+        artifact=relocated,
+        repo_path=None,
+        manifest=relocated.manifest,
+        checkout_commit_observed=None,
+        _requires_authenticated_reader=True,
+        _source_binding=None,
+    )
+
+
 __all__ = [
     "ContextArtifactBinding",
     "SourceBindingCleanupOwner",
     "VerifiedContextArtifact",
     "bind_context_artifact",
     "query_context_artifact",
+    "query_context_artifact_reader",
     "verify_context_artifact",
     "verify_context_artifact_reader",
 ]

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -815,8 +815,74 @@ def _run_index(
     return 0
 
 
-def _run_mcp(args: argparse.Namespace) -> int:
+def _mcp_context_mode(args: argparse.Namespace) -> str:
+    """Select one MCP startup mode before module or filesystem access."""
+
     runtime_probe = bool(getattr(args, "runtime_probe", False))
+    explicit_path = getattr(args, "path", None) is not None
+    artifact = getattr(args, "artifact", None)
+    repo = getattr(args, "repo", None)
+    repository = getattr(args, "repository", None)
+    retained_values = {
+        "--catalog": getattr(args, "catalog", None),
+        "--cas-root": getattr(args, "cas_root", None),
+        "--workspace-root": getattr(args, "workspace_root", None),
+        "--output": getattr(args, "output", None),
+        "--namespace": getattr(args, "namespace", None),
+        "--ref": getattr(args, "ref", None),
+        "--snapshot": getattr(args, "snapshot", None),
+        "--expected-generation": getattr(args, "expected_generation", None),
+    }
+    retained_requested = any(value is not None for value in retained_values.values())
+    any_context = (
+        explicit_path
+        or artifact is not None
+        or repo is not None
+        or repository is not None
+        or retained_requested
+    )
+    if runtime_probe:
+        if any_context:
+            raise CLIError("--runtime-probe cannot be combined with MCP context input")
+        return "probe"
+    if retained_requested:
+        if (
+            retained_values["--snapshot"] is not None
+            and retained_values["--expected-generation"] is not None
+        ):
+            raise CLIError("--expected-generation requires retained ref selection")
+        if explicit_path or artifact is not None or repo is not None:
+            raise CLIError(
+                "retained MCP storage cannot be combined with a manifest, "
+                "--artifact, or --repo"
+            )
+        missing = [
+            option
+            for option in (
+                "--catalog",
+                "--cas-root",
+                "--workspace-root",
+                "--output",
+            )
+            if retained_values[option] is None
+        ]
+        if repository is None:
+            missing.append("--repository")
+        if missing:
+            raise CLIError("retained MCP storage requires " + ", ".join(missing))
+        return "retained"
+    if artifact is not None:
+        if explicit_path:
+            raise CLIError("choose either a manifest or --artifact, not both")
+        return "artifact"
+    if repo is not None or repository is not None:
+        raise CLIError("--repo and --repository require --artifact")
+    return "manifest"
+
+
+def _run_mcp(args: argparse.Namespace) -> int:
+    mode = _mcp_context_mode(args)
+    runtime_probe = mode == "probe"
     if runtime_probe:
         _require_modules(
             ("mcp", "igraph", "google.protobuf"),
@@ -831,7 +897,9 @@ def _run_mcp(args: argparse.Namespace) -> int:
         print("codenib codegraph mcp runtime ready")
         return 0
 
-    if args.artifact:
+    if mode == "retained":
+        return _run_mcp_retained(args)
+    if mode == "artifact":
         command = [
             "--artifact",
             str(Path(os.path.abspath(os.fspath(Path(args.artifact).expanduser())))),
@@ -850,7 +918,7 @@ def _run_mcp(args: argparse.Namespace) -> int:
             command.extend(("--repository", args.repository))
         mcp_main(command)
     else:
-        manifest_path = resolve_manifest_path(args.path)
+        manifest_path = resolve_manifest_path(args.path or ".")
         mcp_main(
             [
                 str(manifest_path),
@@ -861,6 +929,160 @@ def _run_mcp(args: argparse.Namespace) -> int:
             ]
         )
     return 0
+
+
+def _run_mcp_retained(args: argparse.Namespace) -> int:
+    """Cold-start MCP from one retained ref or immutable snapshot."""
+
+    from . import LocalWorkspaceProvider
+    from ._atomic_directory import (
+        _annotate_secondary_error,
+        _OrderedAction,
+        _run_context_with_cleanup_actions,
+    )
+    from .mcp.retained_context import (
+        RetainedServerContextOwner,
+        load_retained_server_context_ref,
+        load_retained_server_context_snapshot,
+    )
+    from .mcp.server import serve_retained_context
+    from .storage import LocalCAS, SQLiteCatalog
+
+    repository, namespace = _retained_materialization_identity(
+        args.repository,
+        args.namespace or "default",
+    )
+    ref_name, snapshot_id, expected_generation = _retained_materialization_selector(
+        ref_name=args.ref,
+        snapshot_id=args.snapshot,
+        expected_generation=args.expected_generation,
+    )
+    catalog_path, cas_root, workspace_root, output = _retained_materialization_paths(
+        args
+    )
+    runtime_owner = RetainedServerContextOwner()
+    topology_owner = _RetainedMaterializationResourceOwner()
+    object_store_owner = _RetainedMaterializationResourceOwner()
+    catalog_owner = _RetainedMaterializationResourceOwner()
+    runtime_cleanup = (
+        _OrderedAction(
+            label="retained MCP runtime cleanup also failed",
+            action=runtime_owner.close,
+            complete=lambda: runtime_owner.closed,
+            retry_incomplete="cancellation",
+            incomplete_owner=runtime_owner,
+        ),
+    )
+    storage_cleanup = (
+        _OrderedAction(
+            label="retained SQLite catalog cleanup also failed",
+            action=catalog_owner.close,
+            complete=lambda: catalog_owner.closed,
+            retry_incomplete="cancellation",
+            incomplete_owner=catalog_owner,
+        ),
+        _OrderedAction(
+            label="retained local CAS cleanup also failed",
+            action=object_store_owner.close,
+            complete=lambda: object_store_owner.closed,
+            retry_incomplete="cancellation",
+            incomplete_owner=object_store_owner,
+        ),
+        _OrderedAction(
+            label="retained path authority cleanup also failed",
+            action=topology_owner.close,
+            complete=lambda: topology_owner.closed,
+            retry_incomplete="cancellation",
+            incomplete_owner=topology_owner,
+        ),
+    )
+    try:
+        with _run_context_with_cleanup_actions(runtime_cleanup):
+            with _run_context_with_cleanup_actions(storage_cleanup):
+                base_provider = LocalWorkspaceProvider(workspace_root)
+                base_provider.require_support()
+                topology = topology_owner.acquire(
+                    lambda: _require_retained_materialization_topology(
+                        catalog_path,
+                        cas_root,
+                        workspace_root,
+                        output,
+                    )
+                )
+                provider = _RetainedTopologyWorkspaceProvider(
+                    base_provider,
+                    topology,
+                )
+                topology.verify()
+                object_store = object_store_owner.acquire(
+                    lambda: LocalCAS(
+                        topology.cas_root,
+                        require_preprovisioned=True,
+                    )
+                )
+                _require_retained_catalog_binding(
+                    topology.catalog_path,
+                    topology.catalog_identity,
+                )
+                catalog = catalog_owner.acquire(
+                    lambda: SQLiteCatalog(
+                        topology.catalog_path,
+                        create=False,
+                        expected_file_identity=topology.catalog_identity,
+                    )
+                )
+                _require_retained_catalog_binding(
+                    topology.catalog_path,
+                    topology.catalog_identity,
+                )
+                if snapshot_id is None:
+                    load_retained_server_context_ref(
+                        repository,
+                        output,
+                        namespace_name=namespace,
+                        ref_name=ref_name or "main",
+                        expected_generation=expected_generation,
+                        catalog=catalog,
+                        object_store=object_store,
+                        workspace_provider=provider,
+                        runtime_owner=runtime_owner,
+                    )
+                else:
+                    load_retained_server_context_snapshot(
+                        repository,
+                        snapshot_id,
+                        output,
+                        namespace_name=namespace,
+                        catalog=catalog,
+                        object_store=object_store,
+                        workspace_provider=provider,
+                        runtime_owner=runtime_owner,
+                    )
+            serve_retained_context(
+                runtime_owner,
+                log_level=args.log_level,
+                tool_surface=args.tool_surface,
+            )
+        return 0
+    except BaseException as primary_error:  # noqa: B036 - preserve cancellation
+        try:
+            _warn_possible_retained_publication(output)
+        except BaseException as warning_error:  # noqa: B036 - diagnostic only
+            _annotate_secondary_error(
+                primary_error,
+                "retained MCP publication warning also failed",
+                warning_error,
+            )
+        if isinstance(primary_error, CLIError):
+            raise
+        if isinstance(
+            primary_error,
+            (OSError, RuntimeError, ValueError, sqlite3.Error),
+        ):
+            wrapped = CLIError(str(primary_error))
+            _inherit_publication_cleanup_owners(wrapped, primary_error)
+            raise wrapped from primary_error
+        raise
 
 
 def _run_export(args: argparse.Namespace) -> int:
@@ -5423,7 +5645,7 @@ def build_parser() -> argparse.ArgumentParser:
     mcp_parser.add_argument(
         "path",
         nargs="?",
-        default=".",
+        default=None,
         help="repository directory or repo_manifest.json",
     )
     mcp_parser.add_argument(
@@ -5436,7 +5658,44 @@ def build_parser() -> argparse.ArgumentParser:
     )
     mcp_parser.add_argument(
         "--repository",
-        help="expected owner/repository identity for --artifact",
+        help=(
+            "expected owner/repository identity for --artifact, or the required "
+            "catalog repository key for retained startup"
+        ),
+    )
+    mcp_parser.add_argument(
+        "--catalog",
+        help="existing initialized SQLite catalog for retained startup",
+    )
+    mcp_parser.add_argument(
+        "--cas-root",
+        help="existing fully preprovisioned local CAS root",
+    )
+    mcp_parser.add_argument(
+        "--workspace-root",
+        help="existing private owner-only LocalWorkspaceProvider root",
+    )
+    mcp_parser.add_argument(
+        "--output",
+        help="missing retained materialization directory below the workspace root",
+    )
+    mcp_parser.add_argument(
+        "--namespace",
+        help="logical retained catalog namespace; defaults to default",
+    )
+    retained_mcp_selector = mcp_parser.add_mutually_exclusive_group()
+    retained_mcp_selector.add_argument(
+        "--ref",
+        help="retained repository ref to resolve once; defaults to main",
+    )
+    retained_mcp_selector.add_argument(
+        "--snapshot",
+        help="immutable retained snapshot ID to load instead of a ref",
+    )
+    mcp_parser.add_argument(
+        "--expected-generation",
+        type=_argparse_positive_int,
+        help="required current generation for retained ref resolution",
     )
     mcp_parser.add_argument(
         "--log-level",

--- a/codenib/mcp/context.py
+++ b/codenib/mcp/context.py
@@ -17,7 +17,7 @@ import json
 import logging
 import math
 import sys
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from threading import RLock
@@ -401,8 +401,10 @@ class ServerContext:
         views: Iterable[str] | None = None,
         artifact: Mapping[str, Any] | None = None,
         artifact_binding: ContextArtifactBinding | None = None,
+        artifact_reader: PublicationDirectoryReader | None = None,
         native_index_authorization: NativeIndexAuthorization | None = None,
         source_binding: RepositorySourceBinding | None = None,
+        _context_owner: Callable[[ServerContext], None] | None = None,
     ) -> ServerContext:
         """Load a manifest and the selected runtime views.
 
@@ -413,6 +415,17 @@ class ServerContext:
         """
         ctx: ServerContext | None = None
         try:
+            if (
+                artifact_reader is not None
+                and type(artifact_reader) is not PublicationDirectoryReader
+            ):
+                raise TypeError(
+                    "authenticated artifact reader must use the exact reader type"
+                )
+            if artifact_reader is not None and artifact_binding is None:
+                raise ValueError(
+                    "an authenticated artifact reader requires its verified binding"
+                )
             selected = _resolve_views(views)
             artifact_origin = artifact is not None or artifact_binding is not None
             if artifact_origin and native_index_authorization is not None:
@@ -450,6 +463,14 @@ class ServerContext:
                 _artifact_binding=artifact_binding,
                 _source_binding=None,
             )
+            if _context_owner is not None:
+                if not callable(_context_owner):
+                    raise TypeError("context owner must be callable")
+                # Publish the context in a stable caller-owned slot before it
+                # acquires any runtime resource.  A cancellation after a view
+                # loader returns can then be reconciled by that owner instead
+                # of dropping an unreturned live context.
+                _context_owner(ctx)
             if artifact_binding is not None:
                 artifact_binding.install_source_binding(
                     ctx._install_repository_source,
@@ -492,7 +513,10 @@ class ServerContext:
                 else "source binding has not been verified"
             )
 
-            ctx.load_views(selected)
+            if artifact_reader is None:
+                ctx.load_views(selected)
+            else:
+                ctx.load_views(selected, artifact_reader=artifact_reader)
             ctx.configure_lsp_provider(
                 allow_native=False,
                 native_disabled_reason=(
@@ -579,6 +603,7 @@ class ServerContext:
         views: Iterable[str],
         *,
         native_index_authorization: NativeIndexAuthorization | None = None,
+        artifact_reader: PublicationDirectoryReader | None = None,
     ) -> Dict[str, str]:
         """Load additional manifest views without disturbing loaded resources.
 
@@ -590,6 +615,17 @@ class ServerContext:
 
         selected = _resolve_views(views)
         with self._view_lock:
+            if (
+                artifact_reader is not None
+                and type(artifact_reader) is not PublicationDirectoryReader
+            ):
+                raise TypeError(
+                    "authenticated artifact reader must use the exact reader type"
+                )
+            if artifact_reader is not None and self._artifact_binding is None:
+                raise ValueError(
+                    "an authenticated artifact reader requires its verified binding"
+                )
             artifact_origin = (
                 self.artifact is not None or self._artifact_binding is not None
             )
@@ -612,7 +648,10 @@ class ServerContext:
             for view, loader_name in _VIEW_LOADERS:
                 if view not in selected or getattr(self, view, None) is not None:
                     continue
-                getattr(self, loader_name)()
+                if view == "bm25" and artifact_reader is not None:
+                    self._load_bm25(artifact_reader=artifact_reader)
+                else:
+                    getattr(self, loader_name)()
                 if getattr(self, view, None) is not None:
                     self.errors.pop(view, None)
             if "symbol_graph" in selected:
@@ -837,7 +876,11 @@ class ServerContext:
             self.errors["symbol_graph"] = str(exc)
             logger.warning("Failed to load symbol_graph: %s", exc)
 
-    def _load_bm25(self) -> None:
+    def _load_bm25(
+        self,
+        *,
+        artifact_reader: PublicationDirectoryReader | None = None,
+    ) -> None:
         entry = self.manifest.indexes.get("bm25")
         if not entry or not self.manifest.index_is_current("bm25"):
             return
@@ -878,11 +921,25 @@ class ServerContext:
                             source_mode=SOURCE_MODE_PERSISTED_ONLY,
                         )
 
-                reopen_authenticated_directory(
-                    artifact.root,
-                    artifact.ownership,  # type: ignore[arg-type]
-                    load_portable_bm25,
-                )
+                if artifact_reader is not None:
+                    observed = artifact_reader._require_expected_ownership_token()
+                    if observed != artifact.ownership:
+                        raise ValueError(
+                            "authenticated artifact reader ownership does not match "
+                            "its verified binding"
+                        )
+                    load_portable_bm25(artifact_reader)
+                elif self._artifact_binding._requires_authenticated_reader:
+                    raise ValueError(
+                        "reader-bound portable BM25 loading requires a fresh "
+                        "authenticated publication reader"
+                    )
+                else:
+                    reopen_authenticated_directory(
+                        artifact.root,
+                        artifact.ownership,  # type: ignore[arg-type]
+                        load_portable_bm25,
+                    )
             if self._source_binding is not None:
                 indexer.bind_repository_source(self._source_binding)
             else:

--- a/codenib/mcp/retained_context.py
+++ b/codenib/mcp/retained_context.py
@@ -1,0 +1,778 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cold-start one MCP context from an exact retained catalog generation.
+
+The retained materializer deliberately returns data while leaving the published
+workspace authority in a caller-created :class:`PublishedWorkspaceReceiptOwner`.
+This module joins those two outputs without reopening the published path.  The
+receipt callback verifies the context artifact, loads its query-only runtime,
+and installs both the live context and a detached result in a PID-bound owner.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping, TypeVar
+
+from .._atomic_directory import (
+    PublicationDirectoryReader,
+    _annotate_secondary_error,
+    _attach_publication_cleanup_owner,
+    _OrderedAction,
+    _run_context_with_cleanup_actions,
+    directory_ownership_file_records,
+    lexical_directory_path,
+)
+from .._captured_directory import (
+    PublishedWorkspaceReceipt,
+    PublishedWorkspaceReceiptOwner,
+)
+from .._owned_file_publication import _CancellationSafeRLock
+from .._workspace_provider import StrictWorkspaceProvider
+from ..artifacts.context import (
+    CONTEXT_ARTIFACT_MANIFEST,
+    CONTEXT_ARTIFACT_SCHEMA,
+    ContextArtifactResult,
+)
+from ..artifacts.runtime import ContextArtifactBinding, query_context_artifact_reader
+from ..compiler.manifest import MANIFEST_FILENAME
+from ..compiler.manifest_import import (
+    DEFAULT_MAX_CONTEXT_BYTES,
+    DEFAULT_MAX_CONTEXT_FILES,
+    DEFAULT_MAX_PROJECTION_BYTES,
+    DEFAULT_NAMESPACE_NAME,
+    DEFAULT_REF_NAME,
+)
+from ..compiler.manifest_materialization import (
+    RepoManifestMaterializationResult,
+    materialize_retained_repo_manifest_ref,
+    materialize_retained_repo_manifest_snapshot,
+)
+from ..compiler.manifest_storage import DEFAULT_MAX_MANIFEST_BYTES
+from ..storage.models import NamespaceIdentity
+from ..storage.protocols import ReceiptRetainingObjectStore, RetainedSnapshotCatalog
+from ..storage.view_bundle import (
+    DEFAULT_MAX_BUNDLE_BYTES,
+    DEFAULT_MAX_BUNDLE_FILES,
+    DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+)
+from .context import ServerContext
+
+_Result = TypeVar("_Result")
+
+_OWNER_EMPTY = object()
+_OWNER_CLOSED = object()
+
+
+@dataclass(frozen=True, slots=True)
+class RetainedServerContextResult:
+    """Detached result for one activated retained query context."""
+
+    materialization: RepoManifestMaterializationResult
+    loaded_views: tuple[str, ...]
+    view_error_items: tuple[tuple[str, str], ...]
+
+    def __post_init__(self) -> None:
+        if type(self) is not RetainedServerContextResult:
+            raise TypeError("retained server context result must use the exact type")
+        if type(self.materialization) is not RepoManifestMaterializationResult:
+            raise TypeError("retained server context materialization is invalid")
+        if type(self.loaded_views) is not tuple or any(
+            type(view) is not str for view in self.loaded_views
+        ):
+            raise TypeError("retained server loaded views must be an exact text tuple")
+        if type(self.view_error_items) is not tuple:
+            raise TypeError("retained server view errors must be an exact tuple")
+
+        selected = self.materialization.artifact.views
+        selected_set = set(selected)
+        loaded_set = set(self.loaded_views)
+        if (
+            len(loaded_set) != len(self.loaded_views)
+            or not loaded_set <= selected_set
+            or self.loaded_views
+            != tuple(view for view in selected if view in loaded_set)
+        ):
+            raise ValueError(
+                "retained server loaded views differ from materialization order"
+            )
+
+        error_views: list[str] = []
+        previous = ""
+        for item in self.view_error_items:
+            if (
+                type(item) is not tuple
+                or len(item) != 2
+                or type(item[0]) is not str
+                or type(item[1]) is not str
+                or not item[1]
+            ):
+                raise TypeError("retained server view error entries are invalid")
+            view = item[0]
+            if view <= previous or view not in selected_set or view in loaded_set:
+                raise ValueError("retained server view errors are not canonical")
+            previous = view
+            error_views.append(view)
+        if loaded_set | set(error_views) != selected_set:
+            raise ValueError("retained server result does not account for every view")
+
+
+class RetainedServerContextOwner:
+    """PID-bound one-shot owner for a retained context and its publication."""
+
+    __slots__ = (
+        "_slot",
+        "_reservation",
+        "_result",
+        "_receipt_owner",
+        "_lock",
+        "_owner_pid",
+        "_process_locks",
+        "_context_close_complete",
+        "_close_failed",
+    )
+
+    def __init__(self) -> None:
+        self._slot: object = _OWNER_EMPTY
+        self._reservation: object | None = None
+        self._result: RetainedServerContextResult | None = None
+        # The publication destination is pre-created with this aggregate.  No
+        # materializer return/store seam ever becomes the sole receipt owner.
+        self._receipt_owner = PublishedWorkspaceReceiptOwner()
+        self._lock = _CancellationSafeRLock()
+        self._owner_pid = os.getpid()
+        self._process_locks = {self._owner_pid: self._lock}
+        self._context_close_complete = False
+        self._close_failed = False
+
+    @property
+    def state(self) -> str:
+        self._require_owner_pid()
+        return self._lock.run(self._state_locked)
+
+    @property
+    def context(self) -> ServerContext:
+        self._require_owner_pid()
+
+        def borrow() -> ServerContext:
+            if (
+                self._state_locked() != "active"
+                or type(self._slot) is not ServerContext
+            ):
+                raise RuntimeError(
+                    "retained server context owner is "
+                    f"{self._state_locked()}, expected active"
+                )
+            return self._slot
+
+        return self._lock.run(borrow)
+
+    @property
+    def result(self) -> RetainedServerContextResult:
+        self._require_owner_pid()
+
+        def borrow() -> RetainedServerContextResult:
+            if self._state_locked() != "active" or self._result is None:
+                raise RuntimeError(
+                    "retained server context owner is "
+                    f"{self._state_locked()}, expected active"
+                )
+            return self._result
+
+        return self._lock.run(borrow)
+
+    @property
+    def closed(self) -> bool:
+        return self.state == "closed"
+
+    def _begin_loading(self, reservation: object) -> None:
+        """Reserve this one-shot owner before any retained-storage operation."""
+
+        self._require_owner_pid()
+
+        def reserve() -> None:
+            if self._slot is not _OWNER_EMPTY:
+                raise RuntimeError(
+                    "retained server context owner is "
+                    f"{self._state_locked()}, expected empty"
+                )
+            if self._receipt_owner.state != "empty":
+                raise RuntimeError(
+                    "retained server context publication owner is not empty"
+                )
+            # Retain the caller-created identity first.  Cleanup can therefore
+            # recognize this invocation even if cancellation lands before the
+            # following slot store or before this method returns.
+            self._reservation = reservation
+            self._slot = reservation
+
+        self._lock.run(reserve)
+
+    def _owns_reservation(self, reservation: object) -> bool:
+        """Return whether this invocation acquired the one-shot owner."""
+
+        self._require_owner_pid()
+        return self._lock.run(lambda: self._reservation is reservation)
+
+    def _close_reservation(self, reservation: object) -> None:
+        """Close only resources acquired by one exact load invocation."""
+
+        if self._owns_reservation(reservation):
+            self.close()
+
+    def _run_loading(
+        self,
+        reservation: object,
+        operation: Callable[[PublishedWorkspaceReceiptOwner], _Result],
+    ) -> _Result:
+        """Serialize materialization, receipt consumption, and activation."""
+
+        if not callable(operation):
+            raise TypeError("retained server context loader must be callable")
+        self._require_owner_pid()
+        if self._lock.held_by_current_thread():
+            raise RuntimeError("retained server context loading is reentrant")
+
+        def run() -> _Result:
+            if (
+                self._reservation is not reservation
+                or self._slot is not reservation
+                or self._result is not None
+            ):
+                raise RuntimeError(
+                    "retained server context loading reservation changed"
+                )
+            return operation(self._receipt_owner)
+
+        return self._lock.run(run)
+
+    def _install_context(self, context: ServerContext) -> None:
+        """Install the live context before its first runtime resource load."""
+
+        self._require_owner_pid()
+
+        def install() -> None:
+            if type(context) is not ServerContext:
+                raise TypeError("retained server context must use the exact type")
+            if (
+                self._reservation is None
+                or self._state_locked() != "loading"
+                or type(self._slot) is ServerContext
+            ):
+                raise RuntimeError("retained server context installation changed")
+            self._slot = context
+            self._context_close_complete = False
+
+        self._lock.run(install)
+
+    def _install_result(self, result: RetainedServerContextResult) -> None:
+        """Make the pure result visible only after every runtime gate passes."""
+
+        self._require_owner_pid()
+
+        def install() -> None:
+            if type(result) is not RetainedServerContextResult:
+                raise TypeError("retained server result must use the exact type")
+            if type(self._slot) is not ServerContext or self._result is not None:
+                raise RuntimeError("retained server result installation changed")
+            self._result = result
+
+        self._lock.run(install)
+
+    def close(self) -> None:
+        """In the owning process, close context before its publication receipt."""
+
+        current_pid = os.getpid()
+        owner_changed = current_pid != self._owner_pid
+        if owner_changed:
+            lifecycle_lock = self._process_locks.setdefault(
+                current_pid,
+                _CancellationSafeRLock(),
+            )
+        else:
+            if self._lock.held_by_current_thread():
+                raise RuntimeError("retained server context close is reentrant")
+            lifecycle_lock = self._lock
+
+        close_error: BaseException | None = None
+        try:
+            lifecycle_lock.run(
+                self._close_inherited_locked if owner_changed else self._close_locked
+            )
+        except BaseException as exc:  # noqa: B036 - reconcile before PID report
+            close_error = exc
+
+        if owner_changed:
+            boundary_error = RuntimeError(
+                "retained server context owner cannot cross a PID boundary"
+            )
+            if close_error is not None:
+                raise boundary_error from close_error
+            raise boundary_error
+        if close_error is not None:
+            if not self.closed:
+                _attach_publication_cleanup_owner(close_error, self)
+            raise close_error
+
+    def _close_inherited_locked(self) -> None:
+        """Revoke inherited publication handles without touching copied locks."""
+
+        # A lock in the copied ServerContext may have been owned by a different
+        # thread at fork time.  That thread does not exist in the child, so
+        # context.close() could block forever before reaching the publication
+        # receipt.  The retained context is source-disabled and native-inert;
+        # the PID-bound receipt is the authority that must be revoked here.
+        self._receipt_owner.close()
+        self._finish_closed_locked()
+
+    def _close_locked(self) -> None:
+        if self._slot is _OWNER_CLOSED:
+            return
+        self._close_failed = False
+
+        context = self._slot if type(self._slot) is ServerContext else None
+        if context is not None and not self._context_close_complete:
+            try:
+                context.close()
+            except BaseException as exc:  # noqa: B036 - receipt must stay active
+                self._close_failed = True
+                _attach_publication_cleanup_owner(exc, self)
+                raise
+            self._context_close_complete = True
+
+        try:
+            self._receipt_owner.close()
+        except BaseException as exc:  # noqa: B036 - retain receipt retry authority
+            receipt_closed = False
+            if os.getpid() == self._owner_pid:
+                try:
+                    receipt_closed = self._receipt_owner.closed
+                except BaseException as observation_error:  # noqa: B036
+                    _annotate_secondary_error(
+                        exc,
+                        "retained publication close-state observation also failed",
+                        observation_error,
+                    )
+            if receipt_closed:
+                self._finish_closed_locked()
+            else:
+                self._close_failed = True
+                _attach_publication_cleanup_owner(exc, self)
+            raise
+
+        if os.getpid() == self._owner_pid and not self._receipt_owner.closed:
+            self._close_failed = True
+            failure = RuntimeError("retained publication cleanup is incomplete")
+            _attach_publication_cleanup_owner(failure, self)
+            raise failure
+        self._finish_closed_locked()
+
+    def _finish_closed_locked(self) -> None:
+        self._slot = _OWNER_CLOSED
+        self._reservation = None
+        self._result = None
+        self._context_close_complete = True
+        self._close_failed = False
+
+    def _state_locked(self) -> str:
+        if self._slot is _OWNER_EMPTY:
+            return "empty"
+        if self._slot is _OWNER_CLOSED:
+            return "closed"
+        if self._close_failed:
+            return "close-failed"
+        if self._result is not None:
+            return "active"
+        return "loading"
+
+    def _require_owner_pid(self) -> None:
+        if os.getpid() != self._owner_pid:
+            raise RuntimeError(
+                "retained server context owner cannot cross a PID boundary"
+            )
+
+    def __enter__(self) -> "RetainedServerContextOwner":
+        self._require_owner_pid()
+        return self
+
+    def __exit__(self, _exc_type: object, _exc: object, _traceback: object) -> None:
+        self.close()
+
+
+def _require_materialization_result(
+    value: object,
+) -> RepoManifestMaterializationResult:
+    if type(value) is not RepoManifestMaterializationResult:
+        raise TypeError("retained MCP materializer returned an invalid result")
+    return value
+
+
+def _require_requested_materialization(
+    value: object,
+    *,
+    repository_key: str,
+    namespace_name: str,
+    destination: Path,
+    ref_name: str | None,
+    snapshot_id: str | None,
+    expected_generation: int | None,
+) -> RepoManifestMaterializationResult:
+    """Bind a materializer result back to the exact cold-start selector."""
+
+    result = _require_materialization_result(value)
+    receipt = result.export_receipt
+    expected_namespace_id = NamespaceIdentity(namespace_name).namespace_id
+    expected_destination = lexical_directory_path(destination)
+    if (
+        receipt.repository_key != repository_key
+        or receipt.namespace_id != expected_namespace_id
+        or result.artifact.repository != repository_key
+    ):
+        raise RuntimeError(
+            "retained MCP materializer returned a different repository or namespace"
+        )
+    if result.artifact.output_dir != expected_destination:
+        raise RuntimeError("retained MCP materializer returned a different destination")
+
+    if ref_name is not None:
+        if (
+            snapshot_id is not None
+            or receipt.ref_name != ref_name
+            or (
+                expected_generation is not None
+                and receipt.ref_generation != expected_generation
+            )
+        ):
+            raise RuntimeError("retained MCP ref observation differs from the request")
+    elif (
+        snapshot_id is None
+        or receipt.snapshot_id != snapshot_id
+        or receipt.ref_name is not None
+        or receipt.ref_generation is not None
+        or receipt.ref_updated_at is not None
+        or expected_generation is not None
+    ):
+        raise RuntimeError("retained MCP snapshot observation differs from the request")
+    return result
+
+
+def _cross_check_binding(
+    materialization: RepoManifestMaterializationResult,
+    receipt: PublishedWorkspaceReceipt,
+    publication: PublicationDirectoryReader,
+) -> ContextArtifactBinding:
+    """Verify and cross-bind every data and authority projection."""
+
+    artifact_result = materialization.artifact
+    export_receipt = materialization.export_receipt
+    if type(artifact_result) is not ContextArtifactResult:
+        raise TypeError("retained MCP materialization artifact is invalid")
+    if (
+        not isinstance(artifact_result.output_dir, Path)
+        or not isinstance(artifact_result.metadata_path, Path)
+        or not isinstance(artifact_result.manifest_path, Path)
+        or type(artifact_result.repository) is not str
+        or type(artifact_result.commit) is not str
+        or type(artifact_result.views) is not tuple
+        or any(type(view) is not str for view in artifact_result.views)
+        or type(artifact_result.file_count) is not int
+        or artifact_result.file_count <= 0
+        or type(artifact_result.byte_count) is not int
+        or artifact_result.byte_count < 0
+    ):
+        raise TypeError("retained MCP materialization artifact fields are invalid")
+    root = lexical_directory_path(artifact_result.output_dir)
+    ownership = receipt.ownership
+    if receipt.path != root:
+        raise RuntimeError("retained MCP receipt root differs from materialization")
+    if artifact_result.output_dir != root:
+        raise RuntimeError("retained MCP materialization root is not canonical")
+    if artifact_result.metadata_path != root / CONTEXT_ARTIFACT_MANIFEST:
+        raise RuntimeError("retained MCP metadata path differs from materialization")
+    if artifact_result.manifest_path != root / MANIFEST_FILENAME:
+        raise RuntimeError("retained MCP manifest path differs from materialization")
+    if publication._require_expected_ownership_token() != ownership:
+        raise RuntimeError("retained MCP publication ownership changed")
+    records = tuple(directory_ownership_file_records(ownership))  # type: ignore[arg-type]
+    manifest_records = tuple(
+        record for record in records if record.path == MANIFEST_FILENAME
+    )
+    if (
+        len(manifest_records) != 1
+        or manifest_records[0].sha256 != export_receipt.manifest_digest
+        or manifest_records[0].size != export_receipt.manifest_byte_size
+    ):
+        raise RuntimeError(
+            "retained MCP export receipt differs from the materialized manifest"
+        )
+
+    binding = query_context_artifact_reader(
+        receipt,
+        publication,
+        expected_root=root,
+        expected_ownership=ownership,
+        expected_repository=artifact_result.repository,
+        expected_commit=artifact_result.commit,
+    )
+    verified = binding.artifact
+    if (
+        verified.root != root
+        or verified.ownership != ownership
+        or verified.metadata_path != artifact_result.metadata_path
+        or verified.manifest_path != artifact_result.manifest_path
+    ):
+        raise RuntimeError("retained MCP verified artifact authority changed")
+    if (
+        verified.repository != artifact_result.repository
+        or export_receipt.repository_key != artifact_result.repository
+        or verified.commit != artifact_result.commit
+        or verified.views != artifact_result.views
+        or export_receipt.views != artifact_result.views
+        or verified.file_count != artifact_result.file_count
+        or verified.byte_count != artifact_result.byte_count
+    ):
+        raise RuntimeError("retained MCP materialization identity is inconsistent")
+
+    inventoried = tuple(
+        record for record in records if record.path != CONTEXT_ARTIFACT_MANIFEST
+    )
+    if (
+        len(inventoried) != artifact_result.file_count
+        or sum(record.size for record in inventoried) != artifact_result.byte_count
+        or len(records) != artifact_result.file_count + 1
+    ):
+        raise RuntimeError("retained MCP receipt counts differ from materialization")
+    return binding
+
+
+def _activate_materialization(
+    materialization: RepoManifestMaterializationResult,
+    receipt_owner: PublishedWorkspaceReceiptOwner,
+    runtime_owner: RetainedServerContextOwner,
+) -> RetainedServerContextResult:
+    """Consume one exact publication reader and activate its query runtime."""
+
+    artifact_result = materialization.artifact
+
+    def activate(
+        receipt: PublishedWorkspaceReceipt,
+        publication: PublicationDirectoryReader,
+    ) -> RetainedServerContextResult:
+        binding = _cross_check_binding(materialization, receipt, publication)
+        if "bm25" not in artifact_result.views:
+            raise ValueError("retained MCP contexts require a selected BM25 view")
+        artifact = binding.artifact
+        metadata: Mapping[str, object] = {
+            "verified": True,
+            "schema": CONTEXT_ARTIFACT_SCHEMA,
+            "repository": artifact.repository,
+            "commit": artifact.commit,
+            "views": list(artifact.views),
+        }
+        context = ServerContext.load(
+            binding.manifest,
+            views=artifact_result.views,
+            artifact=metadata,
+            artifact_binding=binding,
+            artifact_reader=publication,
+            _context_owner=runtime_owner._install_context,
+        )
+        if runtime_owner._slot is not context:
+            raise RuntimeError("retained MCP context ownership changed during load")
+        if (
+            context.manifest is not binding.manifest
+            or context._artifact_binding is not binding
+            or context._source_binding is not None
+            or context._native_index_authorization is not None
+            or context.artifact != metadata
+        ):
+            raise RuntimeError("retained MCP query-only context binding changed")
+        if context.bm25 is None:
+            detail = context.errors.get("bm25", "BM25 view did not load")
+            raise RuntimeError(f"retained MCP BM25 view is unavailable: {detail}")
+        if "vector" in artifact_result.views and context.vector is not None:
+            raise RuntimeError("retained MCP vector view did not remain native-inert")
+
+        loaded = context.loaded_views
+        loaded_views = tuple(view for view in artifact_result.views if view in loaded)
+        view_error_items = tuple(
+            (view, context.errors.get(view, "view did not load"))
+            for view in sorted(set(artifact_result.views) - set(loaded_views))
+        )
+        pure_result = RetainedServerContextResult(
+            materialization=materialization,
+            loaded_views=loaded_views,
+            view_error_items=view_error_items,
+        )
+        runtime_owner._install_result(pure_result)
+        return pure_result
+
+    result = receipt_owner.consume(activate)
+    if type(result) is not RetainedServerContextResult:
+        raise RuntimeError("retained MCP receipt consumer returned an invalid result")
+    if runtime_owner.result is not result:
+        raise RuntimeError("retained MCP activated result ownership changed")
+    return result
+
+
+def _load_retained_server_context(
+    runtime_owner: RetainedServerContextOwner,
+    materialize: Callable[
+        [PublishedWorkspaceReceiptOwner], RepoManifestMaterializationResult
+    ],
+    *,
+    repository_key: str,
+    namespace_name: str,
+    destination: Path,
+    ref_name: str | None,
+    snapshot_id: str | None,
+    expected_generation: int | None,
+) -> RetainedServerContextResult:
+    if type(runtime_owner) is not RetainedServerContextOwner:
+        raise TypeError("runtime_owner must be a RetainedServerContextOwner")
+    if not callable(materialize):
+        raise TypeError("retained MCP materializer must be callable")
+
+    reservation = object()
+    cleanup = (
+        _OrderedAction(
+            label="retained MCP context cleanup also failed",
+            action=lambda: runtime_owner._close_reservation(reservation),
+            complete=lambda: not runtime_owner._owns_reservation(reservation)
+            or runtime_owner.closed,
+            retry_incomplete="cancellation",
+            incomplete_owner=runtime_owner,
+        ),
+    )
+    with _run_context_with_cleanup_actions(cleanup, cleanup_on_success=False):
+        runtime_owner._begin_loading(reservation)
+        return runtime_owner._run_loading(
+            reservation,
+            lambda receipt_owner: _activate_materialization(
+                _require_requested_materialization(
+                    materialize(receipt_owner),
+                    repository_key=repository_key,
+                    namespace_name=namespace_name,
+                    destination=destination,
+                    ref_name=ref_name,
+                    snapshot_id=snapshot_id,
+                    expected_generation=expected_generation,
+                ),
+                receipt_owner,
+                runtime_owner,
+            ),
+        )
+
+
+def load_retained_server_context_ref(
+    repository_key: str,
+    destination: Path,
+    *,
+    catalog: RetainedSnapshotCatalog,
+    object_store: ReceiptRetainingObjectStore,
+    workspace_provider: StrictWorkspaceProvider,
+    runtime_owner: RetainedServerContextOwner,
+    namespace_name: str = DEFAULT_NAMESPACE_NAME,
+    ref_name: str = DEFAULT_REF_NAME,
+    expected_generation: int | None = None,
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
+    max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
+    max_context_bytes: int = DEFAULT_MAX_CONTEXT_BYTES,
+    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
+    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
+    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    environ: Mapping[str, str] | None = None,
+) -> RetainedServerContextResult:
+    """Resolve one retained ref and activate its exact query-only context."""
+
+    return _load_retained_server_context(
+        runtime_owner,
+        lambda receipt_owner: materialize_retained_repo_manifest_ref(
+            repository_key,
+            destination,
+            catalog=catalog,
+            object_store=object_store,
+            workspace_provider=workspace_provider,
+            output_receipt_owner=receipt_owner,
+            namespace_name=namespace_name,
+            ref_name=ref_name,
+            expected_generation=expected_generation,
+            max_manifest_bytes=max_manifest_bytes,
+            max_projection_bytes=max_projection_bytes,
+            max_context_files=max_context_files,
+            max_context_bytes=max_context_bytes,
+            max_bundle_files=max_bundle_files,
+            max_bundle_bytes=max_bundle_bytes,
+            max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+            environ=environ,
+        ),
+        repository_key=repository_key,
+        namespace_name=namespace_name,
+        destination=destination,
+        ref_name=ref_name,
+        snapshot_id=None,
+        expected_generation=expected_generation,
+    )
+
+
+def load_retained_server_context_snapshot(
+    repository_key: str,
+    snapshot_id: str,
+    destination: Path,
+    *,
+    catalog: RetainedSnapshotCatalog,
+    object_store: ReceiptRetainingObjectStore,
+    workspace_provider: StrictWorkspaceProvider,
+    runtime_owner: RetainedServerContextOwner,
+    namespace_name: str = DEFAULT_NAMESPACE_NAME,
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
+    max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
+    max_context_bytes: int = DEFAULT_MAX_CONTEXT_BYTES,
+    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
+    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
+    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    environ: Mapping[str, str] | None = None,
+) -> RetainedServerContextResult:
+    """Read one retained snapshot and activate its exact query-only context."""
+
+    return _load_retained_server_context(
+        runtime_owner,
+        lambda receipt_owner: materialize_retained_repo_manifest_snapshot(
+            repository_key,
+            snapshot_id,
+            destination,
+            catalog=catalog,
+            object_store=object_store,
+            workspace_provider=workspace_provider,
+            output_receipt_owner=receipt_owner,
+            namespace_name=namespace_name,
+            max_manifest_bytes=max_manifest_bytes,
+            max_projection_bytes=max_projection_bytes,
+            max_context_files=max_context_files,
+            max_context_bytes=max_context_bytes,
+            max_bundle_files=max_bundle_files,
+            max_bundle_bytes=max_bundle_bytes,
+            max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+            environ=environ,
+        ),
+        repository_key=repository_key,
+        namespace_name=namespace_name,
+        destination=destination,
+        ref_name=None,
+        snapshot_id=snapshot_id,
+        expected_generation=None,
+    )
+
+
+__all__ = [
+    "RetainedServerContextOwner",
+    "RetainedServerContextResult",
+    "load_retained_server_context_ref",
+    "load_retained_server_context_snapshot",
+]

--- a/codenib/mcp/server.py
+++ b/codenib/mcp/server.py
@@ -948,6 +948,72 @@ def init_server(
         raise
 
 
+def serve_retained_context(
+    owner: object,
+    *,
+    log_level: str = "INFO",
+    tool_surface: str = TOOL_SURFACE_FULL,
+) -> None:
+    """Serve one preloaded retained context for a single stdio lifetime.
+
+    This is deliberately a cold-start boundary.  It never replaces an
+    existing module context and it detaches the exact context before closing
+    the caller-created owner.  Ref polling and live replacement require the
+    request-pinned lifecycle planned for M3.
+    """
+
+    from .._atomic_directory import (
+        _OrderedAction,
+        _run_context_with_cleanup_actions,
+    )
+    from .retained_context import RetainedServerContextOwner
+
+    if type(owner) is not RetainedServerContextOwner:
+        raise TypeError("retained MCP owner must use the exact owner type")
+
+    global _ctx
+    context: ServerContext | None = None
+
+    def detached() -> bool:
+        if context is None:
+            return True
+        return _ctx is None
+
+    def detach() -> None:
+        global _ctx
+        if context is None or _ctx is None:
+            return
+        if _ctx is not context:
+            raise RuntimeError("MCP ServerContext changed during retained serving")
+        _ctx = None
+
+    cleanup_actions = (
+        _OrderedAction(
+            label="retained MCP context detachment also failed",
+            action=detach,
+            complete=detached,
+            retry_incomplete="cancellation",
+            incomplete_owner=owner,
+        ),
+        _OrderedAction(
+            label="retained MCP context cleanup also failed",
+            action=owner.close,
+            complete=lambda: owner.closed,
+            retry_incomplete="cancellation",
+            incomplete_owner=owner,
+        ),
+    )
+    with _run_context_with_cleanup_actions(cleanup_actions):
+        set_console_log_level(log_level)
+        configure_tool_surface(tool_surface)
+        context = owner.context
+        if _ctx is not None:
+            raise RuntimeError("ServerContext is already initialized")
+        _ctx = context
+        logger.info("Starting retained MCP server on stdio...")
+        mcp.run(transport="stdio")
+
+
 def main(argv: list[str] | None = None) -> None:
     """Run the ``codenib-mcp`` console entry point."""
     program_name = _cli_program_name()

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -15,14 +15,15 @@ strict workspace contract. It publishes one fully validated directory into a
 missing destination and transfers the generation to a caller-owned
 `PublishedWorkspaceReceiptOwner`.
 
-The provider is not enabled by CodeNib's default compiler or runtime path.
-Three explicit routes use it: `codenib index --publish-retained` builds and
-publishes current BM25/vector views in one compiler-cache lease,
-`codenib artifact import-cache` recaptures an already existing selected cache,
-and `codenib artifact materialize` publishes a retained catalog ref or
-immutable snapshot to a missing portable-artifact directory. The strict BM25
-replacement path still requires the unsupported `provider-bound-exact`
-destination mode.
+The provider is not enabled by CodeNib's default compiler or runtime path. Four
+explicit routes use it: `codenib index --publish-retained` builds and publishes
+current BM25/vector views in one compiler-cache lease, `codenib artifact
+import-cache` recaptures an already existing selected cache, `codenib artifact
+materialize` publishes a retained catalog ref or immutable snapshot to a
+missing portable-artifact directory, and retained `codenib mcp` cold-start
+materializes and holds one such generation for a single stdio server lifetime.
+The strict BM25 replacement path still requires the unsupported
+`provider-bound-exact` destination mode.
 
 ## Publish a normal index build
 
@@ -80,8 +81,8 @@ advancing the ref again.
 This remains explicit offline dual-write. Keep the source/cache and storage
 namespaces trusted and quiescent, and apply the payload-size and storage-media
 benchmark gate described below before enabling it by default or treating it as
-a latency-sensitive worker path. Catalog-selected MCP cold start is still a
-separate M1 route; runtime hot switching remains M3.
+a latency-sensitive worker path. Catalog-selected MCP cold start is available
+only through the explicit route below; runtime hot switching remains M3.
 
 ## Import compiler query views
 
@@ -273,13 +274,57 @@ warns that the output now exists, do not assume that the path is disposable or
 retry over it; verify the retained artifact before reuse or reclaim it through
 an ownership-aware workflow.
 
-This retained-read bridge and the explicit BM25/vector ingress above do not
-complete the hybrid-storage M1 milestone. Catalog-selected cold-start runtime
-and benchmark-backed promotion of the opt-in compiler route are still missing,
-as is a production provider for the strict BM25 replacement producer's
-`provider-bound-exact` destination contract. Graph and Zoekt ingress remain M2
-or later work; fenced jobs and runtime hot switching remain separate
-milestones.
+## Serve a retained snapshot directly
+
+The retained `codenib mcp` mode combines selection, materialization, and one
+query-server lifetime without serializing a receipt or reopening the artifact
+as an unrelated path capability. It accepts the same prepared authorities as
+`artifact materialize`, plus an explicit missing output:
+
+```bash
+codenib mcp \
+  --catalog /var/lib/codenib/catalog.sqlite3 \
+  --cas-root /var/lib/codenib/cas \
+  --workspace-root /var/lib/codenib/workspaces \
+  --repository owner/repository \
+  --ref main \
+  --expected-generation 7 \
+  --output /var/lib/codenib/workspaces/repository-mcp-v1
+```
+
+Omit `--ref` to resolve `main` once at startup, or use `--snapshot
+<snapshot-id>`. `--expected-generation` is ref-only. These storage arguments
+form one all-or-none mode and cannot be combined with a positional manifest,
+`--artifact`, or `--repo`. The catalog must already be initialized, the strict
+CAS preprovisioned, the workspace private and exact `0700`, and the output
+missing under that workspace; this command does not provision or replace any
+of them.
+
+During startup CodeNib materializes the selected immutable generation, builds
+the query binding through the active publication receipt's authenticated
+reader, and loads the complete `ServerContext` before the reader callback ends.
+It then closes SQLite, CAS, and path-topology authorities before starting MCP
+stdio. The caller-owned workspace receipt remains active until `mcp.run`
+returns or fails. Shutdown first removes the module-global context, then closes
+the runtime context, and only after that releases the receipt. The materialized
+output persists after normal shutdown and after receipt cleanup; a failure
+after publication warns about the existing path rather than deleting it.
+
+This is a source-disabled, query-only cold start. It currently requires a BM25
+view, which loads from canonical persisted documents. A selected portable
+vector remains native-parser inert and reports its authorization error; the
+route never treats cache hashes as permission to parse FAISS, and vector-only
+snapshots are rejected for this runtime. The ref is not polled or re-resolved,
+the receipt is not a catalog/CAS GC pin, and no live context replacement occurs.
+Those in-flight request pins and atomic swaps remain M3 work; durable evidence
+retention and reclamation remain M5 work.
+
+These retained-read routes and the explicit BM25/vector ingress above do not
+complete the hybrid-storage M1 milestone. Benchmark-backed promotion of the
+opt-in compiler and runtime routes is still missing, as is a production
+provider for the strict BM25 replacement producer's `provider-bound-exact`
+destination contract. Graph and Zoekt ingress remain M2 or later work; fenced
+jobs and runtime hot switching remain separate milestones.
 
 ## Lifecycle
 

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -255,8 +255,9 @@ classifier lives outside both artifacts and storage so the artifact layer does
 not depend on the catalog implementation.  These gates close the current
 portable context publication surface, and the injectable retained materializer
 described below now closes the retained filesystem boundary. The explicit local
-CLI bridge described below can invoke it, but default compiler/import/runtime
-wiring and a future streaming payload revision remain.
+CLI bridges described below can invoke it for publication and cold start, but
+benchmark-backed default compiler/runtime promotion and a future streaming
+payload revision remain.
 
 Local filesystem publication now has an explicit strict-authority gate. Regular
 files are written through caller-owned staged descriptors, installed with
@@ -288,9 +289,9 @@ publish permit. The caller-owned receipt slot is the publication-authority
 linearization point: unreceipted same-process failures quarantine the exact
 candidate, while a fork child authenticates and closes only its inherited
 descriptor pairs. The provider is an authority boundary for trusted callbacks,
-not an in-process Python sandbox. The explicit retained-artifact CLI constructs
-it for one operator-requested publication; no compiler, import, or runtime
-route constructs it by default yet.
+not an in-process Python sandbox. The explicit retained workflows construct it
+for operator-requested publication and cold start; no compiler or runtime route
+constructs it by default yet.
 
 Callback-scoped directory results are likewise provisional until ordered
 reader-validity, exact-ownership, child-namespace, and parent-authority
@@ -376,10 +377,11 @@ materialization APIs are now available as injectable library producers. The
 Linux local provider deliberately accepts only missing destinations, so
 whole-context retained materialization can use it explicitly, while strict BM25
 replacement requests `provider-bound-exact` and still lacks a concrete
-production provider. The explicit retained-artifact CLI can now construct the
-whole-context producer for one existing catalog selection, but no default
-compiler/import/runtime route constructs these producers. M1 remains in
-progress and the M2 BM25 profile adapter is still outstanding.
+production provider. The explicit retained workflows can now construct the
+whole-context producer for one existing catalog selection, publish normal
+compiler output, and load one selected generation at MCP cold start, but no
+default compiler/runtime route constructs them. M1 remains in progress and the
+M2 BM25 profile adapter is still outstanding.
 
 Strict whole-context publication can now aggregate already-normalized BM25 and
 vector generations retained by active workspace receipt owners. The plan binds
@@ -440,9 +442,11 @@ The retained exporter described below now supplies equivalent canonical bytes
 for both supported manifest versions, and the injectable retained materializer
 closes their filesystem publication boundary. The explicit local CLI bridge
 uses the concrete local provider only for an operator-selected retained ref or
-snapshot. Default compiler/import/runtime wiring remains outstanding, so M1
-remains in progress. Profile adapters and fenced publication remain M2 work;
-production retention and garbage collection remain M5 work.
+snapshot. Explicit compiler publication and cold-start runtime routing now use
+the same boundary, while benchmark-backed default compiler/runtime promotion
+remains outstanding, so M1 remains in progress. Profile adapters and fenced
+publication remain M2 work; production retention and garbage collection remain
+M5 work.
 
 The retained-import foundation now also exposes schema-v4 compound-generation
 identity as one backend-neutral model rule, including the canonical member
@@ -588,10 +592,11 @@ file may therefore be read more than once. Representative end-to-end corpus,
 payload-size, and storage-media benchmarks are required before either path is
 enabled by default, used as a latency-sensitive service ingress, or has any
 validation pass removed. M1 remains in progress because catalog-selected
-cold-start runtime routing and benchmark-backed default compiler promotion are
-still absent. Graph and Zoekt cache ingress, generic builder profiles, and
-fenced job publication remain M2 or later work, runtime hot switching remains
-M3 work, and evidence retention and reclamation remain M5 work.
+cold-start runtime routing is supplied only by the explicit route below and
+benchmark-backed default compiler promotion is still absent. Graph and Zoekt
+cache ingress, generic builder profiles, and fenced job publication remain M2
+or later work, runtime hot switching remains M3 work, and evidence retention
+and reclamation remain M5 work.
 
 The first read-only retained `RepoManifest` exporter now closes the data-only
 round trip without introducing path authority. It accepts the additive
@@ -666,13 +671,37 @@ handoff starts a separate query-only process with `codenib mcp --artifact
 therefore leave a valid missing-only output; the CLI warns when the path exists
 rather than deleting it.
 
-This command does not initialize or populate the control plane, import a legacy
-cache, build views, advance refs, or make retained storage the default. It is
-the retained-read bridge only. Catalog-selected cold-start runtime and
-benchmark-backed promotion of the explicit compiler route remain outstanding
-M1 work; graph and Zoekt cache ingress and fenced job publication remain M2 or
-later work. Strict BM25 replacement also still lacks the
-`provider-bound-exact` production provider.
+The first catalog-selected cold-start route is now exposed by `codenib mcp`
+with the same explicit catalog, preprovisioned CAS, private workspace,
+repository, ref-or-snapshot, and missing-output inputs. It resolves one ref
+exactly once (or selects one immutable snapshot), materializes the portable
+generation, and creates the query binding through the publication receipt's
+synchronous authenticated reader rather than reopening an unbound path. The
+complete `ServerContext` is installed in a caller-precreated, PID-bound,
+one-shot runtime owner while that reader is active. Catalog, CAS, and retained
+path authorities close before stdio serving begins; the workspace receipt stays
+active for the entire `mcp.run` lifetime. Shutdown first detaches the global
+context, then closes the runtime context and only then releases the receipt.
+Receipt closure does not delete the materialized output.
+
+This startup is query-only and source-disabled. A selected BM25 view loads from
+persisted canonical documents; a selected portable vector remains FAISS-parser
+inert and reports its existing authorization error, so the current cold-start
+route requires BM25 and does not advertise a vector-only runtime. It never
+mints native vector authorization from cache-ingress hashes. The selected
+receipt fixes one local generation but is not a catalog snapshot lease or CAS
+GC pin. The route does not poll or re-resolve a ref, replace a live context,
+hold storage connections while serving, provision storage, delete output, or
+add request-level pins. Those replacement and in-flight lifetime contracts
+remain M3 work, while durable retention and reclamation remain M5 work.
+
+The standalone materialization command and retained MCP cold start do not
+initialize or populate the control plane, import a legacy cache, build views,
+advance refs, or make retained storage the default. Benchmark-backed promotion
+of the explicit compiler and runtime routes remains outstanding M1 work; graph
+and Zoekt cache ingress and fenced job publication remain M2 or later work.
+Strict BM25 replacement also still lacks the `provider-bound-exact` production
+provider.
 
 Schema v2 now adds
 canonical idempotent job requests, immutable
@@ -682,8 +711,9 @@ canonical request; the M2 publication transaction must repeat that gate before
 associating outputs.  An explicit acquire may atomically retire an expired
 holder while taking over its slot; this slice adds no background reaper and is
 not wired to the compiler or Web workers. Catalog-selected cold-start runtime
-and benchmark-backed default compiler promotion remain outstanding M1
-deliverables; fenced job publication remains M2 work.
+is now available only through the explicit local route above, while
+benchmark-backed default compiler/runtime promotion remains an outstanding M1
+deliverable; fenced job publication remains M2 work.
 
 The shared compiler-cache lock is a cooperative serialization boundary for
 compiler and importer processes using a cache namespace private to one OS

--- a/test/artifacts/test_runtime.py
+++ b/test/artifacts/test_runtime.py
@@ -33,14 +33,17 @@ import codenib.index.sparse_idx.bm25_index as bm25_module
 import codenib.mcp.server as server_module
 from codenib._atomic_directory import (
     PublicationDirectoryReader,
+    capture_directory_ownership,
     reopen_authenticated_directory,
 )
+from codenib._captured_directory import PublishedWorkspaceReceipt
 from codenib.artifacts import (
     CONTEXT_ARTIFACT_MANIFEST,
     bind_context_artifact,
     extract_context_artifact_archive,
     fetch_github_context_artifact,
     query_context_artifact,
+    query_context_artifact_reader,
     render_artifact_mcp_config,
     resolve_github_context_artifact,
     stage_context_artifact,
@@ -289,6 +292,16 @@ def _write_metadata(artifact: Path, metadata: dict) -> None:
         json.dumps(metadata, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+
+
+def _receipt_stub(
+    path: Path,
+    ownership: object,
+) -> PublishedWorkspaceReceipt:
+    receipt = object.__new__(PublishedWorkspaceReceipt)
+    receipt.path = path
+    receipt.ownership = ownership
+    return receipt
 
 
 def _refresh_inventory_file(artifact: Path, metadata: dict, relative: str) -> None:
@@ -1078,6 +1091,112 @@ def test_v1_artifact_supports_inert_bm25_query_but_cannot_bind(
 
     with pytest.raises(ValueError, match="query-only"):
         bind_context_artifact(artifact, repo)
+
+
+def test_query_context_artifact_reader_relocates_without_reopening(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _repo, artifact, commit = _bm25_artifact(tmp_path)
+    ownership = capture_directory_ownership(artifact)
+    receipt = _receipt_stub(artifact, ownership)
+    ordinary = query_context_artifact(artifact, expected_commit=commit)
+
+    def consume(publication: PublicationDirectoryReader):
+        def reject_reopen(*_args: object, **_kwargs: object) -> None:
+            raise AssertionError("reader-bound query reopened its artifact path")
+
+        monkeypatch.setattr(
+            runtime_module,
+            "reopen_authenticated_directory",
+            reject_reopen,
+        )
+        return query_context_artifact_reader(
+            receipt,
+            publication,
+            expected_root=artifact,
+            expected_ownership=ownership,
+            expected_repository="example/project",
+            expected_commit=commit,
+        )
+
+    binding = reopen_authenticated_directory(artifact, ownership, consume)
+
+    assert ordinary._requires_authenticated_reader is False
+    assert binding._requires_authenticated_reader is True
+    assert binding.repo_path is None
+    assert binding.source_binding is None
+    assert binding.artifact.root == artifact
+    assert binding.artifact.metadata_path == artifact / CONTEXT_ARTIFACT_MANIFEST
+    assert binding.artifact.manifest_path == artifact / "repo_manifest.json"
+    assert binding.manifest is binding.artifact.manifest
+
+
+def test_query_context_artifact_reader_rejects_receipt_binding_mismatches(
+    tmp_path: Path,
+) -> None:
+    _repo, artifact, _commit = _bm25_artifact(tmp_path)
+    ownership = capture_directory_ownership(artifact)
+    foreign = tmp_path / "foreign-artifact"
+    shutil.copytree(artifact, foreign)
+    foreign_ownership = capture_directory_ownership(foreign)
+
+    def consume(publication: PublicationDirectoryReader) -> None:
+        receipt = _receipt_stub(artifact, ownership)
+        with pytest.raises(RuntimeError, match="receipt path"):
+            query_context_artifact_reader(
+                receipt,
+                publication,
+                expected_root=foreign,
+                expected_ownership=ownership,
+            )
+        with pytest.raises(RuntimeError, match="receipt ownership"):
+            query_context_artifact_reader(
+                receipt,
+                publication,
+                expected_root=artifact,
+                expected_ownership=foreign_ownership,
+            )
+        foreign_receipt = _receipt_stub(artifact, foreign_ownership)
+        with pytest.raises(RuntimeError, match="publication ownership"):
+            query_context_artifact_reader(
+                foreign_receipt,
+                publication,
+                expected_root=artifact,
+                expected_ownership=foreign_ownership,
+            )
+        with pytest.raises(TypeError, match="receipt.*invalid type"):
+            query_context_artifact_reader(
+                SimpleNamespace(path=artifact, ownership=ownership),  # type: ignore[arg-type]
+                publication,
+                expected_root=artifact,
+                expected_ownership=ownership,
+            )
+
+    reopen_authenticated_directory(artifact, ownership, consume)
+
+
+def test_query_context_artifact_reader_rejects_tampered_payload(
+    tmp_path: Path,
+) -> None:
+    _repo, artifact, _commit = _bm25_artifact(tmp_path)
+    (artifact / "views" / "bm25" / "documents.json").write_text(
+        "[]\n",
+        encoding="utf-8",
+    )
+    ownership = capture_directory_ownership(artifact)
+    receipt = _receipt_stub(artifact, ownership)
+
+    def consume(publication: PublicationDirectoryReader) -> None:
+        with pytest.raises(ValueError, match="digest mismatch"):
+            query_context_artifact_reader(
+                receipt,
+                publication,
+                expected_root=artifact,
+                expected_ownership=ownership,
+            )
+
+    reopen_authenticated_directory(artifact, ownership, consume)
 
 
 @pytest.mark.parametrize("excluded_path", ["sample.py", ".git/config"])

--- a/test/compiler/test_retained_context.py
+++ b/test/compiler/test_retained_context.py
@@ -10,8 +10,6 @@ import signal
 import threading
 from dataclasses import replace
 from pathlib import Path
-from test.compiler.test_manifest_export import _retained_fixture
-from test.compiler.test_manifest_import import _TestWorkspaceProvider
 from unittest.mock import patch
 
 import pytest
@@ -27,6 +25,9 @@ from codenib.mcp.retained_context import (
 )
 from codenib.storage import PublishConflict
 from codenib.storage.models import NamespaceIdentity, RepositoryIdentity
+
+from .test_manifest_export import _retained_fixture
+from .test_manifest_import import _TestWorkspaceProvider
 
 
 def test_loads_retained_ref_with_bm25_inside_exact_reader(

--- a/test/compiler/test_retained_mcp_cli_e2e.py
+++ b/test/compiler/test_retained_mcp_cli_e2e.py
@@ -1,0 +1,280 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import inspect
+import os
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codenib import LocalWorkspaceProvider
+from codenib import cli as cli_module
+from codenib._captured_directory import UnsupportedWorkspaceCreation
+from codenib.artifacts import query_context_artifact
+from codenib.compiler.manifest import MANIFEST_FILENAME
+from codenib.mcp import server as server_module
+from codenib.mcp.context import ServerContext
+from codenib.mcp.retained_context import RetainedServerContextOwner
+from codenib.mcp.tools.search import search_bm25_impl
+from codenib.paths import repo_index_dir
+from codenib.storage import LocalCAS, SQLiteCatalog, StorageIntegrityError
+
+_REPOSITORY_KEY = "owner/retained-mcp-route"
+_MARKER = "PRODUCTION_RETAINED_MCP_ROUTE"
+
+
+def _git_commit(repository: Path) -> str:
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", os.fspath(repository)],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            os.fspath(repository),
+            "config",
+            "user.email",
+            "test@example.test",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            os.fspath(repository),
+            "config",
+            "user.name",
+            "CodeNib Test",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", os.fspath(repository), "add", "sample.py"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", os.fspath(repository), "commit", "-qm", "fixture"],
+        check=True,
+    )
+    return subprocess.run(
+        ["git", "-C", os.fspath(repository), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _capture_retained_mcp_cli_state() -> dict[str, object]:
+    """Retain CLI-owned resources while the synchronous transport is active."""
+
+    required = (
+        "runtime_owner",
+        "topology_owner",
+        "object_store_owner",
+        "catalog_owner",
+        "topology",
+        "object_store",
+        "catalog",
+    )
+    frame = inspect.currentframe()
+    captured: dict[str, object] | None = None
+    try:
+        while frame is not None:
+            if (
+                frame.f_code.co_name == "_run_mcp_retained"
+                and frame.f_globals.get("__name__") == cli_module.__name__
+            ):
+                assert all(name in frame.f_locals for name in required)
+                captured = {name: frame.f_locals[name] for name in required}
+                break
+            frame = frame.f_back
+    finally:
+        del frame
+    assert captured is not None, "retained MCP CLI frame was not active"
+    return captured
+
+
+def test_index_publish_retained_then_mcp_cold_starts_real_bm25(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Other MCP tests exercise the legacy module-global startup path.  Keep
+    # this cold-start lifecycle isolated while still requiring the retained
+    # route to detach its own exact context before returning.
+    monkeypatch.setattr(server_module, "_ctx", None)
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    (repository / "sample.py").write_text(
+        f"def retained_mcp_marker():\n    return {_MARKER!r}\n",
+        encoding="utf-8",
+    )
+    commit = _git_commit(repository)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    workspace.chmod(0o700)
+    provider = LocalWorkspaceProvider(workspace)
+    try:
+        provider.require_support()
+    except UnsupportedWorkspaceCreation as error:
+        pytest.skip(f"native local workspace provider is unavailable: {error}")
+
+    catalog_path = tmp_path / "catalog.sqlite"
+    with SQLiteCatalog(catalog_path):
+        pass
+    cas_root = tmp_path / "cas"
+    with LocalCAS.provision(cas_root):
+        pass
+    codenib_home = tmp_path / "codenib-home"
+    codenib_home.mkdir(mode=0o700)
+    monkeypatch.setenv("CODENIB_HOME", os.fspath(codenib_home))
+
+    parser = cli_module.build_parser()
+    index_args = parser.parse_args(
+        [
+            "index",
+            os.fspath(repository),
+            "--preset",
+            "fast",
+            "--publish-retained",
+            "--catalog",
+            os.fspath(catalog_path),
+            "--cas-root",
+            os.fspath(cas_root),
+            "--workspace-root",
+            os.fspath(workspace),
+            "--repository",
+            _REPOSITORY_KEY,
+        ]
+    )
+    assert index_args.handler is cli_module._run_index
+    assert index_args.handler(index_args) == 0
+
+    index_output = capsys.readouterr().out
+    assert "Retained Generation: 1" in index_output
+    assert "Retained Ref:        main" in index_output
+    assert "Retained Views:      bm25" in index_output
+    cache = repo_index_dir(repository)
+    assert (cache / MANIFEST_FILENAME).is_file()
+    assert (cache / "bm25").is_dir()
+
+    materialized_output = workspace / "retained-mcp-context"
+    captured: dict[str, object] = {}
+    installed_contexts: list[ServerContext] = []
+
+    def run_stdio(*, transport: str) -> None:
+        assert transport == "stdio"
+        context = server_module.get_context()
+        assert type(context) is ServerContext
+        assert server_module._ctx is context
+        assert context.manifest.commit == commit
+        assert context.loaded_views == frozenset({"bm25"})
+        assert context.errors == {}
+        assert context.artifact is not None
+        assert context.artifact["verified"] is True
+
+        run_state = _capture_retained_mcp_cli_state()
+        captured.update(run_state)
+        for name in ("topology_owner", "object_store_owner", "catalog_owner"):
+            assert run_state[name].closed  # type: ignore[attr-defined]
+        assert run_state["topology"].closed  # type: ignore[attr-defined]
+        with pytest.raises(StorageIntegrityError, match="closed"):
+            run_state["object_store"].has("0" * 64)  # type: ignore[attr-defined]
+        with pytest.raises(sqlite3.ProgrammingError):
+            run_state["catalog"]._connection.execute(  # type: ignore[attr-defined]
+                "SELECT 1"
+            )
+
+        runtime_owner = run_state["runtime_owner"]
+        assert type(runtime_owner) is RetainedServerContextOwner
+        assert runtime_owner.state == "active"
+        assert runtime_owner.context is context
+        results = search_bm25_impl(context, _MARKER, top_k=5)
+        assert results
+        assert results[0]["file"] == "sample.py"
+        assert context.bm25 is not None
+        normalized_marker = _MARKER.lower().replace("_", " ")
+        assert any(
+            normalized_marker in document.page_content
+            for document in context.bm25.documents
+        )
+        assert search_bm25_impl(context, "retained_mcp_marker", top_k=1)
+        assert server_module.get_context() is context
+        assert runtime_owner.state == "active"
+        assert runtime_owner.context is context
+
+        installed_contexts.append(context)
+
+    monkeypatch.setattr(server_module.mcp, "run", run_stdio)
+    assert server_module._ctx is None
+    mcp_args = parser.parse_args(
+        [
+            "mcp",
+            "--catalog",
+            os.fspath(catalog_path),
+            "--cas-root",
+            os.fspath(cas_root),
+            "--workspace-root",
+            os.fspath(workspace),
+            "--repository",
+            _REPOSITORY_KEY,
+            "--ref",
+            "main",
+            "--expected-generation",
+            "1",
+            "--output",
+            os.fspath(materialized_output),
+        ]
+    )
+    assert mcp_args.handler is cli_module._run_mcp
+    assert mcp_args.handler(mcp_args) == 0
+
+    assert len(installed_contexts) == 1
+    assert server_module._ctx is None
+    with pytest.raises(RuntimeError, match="not initialized"):
+        server_module.get_context()
+
+    runtime_owner = captured["runtime_owner"]
+    assert type(runtime_owner) is RetainedServerContextOwner
+    assert runtime_owner.closed
+    assert runtime_owner._context_close_complete  # noqa: SLF001
+    assert runtime_owner._receipt_owner.closed  # noqa: SLF001
+    with pytest.raises(RuntimeError, match="closed"):
+        runtime_owner.context
+
+    for name in ("topology_owner", "object_store_owner", "catalog_owner"):
+        owner = captured[name]
+        assert type(owner) is cli_module._RetainedMaterializationResourceOwner
+        assert owner.closed
+    assert captured["topology"].closed  # type: ignore[attr-defined]
+
+    object_store = captured["object_store"]
+    assert type(object_store) is LocalCAS
+    with pytest.raises(StorageIntegrityError, match="closed"):
+        object_store.has("0" * 64)
+    catalog = captured["catalog"]
+    assert type(catalog) is SQLiteCatalog
+    with pytest.raises(sqlite3.ProgrammingError):
+        catalog._connection.execute("SELECT 1")
+
+    assert materialized_output.is_dir()
+    binding = query_context_artifact(
+        materialized_output,
+        expected_repository=_REPOSITORY_KEY,
+        expected_commit=commit,
+    )
+    try:
+        assert binding.artifact.root == materialized_output.resolve()
+        assert binding.artifact.views == ("bm25",)
+        assert tuple(binding.manifest.indexes) == ("bm25",)
+    finally:
+        binding.close()
+    assert materialized_output.is_dir()

--- a/test/mcp/test_mcp_server.py
+++ b/test/mcp/test_mcp_server.py
@@ -27,6 +27,7 @@ import codenib.mcp.server as server_module
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.index.embedding.vector_store import CodeVectorStore
 from codenib.mcp.context import ServerContext
+from codenib.mcp.retained_context import RetainedServerContextOwner
 from codenib.mcp.tools.lsp import (
     lsp_definition_impl,
     lsp_references_impl,
@@ -203,6 +204,161 @@ def test_get_context_uninitialized():
 
     with pytest.raises(RuntimeError, match="ServerContext not initialized"):
         server_module.get_context()
+
+
+def _active_retained_server_owner() -> tuple[
+    RetainedServerContextOwner,
+    ServerContext,
+]:
+    owner = RetainedServerContextOwner()
+    owner._begin_loading(object())
+    context = ServerContext(manifest=RepoManifest(repo_path="/retained"))
+    owner._install_context(context)
+    owner._result = object()  # type: ignore[assignment]
+    assert owner.state == "active"
+    return owner, context
+
+
+def test_serve_retained_context_detaches_before_owner_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner, context = _active_retained_server_owner()
+    events: list[str] = []
+    real_close = RetainedServerContextOwner.close
+    previous = server_module._ctx
+    server_module._ctx = None
+
+    def run(*, transport: str) -> None:
+        assert transport == "stdio"
+        assert server_module.get_context() is context
+        assert owner.state == "active"
+        events.append("run")
+
+    def close(observed: RetainedServerContextOwner) -> None:
+        assert observed is owner
+        assert server_module._ctx is None
+        events.append("close")
+        real_close(observed)
+
+    monkeypatch.setattr(server_module.mcp, "run", run)
+    monkeypatch.setattr(RetainedServerContextOwner, "close", close)
+    try:
+        server_module.serve_retained_context(
+            owner,
+            log_level="WARNING",
+            tool_surface="explore",
+        )
+    finally:
+        server_module._ctx = previous
+
+    assert events == ["run", "close"]
+    assert owner.closed
+
+
+@pytest.mark.parametrize("failure", [KeyboardInterrupt("stop"), SystemExit(9)])
+def test_serve_retained_context_preserves_transport_baseexception(
+    failure: BaseException,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner, _context = _active_retained_server_owner()
+    previous = server_module._ctx
+    server_module._ctx = None
+    monkeypatch.setattr(server_module.mcp, "run", MagicMock(side_effect=failure))
+
+    try:
+        with pytest.raises(type(failure)) as caught:
+            server_module.serve_retained_context(owner)
+    finally:
+        server_module._ctx = previous
+
+    assert caught.value is failure
+    assert owner.closed
+
+
+def test_serve_retained_context_preserves_transport_cancellation_over_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner, _context = _active_retained_server_owner()
+    primary = KeyboardInterrupt("transport interrupted")
+    foreign = ServerContext(manifest=RepoManifest(repo_path="/foreign"))
+    real_close = ServerContext.close
+    previous = server_module._ctx
+    server_module._ctx = None
+
+    def replace_global_then_interrupt(*, transport: str) -> None:
+        assert transport == "stdio"
+        server_module._ctx = foreign
+        raise primary
+
+    monkeypatch.setattr(server_module.mcp, "run", replace_global_then_interrupt)
+
+    def fail_close(_context: ServerContext) -> None:
+        raise OSError("context close failed")
+
+    monkeypatch.setattr(ServerContext, "close", fail_close)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            server_module.serve_retained_context(owner)
+        assert caught.value is primary
+        assert server_module._ctx is foreign
+        assert owner.state == "close-failed"
+        assert owner in caught.value.publication_cleanup_owners  # type: ignore[attr-defined]
+        notes = "\n".join(
+            tuple(getattr(caught.value, "__notes__", ()))
+            + tuple(getattr(caught.value, "_codenib_cleanup_notes", ()))
+        )
+        assert "changed during retained serving" in notes
+        assert "context close failed" in notes
+
+        monkeypatch.setattr(ServerContext, "close", real_close)
+        owner.close()
+        assert owner.closed
+    finally:
+        server_module._ctx = previous
+
+
+def test_serve_retained_context_rejects_global_replacement_and_closes_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner, _context = _active_retained_server_owner()
+    existing = ServerContext(manifest=RepoManifest(repo_path="/existing"))
+    previous = server_module._ctx
+    server_module._ctx = existing
+    run = MagicMock()
+    monkeypatch.setattr(server_module.mcp, "run", run)
+
+    try:
+        with pytest.raises(RuntimeError, match="already initialized"):
+            server_module.serve_retained_context(owner)
+        assert server_module._ctx is existing
+    finally:
+        server_module._ctx = previous
+
+    run.assert_not_called()
+    assert owner.closed
+
+
+def test_serve_retained_context_rejects_runtime_global_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner, _context = _active_retained_server_owner()
+    foreign = ServerContext(manifest=RepoManifest(repo_path="/foreign"))
+    previous = server_module._ctx
+    server_module._ctx = None
+
+    def replace_global(*, transport: str) -> None:
+        assert transport == "stdio"
+        server_module._ctx = foreign
+
+    monkeypatch.setattr(server_module.mcp, "run", replace_global)
+    try:
+        with pytest.raises(RuntimeError, match="changed during retained serving"):
+            server_module.serve_retained_context(owner)
+        assert server_module._ctx is foreign
+    finally:
+        server_module._ctx = previous
+
+    assert owner.closed
 
 
 def test_semantic_search_tool_no_vector_index(mock_manifest: Path):

--- a/test/mcp_server/test_context.py
+++ b/test/mcp_server/test_context.py
@@ -30,6 +30,25 @@ _TEST_SOURCE_FINGERPRINT = "sha256-v2:" + ("d" * 64)
 _TEST_SOURCE_SELECTION = RepositorySourceSelection()
 
 
+def test_server_context_rejects_forged_authenticated_readers() -> None:
+    manifest = RepoManifest(repo_path="/repo")
+    forged_reader = object()
+
+    with pytest.raises(TypeError, match="exact reader type"):
+        ServerContext.load(
+            manifest,
+            views=[],
+            artifact_reader=forged_reader,  # type: ignore[arg-type]
+        )
+
+    context = ServerContext(manifest=manifest)
+    with pytest.raises(TypeError, match="exact reader type"):
+        context.load_views(
+            [],
+            artifact_reader=forged_reader,  # type: ignore[arg-type]
+        )
+
+
 def _bind_fresh_entry(manifest: RepoManifest, entry: IndexEntry) -> IndexEntry:
     entry.commit = manifest.commit
     entry.source_fingerprint = manifest.source_fingerprint

--- a/test/mcp_server/test_retained_context.py
+++ b/test/mcp_server/test_retained_context.py
@@ -1,0 +1,803 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import select
+import signal
+import threading
+from dataclasses import replace
+from pathlib import Path
+from test.compiler.test_manifest_export import _retained_fixture
+from test.compiler.test_manifest_import import _TestWorkspaceProvider
+from unittest.mock import patch
+
+import pytest
+
+import codenib.mcp.retained_context as retained_context_module
+from codenib.compiler.manifest import RepoManifest
+from codenib.mcp.context import ServerContext
+from codenib.mcp.retained_context import (
+    RetainedServerContextOwner,
+    RetainedServerContextResult,
+    load_retained_server_context_ref,
+    load_retained_server_context_snapshot,
+)
+from codenib.storage import PublishConflict
+from codenib.storage.models import NamespaceIdentity, RepositoryIdentity
+
+
+def test_loads_retained_ref_with_bm25_inside_exact_reader(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (_fixture, imported, object_store, catalog):
+        owner = RetainedServerContextOwner()
+        destination = tmp_path / "context"
+        try:
+            with (
+                patch(
+                    "codenib.artifacts.runtime.reopen_authenticated_directory",
+                    side_effect=AssertionError(
+                        "retained query binding reopened a path"
+                    ),
+                ),
+                patch(
+                    "codenib.mcp.context.reopen_authenticated_directory",
+                    side_effect=AssertionError("retained BM25 reopened a path"),
+                ),
+            ):
+                result = load_retained_server_context_ref(
+                    "owner/repo",
+                    destination,
+                    catalog=catalog,
+                    object_store=object_store,
+                    workspace_provider=_TestWorkspaceProvider(),
+                    runtime_owner=owner,
+                    expected_generation=imported.generation,
+                )
+
+            assert type(result) is RetainedServerContextResult
+            assert result is owner.result
+            assert owner.state == "active"
+            assert result.materialization.export_receipt.ref_generation == (
+                imported.generation
+            )
+            assert result.loaded_views == ("bm25",)
+            assert result.view_error_items == ()
+            assert owner.context.bm25 is not None
+            hits = owner.context.bm25.search("VALUE", return_code_content=True)
+            assert hits and hits[0].node_id == "sample.VALUE"
+            assert hits[0].content is None
+            assert owner.context.artifact == {
+                "verified": True,
+                "schema": "codenib.context-artifact.v1",
+                "repository": "owner/repo",
+                "commit": "a" * 40,
+                "views": ["bm25"],
+            }
+        finally:
+            owner.close()
+        assert owner.closed
+        assert destination.is_dir()
+
+
+def test_loads_retained_snapshot_with_vector_native_inert(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(tmp_path / "retained") as (
+        _fixture,
+        imported,
+        object_store,
+        catalog,
+    ):
+        owner = RetainedServerContextOwner()
+        destination = tmp_path / "context"
+        try:
+            with patch(
+                "codenib.mcp.context.require_authorized_vector_view"
+            ) as native_gate:
+                result = load_retained_server_context_snapshot(
+                    "owner/repo",
+                    imported.snapshot_id,
+                    destination,
+                    catalog=catalog,
+                    object_store=object_store,
+                    workspace_provider=_TestWorkspaceProvider(),
+                    runtime_owner=owner,
+                )
+
+            native_gate.assert_not_called()
+            assert result.materialization.export_receipt.ref_name is None
+            assert result.loaded_views == ("bm25",)
+            assert result.view_error_items == (
+                (
+                    "vector",
+                    "portable artifact contexts cannot use external authorization "
+                    "for native vector parsing",
+                ),
+            )
+            assert owner.context.vector is None
+            assert owner.context._native_index_authorization is None
+        finally:
+            owner.close()
+
+
+def test_vector_only_generation_fails_before_context_activation(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("vector",),
+    ) as (_fixture, imported, object_store, catalog):
+        owner = RetainedServerContextOwner()
+        destination = tmp_path / "context"
+
+        with pytest.raises(ValueError, match="require.*BM25"):
+            load_retained_server_context_snapshot(
+                "owner/repo",
+                imported.snapshot_id,
+                destination,
+                catalog=catalog,
+                object_store=object_store,
+                workspace_provider=_TestWorkspaceProvider(),
+                runtime_owner=owner,
+            )
+
+        assert owner.closed
+        assert destination.is_dir()
+        with pytest.raises(RuntimeError, match="expected active"):
+            _ = owner.context
+
+
+def test_expected_generation_conflict_never_reads_object_storage(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (_fixture, imported, object_store, catalog):
+        owner = RetainedServerContextOwner()
+        destination = tmp_path / "context"
+
+        forbidden = AssertionError("generation conflict reached object storage")
+        with (
+            patch.object(object_store, "open", side_effect=forbidden),
+            patch.object(object_store, "verify_receipt", side_effect=forbidden),
+            patch.object(object_store, "retain_receipts", side_effect=forbidden),
+            pytest.raises(PublishConflict, match="generation"),
+        ):
+            load_retained_server_context_ref(
+                "owner/repo",
+                destination,
+                catalog=catalog,
+                object_store=object_store,
+                workspace_provider=_TestWorkspaceProvider(),
+                runtime_owner=owner,
+                expected_generation=imported.generation + 1,
+            )
+
+        assert owner.closed
+        assert not destination.exists()
+
+
+@pytest.mark.parametrize("forgery", ["digest", "size"])
+def test_export_receipt_must_match_materialized_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    forgery: str,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (_fixture, imported, object_store, catalog):
+        owner = RetainedServerContextOwner()
+        destination = tmp_path / "context"
+        real_materialize = (
+            retained_context_module.materialize_retained_repo_manifest_ref
+        )
+
+        def forged_materialize(*args: object, **kwargs: object):
+            result = real_materialize(*args, **kwargs)
+            receipt_changes = (
+                {"manifest_digest": "0" * 64}
+                if forgery == "digest"
+                else {
+                    "manifest_byte_size": result.export_receipt.manifest_byte_size + 1
+                }
+            )
+            return replace(
+                result,
+                export_receipt=replace(result.export_receipt, **receipt_changes),
+            )
+
+        monkeypatch.setattr(
+            retained_context_module,
+            "materialize_retained_repo_manifest_ref",
+            forged_materialize,
+        )
+        with (
+            patch.object(
+                retained_context_module,
+                "query_context_artifact_reader",
+                side_effect=AssertionError(
+                    "forged export receipt reached artifact verification"
+                ),
+            ) as query_reader,
+            patch.object(
+                ServerContext,
+                "load",
+                side_effect=AssertionError(
+                    "forged export receipt reached context activation"
+                ),
+            ) as load,
+            pytest.raises(RuntimeError, match="receipt differs"),
+        ):
+            load_retained_server_context_ref(
+                "owner/repo",
+                destination,
+                catalog=catalog,
+                object_store=object_store,
+                workspace_provider=_TestWorkspaceProvider(),
+                runtime_owner=owner,
+                expected_generation=imported.generation,
+            )
+
+        query_reader.assert_not_called()
+        load.assert_not_called()
+        assert owner.closed
+        assert destination.is_dir()
+
+
+@pytest.mark.parametrize("forgery", ["ref", "generation", "namespace"])
+def test_ref_result_must_match_the_exact_request(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    forgery: str,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (_fixture, imported, object_store, catalog):
+        owner = RetainedServerContextOwner()
+        destination = tmp_path / "context"
+        real_materialize = (
+            retained_context_module.materialize_retained_repo_manifest_ref
+        )
+
+        def forged_materialize(*args: object, **kwargs: object):
+            result = real_materialize(*args, **kwargs)
+            if forgery == "ref":
+                receipt = replace(result.export_receipt, ref_name="wrong-ref")
+            elif forgery == "generation":
+                receipt = replace(
+                    result.export_receipt,
+                    ref_generation=result.export_receipt.ref_generation + 1,
+                )
+            else:
+                namespace_id = NamespaceIdentity("other").namespace_id
+                repository_id = RepositoryIdentity(
+                    namespace_id=namespace_id,
+                    repository_key=result.export_receipt.repository_key,
+                ).repository_id
+                receipt = replace(
+                    result.export_receipt,
+                    namespace_id=namespace_id,
+                    repository_id=repository_id,
+                )
+            return replace(result, export_receipt=receipt)
+
+        monkeypatch.setattr(
+            retained_context_module,
+            "materialize_retained_repo_manifest_ref",
+            forged_materialize,
+        )
+        with (
+            patch.object(
+                retained_context_module,
+                "query_context_artifact_reader",
+                side_effect=AssertionError(
+                    "wrong retained selector reached artifact verification"
+                ),
+            ) as query_reader,
+            pytest.raises(RuntimeError, match="observation|repository or namespace"),
+        ):
+            load_retained_server_context_ref(
+                "owner/repo",
+                destination,
+                catalog=catalog,
+                object_store=object_store,
+                workspace_provider=_TestWorkspaceProvider(),
+                runtime_owner=owner,
+                expected_generation=imported.generation,
+            )
+
+        query_reader.assert_not_called()
+        assert owner.closed
+        assert destination.is_dir()
+
+
+def test_snapshot_result_must_match_the_exact_request(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (_fixture, imported, object_store, catalog):
+        owner = RetainedServerContextOwner()
+        destination = tmp_path / "context"
+        real_materialize = (
+            retained_context_module.materialize_retained_repo_manifest_snapshot
+        )
+
+        def forged_materialize(*args: object, **kwargs: object):
+            result = real_materialize(*args, **kwargs)
+            return replace(
+                result,
+                export_receipt=replace(
+                    result.export_receipt,
+                    snapshot_id="wrong-snapshot",
+                ),
+            )
+
+        monkeypatch.setattr(
+            retained_context_module,
+            "materialize_retained_repo_manifest_snapshot",
+            forged_materialize,
+        )
+        with (
+            patch.object(
+                retained_context_module,
+                "query_context_artifact_reader",
+                side_effect=AssertionError(
+                    "wrong retained snapshot reached artifact verification"
+                ),
+            ) as query_reader,
+            pytest.raises(RuntimeError, match="snapshot observation"),
+        ):
+            load_retained_server_context_snapshot(
+                "owner/repo",
+                imported.snapshot_id,
+                destination,
+                catalog=catalog,
+                object_store=object_store,
+                workspace_provider=_TestWorkspaceProvider(),
+                runtime_owner=owner,
+            )
+
+        query_reader.assert_not_called()
+        assert owner.closed
+        assert destination.is_dir()
+
+
+def test_active_owner_is_one_shot_without_disturbing_first_context(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (_fixture, imported, object_store, catalog):
+        owner = RetainedServerContextOwner()
+        first = load_retained_server_context_ref(
+            "owner/repo",
+            tmp_path / "first",
+            catalog=catalog,
+            object_store=object_store,
+            workspace_provider=_TestWorkspaceProvider(),
+            runtime_owner=owner,
+            expected_generation=imported.generation,
+        )
+        original = owner.context
+        try:
+            with (
+                patch.object(
+                    retained_context_module,
+                    "materialize_retained_repo_manifest_ref",
+                ) as materialize,
+                pytest.raises(RuntimeError, match="expected empty"),
+            ):
+                load_retained_server_context_ref(
+                    "owner/repo",
+                    tmp_path / "second",
+                    catalog=catalog,
+                    object_store=object_store,
+                    workspace_provider=_TestWorkspaceProvider(),
+                    runtime_owner=owner,
+                )
+            materialize.assert_not_called()
+            assert owner.state == "active"
+            assert owner.context is original
+            assert owner.result is first
+        finally:
+            owner.close()
+
+
+class _RetryReceiptOwner:
+    def __init__(self, events: list[str], *, fail_once: bool = False) -> None:
+        self.events = events
+        self.fail_once = fail_once
+        self.closed = False
+
+    def close(self) -> None:
+        self.events.append("receipt")
+        if self.fail_once:
+            self.fail_once = False
+            raise RuntimeError("receipt close failed")
+        self.closed = True
+
+
+def _loading_owner_with_context() -> tuple[RetainedServerContextOwner, ServerContext]:
+    owner = RetainedServerContextOwner()
+    owner._begin_loading(object())
+    context = ServerContext(manifest=RepoManifest(repo_path="/repo"))
+    owner._install_context(context)
+    return owner, context
+
+
+def test_context_cleanup_failure_blocks_receipt_and_remains_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner, context = _loading_owner_with_context()
+    events: list[str] = []
+    receipt_owner = _RetryReceiptOwner(events)
+    owner._receipt_owner = receipt_owner  # type: ignore[assignment]
+    attempts = 0
+
+    def close_context(observed: ServerContext) -> None:
+        nonlocal attempts
+        assert observed is context
+        attempts += 1
+        events.append("context")
+        if attempts == 1:
+            raise RuntimeError("context close failed")
+
+    monkeypatch.setattr(ServerContext, "close", close_context)
+
+    with pytest.raises(RuntimeError, match="context close failed") as caught:
+        owner.close()
+    assert owner.state == "close-failed"
+    assert events == ["context"]
+    assert caught.value.publication_cleanup_owners == (owner,)  # type: ignore[attr-defined]
+
+    owner.close()
+    assert events == ["context", "context", "receipt"]
+    assert receipt_owner.closed
+    assert owner.closed
+
+
+def test_receipt_cleanup_retry_does_not_reclose_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner, context = _loading_owner_with_context()
+    events: list[str] = []
+    receipt_owner = _RetryReceiptOwner(events, fail_once=True)
+    owner._receipt_owner = receipt_owner  # type: ignore[assignment]
+
+    def close_context(observed: ServerContext) -> None:
+        assert observed is context
+        events.append("context")
+
+    monkeypatch.setattr(ServerContext, "close", close_context)
+
+    with pytest.raises(RuntimeError, match="receipt close failed") as caught:
+        owner.close()
+    assert owner.state == "close-failed"
+    assert events == ["context", "receipt"]
+    assert caught.value.publication_cleanup_owners == (owner,)  # type: ignore[attr-defined]
+
+    owner.close()
+    assert events == ["context", "receipt", "receipt"]
+    assert owner.closed
+
+
+def test_owner_properties_are_state_and_pid_guarded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = RetainedServerContextOwner()
+    assert owner.state == "empty"
+    with pytest.raises(RuntimeError, match="expected active"):
+        _ = owner.context
+    with pytest.raises(RuntimeError, match="expected active"):
+        _ = owner.result
+
+    owner_pid = owner._owner_pid
+    with monkeypatch.context() as changed:
+        changed.setattr(retained_context_module.os, "getpid", lambda: owner_pid + 1)
+        with pytest.raises(RuntimeError, match="PID boundary"):
+            _ = owner.state
+        with pytest.raises(RuntimeError, match="PID boundary"):
+            _ = owner.context
+        with pytest.raises(RuntimeError, match="PID boundary"):
+            _ = owner.result
+        with pytest.raises(RuntimeError, match="PID boundary"):
+            _ = owner.closed
+        with pytest.raises(RuntimeError, match="PID boundary"):
+            owner.close()
+
+    owner.close()
+    assert owner.closed
+
+
+def test_interruption_after_loading_reservation_closes_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = RetainedServerContextOwner()
+    interruption = KeyboardInterrupt("after loading reservation")
+    begin_loading = RetainedServerContextOwner._begin_loading
+
+    def begin_then_interrupt(
+        observed: RetainedServerContextOwner,
+        reservation: object,
+    ) -> None:
+        begin_loading(observed, reservation)
+        raise interruption
+
+    monkeypatch.setattr(
+        RetainedServerContextOwner,
+        "_begin_loading",
+        begin_then_interrupt,
+    )
+    with (
+        patch.object(
+            retained_context_module,
+            "materialize_retained_repo_manifest_ref",
+        ) as materialize,
+        pytest.raises(KeyboardInterrupt) as caught,
+    ):
+        load_retained_server_context_ref(
+            "owner/repo",
+            tmp_path / "context",
+            catalog=object(),  # type: ignore[arg-type]
+            object_store=object(),  # type: ignore[arg-type]
+            workspace_provider=object(),  # type: ignore[arg-type]
+            runtime_owner=owner,
+        )
+
+    assert caught.value is interruption
+    materialize.assert_not_called()
+    assert owner.closed
+
+
+@pytest.mark.parametrize(
+    ("seam", "failure"),
+    [
+        ("reader", RuntimeError("reader binding failed")),
+        ("context", KeyboardInterrupt("context load interrupted")),
+    ],
+)
+def test_postpublication_preinstall_failure_closes_receipt_and_keeps_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    seam: str,
+    failure: BaseException,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (_fixture, imported, object_store, catalog):
+        owner = RetainedServerContextOwner()
+        destination = tmp_path / "context"
+
+        def fail_after_publication(*_args: object, **_kwargs: object) -> None:
+            assert destination.is_dir()
+            assert owner._receipt_owner.active
+            raise failure
+
+        if seam == "reader":
+            monkeypatch.setattr(
+                retained_context_module,
+                "query_context_artifact_reader",
+                fail_after_publication,
+            )
+        else:
+            monkeypatch.setattr(ServerContext, "load", fail_after_publication)
+
+        with pytest.raises(type(failure)) as caught:
+            load_retained_server_context_ref(
+                "owner/repo",
+                destination,
+                catalog=catalog,
+                object_store=object_store,
+                workspace_provider=_TestWorkspaceProvider(),
+                runtime_owner=owner,
+                expected_generation=imported.generation,
+            )
+
+        assert caught.value is failure
+        assert owner.closed
+        assert owner._receipt_owner.closed
+        with pytest.raises(RuntimeError, match="expected active"):
+            _ = owner.context
+        assert destination.is_dir()
+
+
+@pytest.mark.parametrize("phase", ["context", "result"])
+def test_late_activation_interruption_closes_context_before_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    phase: str,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (_fixture, imported, object_store, catalog):
+        owner = RetainedServerContextOwner()
+        destination = tmp_path / "context"
+        interruption = KeyboardInterrupt(f"after {phase} installation")
+        installed: list[ServerContext] = []
+        closed: list[ServerContext] = []
+        cleanup_events: list[str] = []
+        real_install_context = RetainedServerContextOwner._install_context
+        real_install_result = RetainedServerContextOwner._install_result
+        real_context_close = ServerContext.close
+        receipt_type = type(owner._receipt_owner)
+        real_receipt_close = receipt_type.close
+
+        def install_context_then_maybe_interrupt(
+            observed: RetainedServerContextOwner,
+            context: ServerContext,
+        ) -> None:
+            installed.append(context)
+            real_install_context(observed, context)
+            if phase == "context":
+                raise interruption
+
+        def install_result_then_maybe_interrupt(
+            observed: RetainedServerContextOwner,
+            result: RetainedServerContextResult,
+        ) -> None:
+            real_install_result(observed, result)
+            if phase == "result":
+                raise interruption
+
+        def close_context(context: ServerContext) -> None:
+            cleanup_events.append("context")
+            closed.append(context)
+            real_context_close(context)
+
+        def close_receipt(receipt: object) -> None:
+            assert installed and installed[0] in closed
+            cleanup_events.append("receipt")
+            real_receipt_close(receipt)
+
+        monkeypatch.setattr(
+            RetainedServerContextOwner,
+            "_install_context",
+            install_context_then_maybe_interrupt,
+        )
+        monkeypatch.setattr(
+            RetainedServerContextOwner,
+            "_install_result",
+            install_result_then_maybe_interrupt,
+        )
+        monkeypatch.setattr(ServerContext, "close", close_context)
+        monkeypatch.setattr(receipt_type, "close", close_receipt)
+
+        with pytest.raises(KeyboardInterrupt) as caught:
+            load_retained_server_context_ref(
+                "owner/repo",
+                destination,
+                catalog=catalog,
+                object_store=object_store,
+                workspace_provider=_TestWorkspaceProvider(),
+                runtime_owner=owner,
+                expected_generation=imported.generation,
+            )
+
+        assert caught.value is interruption
+        assert len(installed) == 1
+        assert installed[0] in closed
+        assert owner.closed
+        assert owner._context_close_complete
+        assert owner._receipt_owner.closed
+        assert cleanup_events[-1] == "receipt"
+        assert destination.is_dir()
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "fork") or not Path("/proc/self/fd").is_dir(),
+    reason="requires fork and Linux descriptor inspection",
+)
+def test_fork_child_revokes_inherited_context_authority_only(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (_fixture, imported, object_store, catalog):
+        owner = RetainedServerContextOwner()
+        destination = tmp_path / "context"
+        load_retained_server_context_ref(
+            "owner/repo",
+            destination,
+            catalog=catalog,
+            object_store=object_store,
+            workspace_provider=_TestWorkspaceProvider(),
+            runtime_owner=owner,
+            expected_generation=imported.generation,
+        )
+
+        lock_acquired = threading.Event()
+        release_lock = threading.Event()
+
+        def hold_context_lock() -> None:
+            with owner.context._view_lock:
+                lock_acquired.set()
+                assert release_lock.wait(10)
+
+        holder = threading.Thread(target=hold_context_lock)
+        holder.start()
+        assert lock_acquired.wait(5)
+
+        read_descriptor, write_descriptor = os.pipe()
+        child_pid = -1
+        try:
+            child_pid = os.fork()
+        finally:
+            if child_pid != 0:
+                release_lock.set()
+                holder.join(5)
+        if child_pid != 0:
+            assert not holder.is_alive()
+        if child_pid == 0:
+            os.close(read_descriptor)
+            try:
+                signal.alarm(5)
+                try:
+                    _ = owner.state
+                except RuntimeError as state_error:
+                    state_report = str(state_error)
+                else:  # pragma: no cover - PID guard must fail closed
+                    state_report = "state unexpectedly escaped"
+                try:
+                    owner.close()
+                except RuntimeError as close_error:
+                    descriptor_targets: list[str] = []
+                    for name in os.listdir("/proc/self/fd"):
+                        try:
+                            target = os.readlink(f"/proc/self/fd/{name}")
+                        except OSError:
+                            continue
+                        if str(destination) in target:
+                            descriptor_targets.append(target)
+                    report = repr((state_report, str(close_error), descriptor_targets))
+                    os.write(write_descriptor, report.encode("utf-8"))
+            finally:
+                os.close(write_descriptor)
+                os._exit(0)
+
+        os.close(write_descriptor)
+        readable, _writable, _exceptional = select.select(
+            [read_descriptor],
+            [],
+            [],
+            10,
+        )
+        if not readable:  # pragma: no cover - watchdog for lock regressions
+            os.kill(child_pid, signal.SIGKILL)
+            os.waitpid(child_pid, 0)
+            os.close(read_descriptor)
+            pytest.fail("fork child did not reconcile inherited authority")
+        report = os.read(read_descriptor, 1 << 20).decode("utf-8")
+        os.close(read_descriptor)
+        waited_pid, status = os.waitpid(child_pid, 0)
+
+        assert waited_pid == child_pid
+        assert os.waitstatus_to_exitcode(status) == 0
+        assert report == repr(
+            (
+                "retained server context owner cannot cross a PID boundary",
+                "retained server context owner cannot cross a PID boundary",
+                [],
+            )
+        )
+        assert owner.state == "active"
+        assert owner.context.bm25 is not None
+        owner.close()
+        assert owner.closed

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3865,6 +3865,7 @@ def test_mcp_parser_limits_tool_surface_and_defaults_to_full() -> None:
     parser = cli.build_parser()
 
     assert parser.parse_args(["mcp"]).tool_surface == "full"
+    assert parser.parse_args(["mcp"]).path is None
     assert parser.parse_args(["mcp", "--tool-surface", "explore"]).tool_surface == (
         "explore"
     )
@@ -3872,6 +3873,120 @@ def test_mcp_parser_limits_tool_surface_and_defaults_to_full() -> None:
         parser.parse_args(["mcp", "--tool-surface", "hidden"])
 
     assert exc_info.value.code == 2
+
+
+def _retained_mcp_argv(tmp_path: Path) -> list[str]:
+    return [
+        "mcp",
+        "--catalog",
+        str(tmp_path / "catalog.sqlite3"),
+        "--cas-root",
+        str(tmp_path / "cas"),
+        "--workspace-root",
+        str(tmp_path / "workspaces"),
+        "--output",
+        str(tmp_path / "workspaces" / "runtime"),
+        "--repository",
+        "owner/repo",
+    ]
+
+
+def test_mcp_retained_parser_exposes_ref_and_snapshot_selection(
+    tmp_path: Path,
+) -> None:
+    parser = cli.build_parser()
+    ref = parser.parse_args(
+        [
+            *_retained_mcp_argv(tmp_path),
+            "--ref",
+            "release",
+            "--expected-generation",
+            "7",
+        ]
+    )
+    snapshot = parser.parse_args(
+        [*_retained_mcp_argv(tmp_path), "--snapshot", "snap_123"]
+    )
+
+    assert ref.path is None
+    assert ref.ref == "release"
+    assert ref.snapshot is None
+    assert ref.expected_generation == 7
+    assert snapshot.ref is None
+    assert snapshot.snapshot == "snap_123"
+    assert snapshot.expected_generation is None
+
+    with pytest.raises(SystemExit) as both:
+        parser.parse_args(
+            [*_retained_mcp_argv(tmp_path), "--ref", "main", "--snapshot", "snap"]
+        )
+    assert both.value.code == 2
+
+
+@pytest.mark.parametrize(
+    ("arguments", "message"),
+    (
+        (("--catalog", "catalog.sqlite3"), "retained MCP storage requires"),
+        (("--repository", "owner/repo"), "require --artifact"),
+        (
+            ("--runtime-probe", "--catalog", "catalog.sqlite3"),
+            "--runtime-probe cannot be combined",
+        ),
+    ),
+)
+def test_mcp_context_modes_fail_before_dependency_probe(
+    arguments: tuple[str, ...],
+    message: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        cli,
+        "_require_modules",
+        lambda *_args, **_kwargs: pytest.fail("dependency probe must not run"),
+    )
+
+    assert cli.run(["mcp", *arguments]) == 2
+    assert message in capsys.readouterr().err
+
+
+def test_mcp_retained_rejects_mixed_context_and_snapshot_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        cli,
+        "_require_modules",
+        lambda *_args, **_kwargs: pytest.fail("dependency probe must not run"),
+    )
+    complete = _retained_mcp_argv(tmp_path)
+
+    assert cli.run(["mcp", ".", *complete[1:]]) == 2
+    assert "cannot be combined with a manifest" in capsys.readouterr().err
+    assert cli.run([*complete, "--snapshot", "snap", "--expected-generation", "2"]) == 2
+    assert "requires retained ref selection" in capsys.readouterr().err
+
+
+def test_mcp_retained_dispatches_only_after_dependency_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[object] = []
+    monkeypatch.setattr(
+        cli,
+        "_require_modules",
+        lambda modules, **_kwargs: calls.append(tuple(modules)),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_run_mcp_retained",
+        lambda args: calls.append(args) or 0,
+    )
+    args = cli.build_parser().parse_args(_retained_mcp_argv(tmp_path))
+
+    assert cli._run_mcp(args) == 0
+    assert calls == [("mcp",), args]
 
 
 def test_mcp_runtime_probe_checks_the_complete_codegraph_runtime(


### PR DESCRIPTION
## Summary

Add an explicit catalog-selected cold-start mode to `codenib mcp`. It materializes one exact retained ref or immutable snapshot, loads the query context through its authenticated publication reader, and keeps that authority active for one synchronous stdio server lifetime.

This builds on merged #654 and is related to #199; it does not close the RFC or M1. Default compiler/runtime promotion remains gated on representative benchmarks, while hot switching and durable reclamation remain later milestones.

## Changes

- Bind retained context artifacts to their exact publication reader and fail closed if a reader-bound BM25 runtime is later loaded without that reader.
- Add a PID-bound, one-shot retained MCP owner that validates repository, namespace, ref generation or snapshot selection, manifest evidence, and publication ownership before installing a `ServerContext`.
- Keep catalog, CAS, and topology authorities out of the serving lifetime while retaining the workspace receipt until shutdown; detach the global context before ordered context-to-receipt cleanup.
- Add an all-or-none retained-storage mode to `codenib mcp`, reusing the strict existing-catalog, preprovisioned-CAS, workspace, and physical-topology gates.
- Keep retained cold start source-disabled and BM25-required; portable vector artifacts remain native-parser inert and vector-only snapshots fail closed.
- Cover selector forgery, receipt tampering, cancellation, cleanup retries, fork/PID boundaries, global-context replacement, parser isolation, and a real Git → retained snapshot → MCP BM25 query round trip.
- Document the explicit lifecycle, trust boundary, persisted output behavior, and remaining M1/M2/M3/M5 gates.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Post-rebase unit tier: `6783 passed, 71 skipped, 190 deselected`
- The host lacks `/usr/bin/docker`; the complete unit tier passed in a read-only bwrap namespace mapping that absent executable probe to `/usr/bin/true`
- Focused retained artifact/context/MCP/CLI/E2E matrix: `328 passed`
- Related compiler/materialization/storage matrix: `244 passed`
- Real Git → index → retained publication → catalog-selected MCP BM25 query round trip
- Black, isort, flake8, `py_compile`, and `git diff --check`
- `python scripts/check_public_docs.py`
- `python -m mkdocs build --strict`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
