### PR TITLE
perf(storage): split retained runtime benchmark tracks

### DIFF
--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -332,15 +332,16 @@ jobs and runtime hot switching remain separate milestones.
 report-only: it checks a fixed BM25 `--preset fast` protocol and records
 measurements, but it has no ratified numeric thresholds. Every A1 report has an
 unratified policy and `promotion_eligible=false`, including a complete report
-whose parity checks succeed.
+with one or more green tracks. A complete report means the measurement and its
+safety gates finished; it does not mean every compatibility track passed.
 
 Pass detached repository roots and roots on the storage media being measured.
 Both variables are whitespace-separated `ID=PATH` values, and subject IDs must
 be present in the selected manifest. Because Make uses whitespace to split the
 values, these paths must not contain whitespace. The checked-in manifest fixes
 HTTPie, CodeNib, and Django revisions as its small, medium, and large subjects;
-their three root mappings must match exactly. A canonical run also requires at
-least two approved media classes. For example:
+their three root mappings must match exactly. A canonical run also requires
+exactly two approved, physically distinct media classes. For example:
 
 ```bash
 make retained-storage-gate \
@@ -379,17 +380,28 @@ authorities. The worker then launches a fresh inner route process. Those
 locations are therefore not controller flags, and provisioning is excluded
 from the timed inner route.
 
-The harness compares three pairs and alternates AB/BA order for every pair:
+The v2 harness compares four pairs and alternates AB/BA order for every pair:
 
 - Compiler cold: A runs ordinary `codenib index --preset fast` from an empty
   cache; B runs the same command with retained publication.
 - Compiler current: both arms receive equivalent verified current caches. A
   measures an ordinary update; B performs the retained exact retry with the
   original expected ref generation and verifies that the ref does not advance.
-- Runtime cold: A loads the legacy manifest MCP context; B resolves one catalog
-  ref and loads the retained MCP context. Both use the real parser and command
-  handler. Only `mcp.run` is replaced by a ready callback that executes the
-  same fixed BM25 queries.
+- Runtime cold compatibility: A loads the ordinary source-bound manifest MCP
+  context; B resolves one catalog ref and loads the source-disabled retained
+  context. This sentinel measures the existing behavior gap instead of hiding
+  it.
+- Runtime cold query-only: outside the stopwatch, A packs the current BM25 view
+  as a portable context artifact and B prepares retained storage. Inside the
+  stopwatch, A runs `codenib mcp --artifact` without `--repo`, while B resolves
+  and materializes the retained ref. Both are source-disabled and use the real
+  parser and command handler.
+
+Only `mcp.run` is replaced by a ready callback that executes the same fixed
+BM25 queries. With three subjects, two media classes, four cells, two arms,
+four warmups, and 20 measured rounds, a canonical v2 run contains 1,152 fresh
+inner route processes. The query-only pair adds 288 samples, or 33.3 percent,
+to the original three-cell protocol.
 
 Here, compiler cold means an empty CodeNib compiler cache, and runtime cold
 means a fresh process and unloaded context. The harness does not flush or
@@ -405,17 +417,31 @@ receipt records `route_wall_seconds`, `process_wall_seconds`, `cpu_seconds`,
 nearest-rank p95.
 
 Runtime parity hashes the complete public BM25 result, including optional
-source `content`, ordering, scores, and locations. The legacy route retains an
-authenticated source binding, while the retained artifact route is deliberately
-source-disabled. If that difference changes the public payload, A1 emits a
-negative parity receipt; it must not erase the field or normalize the mismatch
-to make the gate pass.
+source `content`, ordering, scores, and locations, and binds the observed source
+authority contract. The manifest compatibility cell therefore stays red even
+if a particular query omits content: its legacy arm has authenticated live
+source while retained startup is source-disabled. The query-only cell requires
+both arms to remain source-disabled and to produce identical complete payloads.
+A1 never erases `content`, narrows the projection, or encodes a particular
+digest as an expected failure.
+
+Reports aggregate compiler, query-only runtime, and manifest runtime
+compatibility as independent tracks. A parity-red compatibility sentinel still
+allows a complete, reviewable report with `failure=null`; worker, schema,
+source, isolation, cleanup, safety, or postflight faults instead make the
+measurement fail. All tracks remain report-only and promotion-ineligible.
+The controller exits zero for a complete report even when top-level `passed`
+is false; a nonzero exit means the measurement itself failed, not merely that
+a compatibility track remained red.
 
 Do not infer promotion thresholds from one A1 run. A2 must execute the approved
-fixed subject/media matrix, retain its canonical receipts, and ratify the
-numeric policy before B1 can promote BM25 compiler publication or B2 can
-promote retained BM25 cold start to configured defaults. The independent gate
-C `provider-bound-exact` native provider is still required before M1 closes.
+fixed subject/media matrix and retain its canonical receipts. The compiler and
+query-only runtime tracks may ratify their own numeric policies independently;
+B1 requires the former and query-only B2 requires the latter. Replacing the
+ordinary source-bound manifest MCP path remains blocked until a source-capable
+retained route preserves the same public behavior and authority. The
+independent gate C `provider-bound-exact` native provider is still required
+before M1 closes.
 This harness does not add M2 generic generation publication or fenced jobs, M3
 hot switching or request pins, or M5 retention and garbage collection.
 

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -710,10 +710,12 @@ that collecting a fast result cannot silently approve a production route:
 
 | Gate | Required result | Current status |
 | --- | --- | --- |
-| A1 | Run the fixed, report-only retained storage harness. | Implemented; it cannot promote a route. |
-| A2 | Record canonical receipts for the approved subject/media matrix and ratify a numeric policy from measured results. | Pending real measurements. |
-| B1 | Promote BM25 compiler publication to a configured default. | Pending A2. |
-| B2 | Promote BM25 retained cold start to a configured default. | Pending A2. |
+| A1 | Run the fixed, report-only retained storage harness and preserve each route's complete public and authority parity. | Implemented as a four-cell v2 evidence protocol; it cannot promote a route. |
+| A2 compiler | Record canonical compiler receipts for the approved subject/media matrix and ratify numeric compiler policy from measured results. | Pending real measurements. |
+| A2 query-only runtime | Record canonical direct-artifact versus retained receipts and ratify numeric query-only runtime policy. | Pending real measurements. |
+| A2 manifest compatibility | Preserve ordinary manifest MCP public behavior and authority when selecting retained storage. | Blocked: retained startup is source-disabled. |
+| B1 | Promote BM25 compiler publication to a configured default. | Pending A2 compiler. |
+| B2 | Promote query-only BM25 retained cold start to a configured default. | Pending A2 query-only runtime; this does not replace source-bound manifest MCP. |
 | C | Supply the `provider-bound-exact` strict BM25 native provider. | Independent work, but required before M1 closes. |
 
 The A1 harness fixes the BM25 `fast` compiler/runtime comparison rather than
@@ -723,11 +725,15 @@ with retained publication; storage provisioning is outside the measured route.
 For compiler current-cache behavior, both arms start from equivalent verified
 current caches: A measures the ordinary update and B measures the retained
 exact retry with its original expected ref generation, which must not advance
-the ref again. For runtime cold start, A loads the legacy manifest MCP context
-and B resolves one catalog ref and loads the retained MCP context through the
-real parser and command handler. The harness replaces only `mcp.run` with a
-ready callback that executes the same fixed BM25 queries, and semantic parity
-is required before performance data are usable.
+the ref again. Runtime cold start deliberately has two cells. The
+manifest-compatibility cell keeps arm A on the ordinary source-bound manifest
+MCP context and arm B on the source-disabled retained context. It is an honest
+compatibility sentinel, not a performance waiver. The query-only cell prepares
+a direct portable context artifact outside the stopwatch, then compares its
+source-disabled MCP startup with the same retained ref resolution and
+materialization. Both cells use the real parser and command handler. The
+harness replaces only `mcp.run` with a ready callback that executes the same
+fixed BM25 queries.
 
 Every paired round alternates AB/BA order. For each arm, the controller starts
 a short-lived outer sample worker. Every arm receives a fresh `CODENIB_HOME`
@@ -735,7 +741,11 @@ and compiler cache below the selected media root; candidate arms additionally
 provision a fresh catalog, CAS, workspace, and output, while legacy arms never
 touch those retained authorities. The worker then launches a fresh inner route
 process. The canonical matrix fixes one small, medium, and large subject plus
-at least two media classes, with four warmups followed by 20 measured rounds.
+exactly two approved, physically distinct media classes, with four warmups
+followed by 20 measured rounds.
+Four cells, two arms, three subjects, and two media classes therefore require
+1,152 fresh inner route processes; the query-only runtime cell adds 288
+samples, or 33.3 percent, over the original three-cell protocol.
 Each route receipt records
 `route_wall_seconds`, `process_wall_seconds`, `cpu_seconds`, `peak_rss_bytes`,
 `io_read_bytes`, `io_write_bytes`, `payload_bytes`, and `payload_files`.
@@ -750,18 +760,35 @@ and the report records it as `uncontrolled`; A2 must assess its receipts with
 that limitation intact.
 
 Runtime parity covers the complete public BM25 result, including optional
-source content, ordering, scores, and locations. The legacy manifest route is
-source-verified while the retained artifact route is intentionally
-source-disabled. A payload difference caused by that authority distinction is
-a real negative A1 receipt, not metadata to discard; it must be resolved or
-explicitly ratified before runtime promotion can proceed.
+source content, ordering, scores, and locations. It also includes the source
+authority contract, so the manifest-compatibility cell remains blocked even
+when a particular query happens not to return content. Its source-verified
+legacy arm and source-disabled retained arm are not interchangeable. The
+query-only cell instead requires both direct-artifact and retained arms to stay
+source-disabled and to return identical full payloads. The harness never drops
+`content`, narrows the projection, or hard-codes an expected mismatch.
+
+The v2 report aggregates three independent tracks: compiler, query-only
+runtime, and manifest runtime compatibility. Completing all samples safely
+produces a complete report even when a parity track is red; operational,
+schema, isolation, cleanup, source, or postflight failures still fail the
+measurement. A complete report is not a passing compatibility decision and
+never authorizes promotion. This separation lets A2 compiler and A2
+query-only runtime use their own canonical green receipts without laundering
+the blocked manifest-replacement track.
+The controller therefore exits zero when the report status is `complete`, even
+if top-level `passed` is false, and exits nonzero only when the measurement
+status is `failed`.
 
 A1 intentionally has no approved numeric thresholds or threshold override.
 Its policy is unratified and every report sets `promotion_eligible=false`, even
-when parity holds and all measurements complete. Only A2 measurements over the
-fixed approved subject/media matrix may establish canonical receipts and
-ratify numeric thresholds. B1 and B2 require that ratified policy; neither is
-approved by landing the harness. This leaves M1 in progress.
+when a track passes and all measurements complete. Only A2 measurements over
+the fixed approved subject/media matrix may establish canonical receipts and
+ratify numeric thresholds. B1 requires the compiler track; query-only B2
+requires the query-only runtime track. Replacing ordinary source-bound manifest
+MCP remains blocked until a source-capable retained route preserves its public
+and authority behavior. None of these promotions is approved by landing the
+harness. This leaves M1 in progress.
 
 These gates do not move the existing milestone boundaries. Generic generation
 publication and fenced jobs remain M2, live bundle replacement and in-flight

--- a/scripts/profiling/profile_retained_storage_gate.py
+++ b/scripts/profiling/profile_retained_storage_gate.py
@@ -15,7 +15,13 @@ Every measured route runs in a fresh inner process.  A short-lived outer sample
 worker provisions an isolated storage root and performs any required warm-cache
 preparation before starting that process, keeping preparation out of Linux
 ``VmHWM`` and ``/proc/self/io`` observations.  The controller alternates AB/BA
-pairs and validates exact BM25 artifact and public-query parity.
+pairs and validates exact BM25 artifact, authority, and public-query parity.
+
+The manifest-backed ``runtime-cold`` cell is intentionally retained as a
+compatibility sentinel: its live-source legacy arm and source-disabled retained
+arm are not authority-equivalent.  ``runtime-cold-query-only`` is the comparable
+runtime cost cell; it measures a direct portable artifact without ``--repo``
+against the retained portable-artifact route.
 """
 
 from __future__ import annotations
@@ -44,21 +50,50 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _DEFAULT_MANIFEST = Path(__file__).with_name("retained_storage_subjects.json")
 _DEFAULT_OUTPUT = Path(tempfile.gettempdir()) / "codenib-retained-storage-gate.json"
 
-BENCHMARK_ID = "retained_storage_explicit_route_gate_v1"
-MANIFEST_SCHEMA_VERSION = 1
-REPORT_SCHEMA_VERSION = 1
+BENCHMARK_ID = "retained_storage_explicit_route_gate_v2"
+MANIFEST_SCHEMA_VERSION = 2
+REPORT_SCHEMA_VERSION = 2
 DEFAULT_ITERATIONS = 20
 DEFAULT_WARMUPS = 4
 DEFAULT_WORKER_TIMEOUT_SECONDS = 1800.0
 CANONICAL_PEAK_RSS_SOURCE = "proc-self-status-vmhwm-kib-v1"
 CANONICAL_IO_SOURCE = "proc-self-io-v1"
 _CANONICAL_MANIFEST_SHA256 = (
-    "sha256:e2cc9d98ec625fc7eb7d54b5fe745e1793461957be3836fc516240251998a883"
+    "sha256:2d7f95489567ef17993bd1f87b46864931645719e172731a68d15d7e7e6913cb"
 )
-_CANONICAL_MANIFEST_SIZE = 3133
+_CANONICAL_MANIFEST_SIZE = 3164
 
 ARMS = ("legacy", "candidate")
-CELLS = ("compiler-cold", "compiler-current", "runtime-cold")
+CELLS = (
+    "compiler-cold",
+    "compiler-current",
+    "runtime-cold",
+    "runtime-cold-query-only",
+)
+TRACKS = {
+    "compiler": ("compiler-cold", "compiler-current"),
+    "query-only-runtime": ("runtime-cold-query-only",),
+    "manifest-runtime-compatibility": ("runtime-cold",),
+}
+CELL_AUTHORITY_CONTRACTS = {
+    "compiler-cold": {
+        "legacy": "compiler-cache-index",
+        "candidate": "compiler-cache-index-and-retained-publication",
+    },
+    "compiler-current": {
+        "legacy": "compiler-cache-index",
+        "candidate": "compiler-cache-index-and-retained-publication",
+    },
+    "runtime-cold": {
+        "legacy": "manifest-live-source",
+        "candidate": "retained-portable-artifact-query-only",
+    },
+    "runtime-cold-query-only": {
+        "legacy": "direct-portable-artifact-query-only-no-repo",
+        "candidate": "retained-portable-artifact-query-only",
+    },
+}
+CANONICAL_SAMPLE_COUNT = 1152
 PHASES = ("warmup", "measured")
 PAYLOAD_CLASSES = ("small", "medium", "large")
 VIEW_SET_ID = "bm25-fast"
@@ -150,7 +185,9 @@ _SAFETY_FIELDS = frozenset(
         "retained_matches_raw",
     }
 )
-_RESULT_FIELDS = frozenset({"manifest", "view", "retained_view", "queries", "snapshot"})
+_RESULT_FIELDS = frozenset(
+    {"manifest", "view", "retained_view", "queries", "snapshot", "authority"}
+)
 _MANIFEST_IDENTITY_FIELDS = frozenset(
     {
         "commit",
@@ -171,7 +208,15 @@ _VIEW_IDENTITY_FIELDS = frozenset(
 )
 _QUERY_IDENTITY_FIELDS = frozenset({"sha256", "count", "nonempty"})
 _SNAPSHOT_FIELDS = frozenset({"snapshot_id", "ref_name", "generation", "changed"})
-_PARITY_FIELDS = frozenset({"manifest", "view", "queries"})
+_PARITY_FIELDS = frozenset({"manifest", "view", "queries", "authority"})
+_AUTHORITY_IDENTITY_FIELDS = frozenset(
+    {
+        "context_kind",
+        "artifact",
+        "source_verified",
+        "source_verification_scope",
+    }
+)
 _SOURCE_SELECTION_FIELDS = frozenset(
     {"schema", "repository_filter_policy", "exclude_subtrees"}
 )
@@ -563,7 +608,7 @@ def load_subject_manifest(path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
         or receipt["size"] != _CANONICAL_MANIFEST_SIZE
     ):
         raise ValueError(
-            "checked-in subject manifest differs from the v1 canonical anchor"
+            "checked-in subject manifest differs from the v2 canonical anchor"
         )
     if payload_bytes.startswith(b"\xef\xbb\xbf"):
         raise ValueError("subject manifest must not use a UTF-8 BOM")
@@ -942,6 +987,21 @@ def _io_source() -> str:
     return CANONICAL_IO_SOURCE if sys.platform.startswith("linux") else "unsupported"
 
 
+def _empty_tracks() -> dict[str, dict[str, Any]]:
+    return {
+        track: {
+            "cells": list(cells),
+            "measurement_complete": False,
+            "parity_passed": False,
+            "safety_passed": False,
+            "passed": False,
+            "policy_status": "unratified",
+            "promotion_eligible": False,
+        }
+        for track, cells in TRACKS.items()
+    }
+
+
 def _base_report(
     *,
     manifest_path: Path,
@@ -1000,6 +1060,11 @@ def _base_report(
                     "fresh-inner-import-parser-handler-through-ready-callback-"
                     "fixed-queries-and-normal-cleanup-return"
                 ),
+                "runtime-cold-query-only": (
+                    "fresh-inner-import-parser-direct-or-retained-portable-"
+                    "artifact-handler-through-ready-callback-fixed-queries-and-"
+                    "normal-cleanup-return"
+                ),
             },
             "process_wall_boundary": (
                 "full-inner-subprocess-lifecycle-including-post-timing-parity"
@@ -1008,11 +1073,9 @@ def _base_report(
             "cold_definitions": {
                 "compiler-cold": "empty-codenib-cache",
                 "runtime-cold": "fresh-process-and-context",
+                "runtime-cold-query-only": "fresh-process-and-context",
             },
-            "runtime_authority_contract": {
-                "legacy": "authenticated-live-source-content-bytes",
-                "candidate": "retained-query-only-source-disabled",
-            },
+            "cell_authority_contracts": _json_snapshot(CELL_AUTHORITY_CONTRACTS),
         },
         "benchmark_receipts": {
             "before": None,
@@ -1022,6 +1085,7 @@ def _base_report(
         "subjects": {},
         "media": {},
         "cells": {},
+        "tracks": _empty_tracks(),
         "process_isolation": {
             "expected_samples": 0,
             "observed_samples": 0,
@@ -1108,6 +1172,9 @@ def _protocol(
         "iterations_per_arm": DEFAULT_ITERATIONS,
         "warmups_per_arm": DEFAULT_WARMUPS,
         "cells": list(CELLS),
+        "tracks": {track: list(cells) for track, cells in TRACKS.items()},
+        "cell_authority_contracts": _json_snapshot(CELL_AUTHORITY_CONTRACTS),
+        "canonical_sample_count": CANONICAL_SAMPLE_COUNT,
         "view_set_ids": [VIEW_SET_ID],
         "payload_classes": list(PAYLOAD_CLASSES),
         "minimum_media_classes": 2,
@@ -1116,10 +1183,6 @@ def _protocol(
         "paired_arm_order": "alternating-ab-ba",
         "peak_rss_source": CANONICAL_PEAK_RSS_SOURCE,
         "io_source": CANONICAL_IO_SOURCE,
-        "runtime_authority_contract": {
-            "legacy": "authenticated-live-source-content-bytes",
-            "candidate": "retained-query-only-source-disabled",
-        },
         "fixed_manifest_sha256": _CANONICAL_MANIFEST_SHA256,
         "fixed_manifest_size": _CANONICAL_MANIFEST_SIZE,
         "subject_receipts": fixed_subject_receipts,
@@ -1136,6 +1199,16 @@ def _protocol(
         "iterations_per_arm": iterations,
         "warmups_per_arm": warmups,
         "cells": list(manifest["cells"]),
+        "tracks": {track: list(cells) for track, cells in TRACKS.items()},
+        "cell_authority_contracts": _json_snapshot(CELL_AUTHORITY_CONTRACTS),
+        "canonical_sample_count": (
+            len(manifest["subjects"])
+            * len(media)
+            * len(manifest["view_sets"])
+            * len(manifest["cells"])
+            * (iterations + warmups)
+            * len(ARMS)
+        ),
         "view_set_ids": [item["id"] for item in manifest["view_sets"]],
         "payload_classes": [item["payload_class"] for item in manifest["subjects"]],
         "minimum_media_classes": min(len(distinct_media), 2),
@@ -1146,10 +1219,6 @@ def _protocol(
         "paired_arm_order": "alternating-ab-ba",
         "peak_rss_source": _peak_rss_source(),
         "io_source": _io_source(),
-        "runtime_authority_contract": {
-            "legacy": "authenticated-live-source-content-bytes",
-            "candidate": "retained-query-only-source-disabled",
-        },
         "fixed_manifest_sha256": manifest_receipt["sha256"],
         "fixed_manifest_size": manifest_receipt["size"],
         "subject_receipts": subject_receipts,
@@ -1249,6 +1318,56 @@ def _validate_query_identity(
     return {"sha256": digest, "count": count, "nonempty": True}
 
 
+def _portable_artifact_identity(subject: Mapping[str, Any]) -> dict[str, Any]:
+    from codenib.artifacts.context import CONTEXT_ARTIFACT_SCHEMA
+
+    return {
+        "verified": True,
+        "schema": CONTEXT_ARTIFACT_SCHEMA,
+        "repository": subject["repository_key"],
+        "commit": subject["revision"],
+        "views": ["bm25"],
+    }
+
+
+def _expected_authority_identity(request: Mapping[str, Any]) -> dict[str, Any]:
+    cell = request["cell"]
+    arm = request["arm"]
+    if cell in {"compiler-cold", "compiler-current"}:
+        return {
+            "context_kind": "compiler-portable-plan",
+            "artifact": None,
+            "source_verified": None,
+            "source_verification_scope": None,
+        }
+    if cell == "runtime-cold" and arm == "legacy":
+        return {
+            "context_kind": "manifest-live-source",
+            "artifact": None,
+            "source_verified": True,
+            "source_verification_scope": "content-bytes",
+        }
+    return {
+        "context_kind": "portable-artifact-query-only",
+        "artifact": _portable_artifact_identity(request["subject"]),
+        "source_verified": False,
+        "source_verification_scope": None,
+    }
+
+
+def _validate_authority_identity(
+    value: object,
+    *,
+    request: Mapping[str, Any],
+    label: str,
+) -> dict[str, Any]:
+    identity = _require_exact_dict(value, _AUTHORITY_IDENTITY_FIELDS, label=label)
+    expected = _expected_authority_identity(request)
+    if identity != expected:
+        raise RuntimeError(f"{label} differs from its exact per-cell contract")
+    return _json_snapshot(expected)
+
+
 def _validate_snapshot(
     value: object,
     *,
@@ -1274,6 +1393,7 @@ def _validate_snapshot(
         "compiler-cold": True,
         "compiler-current": False,
         "runtime-cold": None,
+        "runtime-cold-query-only": None,
     }[cell]
     if snapshot["changed"] is not expected_changed:
         raise RuntimeError("candidate sample changed flag violates its cell contract")
@@ -1334,6 +1454,11 @@ def _validate_sample_receipt(
     queries = _validate_query_identity(
         result["queries"], subject=subject, label="sample query identity"
     )
+    authority = _validate_authority_identity(
+        result["authority"],
+        request=request,
+        label="sample authority identity",
+    )
     retained_view = result["retained_view"]
     if retained_view is not None:
         retained_view = _validate_view_identity(
@@ -1363,6 +1488,7 @@ def _validate_sample_receipt(
             "metadata_sha256": view["metadata_sha256"],
         },
         "queries": queries,
+        "authority": authority,
     }
     if parity != expected_parity:
         raise RuntimeError("sample parity projection differs from its result")
@@ -1394,6 +1520,7 @@ def _validate_sample_receipt(
             "retained_view": retained_view,
             "queries": queries,
             "snapshot": snapshot,
+            "authority": authority,
         },
         "safety": dict(safety),
     }
@@ -1553,6 +1680,123 @@ def _run_cell(
             "promotion_eligible": False,
         },
     }
+
+
+def _cell_measurement_complete(
+    cell: object,
+    *,
+    iterations: int,
+    warmups: int,
+) -> bool:
+    if type(cell) is not dict:
+        return False
+    runs = cell.get("runs")
+    if type(runs) is not dict or set(runs) != {"warmups", "measured"}:
+        return False
+    for phase_name, expected_rounds in (
+        ("warmups", warmups),
+        ("measured", iterations),
+    ):
+        rounds = runs[phase_name]
+        if type(rounds) is not list or len(rounds) != expected_rounds:
+            return False
+        for round_index, pair in enumerate(rounds):
+            if type(pair) is not dict:
+                return False
+            order = list(paired_arm_order(round_index))
+            samples = pair.get("samples")
+            if (
+                pair.get("round_index") != round_index
+                or pair.get("arm_order") != order
+                or type(pair.get("parity")) is not bool
+                or type(samples) is not list
+                or len(samples) != len(ARMS)
+                or [sample.get("arm") for sample in samples] != order
+            ):
+                return False
+    summary = cell.get("summary")
+    if type(summary) is not dict or set(summary) != set(ARMS):
+        return False
+    for arm in ARMS:
+        metrics = summary[arm]
+        if type(metrics) is not dict or set(metrics) != _METRIC_FIELDS:
+            return False
+        for metric in _METRIC_FIELDS:
+            aggregate = metrics[metric]
+            if type(aggregate) is not dict or aggregate.get("samples") != iterations:
+                return False
+    return True
+
+
+def _aggregate_tracks(
+    cells: Mapping[str, Mapping[str, Any]],
+    *,
+    expected_instances_per_cell: int,
+    iterations: int,
+    warmups: int,
+) -> dict[str, dict[str, Any]]:
+    """Reduce exact cell instances into independent report-only tracks."""
+
+    expected_instances = _positive_int(
+        expected_instances_per_cell,
+        label="expected instances per cell",
+    )
+    measured_iterations = _positive_int(iterations, label="iterations")
+    measured_warmups = _nonnegative_int(warmups, label="warmups")
+    if not isinstance(cells, Mapping):
+        raise TypeError("cells must be a mapping")
+    by_cell: dict[str, list[Mapping[str, Any]]] = {cell: [] for cell in CELLS}
+    unknown = False
+    for value in cells.values():
+        if not isinstance(value, Mapping) or value.get("cell") not in by_cell:
+            unknown = True
+            continue
+        by_cell[str(value["cell"])].append(value)
+
+    tracks: dict[str, dict[str, Any]] = {}
+    for track, track_cells in TRACKS.items():
+        instances = [item for cell in track_cells for item in by_cell[cell]]
+        expected_count = expected_instances * len(track_cells)
+        identities = {
+            (
+                item.get("subject_id"),
+                item.get("media_id"),
+                item.get("view_set_id"),
+                item.get("cell"),
+            )
+            for item in instances
+        }
+        measurement_complete = (
+            not unknown
+            and len(instances) == expected_count
+            and len(identities) == expected_count
+            and all(
+                _cell_measurement_complete(
+                    item,
+                    iterations=measured_iterations,
+                    warmups=measured_warmups,
+                )
+                for item in instances
+            )
+        )
+        parity_passed = measurement_complete and all(
+            type(item.get("parity")) is dict and item["parity"].get("passed") is True
+            for item in instances
+        )
+        safety_passed = measurement_complete and all(
+            type(item.get("safety")) is dict and item["safety"].get("passed") is True
+            for item in instances
+        )
+        tracks[track] = {
+            "cells": list(track_cells),
+            "measurement_complete": measurement_complete,
+            "parity_passed": parity_passed,
+            "safety_passed": safety_passed,
+            "passed": measurement_complete and parity_passed and safety_passed,
+            "policy_status": "unratified",
+            "promotion_eligible": False,
+        }
+    return tracks
 
 
 def _duplicate_process_ids(process_ids: Sequence[int]) -> list[int]:
@@ -1749,6 +1993,16 @@ def profile_retained_storage_gate(
         "duplicate_process_ids": duplicates,
         "passed": isolation_passed,
     }
+    report["tracks"] = _aggregate_tracks(
+        report["cells"],
+        expected_instances_per_cell=(
+            len(manifest["subjects"])
+            * len(normalized_media_roots)
+            * len(manifest["view_sets"])
+        ),
+        iterations=iterations,
+        warmups=warmups,
+    )
     if measurement_failure is not None:
         if postflight_error is not None:
             measurement_failure["failure"][
@@ -1757,26 +2011,58 @@ def profile_retained_storage_gate(
         return measurement_failure
     if postflight_error is not None:
         return _failure(report, "postflight", postflight_error)
-
-    cells_passed = bool(report["cells"]) and all(
-        cell["passed"] for cell in report["cells"].values()
-    )
-    if not (cells_passed and isolation_passed):
-        failed_gates = []
-        if not cells_passed:
-            failed_gates.append("cell parity or safety")
-        if not isolation_passed:
-            failed_gates.append("global inner-process isolation")
+    if not isolation_passed:
         return _failure(
             report,
-            "postflight",
-            RuntimeError("gate failed: " + ", ".join(failed_gates)),
+            "isolation",
+            RuntimeError("global inner-process isolation failed"),
+        )
+    incomplete_tracks = [
+        track
+        for track, aggregate in report["tracks"].items()
+        if aggregate["measurement_complete"] is not True
+    ]
+    if incomplete_tracks:
+        return _failure(
+            report,
+            "measurement",
+            RuntimeError(
+                "track measurement incomplete: " + ", ".join(incomplete_tracks)
+            ),
+        )
+    unsafe_tracks = [
+        track
+        for track, aggregate in report["tracks"].items()
+        if aggregate["safety_passed"] is not True
+    ]
+    if unsafe_tracks:
+        return _failure(
+            report,
+            "safety",
+            RuntimeError("track safety failed: " + ", ".join(unsafe_tracks)),
+        )
+    if report["protocol"]["canonical"] is not True:
+        return _failure(
+            report,
+            "protocol",
+            RuntimeError("measurement protocol is not canonical v2"),
         )
 
-    report["status"] = "passed"
-    report["passed"] = True
+    tracks_passed = all(
+        aggregate["passed"] is True for aggregate in report["tracks"].values()
+    )
+    report["status"] = "complete"
+    report["passed"] = tracks_passed
     report["promotion_eligible"] = False
     report["failure"] = None
+    if not tracks_passed:
+        report["decision"] = {
+            "policy_status": "unratified",
+            "report_only": True,
+            "promotion_eligible": False,
+            "recommendation": "retain-explicit-routes",
+            "reason": "one or more compatibility tracks are parity red",
+        }
     return report
 
 
@@ -1990,6 +2276,7 @@ def _sample_paths(sample_root: Path, run_id: str) -> dict[str, str]:
         "catalog": os.fspath(sample_root / "catalog.sqlite"),
         "cas_root": os.fspath(sample_root / "cas"),
         "workspace_root": os.fspath(sample_root / "workspace"),
+        "direct_artifact": os.fspath(sample_root / f"direct-artifact-{run_id}"),
         "runtime_output": os.fspath(sample_root / "workspace" / f"runtime-{run_id}"),
         "materialized_output": os.fspath(
             sample_root / "workspace" / f"materialized-{run_id}"
@@ -2159,8 +2446,22 @@ def _prepare_sample(request: Mapping[str, Any], paths: Mapping[str, str]) -> Non
         _provision_storage(paths)
     if cell == "compiler-current":
         _invoke_cli(_index_arguments(request, paths, candidate=arm == "candidate"))
-    elif cell == "runtime-cold":
+    elif cell in {"runtime-cold", "runtime-cold-query-only"}:
         _invoke_cli(_index_arguments(request, paths, candidate=arm == "candidate"))
+        if cell == "runtime-cold-query-only" and arm == "legacy":
+            _invoke_cli(
+                (
+                    "artifact",
+                    "pack",
+                    request["subject_root"],
+                    "--output",
+                    paths["direct_artifact"],
+                    "--repository",
+                    request["subject"]["repository_key"],
+                    "--view",
+                    "bm25",
+                )
+            )
 
 
 def _cleanup_sample_root(sample_root: Path, media_root: Path, run_id: str) -> None:
@@ -2527,6 +2828,7 @@ def _query_identity(context: Any, subject: Mapping[str, Any]) -> dict[str, Any]:
 def _route_result_from_manifest(
     manifest_path: Path,
     *,
+    request: Mapping[str, Any],
     subject: Mapping[str, Any],
     manifest_identity: Mapping[str, Any],
     view_identity: Mapping[str, Any],
@@ -2557,6 +2859,7 @@ def _route_result_from_manifest(
         "retained_view": None,
         "queries": queries,
         "snapshot": {field: None for field in _SNAPSHOT_FIELDS},
+        "authority": _expected_authority_identity(request),
     }
     return result, closed
 
@@ -2576,7 +2879,7 @@ def _validate_runtime_context_state(
     value: object,
     *,
     request: Mapping[str, Any],
-) -> None:
+) -> dict[str, Any]:
     fields = frozenset(
         {
             "loaded_views",
@@ -2594,30 +2897,21 @@ def _validate_runtime_context_state(
         or state["vector_loaded"] is not False
     ):
         raise RuntimeError("MCP route is not an exact clean BM25 context")
-    if request["arm"] == "legacy":
-        if (
-            state["artifact"] is not None
-            or state["source_verified"] is not True
-            or state["source_verification_scope"] != "content-bytes"
-        ):
-            raise RuntimeError("legacy MCP source-authority contract changed")
-        return
-    if (
-        state["source_verified"] is not False
-        or state["source_verification_scope"] is not None
-    ):
-        raise RuntimeError("candidate MCP route did not remain source-disabled")
-    from codenib.artifacts.context import CONTEXT_ARTIFACT_SCHEMA
-
-    expected_artifact = {
-        "verified": True,
-        "schema": CONTEXT_ARTIFACT_SCHEMA,
-        "repository": request["subject"]["repository_key"],
-        "commit": request["subject"]["revision"],
-        "views": ["bm25"],
+    observed = {
+        "context_kind": (
+            "manifest-live-source"
+            if state["artifact"] is None
+            else "portable-artifact-query-only"
+        ),
+        "artifact": state["artifact"],
+        "source_verified": state["source_verified"],
+        "source_verification_scope": state["source_verification_scope"],
     }
-    if state["artifact"] != expected_artifact:
-        raise RuntimeError("candidate MCP route artifact binding changed")
+    return _validate_authority_identity(
+        observed,
+        request=request,
+        label="runtime context authority",
+    )
 
 
 def _read_proc_io() -> tuple[int, int]:
@@ -2694,6 +2988,14 @@ def _runtime_arguments(
     if request["arm"] == "legacy":
         if generation is not None:
             raise RuntimeError("legacy runtime route must not receive a retained ref")
+        if request["cell"] == "runtime-cold-query-only":
+            return [
+                "mcp",
+                "--artifact",
+                paths["direct_artifact"],
+                "--repository",
+                request["subject"]["repository_key"],
+            ]
         return ["mcp", os.fspath(_cache_manifest_path(Path(request["subject_root"])))]
     if generation is None:
         raise RuntimeError("candidate runtime route requires a retained ref")
@@ -2735,6 +3037,7 @@ def _validate_route_config(value: object) -> tuple[dict[str, Any], dict[str, str
             "catalog",
             "cas_root",
             "workspace_root",
+            "direct_artifact",
             "runtime_output",
             "materialized_output",
         }
@@ -2795,6 +3098,7 @@ def _route_worker(value: object) -> dict[str, Any]:
             )
             route_result, context_closed = _route_result_from_manifest(
                 _cache_manifest_path(Path(request["subject_root"])),
+                request=request,
                 subject=request["subject"],
                 manifest_identity=canonical_manifest,
                 view_identity=canonical_view,
@@ -2806,6 +3110,9 @@ def _route_worker(value: object) -> dict[str, Any]:
             if request["arm"] == "candidate":
                 runtime_manifest = Path(paths["runtime_output"]) / MANIFEST_FILENAME
                 expected_generation = 1
+            elif request["cell"] == "runtime-cold-query-only":
+                runtime_manifest = Path(paths["direct_artifact"]) / MANIFEST_FILENAME
+                expected_generation = None
             else:
                 runtime_manifest = _cache_manifest_path(Path(request["subject_root"]))
                 expected_generation = None
@@ -2851,12 +3158,18 @@ def _route_worker(value: object) -> dict[str, Any]:
                 or type(query_payload) is not list
             ):
                 raise RuntimeError("MCP benchmark callback did not observe a context")
-            _validate_runtime_context_state(context_state, request=request)
+            authority = _validate_runtime_context_state(
+                context_state,
+                request=request,
+            )
             canonical_manifest, canonical_view = _canonical_cache_identity(
                 request,
                 paths,
             )
-            if request["arm"] == "candidate":
+            if (
+                request["arm"] == "candidate"
+                or request["cell"] == "runtime-cold-query-only"
+            ):
                 actual_manifest, actual_view, manifest = _manifest_view_identity(
                     runtime_manifest,
                     subject=request["subject"],
@@ -2888,6 +3201,7 @@ def _route_worker(value: object) -> dict[str, Any]:
                     subject=request["subject"],
                 ),
                 "snapshot": {field: None for field in _SNAPSHOT_FIELDS},
+                "authority": authority,
             }
             if request["arm"] == "candidate":
                 route_result["retained_view"] = actual_view
@@ -3077,6 +3391,7 @@ def _sample_worker(value: object) -> dict[str, Any]:
                     "metadata_sha256": view["metadata_sha256"],
                 },
                 "queries": dict(result["queries"]),
+                "authority": _json_snapshot(result["authority"]),
             }
             receipt = {
                 "schema_version": REPORT_SCHEMA_VERSION,
@@ -3393,7 +3708,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     except Exception as exc:
         _emit_cli_error(exc)
         return 2
-    return 0 if report["passed"] is True else 1
+    return 0 if report["status"] == "complete" else 1
 
 
 if __name__ == "__main__":

--- a/scripts/profiling/retained_storage_subjects.json
+++ b/scripts/profiling/retained_storage_subjects.json
@@ -1,6 +1,6 @@
 {
-  "schema_version": 1,
-  "benchmark": "retained_storage_explicit_route_gate_v1",
+  "schema_version": 2,
+  "benchmark": "retained_storage_explicit_route_gate_v2",
   "policy": {
     "status": "unratified",
     "canonical_iterations": 20,
@@ -15,7 +15,8 @@
   "cells": [
     "compiler-cold",
     "compiler-current",
-    "runtime-cold"
+    "runtime-cold",
+    "runtime-cold-query-only"
   ],
   "view_sets": [
     {

--- a/test/scripts/test_profile_retained_storage_gate.py
+++ b/test/scripts/test_profile_retained_storage_gate.py
@@ -180,6 +180,11 @@ def _use_distinct_media_classes(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def _parity_identity(request: Mapping[str, Any]) -> dict[str, Any]:
     subject = request["subject"]
+    queries_sha256 = (
+        _SHA_B
+        if request["cell"] == "runtime-cold" and request["arm"] == "candidate"
+        else _SHA_A
+    )
     return {
         "manifest": {
             "commit": subject["revision"],
@@ -194,10 +199,45 @@ def _parity_identity(request: Mapping[str, Any]) -> dict[str, Any]:
             "metadata_sha256": _SHA_D,
         },
         "queries": {
-            "sha256": _SHA_A,
+            "sha256": queries_sha256,
             "count": len(subject["queries"]),
             "nonempty": True,
         },
+        "authority": _authority_identity(request),
+    }
+
+
+def _authority_identity(request: Mapping[str, Any]) -> dict[str, Any]:
+    cell = request["cell"]
+    arm = request["arm"]
+    if cell in {"compiler-cold", "compiler-current"}:
+        return {
+            "context_kind": "compiler-portable-plan",
+            "artifact": None,
+            "source_verified": None,
+            "source_verification_scope": None,
+        }
+    if cell == "runtime-cold" and arm == "legacy":
+        return {
+            "context_kind": "manifest-live-source",
+            "artifact": None,
+            "source_verified": True,
+            "source_verification_scope": "content-bytes",
+        }
+
+    from codenib.artifacts.context import CONTEXT_ARTIFACT_SCHEMA
+
+    return {
+        "context_kind": "portable-artifact-query-only",
+        "artifact": {
+            "verified": True,
+            "schema": CONTEXT_ARTIFACT_SCHEMA,
+            "repository": request["subject"]["repository_key"],
+            "commit": request["subject"]["revision"],
+            "views": ["bm25"],
+        },
+        "source_verified": False,
+        "source_verification_scope": None,
     }
 
 
@@ -220,6 +260,7 @@ def _sample_receipt(request: Mapping[str, Any], *, process_id: int) -> dict[str,
             "compiler-cold": True,
             "compiler-current": False,
             "runtime-cold": None,
+            "runtime-cold-query-only": None,
         }[request["cell"]]
         result["snapshot"] = {
             "snapshot_id": _SNAPSHOT_ID,
@@ -279,15 +320,213 @@ def _fake_sample_runner(
     return run
 
 
-def test_public_contract_and_deterministic_paired_order() -> None:
+def _run_fake_cell(
+    *,
+    manifest_path: Path,
+    subject_roots: Mapping[str, Path],
+    media_roots: Mapping[str, Path],
+    cell: str,
+    sample_runner: Callable[[Mapping[str, Any]], Mapping[str, Any]],
+) -> dict[str, Any]:
+    manifest, _receipt = profiler.load_subject_manifest(manifest_path)
+    subject = manifest["subjects"][0]
+    media_id, media_root = next(iter(media_roots.items()))
+    process_ids: list[int] = []
+    result = profiler._run_cell(
+        subject=subject,
+        subject_root=subject_roots[subject["id"]],
+        media_id=media_id,
+        media_root=media_root,
+        media_identity=profiler._media_identity(media_root),
+        view_set=manifest["view_sets"][0],
+        cell=cell,
+        iterations=1,
+        warmups=0,
+        sample_runner=sample_runner,
+        process_ids=process_ids,
+    )
+    assert len(process_ids) == 2
+    assert len(set(process_ids)) == 2
+    return result
+
+
+def test_public_v2_contract_and_deterministic_paired_order() -> None:
     assert profiler.ARMS == ("legacy", "candidate")
-    assert profiler.CELLS == ("compiler-cold", "compiler-current", "runtime-cold")
+    assert profiler.CELLS == (
+        "compiler-cold",
+        "compiler-current",
+        "runtime-cold",
+        "runtime-cold-query-only",
+    )
+    assert profiler.TRACKS == {
+        "compiler": ("compiler-cold", "compiler-current"),
+        "query-only-runtime": ("runtime-cold-query-only",),
+        "manifest-runtime-compatibility": ("runtime-cold",),
+    }
+    assert profiler.CANONICAL_SAMPLE_COUNT == 1152
     assert [profiler.paired_arm_order(index) for index in range(4)] == [
         ("legacy", "candidate"),
         ("candidate", "legacy"),
         ("legacy", "candidate"),
         ("candidate", "legacy"),
     ]
+
+
+def test_runtime_manifest_sentinel_is_negative_but_query_only_is_exact(
+    tmp_path: Path,
+) -> None:
+    manifest_path, subject_roots, media_roots = _fixture(tmp_path)
+    manifest, _receipt = profiler.load_subject_manifest(manifest_path)
+    subject = manifest["subjects"][0]
+
+    sentinel = _run_fake_cell(
+        manifest_path=manifest_path,
+        subject_roots=subject_roots,
+        media_roots=media_roots,
+        cell="runtime-cold",
+        sample_runner=_fake_sample_runner(),
+    )
+    query_only = _run_fake_cell(
+        manifest_path=manifest_path,
+        subject_roots=subject_roots,
+        media_roots=media_roots,
+        cell="runtime-cold-query-only",
+        sample_runner=_fake_sample_runner(),
+    )
+
+    sentinel_pair = sentinel["runs"]["measured"][0]
+    legacy_sentinel, candidate_sentinel = sentinel_pair["samples"]
+    assert sentinel_pair["parity"] is False
+    assert sentinel["parity"]["every_pair"] is False
+    assert sentinel["parity"]["stable_across_runs"] is False
+    assert sentinel["parity"]["passed"] is False
+    assert len(sentinel["parity"]["identity_sha256"]) == 2
+    assert (
+        legacy_sentinel["result"]["queries"]["sha256"]
+        != candidate_sentinel["result"]["queries"]["sha256"]
+    )
+    assert legacy_sentinel["result"]["authority"] == {
+        "context_kind": "manifest-live-source",
+        "artifact": None,
+        "source_verified": True,
+        "source_verification_scope": "content-bytes",
+    }
+    assert candidate_sentinel["result"]["authority"] == _authority_identity(
+        {
+            "cell": "runtime-cold",
+            "arm": "candidate",
+            "subject": subject,
+        }
+    )
+
+    query_only_pair = query_only["runs"]["measured"][0]
+    assert query_only_pair["parity"] is True
+    assert query_only["parity"]["passed"] is True
+    assert (
+        query_only_pair["samples"][0]["parity_identity"]
+        == query_only_pair["samples"][1]["parity_identity"]
+    )
+
+
+def test_runtime_manifest_authority_mismatch_blocks_equal_query_digest(
+    tmp_path: Path,
+) -> None:
+    manifest_path, subject_roots, media_roots = _fixture(tmp_path)
+
+    def align_query_digest(
+        receipt: dict[str, Any], request: Mapping[str, Any], _call: int
+    ) -> None:
+        if request["cell"] == "runtime-cold" and request["arm"] == "candidate":
+            receipt["result"]["queries"]["sha256"] = _SHA_A
+            receipt["parity_identity"]["queries"]["sha256"] = _SHA_A
+
+    sentinel = _run_fake_cell(
+        manifest_path=manifest_path,
+        subject_roots=subject_roots,
+        media_roots=media_roots,
+        cell="runtime-cold",
+        sample_runner=_fake_sample_runner(align_query_digest),
+    )
+
+    pair = sentinel["runs"]["measured"][0]
+    legacy, candidate = pair["samples"]
+    assert legacy["result"]["queries"] == candidate["result"]["queries"]
+    assert legacy["result"]["authority"] != candidate["result"]["authority"]
+    assert pair["parity"] is False
+    assert sentinel["parity"]["passed"] is False
+
+
+def test_track_aggregation_isolates_parity_and_completeness(
+    tmp_path: Path,
+) -> None:
+    manifest_path, subject_roots, media_roots = _fixture(tmp_path)
+    cells = {
+        cell: _run_fake_cell(
+            manifest_path=manifest_path,
+            subject_roots=subject_roots,
+            media_roots=media_roots,
+            cell=cell,
+            sample_runner=_fake_sample_runner(),
+        )
+        for cell in profiler.CELLS
+    }
+
+    baseline = profiler._aggregate_tracks(
+        cells,
+        expected_instances_per_cell=1,
+        iterations=1,
+        warmups=0,
+    )
+    assert {name: track["passed"] for name, track in baseline.items()} == {
+        "compiler": True,
+        "query-only-runtime": True,
+        "manifest-runtime-compatibility": False,
+    }
+    assert all(track["measurement_complete"] for track in baseline.values())
+
+    query_parity_red = deepcopy(cells)
+    query_parity_red["runtime-cold-query-only"]["parity"]["passed"] = False
+    query_tracks = profiler._aggregate_tracks(
+        query_parity_red,
+        expected_instances_per_cell=1,
+        iterations=1,
+        warmups=0,
+    )
+    assert query_tracks["compiler"] == baseline["compiler"]
+    assert query_tracks["query-only-runtime"]["measurement_complete"] is True
+    assert query_tracks["query-only-runtime"]["parity_passed"] is False
+    assert query_tracks["query-only-runtime"]["safety_passed"] is True
+    assert query_tracks["query-only-runtime"]["passed"] is False
+    assert (
+        query_tracks["manifest-runtime-compatibility"]
+        == baseline["manifest-runtime-compatibility"]
+    )
+
+    missing_query_cell = {
+        name: value
+        for name, value in cells.items()
+        if name != "runtime-cold-query-only"
+    }
+    incomplete_tracks = profiler._aggregate_tracks(
+        missing_query_cell,
+        expected_instances_per_cell=1,
+        iterations=1,
+        warmups=0,
+    )
+    assert incomplete_tracks["compiler"] == baseline["compiler"]
+    assert incomplete_tracks["query-only-runtime"] == {
+        "cells": ["runtime-cold-query-only"],
+        "measurement_complete": False,
+        "parity_passed": False,
+        "safety_passed": False,
+        "passed": False,
+        "policy_status": "unratified",
+        "promotion_eligible": False,
+    }
+    assert (
+        incomplete_tracks["manifest-runtime-compatibility"]
+        == baseline["manifest-runtime-compatibility"]
+    )
 
 
 def test_summary_uses_median_and_nearest_rank_p95() -> None:
@@ -297,9 +536,50 @@ def test_summary_uses_median_and_nearest_rank_p95() -> None:
     assert summary["p95"] == 19.0
 
 
+def test_full_public_query_payload_keeps_optional_content_in_the_digest() -> None:
+    subject = {"queries": [{"text": "package", "top_k": 5, "filter_test": False}]}
+    live_source_payload = [
+        {
+            "query": dict(subject["queries"][0]),
+            "results": [
+                {
+                    "file_path": "package.py",
+                    "start_line": 1,
+                    "end_line": 2,
+                    "score": 1.0,
+                    "content": "def package():\n    return True\n",
+                }
+            ],
+        }
+    ]
+    source_disabled_payload = deepcopy(live_source_payload)
+    source_disabled_payload[0]["results"][0]["content"] = None
+
+    live_identity = profiler._query_identity_from_payload(  # noqa: SLF001
+        live_source_payload,
+        subject=subject,
+    )
+    source_disabled_identity = profiler._query_identity_from_payload(  # noqa: SLF001
+        source_disabled_payload,
+        subject=subject,
+    )
+
+    assert live_identity["sha256"] == _json_digest(live_source_payload)
+    assert source_disabled_identity["sha256"] == _json_digest(source_disabled_payload)
+    assert live_identity != source_disabled_identity
+    assert (
+        profiler._query_identity_from_payload(  # noqa: SLF001
+            deepcopy(source_disabled_payload),
+            subject=subject,
+        )
+        == source_disabled_identity
+    )
+
+
 @pytest.mark.parametrize(
     "mutation",
     [
+        lambda manifest: manifest.__setitem__("schema_version", 1),
         lambda manifest: manifest.__setitem__("unexpected", True),
         lambda manifest: manifest.__setitem__("benchmark", "wrong"),
         lambda manifest: manifest["cells"].reverse(),
@@ -329,6 +609,42 @@ def test_manifest_schema_is_exact_and_bm25_only(
         profiler.load_subject_manifest(path)
 
 
+def test_v2_manifest_accepts_only_the_frozen_four_cell_order(tmp_path: Path) -> None:
+    subjects = [
+        _subject_row(
+            identifier=f"fixture-{payload_class}",
+            repository=f"https://github.com/example/fixture-{payload_class}.git",
+            revision=str(index) * 40,
+            tree=str(index + 3) * 40,
+            payload_class=payload_class,
+        )
+        for index, payload_class in enumerate(("small", "medium", "large"), start=1)
+    ]
+    path = _write_manifest(tmp_path / "manifest.json", _manifest(subjects))
+
+    manifest, receipt = profiler.load_subject_manifest(path)
+
+    assert set(manifest) == {
+        "schema_version",
+        "benchmark",
+        "policy",
+        "cells",
+        "view_sets",
+        "subjects",
+    }
+    assert manifest["schema_version"] == 2
+    assert manifest["benchmark"] == "retained_storage_explicit_route_gate_v2"
+    assert manifest["cells"] == list(profiler.CELLS)
+    metadata = path.stat()
+    assert receipt == {
+        "path": os.fspath(path.resolve()),
+        "sha256": "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest(),
+        "size": len(path.read_bytes()),
+        "device": metadata.st_dev,
+        "inode": metadata.st_ino,
+    }
+
+
 def test_atomic_writer_emits_canonical_json_and_preserves_old_report_on_nan(
     tmp_path: Path,
 ) -> None:
@@ -351,7 +667,7 @@ def test_atomic_writer_emits_canonical_json_and_preserves_old_report_on_nan(
     assert list(tmp_path.iterdir()) == [output]
 
 
-def test_canonical_report_has_exact_schema_and_remains_report_only(
+def test_canonical_v2_report_has_exact_shape_tracks_and_process_count(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     manifest_path, subject_roots, media_roots = _fixture(tmp_path)
@@ -393,13 +709,14 @@ def test_canonical_report_has_exact_schema_and_remains_report_only(
         "subjects",
         "media",
         "cells",
+        "tracks",
         "process_isolation",
         "decision",
     }
     assert report["schema_version"] == profiler.REPORT_SCHEMA_VERSION
     assert report["benchmark"] == profiler.BENCHMARK_ID
-    assert report["status"] == "passed", report["failure"]
-    assert report["passed"] is True
+    assert report["status"] == "complete", report["failure"]
+    assert report["passed"] is False
     assert report["promotion_eligible"] is False
     assert report["failure"] is None
     assert report["policy"] == {
@@ -407,22 +724,94 @@ def test_canonical_report_has_exact_schema_and_remains_report_only(
         "performance_budgets": None,
         "promotion_eligible": False,
     }
+    assert set(report["protocol"]) == {"expected", "observed", "canonical"}
     assert report["protocol"]["canonical"] is True
     assert report["protocol"]["expected"] == report["protocol"]["observed"]
+    assert set(report["protocol"]["expected"]) == {
+        "iterations_per_arm",
+        "warmups_per_arm",
+        "cells",
+        "tracks",
+        "cell_authority_contracts",
+        "canonical_sample_count",
+        "view_set_ids",
+        "payload_classes",
+        "minimum_media_classes",
+        "fresh_inner_process_per_sample",
+        "runner",
+        "paired_arm_order",
+        "peak_rss_source",
+        "io_source",
+        "fixed_manifest_sha256",
+        "fixed_manifest_size",
+        "subject_receipts",
+    }
+    assert report["protocol"]["expected"]["cells"] == list(profiler.CELLS)
+    assert report["protocol"]["expected"]["tracks"] == {
+        name: list(cells) for name, cells in profiler.TRACKS.items()
+    }
+    assert report["protocol"]["expected"]["cell_authority_contracts"] == (
+        profiler.CELL_AUTHORITY_CONTRACTS
+    )
+    assert report["protocol"]["expected"]["canonical_sample_count"] == 1152
+    assert report["configuration"]["cell_authority_contracts"] == (
+        profiler.CELL_AUTHORITY_CONTRACTS
+    )
     assert report["decision"] == {
         "policy_status": "unratified",
         "report_only": True,
         "promotion_eligible": False,
         "recommendation": "retain-explicit-routes",
-        "reason": "performance budgets are unratified",
+        "reason": "one or more compatibility tracks are parity red",
     }
     assert report["benchmark_receipts"]["unchanged"] is True
     assert len(report["subjects"]) == 3
     assert len(report["media"]) == 2
-    assert len(report["cells"]) == 18
+    assert len(report["cells"]) == 24
+    assert {
+        cell: sum(item["cell"] == cell for item in report["cells"].values())
+        for cell in profiler.CELLS
+    } == {cell: 6 for cell in profiler.CELLS}
+    assert list(report["tracks"]) == [
+        "compiler",
+        "query-only-runtime",
+        "manifest-runtime-compatibility",
+    ]
+    assert report["tracks"] == {
+        "compiler": {
+            "cells": ["compiler-cold", "compiler-current"],
+            "measurement_complete": True,
+            "parity_passed": True,
+            "safety_passed": True,
+            "passed": True,
+            "policy_status": "unratified",
+            "promotion_eligible": False,
+        },
+        "query-only-runtime": {
+            "cells": ["runtime-cold-query-only"],
+            "measurement_complete": True,
+            "parity_passed": True,
+            "safety_passed": True,
+            "passed": True,
+            "policy_status": "unratified",
+            "promotion_eligible": False,
+        },
+        "manifest-runtime-compatibility": {
+            "cells": ["runtime-cold"],
+            "measurement_complete": True,
+            "parity_passed": False,
+            "safety_passed": True,
+            "passed": False,
+            "policy_status": "unratified",
+            "promotion_eligible": False,
+        },
+    }
     assert report["process_isolation"]["passed"] is True
-    assert report["process_isolation"]["expected_samples"] == 864
-    assert report["process_isolation"]["observed_samples"] == 864
+    assert report["process_isolation"]["expected_samples"] == 1152
+    assert report["process_isolation"]["observed_samples"] == 1152
+    assert len(report["process_isolation"]["inner_process_ids"]) == 1152
+    assert len(set(report["process_isolation"]["inner_process_ids"])) == 1152
+    assert report["process_isolation"]["duplicate_process_ids"] == []
     for cell in report["cells"].values():
         assert {"runs", "summary", "parity", "safety", "performance"} <= set(cell)
         assert len(cell["runs"]["warmups"]) == profiler.DEFAULT_WARMUPS
@@ -449,7 +838,9 @@ def test_injected_sample_runner_cannot_claim_process_isolated_protocol(
         sample_runner=_fake_sample_runner(),
     )
 
-    assert report["status"] == "passed", report["failure"]
+    assert report["status"] == "failed"
+    assert report["failure"]["stage"] == "protocol"
+    assert report["process_isolation"]["passed"] is True
     assert report["protocol"]["canonical"] is False
     assert report["protocol"]["observed"]["fresh_inner_process_per_sample"] is False
     assert report["protocol"]["observed"]["runner"] == "injected-sample-runner"
@@ -470,8 +861,9 @@ def test_custom_manifest_receipt_cannot_claim_the_canonical_protocol(
         sample_runner=_fake_sample_runner(),
     )
 
-    assert report["status"] == "passed", report["failure"]
-    assert report["passed"] is True
+    assert report["status"] == "failed"
+    assert report["passed"] is False
+    assert report["failure"]["stage"] == "protocol"
     assert report["protocol"]["canonical"] is False
     assert report["promotion_eligible"] is False
 
@@ -512,7 +904,7 @@ def test_mutating_default_manifest_bytes_cannot_move_the_canonical_anchor(
     assert protocol["canonical"] is False
 
 
-def test_override_protocol_is_noncanonical_but_still_complete(
+def test_override_protocol_is_an_operational_failure_after_measurement(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     manifest_path, subject_roots, media_roots = _fixture(tmp_path)
@@ -528,8 +920,10 @@ def test_override_protocol_is_noncanonical_but_still_complete(
         sample_runner=_fake_sample_runner(),
     )
 
-    assert report["status"] == "passed"
-    assert report["passed"] is True
+    assert report["status"] == "failed"
+    assert report["passed"] is False
+    assert report["failure"]["stage"] == "protocol"
+    assert report["process_isolation"]["observed_samples"] == 48
     assert report["protocol"]["canonical"] is False
     assert report["protocol"]["observed"]["iterations_per_arm"] == 1
     assert report["protocol"]["observed"]["warmups_per_arm"] == 0
@@ -557,7 +951,8 @@ def test_sample_requests_are_exact_and_use_ab_ba_round_order(
         sample_runner=runner,
     )
 
-    assert report["status"] == "passed"
+    assert report["status"] == "failed"
+    assert report["failure"]["stage"] == "protocol"
     assert all(
         set(request)
         == {
@@ -762,6 +1157,161 @@ def test_missing_subject_and_non_directory_media_fail_before_measurement(
     )
 
 
+def test_each_cell_uses_its_exact_prep_and_runtime_cli_contract(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest_path, subject_roots, media_roots = _fixture(tmp_path)
+    manifest, _receipt = profiler.load_subject_manifest(manifest_path)
+    subject = manifest["subjects"][0]
+    subject_root = subject_roots[subject["id"]]
+    media_id, media_root = next(iter(media_roots.items()))
+    sample_root = media_root / f"{profiler._TEMP_PREFIX}{'7' * 32}"
+    paths = profiler._sample_paths(sample_root, "7" * 32)
+    calls: list[tuple[str, Any]] = []
+
+    monkeypatch.setattr(
+        profiler,
+        "_provision_storage",
+        lambda actual_paths: calls.append(("provision", dict(actual_paths))),
+    )
+    monkeypatch.setattr(
+        profiler,
+        "_invoke_cli",
+        lambda arguments: calls.append(("cli", list(arguments))),
+    )
+
+    def request(cell: str, arm: str) -> dict[str, Any]:
+        return {
+            "operation": "sample",
+            "arm": arm,
+            "phase": "measured",
+            "round_index": 0,
+            "cell": cell,
+            "subject": subject,
+            "subject_root": os.fspath(subject_root.resolve()),
+            "media_id": media_id,
+            "media_root": os.fspath(media_root.resolve()),
+            "media_identity": profiler._media_identity(media_root.resolve()),
+            "view_set": manifest["view_sets"][0],
+            "run_id": "7" * 32,
+        }
+
+    expected: dict[tuple[str, str], list[tuple[str, Any]]] = {
+        ("compiler-cold", "legacy"): [],
+        ("compiler-cold", "candidate"): [("provision", paths)],
+        ("compiler-current", "legacy"): [
+            (
+                "cli",
+                profiler._index_arguments(
+                    request("compiler-current", "legacy"), paths, candidate=False
+                ),
+            )
+        ],
+        ("compiler-current", "candidate"): [
+            ("provision", paths),
+            (
+                "cli",
+                profiler._index_arguments(
+                    request("compiler-current", "candidate"), paths, candidate=True
+                ),
+            ),
+        ],
+        ("runtime-cold", "legacy"): [
+            (
+                "cli",
+                profiler._index_arguments(
+                    request("runtime-cold", "legacy"), paths, candidate=False
+                ),
+            )
+        ],
+        ("runtime-cold", "candidate"): [
+            ("provision", paths),
+            (
+                "cli",
+                profiler._index_arguments(
+                    request("runtime-cold", "candidate"), paths, candidate=True
+                ),
+            ),
+        ],
+        ("runtime-cold-query-only", "legacy"): [
+            (
+                "cli",
+                profiler._index_arguments(
+                    request("runtime-cold-query-only", "legacy"),
+                    paths,
+                    candidate=False,
+                ),
+            ),
+            (
+                "cli",
+                [
+                    "artifact",
+                    "pack",
+                    os.fspath(subject_root.resolve()),
+                    "--output",
+                    paths["direct_artifact"],
+                    "--repository",
+                    subject["repository_key"],
+                    "--view",
+                    "bm25",
+                ],
+            ),
+        ],
+        ("runtime-cold-query-only", "candidate"): [
+            ("provision", paths),
+            (
+                "cli",
+                profiler._index_arguments(
+                    request("runtime-cold-query-only", "candidate"),
+                    paths,
+                    candidate=True,
+                ),
+            ),
+        ],
+    }
+
+    for cell in profiler.CELLS:
+        for arm in profiler.ARMS:
+            calls.clear()
+            sample_request = request(cell, arm)
+            profiler._prepare_sample(sample_request, paths)
+            assert calls == expected[(cell, arm)]
+
+    assert profiler._runtime_arguments(
+        request("runtime-cold", "legacy"), paths, generation=None
+    ) == ["mcp", os.fspath(profiler._cache_manifest_path(subject_root))]
+    assert profiler._runtime_arguments(
+        request("runtime-cold-query-only", "legacy"), paths, generation=None
+    ) == [
+        "mcp",
+        "--artifact",
+        paths["direct_artifact"],
+        "--repository",
+        subject["repository_key"],
+    ]
+    retained_arguments = profiler._runtime_arguments(
+        request("runtime-cold-query-only", "candidate"), paths, generation=1
+    )
+    assert retained_arguments == [
+        "mcp",
+        "--catalog",
+        paths["catalog"],
+        "--cas-root",
+        paths["cas_root"],
+        "--workspace-root",
+        paths["workspace_root"],
+        "--repository",
+        subject["repository_key"],
+        "--ref",
+        "main",
+        "--expected-generation",
+        "1",
+        "--output",
+        paths["runtime_output"],
+    ]
+    assert "--repo" not in retained_arguments
+
+
 def test_outer_sample_hides_prep_and_reports_the_inner_route_pid(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -831,6 +1381,54 @@ def test_outer_sample_hides_prep_and_reports_the_inner_route_pid(
     assert not any(media_root.iterdir())
 
 
+def test_query_only_direct_artifact_prep_cancellation_cleans_exact_sample_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest_path, subject_roots, media_roots = _fixture(tmp_path)
+    manifest, _receipt = profiler.load_subject_manifest(manifest_path)
+    subject = manifest["subjects"][0]
+    media_id, media_root = next(iter(media_roots.items()))
+    request = {
+        "operation": "sample",
+        "arm": "legacy",
+        "phase": "measured",
+        "round_index": 0,
+        "cell": "runtime-cold-query-only",
+        "subject": subject,
+        "subject_root": os.fspath(subject_roots[subject["id"]].resolve()),
+        "media_id": media_id,
+        "media_root": os.fspath(media_root.resolve()),
+        "media_identity": profiler._media_identity(media_root.resolve()),
+        "view_set": manifest["view_sets"][0],
+        "run_id": "8" * 32,
+    }
+    primary = KeyboardInterrupt("synthetic direct-artifact interruption")
+    observed_direct_artifact: Path | None = None
+
+    def interrupted_prep(_request: Mapping[str, Any], paths: Mapping[str, str]) -> None:
+        nonlocal observed_direct_artifact
+        observed_direct_artifact = Path(paths["direct_artifact"])
+        observed_direct_artifact.mkdir()
+        (observed_direct_artifact / "partial").write_text(
+            "partial",
+            encoding="utf-8",
+        )
+        raise primary
+
+    monkeypatch.setattr(profiler, "_prepare_sample", interrupted_prep)
+
+    with pytest.raises(KeyboardInterrupt) as raised:
+        profiler._sample_worker(request)
+
+    assert raised.value is primary
+    assert observed_direct_artifact is not None
+    assert observed_direct_artifact == (
+        profiler._owned_sample_root(request) / f"direct-artifact-{request['run_id']}"
+    )
+    assert not observed_direct_artifact.exists()
+    assert not any(media_root.iterdir())
+
+
 def test_inner_route_requires_the_exact_derived_authority_paths(
     tmp_path: Path,
 ) -> None:
@@ -862,15 +1460,19 @@ def test_inner_route_requires_the_exact_derived_authority_paths(
 
     assert normalized_request == request
     assert normalized_paths == paths
-    redirected = dict(paths)
-    redirected["catalog"] = os.fspath(sample_root / "redirected.sqlite")
-    with pytest.raises(ValueError, match="exact binding"):
-        profiler._validate_route_config(
-            {"operation": "route", "request": request, "paths": redirected}
-        )
+    for path_name, replacement in (
+        ("catalog", sample_root / "redirected.sqlite"),
+        ("direct_artifact", sample_root / "redirected-artifact"),
+    ):
+        redirected = dict(paths)
+        redirected[path_name] = os.fspath(replacement)
+        with pytest.raises(ValueError, match="exact binding"):
+            profiler._validate_route_config(
+                {"operation": "route", "request": request, "paths": redirected}
+            )
 
 
-def test_runtime_context_authority_contract_is_arm_specific() -> None:
+def test_runtime_context_authority_contract_is_cell_and_arm_specific() -> None:
     from codenib.artifacts.context import CONTEXT_ARTIFACT_SCHEMA
 
     subject = {
@@ -898,24 +1500,50 @@ def test_runtime_context_authority_contract_is_arm_specific() -> None:
         "source_verification_scope": None,
     }
 
-    profiler._validate_runtime_context_state(
+    legacy_authority = profiler._validate_runtime_context_state(
         legacy,
-        request={"arm": "legacy", "subject": subject},
+        request={"cell": "runtime-cold", "arm": "legacy", "subject": subject},
     )
-    profiler._validate_runtime_context_state(
+    candidate_authority = profiler._validate_runtime_context_state(
         candidate,
-        request={"arm": "candidate", "subject": subject},
+        request={"cell": "runtime-cold", "arm": "candidate", "subject": subject},
+    )
+    direct_authority = profiler._validate_runtime_context_state(
+        candidate,
+        request={
+            "cell": "runtime-cold-query-only",
+            "arm": "legacy",
+            "subject": subject,
+        },
     )
 
-    with pytest.raises(RuntimeError, match="source-authority"):
+    assert legacy_authority == {
+        "context_kind": "manifest-live-source",
+        "artifact": None,
+        "source_verified": True,
+        "source_verification_scope": "content-bytes",
+    }
+    assert direct_authority == candidate_authority
+    assert candidate_authority["context_kind"] == "portable-artifact-query-only"
+    assert candidate_authority["source_verified"] is False
+
+    with pytest.raises(RuntimeError, match="exact per-cell contract"):
         profiler._validate_runtime_context_state(
             {**legacy, "source_verified": False},
-            request={"arm": "legacy", "subject": subject},
+            request={
+                "cell": "runtime-cold",
+                "arm": "legacy",
+                "subject": subject,
+            },
         )
-    with pytest.raises(RuntimeError, match="source-disabled"):
+    with pytest.raises(RuntimeError, match="exact per-cell contract"):
         profiler._validate_runtime_context_state(
             {**candidate, "source_verified": True},
-            request={"arm": "candidate", "subject": subject},
+            request={
+                "cell": "runtime-cold-query-only",
+                "arm": "legacy",
+                "subject": subject,
+            },
         )
 
 
@@ -1079,14 +1707,13 @@ def test_worker_interruption_reaps_the_process_group_and_preserves_primary(
 
 
 @pytest.mark.parametrize(
-    ("passed", "expected_status", "expected_exit"),
+    ("expected_status", "expected_exit"),
     [
-        (True, "passed", 0),
-        (False, "failed", 1),
+        ("complete", 0),
+        ("failed", 1),
     ],
 )
-def test_cli_atomically_writes_success_and_negative_reports(
-    passed: bool,
+def test_cli_atomically_writes_complete_parity_red_and_operational_failure_reports(
     expected_status: str,
     expected_exit: int,
     monkeypatch: pytest.MonkeyPatch,
@@ -1104,8 +1731,8 @@ def test_cli_atomically_writes_success_and_negative_reports(
         subject_roots=subject_roots,
         media_roots=media_roots,
     )
-    if passed:
-        report.update({"status": "passed", "passed": True, "failure": None})
+    if expected_status == "complete":
+        report.update({"status": "complete", "passed": False, "failure": None})
     else:
         profiler._failure(report, "measurement", RuntimeError("synthetic failure"))
     assert report["promotion_eligible"] is False


### PR DESCRIPTION
## Summary

Split the report-only retained-storage v2 evidence protocol so the comparable source-disabled runtime pair is measured independently from the source-bound manifest compatibility sentinel. Numeric policy remains unratified, every track remains promotion-ineligible, and no production default route changes.

Related to #199.

## Changes

- add `runtime-cold-query-only`, comparing direct portable-artifact MCP startup without `--repo` against retained ref resolution and materialization
- preserve `runtime-cold` as an explicit source-bound versus source-disabled compatibility sentinel, with authority included in exact parity
- emit independent compiler, query-only runtime, and manifest compatibility tracks with `complete` versus operational `failed` report semantics
- update the fixed v2 manifest and canonical 1,152-sample protocol
- document the independent A2/B1/B2 gates and keep manifest replacement blocked pending a source-capable retained route

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/scripts/test_profile_retained_storage_gate.py` — 43 passed
- `pytest -m 'not slow and not integration and not integration_serial and not integration_serial_consumer' -x --tb=short` — 6826 passed, 71 skipped, 190 deselected in a read-only namespace; two expected pytest-cache warnings
- Black, isort, flake8, `py_compile`, and `git diff --check`
- `python -m mkdocs build --strict`
- `python scripts/check_public_docs.py`
- `make -n retained-storage-gate`
- real four-sample runtime smoke: the query-only pair passed exact payload and authority parity; the manifest compatibility pair remained intentionally red; all safety and cleanup receipts passed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
