### PR TITLE
feat(storage): bind retained contexts to source readers

### DIFF
--- a/codenib/artifacts/__init__.py
+++ b/codenib/artifacts/__init__.py
@@ -27,8 +27,10 @@ from .portable_views import (
 )
 from .runtime import (
     ContextArtifactBinding,
+    SourceBindingCleanupOwner,
     VerifiedContextArtifact,
     bind_context_artifact,
+    bind_context_artifact_reader,
     query_context_artifact,
     query_context_artifact_reader,
     verify_context_artifact,
@@ -63,8 +65,10 @@ __all__ = [
     "PlannedContextView",
     "PlannedVectorView",
     "SourceTrust",
+    "SourceBindingCleanupOwner",
     "VerifiedContextArtifact",
     "bind_context_artifact",
+    "bind_context_artifact_reader",
     "extract_context_artifact_archive",
     "fetch_github_context_artifact",
     "normalize_owned_query_view",

--- a/codenib/artifacts/runtime.py
+++ b/codenib/artifacts/runtime.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Verify and bind portable context artifacts for query-only runtimes."""
+"""Verify and bind portable context artifacts to exact runtime authorities."""
 
 from __future__ import annotations
 
@@ -20,6 +20,7 @@ from .._atomic_directory import (
     PublicationAuthenticatedFile,
     PublicationDirectoryReader,
     TreeFileRecord,
+    _annotate_secondary_error,
     capture_directory_ownership,
     directory_ownership_file_records,
     lexical_directory_path,
@@ -154,19 +155,46 @@ class SourceBindingCleanupOwner:
             try:
                 source.close()  # type: ignore[attr-defined]
             except BaseException as exc:  # noqa: B036 - cleanup all sources
-                if first_failure is None:
-                    first_failure = exc
+                first_failure = _retain_source_owner_cleanup_failure(
+                    first_failure,
+                    exc,
+                )
             try:
                 fully_closed = bool(source.closed)  # type: ignore[attr-defined]
             except BaseException as exc:  # noqa: B036 - retain uncertain owner
                 fully_closed = False
-                if first_failure is None:
-                    first_failure = exc
+                first_failure = _retain_source_owner_cleanup_failure(
+                    first_failure,
+                    exc,
+                )
             if not fully_closed:
                 pending.append(source)
         self._sources[:] = pending
         if first_failure is not None:
             raise first_failure
+
+
+def _retain_source_owner_cleanup_failure(
+    deferred: BaseException | None,
+    failure: BaseException,
+) -> BaseException:
+    """Preserve cancellation priority while retaining all cleanup diagnostics."""
+
+    if deferred is None:
+        return failure
+    if isinstance(deferred, Exception) and not isinstance(failure, Exception):
+        _annotate_secondary_error(
+            failure,
+            "earlier source cleanup also failed",
+            deferred,
+        )
+        return failure
+    _annotate_secondary_error(
+        deferred,
+        "additional source cleanup also failed",
+        failure,
+    )
+    return deferred
 
 
 def _source_cleanup_owner_is_pending(owner: object | None) -> bool:
@@ -1181,57 +1209,11 @@ def bind_context_artifact(
     cleanup_owner = SourceBindingCleanupOwner()
 
     def bind(_publication: PublicationDirectoryReader) -> ContextArtifactBinding:
-        if not is_secure_source_fingerprint_v2(artifact.source_fingerprint):
-            raise ValueError(
-                "legacy context artifact source fingerprints are query-only; "
-                "rebuild with source fingerprint v2 before binding a live checkout"
-            )
-        repo = lexical_repository_path(repo_path)
-        source = capture_repository_source(
-            repo,
-            manifest=artifact.manifest,
-            exclude_roots=(artifact.root,),
-            _source_owner=cleanup_owner.retain,
-        )
-        # This is diagnostic provenance only. A mutable Git HEAD cannot be
-        # attested by any finite sequence of path reads, so it never gates the
-        # retained content authority or native trust.
-        actual_commit = checkout_commit(repo)
-        source_identity = source.authenticated_identity_snapshot()
-        authenticated_repo = source_identity.root
-        require_manifest_source_identity(
-            source_identity,
-            artifact.manifest,
-            label="context artifact repository",
-            mismatch_message=(
-                "repository source files do not match the context artifact fingerprint"
-            ),
-        )
-        source_records = {record.path for record in source_identity.file_records}
-        missing_source_paths = sorted(set(artifact.source_paths) - source_records)
-        if missing_source_paths:
-            raise ValueError(
-                "context artifact source paths are absent from the authenticated "
-                "repository: " + ", ".join(missing_source_paths)
-            )
-
-        manifest_data = artifact.manifest.to_dict()
-        manifest_data["repo"]["path"] = str(authenticated_repo)
-        for view, entry in manifest_data["indexes"].items():
-            entry["path"] = str(
-                _artifact_path(
-                    artifact.root,
-                    entry["path"],
-                    label=f"context artifact {view} view path",
-                )
-            )
-        manifest = RepoManifest.from_dict(manifest_data)
-        return ContextArtifactBinding(
-            artifact=artifact,
-            repo_path=authenticated_repo,
-            manifest=manifest,
-            checkout_commit_observed=actual_commit or None,
-            _source_binding=source,
+        return _bind_verified_context_artifact(
+            artifact,
+            repo_path,
+            source_cleanup_owner=cleanup_owner,
+            requires_authenticated_reader=False,
         )
 
     try:
@@ -1241,40 +1223,115 @@ def bind_context_artifact(
             bind,
         )
     except BaseException as exc:  # noqa: B036 - cleanup before propagation
-        cleanup_failure: BaseException | None = None
-        try:
-            cleanup_owner.close()
-        except BaseException as failure:  # noqa: B036 - shared priority below
-            cleanup_failure = failure
-        pending_owner = (
-            cleanup_owner if _source_cleanup_owner_is_pending(cleanup_owner) else None
+        _raise_context_artifact_bind_failure(exc, cleanup_owner)
+
+
+def _bind_verified_context_artifact(
+    artifact: VerifiedContextArtifact,
+    repo_path: str | Path,
+    *,
+    source_cleanup_owner: SourceBindingCleanupOwner,
+    requires_authenticated_reader: bool,
+) -> ContextArtifactBinding:
+    """Bind source bytes after an artifact authority has already been verified."""
+
+    if not is_secure_source_fingerprint_v2(artifact.source_fingerprint):
+        raise ValueError(
+            "legacy context artifact source fingerprints are query-only; "
+            "rebuild with source fingerprint v2 before binding a live checkout"
         )
-        if isinstance(exc, ValueError):
-            if cleanup_failure is not None or pending_owner is not None:
-                _raise_source_cleanup_failure(
-                    exc,
-                    cleanup_failure,
-                    pending_owner,
-                )
-            raise
-        if not isinstance(exc, (OSError, RuntimeError)):
-            if cleanup_failure is not None or pending_owner is not None:
-                _raise_source_cleanup_failure(
-                    exc,
-                    cleanup_failure,
-                    pending_owner,
-                )
-            raise
-        translated = ValueError(
-            "context artifact changed between verification and source binding"
+    repo = lexical_repository_path(repo_path)
+    source = capture_repository_source(
+        repo,
+        manifest=artifact.manifest,
+        exclude_roots=(artifact.root,),
+        _source_owner=source_cleanup_owner.retain,
+    )
+    # This is diagnostic provenance only. A mutable Git HEAD cannot be
+    # attested by any finite sequence of path reads, so it never gates the
+    # retained content authority or native trust.
+    actual_commit = checkout_commit(repo)
+    source_identity = source.authenticated_identity_snapshot()
+    authenticated_repo = source_identity.root
+    require_manifest_source_identity(
+        source_identity,
+        artifact.manifest,
+        label="context artifact repository",
+        mismatch_message=(
+            "repository source files do not match the context artifact fingerprint"
+        ),
+    )
+    source_records = {record.path for record in source_identity.file_records}
+    missing_source_paths = sorted(set(artifact.source_paths) - source_records)
+    if missing_source_paths:
+        raise ValueError(
+            "context artifact source paths are absent from the authenticated "
+            "repository: " + ", ".join(missing_source_paths)
         )
+
+    manifest_data = artifact.manifest.to_dict()
+    manifest_data["repo"]["path"] = str(authenticated_repo)
+    for view, entry in manifest_data["indexes"].items():
+        entry["path"] = str(
+            _artifact_path(
+                artifact.root,
+                entry["path"],
+                label=f"context artifact {view} view path",
+            )
+        )
+    manifest = RepoManifest.from_dict(manifest_data)
+    return ContextArtifactBinding(
+        artifact=artifact,
+        repo_path=authenticated_repo,
+        manifest=manifest,
+        checkout_commit_observed=actual_commit or None,
+        _requires_authenticated_reader=requires_authenticated_reader,
+        _source_binding=source,
+    )
+
+
+def _raise_context_artifact_bind_failure(
+    primary: BaseException,
+    source_cleanup_owner: SourceBindingCleanupOwner,
+) -> NoReturn:
+    """Close a failed bind and retain any source authority that did not close."""
+
+    cleanup_failure: BaseException | None = None
+    try:
+        source_cleanup_owner.close()
+    except BaseException as failure:  # noqa: B036 - shared priority below
+        cleanup_failure = failure
+    pending_owner = (
+        source_cleanup_owner
+        if _source_cleanup_owner_is_pending(source_cleanup_owner)
+        else None
+    )
+    if isinstance(primary, ValueError):
         if cleanup_failure is not None or pending_owner is not None:
             _raise_source_cleanup_failure(
-                translated,
+                primary,
                 cleanup_failure,
                 pending_owner,
             )
-        raise translated from exc
+        raise primary
+    if not isinstance(primary, (OSError, RuntimeError)):
+        if cleanup_failure is not None or pending_owner is not None:
+            _raise_source_cleanup_failure(
+                primary,
+                cleanup_failure,
+                pending_owner,
+            )
+        raise primary
+    translated = ValueError(
+        "context artifact changed between verification and source binding"
+    )
+    if cleanup_failure is not None or pending_owner is not None:
+        _raise_source_cleanup_failure(
+            translated,
+            cleanup_failure,
+            pending_owner,
+        )
+    raise translated from primary
 
 
 def query_context_artifact(
@@ -1300,16 +1357,14 @@ def query_context_artifact(
     )
 
 
-def query_context_artifact_reader(
+def _require_context_artifact_reader_authority(
     receipt: PublishedWorkspaceReceipt,
     publication: PublicationDirectoryReader,
     *,
     expected_root: str | Path,
     expected_ownership: object,
-    expected_repository: str | None = None,
-    expected_commit: str | None = None,
-) -> ContextArtifactBinding:
-    """Create a query binding inside one exact workspace-receipt callback."""
+) -> Path:
+    """Validate the exact receipt and active publication-reader relationship."""
 
     if type(receipt) is not PublishedWorkspaceReceipt:
         raise TypeError("context artifact receipt has an invalid type")
@@ -1325,6 +1380,18 @@ def query_context_artifact_reader(
         raise RuntimeError("context artifact receipt ownership changed")
     if publication._require_expected_ownership_token() != expected_ownership:
         raise RuntimeError("context artifact publication ownership changed")
+    return real_root
+
+
+def _relocate_context_artifact_reader(
+    publication: PublicationDirectoryReader,
+    *,
+    real_root: Path,
+    expected_ownership: object,
+    expected_repository: str | None = None,
+    expected_commit: str | None = None,
+) -> VerifiedContextArtifact:
+    """Verify and relocate reader-native artifact paths to their receipt root."""
 
     artifact = verify_context_artifact_reader(
         publication,
@@ -1354,6 +1421,80 @@ def query_context_artifact_reader(
         metadata_path=real_root / metadata_relative,
         manifest_path=real_root / manifest_relative,
     )
+    return relocated
+
+
+def bind_context_artifact_reader(
+    receipt: PublishedWorkspaceReceipt,
+    publication: PublicationDirectoryReader,
+    repo_path: str | Path,
+    *,
+    expected_root: str | Path,
+    expected_ownership: object,
+    source_cleanup_owner: SourceBindingCleanupOwner,
+    expected_repository: str | None = None,
+    expected_commit: str | None = None,
+) -> ContextArtifactBinding:
+    """Bind source inside one exact, still-active workspace-receipt callback.
+
+    The caller-provided cleanup owner must be a dedicated empty owner. It stays
+    retained across a successful return so cancellation cannot strand source
+    authority before the binding is installed into its runtime owner.
+    """
+
+    real_root = _require_context_artifact_reader_authority(
+        receipt,
+        publication,
+        expected_root=expected_root,
+        expected_ownership=expected_ownership,
+    )
+    if type(source_cleanup_owner) is not SourceBindingCleanupOwner:
+        raise TypeError("context artifact source cleanup owner has an invalid type")
+    if not source_cleanup_owner.closed:
+        raise ValueError("context artifact source cleanup owner must be empty")
+
+    artifact = _relocate_context_artifact_reader(
+        publication,
+        real_root=real_root,
+        expected_ownership=expected_ownership,
+        expected_repository=expected_repository,
+        expected_commit=expected_commit,
+    )
+    try:
+        return _bind_verified_context_artifact(
+            artifact,
+            repo_path,
+            source_cleanup_owner=source_cleanup_owner,
+            requires_authenticated_reader=True,
+        )
+    except BaseException as exc:  # noqa: B036 - cleanup before propagation
+        _raise_context_artifact_bind_failure(exc, source_cleanup_owner)
+
+
+def query_context_artifact_reader(
+    receipt: PublishedWorkspaceReceipt,
+    publication: PublicationDirectoryReader,
+    *,
+    expected_root: str | Path,
+    expected_ownership: object,
+    expected_repository: str | None = None,
+    expected_commit: str | None = None,
+) -> ContextArtifactBinding:
+    """Create a query binding inside one exact workspace-receipt callback."""
+
+    real_root = _require_context_artifact_reader_authority(
+        receipt,
+        publication,
+        expected_root=expected_root,
+        expected_ownership=expected_ownership,
+    )
+    relocated = _relocate_context_artifact_reader(
+        publication,
+        real_root=real_root,
+        expected_ownership=expected_ownership,
+        expected_repository=expected_repository,
+        expected_commit=expected_commit,
+    )
     return ContextArtifactBinding(
         artifact=relocated,
         repo_path=None,
@@ -1369,6 +1510,7 @@ __all__ = [
     "SourceBindingCleanupOwner",
     "VerifiedContextArtifact",
     "bind_context_artifact",
+    "bind_context_artifact_reader",
     "query_context_artifact",
     "query_context_artifact_reader",
     "verify_context_artifact",

--- a/codenib/mcp/retained_context.py
+++ b/codenib/mcp/retained_context.py
@@ -7,8 +7,9 @@
 The retained materializer deliberately returns data while leaving the published
 workspace authority in a caller-created :class:`PublishedWorkspaceReceiptOwner`.
 This module joins those two outputs without reopening the published path.  The
-receipt callback verifies the context artifact, loads its query-only runtime,
-and installs both the live context and a detached result in a PID-bound owner.
+receipt callback verifies the context artifact, loads its query-only or
+explicitly source-bound runtime, and installs both the live context and a
+detached result in a PID-bound owner.
 """
 
 from __future__ import annotations
@@ -38,7 +39,12 @@ from ..artifacts.context import (
     CONTEXT_ARTIFACT_SCHEMA,
     ContextArtifactResult,
 )
-from ..artifacts.runtime import ContextArtifactBinding, query_context_artifact_reader
+from ..artifacts.runtime import (
+    ContextArtifactBinding,
+    SourceBindingCleanupOwner,
+    bind_context_artifact_reader,
+    query_context_artifact_reader,
+)
 from ..compiler.manifest import MANIFEST_FILENAME
 from ..compiler.manifest_import import (
     DEFAULT_MAX_CONTEXT_BYTES,
@@ -53,6 +59,7 @@ from ..compiler.manifest_materialization import (
     materialize_retained_repo_manifest_snapshot,
 )
 from ..compiler.manifest_storage import DEFAULT_MAX_MANIFEST_BYTES
+from ..source_fingerprint import lexical_repository_path
 from ..storage.models import NamespaceIdentity
 from ..storage.protocols import ReceiptRetainingObjectStore, RetainedSnapshotCatalog
 from ..storage.view_bundle import (
@@ -66,6 +73,24 @@ _Result = TypeVar("_Result")
 
 _OWNER_EMPTY = object()
 _OWNER_CLOSED = object()
+
+
+def _retain_ordered_cleanup_error(
+    current: BaseException | None,
+    later: BaseException,
+    *,
+    earlier_label: str,
+    later_label: str,
+) -> BaseException:
+    """Retain cleanup order while never demoting cancellation-class failures."""
+
+    if current is None:
+        return later
+    if isinstance(current, Exception) and not isinstance(later, Exception):
+        _annotate_secondary_error(later, earlier_label, current)
+        return later
+    _annotate_secondary_error(current, later_label, later)
+    return current
 
 
 @dataclass(frozen=True, slots=True)
@@ -129,10 +154,12 @@ class RetainedServerContextOwner:
         "_reservation",
         "_result",
         "_receipt_owner",
+        "_source_owner",
         "_lock",
         "_owner_pid",
         "_process_locks",
         "_context_close_complete",
+        "_source_close_complete",
         "_close_failed",
     )
 
@@ -143,10 +170,16 @@ class RetainedServerContextOwner:
         # The publication destination is pre-created with this aggregate.  No
         # materializer return/store seam ever becomes the sole receipt owner.
         self._receipt_owner = PublishedWorkspaceReceiptOwner()
+        # Source capture can acquire native authority before returning a
+        # binding.  Keep its cleanup owner reachable for the entire one-shot
+        # lifecycle, including cancellation between binding and context
+        # installation.
+        self._source_owner = SourceBindingCleanupOwner()
         self._lock = _CancellationSafeRLock()
         self._owner_pid = os.getpid()
         self._process_locks = {self._owner_pid: self._lock}
         self._context_close_complete = False
+        self._source_close_complete = False
         self._close_failed = False
 
     @property
@@ -204,6 +237,8 @@ class RetainedServerContextOwner:
                 raise RuntimeError(
                     "retained server context publication owner is not empty"
                 )
+            if not self._source_owner.closed:
+                raise RuntimeError("retained server context source owner is not empty")
             # Retain the caller-created identity first.  Cleanup can therefore
             # recognize this invocation even if cancellation lands before the
             # following slot store or before this method returns.
@@ -284,7 +319,7 @@ class RetainedServerContextOwner:
         self._lock.run(install)
 
     def close(self) -> None:
-        """In the owning process, close context before its publication receipt."""
+        """In the owning process, close context and source before the receipt."""
 
         current_pid = os.getpid()
         owner_changed = current_pid != self._owner_pid
@@ -311,71 +346,156 @@ class RetainedServerContextOwner:
                 "retained server context owner cannot cross a PID boundary"
             )
             if close_error is not None:
+                if not isinstance(close_error, Exception):
+                    _annotate_secondary_error(
+                        close_error,
+                        "retained server context PID boundary also observed",
+                        boundary_error,
+                    )
+                    raise close_error
                 raise boundary_error from close_error
             raise boundary_error
         if close_error is not None:
-            if not self.closed:
+            owner_closed = False
+            try:
+                owner_closed = self.closed
+            except BaseException as observation_error:  # noqa: B036
+                close_error = _retain_ordered_cleanup_error(
+                    close_error,
+                    observation_error,
+                    earlier_label="retained owner cleanup also failed",
+                    later_label="retained owner close-state observation also failed",
+                )
+            if not owner_closed:
                 _attach_publication_cleanup_owner(close_error, self)
             raise close_error
 
     def _close_inherited_locked(self) -> None:
-        """Revoke inherited publication handles without touching copied locks."""
+        """Revoke inherited source and publication handles without context locks."""
 
         # A lock in the copied ServerContext may have been owned by a different
         # thread at fork time.  That thread does not exist in the child, so
-        # context.close() could block forever before reaching the publication
-        # receipt.  The retained context is source-disabled and native-inert;
-        # the PID-bound receipt is the authority that must be revoked here.
-        self._receipt_owner.close()
+        # context.close() could block forever before reaching either authority.
+        # Both lower-level owners have their own child-process cleanup paths;
+        # visit both even though each reports its PID boundary after cleanup.
+        first_error: BaseException | None = None
+        try:
+            self._source_owner.close()
+        except BaseException as exc:  # noqa: B036 - visit receipt after source
+            first_error = exc
+        try:
+            self._receipt_owner.close()
+        except BaseException as exc:  # noqa: B036 - preserve first child fault
+            first_error = _retain_ordered_cleanup_error(
+                first_error,
+                exc,
+                earlier_label="retained source cleanup also failed",
+                later_label="retained publication cleanup also failed",
+            )
         self._finish_closed_locked()
+        if first_error is not None:
+            raise first_error
 
     def _close_locked(self) -> None:
         if self._slot is _OWNER_CLOSED:
             return
         self._close_failed = False
 
+        primary_error: BaseException | None = None
         context = self._slot if type(self._slot) is ServerContext else None
-        if context is not None and not self._context_close_complete:
+        if context is None:
+            self._context_close_complete = True
+        elif not self._context_close_complete:
             try:
                 context.close()
-            except BaseException as exc:  # noqa: B036 - receipt must stay active
-                self._close_failed = True
-                _attach_publication_cleanup_owner(exc, self)
-                raise
-            self._context_close_complete = True
+            except BaseException as exc:  # noqa: B036 - still visit source owner
+                primary_error = exc
+            else:
+                self._context_close_complete = True
+
+        if not self._source_close_complete:
+            source_error: BaseException | None = None
+            try:
+                self._source_owner.close()
+            except BaseException as exc:  # noqa: B036 - observe retry authority
+                source_error = exc
+            try:
+                source_closed = self._source_owner.closed
+            except BaseException as observation_error:  # noqa: B036
+                source_closed = False
+                source_error = _retain_ordered_cleanup_error(
+                    source_error,
+                    observation_error,
+                    earlier_label="retained source cleanup also failed",
+                    later_label=("retained source close-state observation also failed"),
+                )
+            self._source_close_complete = source_closed
+            if source_error is not None:
+                primary_error = _retain_ordered_cleanup_error(
+                    primary_error,
+                    source_error,
+                    earlier_label="retained context cleanup also failed",
+                    later_label="retained source cleanup also failed",
+                )
+            elif not source_closed:
+                incomplete = RuntimeError("retained source cleanup is incomplete")
+                primary_error = _retain_ordered_cleanup_error(
+                    primary_error,
+                    incomplete,
+                    earlier_label="retained context cleanup also failed",
+                    later_label="retained source cleanup also failed",
+                )
+
+        if not self._context_close_complete or not self._source_close_complete:
+            self._close_failed = True
+            failure = primary_error or RuntimeError(
+                "retained context or source cleanup is incomplete"
+            )
+            _attach_publication_cleanup_owner(failure, self)
+            raise failure
 
         try:
             self._receipt_owner.close()
-        except BaseException as exc:  # noqa: B036 - retain receipt retry authority
+        except BaseException as exc:  # noqa: B036 - observe retry authority
+            primary_error = _retain_ordered_cleanup_error(
+                primary_error,
+                exc,
+                earlier_label="retained context or source cleanup also failed",
+                later_label="retained publication cleanup also failed",
+            )
+        try:
+            receipt_closed = self._receipt_owner.closed
+        except BaseException as observation_error:  # noqa: B036
             receipt_closed = False
-            if os.getpid() == self._owner_pid:
-                try:
-                    receipt_closed = self._receipt_owner.closed
-                except BaseException as observation_error:  # noqa: B036
-                    _annotate_secondary_error(
-                        exc,
-                        "retained publication close-state observation also failed",
-                        observation_error,
-                    )
-            if receipt_closed:
-                self._finish_closed_locked()
-            else:
-                self._close_failed = True
-                _attach_publication_cleanup_owner(exc, self)
-            raise
-
-        if os.getpid() == self._owner_pid and not self._receipt_owner.closed:
+            primary_error = _retain_ordered_cleanup_error(
+                primary_error,
+                observation_error,
+                earlier_label="retained earlier cleanup also failed",
+                later_label=(
+                    "retained publication close-state observation also failed"
+                ),
+            )
+        if not receipt_closed:
             self._close_failed = True
-            failure = RuntimeError("retained publication cleanup is incomplete")
+            failure = primary_error or RuntimeError(
+                "retained publication cleanup is incomplete"
+            )
             _attach_publication_cleanup_owner(failure, self)
             raise failure
+
         self._finish_closed_locked()
+        if primary_error is not None:
+            # A close may report cancellation after fully revoking its owner.
+            # Preserve that exact fault without retaining an already-closed
+            # aggregate for retry.
+            raise primary_error
 
     def _finish_closed_locked(self) -> None:
         self._slot = _OWNER_CLOSED
         self._reservation = None
         self._result = None
         self._context_close_complete = True
+        self._source_close_complete = True
         self._close_failed = False
 
     def _state_locked(self) -> str:
@@ -409,6 +529,19 @@ def _require_materialization_result(
     if type(value) is not RepoManifestMaterializationResult:
         raise TypeError("retained MCP materializer returned an invalid result")
     return value
+
+
+def _optional_lexical_repository_path(value: object) -> Path | None:
+    """Validate source-binding intent without opening the repository."""
+
+    if value is None:
+        return None
+    if not isinstance(value, (str, Path)):
+        raise TypeError("repo_path must be text or a Path")
+    raw = os.fspath(value)
+    if not raw or "\x00" in raw:
+        raise ValueError("repo_path must be non-empty path text without NUL")
+    return lexical_repository_path(value)
 
 
 def _require_requested_materialization(
@@ -464,6 +597,9 @@ def _cross_check_binding(
     materialization: RepoManifestMaterializationResult,
     receipt: PublishedWorkspaceReceipt,
     publication: PublicationDirectoryReader,
+    *,
+    repo_path: str | Path | None,
+    source_cleanup_owner: SourceBindingCleanupOwner,
 ) -> ContextArtifactBinding:
     """Verify and cross-bind every data and authority projection."""
 
@@ -510,13 +646,26 @@ def _cross_check_binding(
             "retained MCP export receipt differs from the materialized manifest"
         )
 
-    binding = query_context_artifact_reader(
-        receipt,
-        publication,
-        expected_root=root,
-        expected_ownership=ownership,
-        expected_repository=artifact_result.repository,
-        expected_commit=artifact_result.commit,
+    binding = (
+        query_context_artifact_reader(
+            receipt,
+            publication,
+            expected_root=root,
+            expected_ownership=ownership,
+            expected_repository=artifact_result.repository,
+            expected_commit=artifact_result.commit,
+        )
+        if repo_path is None
+        else bind_context_artifact_reader(
+            receipt,
+            publication,
+            repo_path,
+            expected_root=root,
+            expected_ownership=ownership,
+            source_cleanup_owner=source_cleanup_owner,
+            expected_repository=artifact_result.repository,
+            expected_commit=artifact_result.commit,
+        )
     )
     verified = binding.artifact
     if (
@@ -553,8 +702,10 @@ def _activate_materialization(
     materialization: RepoManifestMaterializationResult,
     receipt_owner: PublishedWorkspaceReceiptOwner,
     runtime_owner: RetainedServerContextOwner,
+    *,
+    repo_path: str | Path | None,
 ) -> RetainedServerContextResult:
-    """Consume one exact publication reader and activate its query runtime."""
+    """Consume one publication reader and activate its selected runtime."""
 
     artifact_result = materialization.artifact
 
@@ -562,7 +713,13 @@ def _activate_materialization(
         receipt: PublishedWorkspaceReceipt,
         publication: PublicationDirectoryReader,
     ) -> RetainedServerContextResult:
-        binding = _cross_check_binding(materialization, receipt, publication)
+        binding = _cross_check_binding(
+            materialization,
+            receipt,
+            publication,
+            repo_path=repo_path,
+            source_cleanup_owner=runtime_owner._source_owner,
+        )
         if "bm25" not in artifact_result.views:
             raise ValueError("retained MCP contexts require a selected BM25 view")
         artifact = binding.artifact
@@ -579,6 +736,7 @@ def _activate_materialization(
             artifact=metadata,
             artifact_binding=binding,
             artifact_reader=publication,
+            source_binding=binding.source_binding,
             _context_owner=runtime_owner._install_context,
         )
         if runtime_owner._slot is not context:
@@ -586,11 +744,15 @@ def _activate_materialization(
         if (
             context.manifest is not binding.manifest
             or context._artifact_binding is not binding
-            or context._source_binding is not None
             or context._native_index_authorization is not None
             or context.artifact != metadata
         ):
-            raise RuntimeError("retained MCP query-only context binding changed")
+            raise RuntimeError("retained MCP context binding changed")
+        if repo_path is None:
+            if context._source_binding is not None or context.source_verified:
+                raise RuntimeError("retained MCP query-only source binding changed")
+        elif context._source_binding is None or not context.source_verified:
+            raise RuntimeError("retained MCP source authority was not installed")
         if context.bm25 is None:
             detail = context.errors.get("bm25", "BM25 view did not load")
             raise RuntimeError(f"retained MCP BM25 view is unavailable: {detail}")
@@ -631,11 +793,15 @@ def _load_retained_server_context(
     ref_name: str | None,
     snapshot_id: str | None,
     expected_generation: int | None,
+    repo_path: str | Path | None,
 ) -> RetainedServerContextResult:
     if type(runtime_owner) is not RetainedServerContextOwner:
         raise TypeError("runtime_owner must be a RetainedServerContextOwner")
     if not callable(materialize):
         raise TypeError("retained MCP materializer must be callable")
+    # Fail before catalog/object-store/provider work, while leaving the actual
+    # source capture inside the authenticated publication-reader callback.
+    resolved_repo_path = _optional_lexical_repository_path(repo_path)
 
     reservation = object()
     cleanup = (
@@ -664,6 +830,7 @@ def _load_retained_server_context(
                 ),
                 receipt_owner,
                 runtime_owner,
+                repo_path=resolved_repo_path,
             ),
         )
 
@@ -679,6 +846,7 @@ def load_retained_server_context_ref(
     namespace_name: str = DEFAULT_NAMESPACE_NAME,
     ref_name: str = DEFAULT_REF_NAME,
     expected_generation: int | None = None,
+    repo_path: str | Path | None = None,
     max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
     max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
     max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
@@ -688,7 +856,7 @@ def load_retained_server_context_ref(
     max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
     environ: Mapping[str, str] | None = None,
 ) -> RetainedServerContextResult:
-    """Resolve one retained ref and activate its exact query-only context."""
+    """Resolve one retained ref and activate its exact portable context."""
 
     return _load_retained_server_context(
         runtime_owner,
@@ -717,6 +885,7 @@ def load_retained_server_context_ref(
         ref_name=ref_name,
         snapshot_id=None,
         expected_generation=expected_generation,
+        repo_path=repo_path,
     )
 
 
@@ -730,6 +899,7 @@ def load_retained_server_context_snapshot(
     workspace_provider: StrictWorkspaceProvider,
     runtime_owner: RetainedServerContextOwner,
     namespace_name: str = DEFAULT_NAMESPACE_NAME,
+    repo_path: str | Path | None = None,
     max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
     max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
     max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
@@ -739,7 +909,7 @@ def load_retained_server_context_snapshot(
     max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
     environ: Mapping[str, str] | None = None,
 ) -> RetainedServerContextResult:
-    """Read one retained snapshot and activate its exact query-only context."""
+    """Read one retained snapshot and activate its exact portable context."""
 
     return _load_retained_server_context(
         runtime_owner,
@@ -767,6 +937,7 @@ def load_retained_server_context_snapshot(
         ref_name=None,
         snapshot_id=snapshot_id,
         expected_generation=None,
+        repo_path=repo_path,
     )
 
 

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -319,6 +319,17 @@ the receipt is not a catalog/CAS GC pin, and no live context replacement occurs.
 Those in-flight request pins and atomic swaps remain M3 work; durable evidence
 retention and reclamation remain M5 work.
 
+The library also provides a preparatory source-bound seam for future manifest
+compatibility. `bind_context_artifact_reader` captures a source-fingerprint-v2
+checkout inside the active publication-reader callback, and the retained
+ref/snapshot loaders accept an optional `repo_path`. Their one-shot owner keeps
+the captured source reachable through cancellation, closes context, source,
+then publication receipt in the parent, and revokes source before receipt in a
+forked child without acquiring the copied context lock. This does not change
+the command above: retained `codenib mcp` still cannot be combined with
+`--repo`. A later slice must add the source/storage topology gate, CLI wiring,
+and compatibility E2E before the manifest runtime track can advance.
+
 These retained-read routes and the explicit BM25/vector ingress above do not
 complete the hybrid-storage M1 milestone. Benchmark-backed promotion of the
 opt-in compiler and runtime routes is still missing, as is a production
@@ -438,10 +449,10 @@ Do not infer promotion thresholds from one A1 run. A2 must execute the approved
 fixed subject/media matrix and retain its canonical receipts. The compiler and
 query-only runtime tracks may ratify their own numeric policies independently;
 B1 requires the former and query-only B2 requires the latter. Replacing the
-ordinary source-bound manifest MCP path remains blocked until a source-capable
-retained route preserves the same public behavior and authority. The
-independent gate C `provider-bound-exact` native provider is still required
-before M1 closes.
+ordinary source-bound manifest MCP path remains blocked until the reader-native
+source seam is exposed through a topology-safe production route and preserves
+the same public behavior and authority. The independent gate C
+`provider-bound-exact` native provider is still required before M1 closes.
 This harness does not add M2 generic generation publication or fenced jobs, M3
 hot switching or request pins, or M5 retention and garbage collection.
 

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -695,6 +695,19 @@ hold storage connections while serving, provision storage, delete output, or
 add request-level pins. Those replacement and in-flight lifetime contracts
 remain M3 work, while durable retention and reclamation remain M5 work.
 
+A preparatory library seam can now bind an exact checkout without reopening the
+materialized artifact path. `bind_context_artifact_reader` captures and verifies
+source fingerprint v2 while the publication receipt's authenticated reader is
+active, and the retained ref/snapshot loaders accept an optional `repo_path`
+for callers that already own the surrounding topology. The one-shot runtime
+owner retains source authority across cancellation, closes context, source, and
+receipt in that order in the parent, and revokes source before receipt in a
+forked child without taking an inherited context lock. Portable vector payloads
+remain native-parser inert. This is not yet exposed by `codenib mcp`: the CLI
+still rejects retained storage combined with `--repo`, and the production
+source-versus-storage topology gate and route-level compatibility evidence are
+still missing. The explicit command above therefore remains source-disabled.
+
 The standalone materialization command and retained MCP cold start do not
 initialize or populate the control plane, import a legacy cache, build views,
 advance refs, or make retained storage the default. Benchmark-backed promotion
@@ -713,7 +726,7 @@ that collecting a fast result cannot silently approve a production route:
 | A1 | Run the fixed, report-only retained storage harness and preserve each route's complete public and authority parity. | Implemented as a four-cell v2 evidence protocol; it cannot promote a route. |
 | A2 compiler | Record canonical compiler receipts for the approved subject/media matrix and ratify numeric compiler policy from measured results. | Pending real measurements. |
 | A2 query-only runtime | Record canonical direct-artifact versus retained receipts and ratify numeric query-only runtime policy. | Pending real measurements. |
-| A2 manifest compatibility | Preserve ordinary manifest MCP public behavior and authority when selecting retained storage. | Blocked: retained startup is source-disabled. |
+| A2 manifest compatibility | Preserve ordinary manifest MCP public behavior and authority when selecting retained storage. | Reader-native source binding is implemented at the library boundary; explicit CLI topology, end-to-end routing, and compatibility evidence remain pending. |
 | B1 | Promote BM25 compiler publication to a configured default. | Pending A2 compiler. |
 | B2 | Promote query-only BM25 retained cold start to a configured default. | Pending A2 query-only runtime; this does not replace source-bound manifest MCP. |
 | C | Supply the `provider-bound-exact` strict BM25 native provider. | Independent work, but required before M1 closes. |
@@ -786,9 +799,10 @@ when a track passes and all measurements complete. Only A2 measurements over
 the fixed approved subject/media matrix may establish canonical receipts and
 ratify numeric thresholds. B1 requires the compiler track; query-only B2
 requires the query-only runtime track. Replacing ordinary source-bound manifest
-MCP remains blocked until a source-capable retained route preserves its public
-and authority behavior. None of these promotions is approved by landing the
-harness. This leaves M1 in progress.
+MCP remains blocked until the reader-native source seam is exposed through a
+topology-safe production route and preserves the same public and authority
+behavior in compatibility evidence. None of these promotions is approved by
+landing either the seam or the harness. This leaves M1 in progress.
 
 These gates do not move the existing milestone boundaries. Generic generation
 publication and fenced jobs remain M2, live bundle replacement and in-flight

--- a/test/artifacts/test_runtime.py
+++ b/test/artifacts/test_runtime.py
@@ -39,7 +39,9 @@ from codenib._atomic_directory import (
 from codenib._captured_directory import PublishedWorkspaceReceipt
 from codenib.artifacts import (
     CONTEXT_ARTIFACT_MANIFEST,
+    SourceBindingCleanupOwner,
     bind_context_artifact,
+    bind_context_artifact_reader,
     extract_context_artifact_archive,
     fetch_github_context_artifact,
     query_context_artifact,
@@ -805,6 +807,34 @@ def test_bind_promotes_source_cleanup_cancellation_over_value_error(
     assert captured[0].closed
 
 
+def test_source_cleanup_owner_promotes_observation_interruption() -> None:
+    owner = SourceBindingCleanupOwner()
+    close_failure = RuntimeError("source close failed")
+    interruption = KeyboardInterrupt("source close observation interrupted")
+
+    class InterruptedSource:
+        def close(self) -> None:
+            raise close_failure
+
+        @property
+        def closed(self) -> bool:
+            raise interruption
+
+    source = InterruptedSource()
+    owner.retain(source)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        owner.close()
+
+    assert caught.value is interruption
+    assert owner.pending_sources == (source,)
+    notes = (
+        *getattr(caught.value, "__notes__", ()),
+        *getattr(caught.value, "_codenib_cleanup_notes", ()),
+    )
+    assert any("earlier source cleanup also failed" in note for note in notes)
+
+
 def test_bind_rejects_artifact_root_replaced_after_internal_verification(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1091,6 +1121,330 @@ def test_v1_artifact_supports_inert_bm25_query_but_cannot_bind(
 
     with pytest.raises(ValueError, match="query-only"):
         bind_context_artifact(artifact, repo)
+
+
+def test_bind_context_artifact_reader_loads_source_without_path_reopen(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    ownership = capture_directory_ownership(artifact)
+    receipt = _receipt_stub(artifact, ownership)
+    source_owner = SourceBindingCleanupOwner()
+
+    def consume(publication: PublicationDirectoryReader):
+        def reject_reopen(*_args: object, **_kwargs: object) -> None:
+            raise AssertionError("reader-bound source bind reopened its artifact path")
+
+        monkeypatch.setattr(
+            runtime_module,
+            "reopen_authenticated_directory",
+            reject_reopen,
+        )
+        binding = bind_context_artifact_reader(
+            receipt,
+            publication,
+            repo,
+            expected_root=artifact,
+            expected_ownership=ownership,
+            source_cleanup_owner=source_owner,
+            expected_repository="example/project",
+            expected_commit=commit,
+        )
+        source = binding.source_binding
+        assert source is not None
+        context = ServerContext.load(
+            binding.manifest,
+            views=["bm25"],
+            artifact_binding=binding,
+            artifact_reader=publication,
+            source_binding=source,
+        )
+        return binding, context, source
+
+    binding, context, source = reopen_authenticated_directory(
+        artifact,
+        ownership,
+        consume,
+    )
+    try:
+        assert binding._requires_authenticated_reader is True
+        assert binding.source_binding is None
+        assert binding.repo_path == repo
+        assert binding.manifest.repo_path == str(repo)
+        assert binding.manifest.indexes["bm25"].path == str(artifact / "views" / "bm25")
+        assert binding.artifact.root == artifact
+        assert binding.artifact.ownership == ownership
+        assert binding.artifact.metadata_path == artifact / CONTEXT_ARTIFACT_MANIFEST
+        assert binding.artifact.manifest_path == artifact / "repo_manifest.json"
+        assert binding.checkout_commit_observed == commit
+        assert source_owner.pending_sources == (source,)
+        assert not source_owner.closed
+        assert context.source_verified
+        assert context.bm25 is not None
+        results = context.bm25.search("value", return_code_content=True)
+        assert results[0].file == "sample.py"
+        assert "VALUE = 1" in (results[0].content or "")
+    finally:
+        context.close()
+        source_owner.close()
+    assert source.closed
+    assert source_owner.closed
+
+
+def test_bind_context_artifact_reader_requires_exact_empty_cleanup_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, _commit = _bm25_artifact(tmp_path)
+    ownership = capture_directory_ownership(artifact)
+    receipt = _receipt_stub(artifact, ownership)
+
+    class CleanupOwnerSubclass(SourceBindingCleanupOwner):
+        pass
+
+    class PendingSource:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    pending = PendingSource()
+    occupied_owner = SourceBindingCleanupOwner()
+    occupied_owner.retain(pending)
+
+    def consume(publication: PublicationDirectoryReader) -> None:
+        def reject_verification(*_args: object, **_kwargs: object) -> None:
+            raise AssertionError("invalid cleanup owner reached artifact verification")
+
+        monkeypatch.setattr(
+            runtime_module,
+            "verify_context_artifact_reader",
+            reject_verification,
+        )
+        with pytest.raises(TypeError, match="cleanup owner.*invalid type"):
+            bind_context_artifact_reader(
+                receipt,
+                publication,
+                repo,
+                expected_root=artifact,
+                expected_ownership=ownership,
+                source_cleanup_owner=CleanupOwnerSubclass(),
+            )
+        with pytest.raises(ValueError, match="cleanup owner must be empty"):
+            bind_context_artifact_reader(
+                receipt,
+                publication,
+                repo,
+                expected_root=artifact,
+                expected_ownership=ownership,
+                source_cleanup_owner=occupied_owner,
+            )
+
+    reopen_authenticated_directory(artifact, ownership, consume)
+    assert occupied_owner.pending_sources == (pending,)
+    occupied_owner.close()
+    assert occupied_owner.closed
+
+
+def test_bind_context_artifact_reader_requires_exact_receipt_and_reader_types(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, _commit = _bm25_artifact(tmp_path)
+    ownership = capture_directory_ownership(artifact)
+    receipt = _receipt_stub(artifact, ownership)
+
+    with pytest.raises(TypeError, match="publication reader.*invalid type"):
+        bind_context_artifact_reader(
+            receipt,
+            SimpleNamespace(),  # type: ignore[arg-type]
+            repo,
+            expected_root=artifact,
+            expected_ownership=ownership,
+            source_cleanup_owner=SourceBindingCleanupOwner(),
+        )
+
+    def consume(publication: PublicationDirectoryReader) -> None:
+        with pytest.raises(TypeError, match="receipt.*invalid type"):
+            bind_context_artifact_reader(
+                SimpleNamespace(path=artifact, ownership=ownership),  # type: ignore[arg-type]
+                publication,
+                repo,
+                expected_root=artifact,
+                expected_ownership=ownership,
+                source_cleanup_owner=SourceBindingCleanupOwner(),
+            )
+
+    reopen_authenticated_directory(artifact, ownership, consume)
+
+
+def test_bind_context_artifact_reader_rejects_legacy_before_source_capture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, _commit = _bm25_artifact(tmp_path)
+    legacy = f"sha256:{'a' * 64}"
+    _rewrite_artifact_as_legacy_source_fingerprint(artifact, legacy)
+    ownership = capture_directory_ownership(artifact)
+    receipt = _receipt_stub(artifact, ownership)
+    source_owner = SourceBindingCleanupOwner()
+
+    def consume(publication: PublicationDirectoryReader) -> None:
+        def reject_capture(*_args: object, **_kwargs: object) -> None:
+            raise AssertionError("legacy artifact reached source capture")
+
+        monkeypatch.setattr(
+            runtime_module,
+            "capture_repository_source",
+            reject_capture,
+        )
+        with pytest.raises(ValueError, match="query-only"):
+            bind_context_artifact_reader(
+                receipt,
+                publication,
+                repo,
+                expected_root=artifact,
+                expected_ownership=ownership,
+                source_cleanup_owner=source_owner,
+            )
+
+    reopen_authenticated_directory(artifact, ownership, consume)
+    assert source_owner.closed
+
+
+def test_bind_context_artifact_reader_source_mismatch_closes_caller_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    (repo / "sample.py").write_text("VALUE = 2\n", encoding="utf-8")
+    ownership = capture_directory_ownership(artifact)
+    receipt = _receipt_stub(artifact, ownership)
+    source_owner = SourceBindingCleanupOwner()
+    captured = []
+    real_capture = runtime_module.capture_repository_source
+
+    def capture(*args, **kwargs):
+        source = real_capture(*args, **kwargs)
+        captured.append(source)
+        return source
+
+    monkeypatch.setattr(runtime_module, "capture_repository_source", capture)
+
+    def consume(publication: PublicationDirectoryReader) -> None:
+        with pytest.raises(ValueError, match="do not match"):
+            bind_context_artifact_reader(
+                receipt,
+                publication,
+                repo,
+                expected_root=artifact,
+                expected_ownership=ownership,
+                source_cleanup_owner=source_owner,
+                expected_commit=commit,
+            )
+
+    reopen_authenticated_directory(artifact, ownership, consume)
+    assert len(captured) == 1
+    assert captured[0].closed
+    assert source_owner.closed
+
+
+def test_bind_context_artifact_reader_cancellation_closes_caller_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    ownership = capture_directory_ownership(artifact)
+    receipt = _receipt_stub(artifact, ownership)
+    source_owner = SourceBindingCleanupOwner()
+    captured = []
+    real_capture = runtime_module.capture_repository_source
+    interruption = KeyboardInterrupt("injected reader-bind cancellation")
+
+    def capture(*args, **kwargs):
+        source = real_capture(*args, **kwargs)
+        captured.append(source)
+        raise interruption
+
+    monkeypatch.setattr(runtime_module, "capture_repository_source", capture)
+
+    def consume(publication: PublicationDirectoryReader) -> None:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            bind_context_artifact_reader(
+                receipt,
+                publication,
+                repo,
+                expected_root=artifact,
+                expected_ownership=ownership,
+                source_cleanup_owner=source_owner,
+                expected_commit=commit,
+            )
+        assert caught.value is interruption
+
+    reopen_authenticated_directory(artifact, ownership, consume)
+    assert len(captured) == 1
+    assert captured[0].closed
+    assert source_owner.closed
+
+
+def test_bind_context_artifact_reader_exposes_retryable_caller_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    ownership = capture_directory_ownership(artifact)
+    receipt = _receipt_stub(artifact, ownership)
+    source_owner = SourceBindingCleanupOwner()
+    captured = []
+    real_capture = runtime_module.capture_repository_source
+    interruption = KeyboardInterrupt("injected reader-bind cancellation")
+
+    def capture(*args, **kwargs):
+        source = real_capture(*args, **kwargs)
+        captured.append(source)
+        return source
+
+    def interrupt_checkout(_repo: Path) -> str:
+        raise interruption
+
+    monkeypatch.setattr(runtime_module, "capture_repository_source", capture)
+    monkeypatch.setattr(runtime_module, "checkout_commit", interrupt_checkout)
+    probe = capture_repository_source(repo, exclude_roots=(artifact,))
+    source_type = type(probe)
+    probe.close()
+    real_close = source_type.close
+
+    def persistent_close(source) -> None:
+        if source in captured:
+            raise OSError("injected persistent reader-source close failure")
+        real_close(source)
+
+    monkeypatch.setattr(source_type, "close", persistent_close)
+
+    def consume(publication: PublicationDirectoryReader) -> None:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            bind_context_artifact_reader(
+                receipt,
+                publication,
+                repo,
+                expected_root=artifact,
+                expected_ownership=ownership,
+                source_cleanup_owner=source_owner,
+                expected_commit=commit,
+            )
+        assert caught.value is interruption
+        assert caught.value.source_cleanup_owner is source_owner
+
+    reopen_authenticated_directory(artifact, ownership, consume)
+    assert len(captured) == 1
+    assert source_owner.pending_sources == (captured[0],)
+    assert not captured[0].closed
+
+    monkeypatch.setattr(source_type, "close", real_close)
+    source_owner.close()
+    assert source_owner.closed
+    assert captured[0].closed
 
 
 def test_query_context_artifact_reader_relocates_without_reopening(

--- a/test/compiler/test_retained_context.py
+++ b/test/compiler/test_retained_context.py
@@ -81,10 +81,86 @@ def test_loads_retained_ref_with_bm25_inside_exact_reader(
                 "commit": "a" * 40,
                 "views": ["bm25"],
             }
+            assert owner.context.source_verified is False
+            assert owner._source_owner.closed
         finally:
             owner.close()
         assert owner.closed
         assert destination.is_dir()
+
+
+def test_loads_retained_ref_with_reader_bound_source(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (fixture, imported, object_store, catalog):
+        owner = RetainedServerContextOwner()
+        destination = tmp_path / "context"
+        captured_sources: list[object] = []
+        real_bind = retained_context_module.bind_context_artifact_reader
+
+        def capture_binding(*args: object, **kwargs: object):
+            binding = real_bind(*args, **kwargs)
+            source = binding.source_binding
+            assert source is not None
+            captured_sources.append(source)
+            return binding
+
+        try:
+            with (
+                patch(
+                    "codenib.artifacts.runtime.reopen_authenticated_directory",
+                    side_effect=AssertionError(
+                        "reader-bound retained artifact reopened a path"
+                    ),
+                ),
+                patch(
+                    "codenib.mcp.context.reopen_authenticated_directory",
+                    side_effect=AssertionError("retained BM25 reopened a path"),
+                ),
+                patch.object(
+                    retained_context_module,
+                    "bind_context_artifact_reader",
+                    side_effect=capture_binding,
+                ),
+            ):
+                result = load_retained_server_context_ref(
+                    "owner/repo",
+                    destination,
+                    catalog=catalog,
+                    object_store=object_store,
+                    workspace_provider=_TestWorkspaceProvider(),
+                    runtime_owner=owner,
+                    expected_generation=imported.generation,
+                    repo_path=fixture.repository,
+                )
+
+            assert result is owner.result
+            assert owner.state == "active"
+            assert len(captured_sources) == 1
+            source = captured_sources[0]
+            assert owner.context._source_binding is source
+            assert owner._source_owner.pending_sources == (source,)
+            assert owner.context.source_verified is True
+            assert owner.context.source_verification_scope == "content-bytes"
+            assert owner.context.commit_verified is False
+            assert owner.context.manifest.repo_path == str(fixture.repository)
+            assert (
+                owner.context.read_source_bytes(
+                    "sample.py",
+                    max_bytes=1024,
+                )
+                == b"VALUE = 1\n"
+            )
+            hits = owner.context.bm25.search("VALUE", return_code_content=True)
+            assert hits and hits[0].node_id == "sample.VALUE"
+        finally:
+            owner.close()
+        assert owner.closed
+        assert owner._source_owner.closed
+        assert captured_sources and captured_sources[0].closed
 
 
 def test_loads_retained_snapshot_with_vector_native_inert(
@@ -124,6 +200,55 @@ def test_loads_retained_snapshot_with_vector_native_inert(
             )
             assert owner.context.vector is None
             assert owner.context._native_index_authorization is None
+        finally:
+            owner.close()
+
+
+def test_loads_retained_snapshot_with_source_and_vector_native_inert(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(tmp_path / "retained") as (
+        fixture,
+        imported,
+        object_store,
+        catalog,
+    ):
+        owner = RetainedServerContextOwner()
+        destination = tmp_path / "context"
+        try:
+            with patch(
+                "codenib.mcp.context.require_authorized_vector_view"
+            ) as native_gate:
+                result = load_retained_server_context_snapshot(
+                    "owner/repo",
+                    imported.snapshot_id,
+                    destination,
+                    catalog=catalog,
+                    object_store=object_store,
+                    workspace_provider=_TestWorkspaceProvider(),
+                    runtime_owner=owner,
+                    repo_path=fixture.repository,
+                )
+
+            native_gate.assert_not_called()
+            assert result.loaded_views == ("bm25",)
+            assert result.view_error_items == (
+                (
+                    "vector",
+                    "portable artifact contexts cannot use external authorization "
+                    "for native vector parsing",
+                ),
+            )
+            assert owner.context.vector is None
+            assert owner.context._native_index_authorization is None
+            assert owner.context.source_verified is True
+            assert (
+                owner.context.read_source_bytes(
+                    "sample.py",
+                    max_bytes=1024,
+                )
+                == b"VALUE = 1\n"
+            )
         finally:
             owner.close()
 
@@ -184,6 +309,44 @@ def test_expected_generation_conflict_never_reads_object_storage(
 
         assert owner.closed
         assert not destination.exists()
+
+
+@pytest.mark.parametrize(
+    ("repo_path", "error_type", "message"),
+    [
+        (object(), TypeError, "text or a Path"),
+        ("", ValueError, "non-empty path text"),
+        ("bad\x00path", ValueError, "without NUL"),
+    ],
+)
+def test_invalid_source_repo_path_fails_before_materialization(
+    tmp_path: Path,
+    repo_path: object,
+    error_type: type[BaseException],
+    message: str,
+) -> None:
+    owner = RetainedServerContextOwner()
+    with (
+        patch.object(
+            retained_context_module,
+            "materialize_retained_repo_manifest_ref",
+        ) as materialize,
+        pytest.raises(error_type, match=message),
+    ):
+        load_retained_server_context_ref(
+            "owner/repo",
+            tmp_path / "context",
+            catalog=object(),  # type: ignore[arg-type]
+            object_store=object(),  # type: ignore[arg-type]
+            workspace_provider=object(),  # type: ignore[arg-type]
+            runtime_owner=owner,
+            repo_path=repo_path,  # type: ignore[arg-type]
+        )
+
+    materialize.assert_not_called()
+    assert owner.state == "empty"
+    owner.close()
+    assert owner.closed
 
 
 @pytest.mark.parametrize("forgery", ["digest", "size"])
@@ -432,6 +595,83 @@ class _RetryReceiptOwner:
         self.closed = True
 
 
+class _RetrySourceOwner:
+    def __init__(self, events: list[str], *, fail_once: bool = False) -> None:
+        self.events = events
+        self.fail_once = fail_once
+        self.closed = False
+
+    @property
+    def pending_sources(self) -> tuple[object, ...]:
+        return () if self.closed else (self,)
+
+    def close(self) -> None:
+        self.events.append("source")
+        if self.fail_once:
+            self.fail_once = False
+            raise RuntimeError("source close failed")
+        self.closed = True
+
+
+class _InjectedSourceOwner:
+    def __init__(
+        self,
+        events: list[str],
+        failure: BaseException,
+        *,
+        closes_before_failure: bool,
+    ) -> None:
+        self.events = events
+        self.failure: BaseException | None = failure
+        self.closes_before_failure = closes_before_failure
+        self.closed = False
+
+    @property
+    def pending_sources(self) -> tuple[object, ...]:
+        return () if self.closed else (self,)
+
+    def close(self) -> None:
+        self.events.append("source")
+        failure = self.failure
+        self.failure = None
+        if failure is not None:
+            if self.closes_before_failure:
+                self.closed = True
+            raise failure
+        self.closed = True
+
+
+class _InjectedReceiptOwner:
+    def __init__(
+        self,
+        events: list[str],
+        failure: BaseException,
+        *,
+        closes_before_failure: bool,
+    ) -> None:
+        self.events = events
+        self.failure: BaseException | None = failure
+        self.closes_before_failure = closes_before_failure
+        self.closed = False
+
+    def close(self) -> None:
+        self.events.append("receipt")
+        failure = self.failure
+        self.failure = None
+        if failure is not None:
+            if self.closes_before_failure:
+                self.closed = True
+            raise failure
+        self.closed = True
+
+
+def _cleanup_notes(error: BaseException) -> tuple[str, ...]:
+    return (
+        *getattr(error, "__notes__", ()),
+        *getattr(error, "_codenib_cleanup_notes", ()),
+    )
+
+
 def _loading_owner_with_context() -> tuple[RetainedServerContextOwner, ServerContext]:
     owner = RetainedServerContextOwner()
     owner._begin_loading(object())
@@ -445,7 +685,9 @@ def test_context_cleanup_failure_blocks_receipt_and_remains_retryable(
 ) -> None:
     owner, context = _loading_owner_with_context()
     events: list[str] = []
+    source_owner = _RetrySourceOwner(events)
     receipt_owner = _RetryReceiptOwner(events)
+    owner._source_owner = source_owner  # type: ignore[assignment]
     owner._receipt_owner = receipt_owner  # type: ignore[assignment]
     attempts = 0
 
@@ -462,12 +704,186 @@ def test_context_cleanup_failure_blocks_receipt_and_remains_retryable(
     with pytest.raises(RuntimeError, match="context close failed") as caught:
         owner.close()
     assert owner.state == "close-failed"
-    assert events == ["context"]
+    assert events == ["context", "source"]
+    assert source_owner.closed
+    assert not receipt_owner.closed
     assert caught.value.publication_cleanup_owners == (owner,)  # type: ignore[attr-defined]
 
     owner.close()
-    assert events == ["context", "context", "receipt"]
+    assert events == ["context", "source", "context", "receipt"]
+    assert source_owner.closed
     assert receipt_owner.closed
+    assert owner.closed
+
+
+def test_context_cleanup_failure_remains_primary_when_source_cleanup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner, context = _loading_owner_with_context()
+    events: list[str] = []
+    source_owner = _RetrySourceOwner(events, fail_once=True)
+    receipt_owner = _RetryReceiptOwner(events)
+    owner._source_owner = source_owner  # type: ignore[assignment]
+    owner._receipt_owner = receipt_owner  # type: ignore[assignment]
+    context_failure = RuntimeError("context close failed")
+    attempts = 0
+
+    def close_context(observed: ServerContext) -> None:
+        nonlocal attempts
+        assert observed is context
+        attempts += 1
+        events.append("context")
+        if attempts == 1:
+            raise context_failure
+
+    monkeypatch.setattr(ServerContext, "close", close_context)
+
+    with pytest.raises(RuntimeError) as caught:
+        owner.close()
+    assert caught.value is context_failure
+    assert owner.state == "close-failed"
+    assert events == ["context", "source"]
+    assert not source_owner.closed
+    assert not receipt_owner.closed
+    assert any(
+        "retained source cleanup also failed" in note
+        for note in _cleanup_notes(caught.value)
+    )
+
+    owner.close()
+    assert events == ["context", "source", "context", "source", "receipt"]
+    assert owner.closed
+
+
+def test_source_cancellation_promotes_context_cleanup_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner, context = _loading_owner_with_context()
+    events: list[str] = []
+    context_failure = RuntimeError("context close failed")
+    source_interruption = KeyboardInterrupt("source close interrupted")
+    source_owner = _InjectedSourceOwner(
+        events,
+        source_interruption,
+        closes_before_failure=False,
+    )
+    receipt_owner = _RetryReceiptOwner(events)
+    owner._source_owner = source_owner  # type: ignore[assignment]
+    owner._receipt_owner = receipt_owner  # type: ignore[assignment]
+    attempts = 0
+
+    def close_context(observed: ServerContext) -> None:
+        nonlocal attempts
+        assert observed is context
+        attempts += 1
+        events.append("context")
+        if attempts == 1:
+            raise context_failure
+
+    monkeypatch.setattr(ServerContext, "close", close_context)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        owner.close()
+    assert caught.value is source_interruption
+    assert owner.state == "close-failed"
+    assert events == ["context", "source"]
+    assert not source_owner.closed
+    assert not receipt_owner.closed
+    assert caught.value.publication_cleanup_owners == (owner,)  # type: ignore[attr-defined]
+    assert any(
+        "retained context cleanup also failed" in note
+        and "context close failed" in note
+        for note in _cleanup_notes(caught.value)
+    )
+
+    owner.close()
+    assert events == ["context", "source", "context", "source", "receipt"]
+    assert owner.closed
+
+
+def test_receipt_cancellation_promotes_completed_source_cleanup_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner, context = _loading_owner_with_context()
+    events: list[str] = []
+    source_failure = RuntimeError("source close failed after completion")
+    receipt_exit = SystemExit("receipt close interrupted")
+    source_owner = _InjectedSourceOwner(
+        events,
+        source_failure,
+        closes_before_failure=True,
+    )
+    receipt_owner = _InjectedReceiptOwner(
+        events,
+        receipt_exit,
+        closes_before_failure=False,
+    )
+    owner._source_owner = source_owner  # type: ignore[assignment]
+    owner._receipt_owner = receipt_owner  # type: ignore[assignment]
+
+    def close_context(observed: ServerContext) -> None:
+        assert observed is context
+        events.append("context")
+
+    monkeypatch.setattr(ServerContext, "close", close_context)
+
+    with pytest.raises(SystemExit) as caught:
+        owner.close()
+    assert caught.value is receipt_exit
+    assert owner.state == "close-failed"
+    assert events == ["context", "source", "receipt"]
+    assert source_owner.closed
+    assert not receipt_owner.closed
+    assert caught.value.publication_cleanup_owners == (owner,)  # type: ignore[attr-defined]
+    assert any(
+        "retained context or source cleanup also failed" in note
+        and "source close failed after completion" in note
+        for note in _cleanup_notes(caught.value)
+    )
+
+    owner.close()
+    assert events == ["context", "source", "receipt", "receipt"]
+    assert owner.closed
+
+
+def test_inherited_receipt_cancellation_promotes_source_cleanup_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = RetainedServerContextOwner()
+    events: list[str] = []
+    source_failure = RuntimeError("inherited source close failed")
+    receipt_exit = SystemExit("inherited receipt close interrupted")
+    source_owner = _InjectedSourceOwner(
+        events,
+        source_failure,
+        closes_before_failure=True,
+    )
+    receipt_owner = _InjectedReceiptOwner(
+        events,
+        receipt_exit,
+        closes_before_failure=True,
+    )
+    owner._source_owner = source_owner  # type: ignore[assignment]
+    owner._receipt_owner = receipt_owner  # type: ignore[assignment]
+    owner_pid = owner._owner_pid
+
+    with monkeypatch.context() as child:
+        child.setattr(retained_context_module.os, "getpid", lambda: owner_pid + 1)
+        with pytest.raises(SystemExit) as caught:
+            owner.close()
+
+    assert caught.value is receipt_exit
+    assert events == ["source", "receipt"]
+    assert source_owner.closed
+    assert receipt_owner.closed
+    assert any(
+        "retained source cleanup also failed" in note
+        and "inherited source close failed" in note
+        for note in _cleanup_notes(receipt_exit)
+    )
+    assert any(
+        "PID boundary also observed" in note for note in _cleanup_notes(receipt_exit)
+    )
     assert owner.closed
 
 
@@ -476,7 +892,9 @@ def test_receipt_cleanup_retry_does_not_reclose_context(
 ) -> None:
     owner, context = _loading_owner_with_context()
     events: list[str] = []
+    source_owner = _RetrySourceOwner(events)
     receipt_owner = _RetryReceiptOwner(events, fail_once=True)
+    owner._source_owner = source_owner  # type: ignore[assignment]
     owner._receipt_owner = receipt_owner  # type: ignore[assignment]
 
     def close_context(observed: ServerContext) -> None:
@@ -488,11 +906,43 @@ def test_receipt_cleanup_retry_does_not_reclose_context(
     with pytest.raises(RuntimeError, match="receipt close failed") as caught:
         owner.close()
     assert owner.state == "close-failed"
-    assert events == ["context", "receipt"]
+    assert events == ["context", "source", "receipt"]
     assert caught.value.publication_cleanup_owners == (owner,)  # type: ignore[attr-defined]
 
     owner.close()
-    assert events == ["context", "receipt", "receipt"]
+    assert events == ["context", "source", "receipt", "receipt"]
+    assert source_owner.closed
+    assert owner.closed
+
+
+def test_source_cleanup_failure_blocks_receipt_and_remains_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner, context = _loading_owner_with_context()
+    events: list[str] = []
+    source_owner = _RetrySourceOwner(events, fail_once=True)
+    receipt_owner = _RetryReceiptOwner(events)
+    owner._source_owner = source_owner  # type: ignore[assignment]
+    owner._receipt_owner = receipt_owner  # type: ignore[assignment]
+
+    def close_context(observed: ServerContext) -> None:
+        assert observed is context
+        events.append("context")
+
+    monkeypatch.setattr(ServerContext, "close", close_context)
+
+    with pytest.raises(RuntimeError, match="source close failed") as caught:
+        owner.close()
+    assert owner.state == "close-failed"
+    assert events == ["context", "source"]
+    assert not source_owner.closed
+    assert not receipt_owner.closed
+    assert caught.value.publication_cleanup_owners == (owner,)  # type: ignore[attr-defined]
+
+    owner.close()
+    assert events == ["context", "source", "source", "receipt"]
+    assert source_owner.closed
+    assert receipt_owner.closed
     assert owner.closed
 
 
@@ -618,6 +1068,148 @@ def test_postpublication_preinstall_failure_closes_receipt_and_keeps_output(
         assert destination.is_dir()
 
 
+def test_interruption_after_reader_source_bind_closes_source_before_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (fixture, imported, object_store, catalog):
+        owner = RetainedServerContextOwner()
+        destination = tmp_path / "context"
+        interruption = KeyboardInterrupt("after reader source binding")
+        captured_sources: list[object] = []
+        cleanup_events: list[str] = []
+        real_bind = retained_context_module.bind_context_artifact_reader
+        receipt_type = type(owner._receipt_owner)
+        real_receipt_close = receipt_type.close
+
+        def bind_then_interrupt(*args: object, **kwargs: object) -> None:
+            binding = real_bind(*args, **kwargs)
+            source = binding.source_binding
+            assert source is not None
+            captured_sources.append(source)
+            raise interruption
+
+        def close_receipt(receipt: object) -> None:
+            assert captured_sources and captured_sources[0].closed
+            cleanup_events.append("receipt")
+            real_receipt_close(receipt)
+
+        monkeypatch.setattr(
+            retained_context_module,
+            "bind_context_artifact_reader",
+            bind_then_interrupt,
+        )
+        monkeypatch.setattr(receipt_type, "close", close_receipt)
+
+        with pytest.raises(KeyboardInterrupt) as caught:
+            load_retained_server_context_ref(
+                "owner/repo",
+                destination,
+                catalog=catalog,
+                object_store=object_store,
+                workspace_provider=_TestWorkspaceProvider(),
+                runtime_owner=owner,
+                expected_generation=imported.generation,
+                repo_path=fixture.repository,
+            )
+
+        assert caught.value is interruption
+        assert len(captured_sources) == 1
+        assert captured_sources[0].closed
+        assert owner._source_owner.closed
+        assert owner._receipt_owner.closed
+        assert cleanup_events == ["receipt"]
+        assert owner.closed
+        assert destination.is_dir()
+
+
+def test_source_bound_result_interruption_closes_context_source_then_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (fixture, imported, object_store, catalog):
+        owner = RetainedServerContextOwner()
+        destination = tmp_path / "context"
+        interruption = KeyboardInterrupt("after source-bound result installation")
+        cleanup_events: list[str] = []
+        installed: list[ServerContext] = []
+        real_install_context = RetainedServerContextOwner._install_context
+        real_install_result = RetainedServerContextOwner._install_result
+        real_context_close = ServerContext.close
+        source_owner_type = type(owner._source_owner)
+        real_source_close = source_owner_type.close
+        receipt_type = type(owner._receipt_owner)
+        real_receipt_close = receipt_type.close
+
+        def install_context(
+            observed: RetainedServerContextOwner,
+            context: ServerContext,
+        ) -> None:
+            installed.append(context)
+            real_install_context(observed, context)
+
+        def install_result_then_interrupt(
+            observed: RetainedServerContextOwner,
+            result: RetainedServerContextResult,
+        ) -> None:
+            real_install_result(observed, result)
+            raise interruption
+
+        def close_context(context: ServerContext) -> None:
+            cleanup_events.append("context")
+            real_context_close(context)
+
+        def close_source(source_owner: object) -> None:
+            assert installed and installed[0]._source_binding is None
+            cleanup_events.append("source")
+            real_source_close(source_owner)
+
+        def close_receipt(receipt: object) -> None:
+            assert owner._source_owner.closed
+            cleanup_events.append("receipt")
+            real_receipt_close(receipt)
+
+        monkeypatch.setattr(
+            RetainedServerContextOwner,
+            "_install_context",
+            install_context,
+        )
+        monkeypatch.setattr(
+            RetainedServerContextOwner,
+            "_install_result",
+            install_result_then_interrupt,
+        )
+        monkeypatch.setattr(ServerContext, "close", close_context)
+        monkeypatch.setattr(source_owner_type, "close", close_source)
+        monkeypatch.setattr(receipt_type, "close", close_receipt)
+
+        with pytest.raises(KeyboardInterrupt) as caught:
+            load_retained_server_context_ref(
+                "owner/repo",
+                destination,
+                catalog=catalog,
+                object_store=object_store,
+                workspace_provider=_TestWorkspaceProvider(),
+                runtime_owner=owner,
+                expected_generation=imported.generation,
+                repo_path=fixture.repository,
+            )
+
+        assert caught.value is interruption
+        assert len(installed) == 1
+        assert cleanup_events == ["context", "source", "receipt"]
+        assert owner.closed
+        assert owner._source_owner.closed
+        assert owner._receipt_owner.closed
+        assert destination.is_dir()
+
+
 @pytest.mark.parametrize("phase", ["context", "result"])
 def test_late_activation_interruption_closes_context_before_receipt(
     tmp_path: Path,
@@ -705,13 +1297,17 @@ def test_late_activation_interruption_closes_context_before_receipt(
     not hasattr(os, "fork") or not Path("/proc/self/fd").is_dir(),
     reason="requires fork and Linux descriptor inspection",
 )
-def test_fork_child_revokes_inherited_context_authority_only(
+def test_fork_child_revokes_source_and_publication_without_context_lock(
     tmp_path: Path,
 ) -> None:
     with _retained_fixture(
         tmp_path / "retained",
         views=("bm25",),
-    ) as (_fixture, imported, object_store, catalog):
+    ) as (fixture, imported, object_store, catalog):
+        # The fixture's import authority is unrelated to the runtime owner.
+        # Release it before the fork so any remaining repository descriptor in
+        # the child can only belong to the source-bound retained context.
+        fixture.repository_source.close()
         owner = RetainedServerContextOwner()
         destination = tmp_path / "context"
         load_retained_server_context_ref(
@@ -722,7 +1318,9 @@ def test_fork_child_revokes_inherited_context_authority_only(
             workspace_provider=_TestWorkspaceProvider(),
             runtime_owner=owner,
             expected_generation=imported.generation,
+            repo_path=fixture.repository,
         )
+        assert owner.context.source_verified
 
         lock_acquired = threading.Event()
         release_lock = threading.Event()
@@ -765,7 +1363,10 @@ def test_fork_child_revokes_inherited_context_authority_only(
                             target = os.readlink(f"/proc/self/fd/{name}")
                         except OSError:
                             continue
-                        if str(destination) in target:
+                        if (
+                            str(destination) in target
+                            or str(fixture.repository) in target
+                        ):
                             descriptor_targets.append(target)
                     report = repr((state_report, str(close_error), descriptor_targets))
                     os.write(write_descriptor, report.encode("utf-8"))


### PR DESCRIPTION
## Summary

Add the preparatory reader-native source-binding seam for retained MCP contexts. The library can now preserve authenticated live-source behavior without reopening a materialized artifact path, while the shipping retained CLI remains source-disabled until a separate topology and routing slice.

Related to #199.

## Changes

- add `bind_context_artifact_reader` with an explicit retryable source cleanup owner and shared source-fingerprint-v2 validation
- let retained ref and snapshot loaders optionally bind an exact checkout inside the active publication-reader callback
- retain source authority across cancellation and enforce parent context-to-source-to-receipt plus fork-child source-to-receipt cleanup
- preserve query-only behavior and portable-vector native-parser inertness
- document that CLI topology, compatibility evidence, default promotion, and `provider-bound-exact` gate C remain outstanding

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/artifacts/test_runtime.py test/compiler/test_retained_context.py -x --tb=short` — 120 passed
- adjacent MCP, source-tool, context, and retained CLI regressions — 120 passed
- unit marker tier — 6,846 passed, 71 skipped, 190 deselected in a read-only namespace; two expected pytest-cache warnings
- Black, isort, flake8, `py_compile`, and `git diff --check`
- `python -m mkdocs build --strict`
- `python scripts/check_public_docs.py`

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published