### PR TITLE
feat(cli): bind retained MCP startup to repository source

### DIFF
--- a/codenib/artifacts/runtime.py
+++ b/codenib/artifacts/runtime.py
@@ -50,6 +50,7 @@ from ..repository_filters import (
 from ..repository_source_selection import DEFAULT_REPOSITORY_SOURCE_SELECTION
 from ..source_fingerprint import (
     RepositorySourceBinding,
+    RepositorySourceRootAuthority,
     _SourceLifecycleRLock,
     _SourceLockLease,
     is_secure_source_fingerprint_v2,
@@ -1232,6 +1233,7 @@ def _bind_verified_context_artifact(
     *,
     source_cleanup_owner: SourceBindingCleanupOwner,
     requires_authenticated_reader: bool,
+    expected_root_authority: RepositorySourceRootAuthority | None = None,
 ) -> ContextArtifactBinding:
     """Bind source bytes after an artifact authority has already been verified."""
 
@@ -1246,6 +1248,7 @@ def _bind_verified_context_artifact(
         manifest=artifact.manifest,
         exclude_roots=(artifact.root,),
         _source_owner=source_cleanup_owner.retain,
+        expected_root_authority=expected_root_authority,
     )
     # This is diagnostic provenance only. A mutable Git HEAD cannot be
     # attested by any finite sequence of path reads, so it never gates the
@@ -1432,6 +1435,7 @@ def bind_context_artifact_reader(
     expected_root: str | Path,
     expected_ownership: object,
     source_cleanup_owner: SourceBindingCleanupOwner,
+    expected_root_authority: RepositorySourceRootAuthority | None = None,
     expected_repository: str | None = None,
     expected_commit: str | None = None,
 ) -> ContextArtifactBinding:
@@ -1466,6 +1470,7 @@ def bind_context_artifact_reader(
             repo_path,
             source_cleanup_owner=source_cleanup_owner,
             requires_authenticated_reader=True,
+            expected_root_authority=expected_root_authority,
         )
     except BaseException as exc:  # noqa: B036 - cleanup before propagation
         _raise_context_artifact_bind_failure(exc, source_cleanup_owner)

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -851,10 +851,9 @@ def _mcp_context_mode(args: argparse.Namespace) -> str:
             and retained_values["--expected-generation"] is not None
         ):
             raise CLIError("--expected-generation requires retained ref selection")
-        if explicit_path or artifact is not None or repo is not None:
+        if explicit_path or artifact is not None:
             raise CLIError(
-                "retained MCP storage cannot be combined with a manifest, "
-                "--artifact, or --repo"
+                "retained MCP storage cannot be combined with a manifest or --artifact"
             )
         missing = [
             option
@@ -875,7 +874,9 @@ def _mcp_context_mode(args: argparse.Namespace) -> str:
         if explicit_path:
             raise CLIError("choose either a manifest or --artifact, not both")
         return "artifact"
-    if repo is not None or repository is not None:
+    if repo is not None:
+        raise CLIError("--repo requires --artifact or retained MCP storage")
+    if repository is not None:
         raise CLIError("--repo and --repository require --artifact")
     return "manifest"
 
@@ -940,12 +941,14 @@ def _run_mcp_retained(args: argparse.Namespace) -> int:
         _OrderedAction,
         _run_context_with_cleanup_actions,
     )
+    from .artifacts.runtime import SourceBindingCleanupOwner
     from .mcp.retained_context import (
         RetainedServerContextOwner,
         load_retained_server_context_ref,
         load_retained_server_context_snapshot,
     )
     from .mcp.server import serve_retained_context
+    from .source_fingerprint import pin_repository_source_root
     from .storage import LocalCAS, SQLiteCatalog
 
     repository, namespace = _retained_materialization_identity(
@@ -957,13 +960,16 @@ def _run_mcp_retained(args: argparse.Namespace) -> int:
         snapshot_id=args.snapshot,
         expected_generation=args.expected_generation,
     )
+    repo_path = _retained_mcp_repository_path(getattr(args, "repo", None))
     catalog_path, cas_root, workspace_root, output = _retained_materialization_paths(
-        args
+        args,
+        repo_path=repo_path,
     )
     runtime_owner = RetainedServerContextOwner()
     topology_owner = _RetainedMaterializationResourceOwner()
     object_store_owner = _RetainedMaterializationResourceOwner()
     catalog_owner = _RetainedMaterializationResourceOwner()
+    repository_authority_owner = SourceBindingCleanupOwner()
     runtime_cleanup = (
         _OrderedAction(
             label="retained MCP runtime cleanup also failed",
@@ -995,10 +1001,25 @@ def _run_mcp_retained(args: argparse.Namespace) -> int:
             retry_incomplete="cancellation",
             incomplete_owner=topology_owner,
         ),
+        _OrderedAction(
+            label="retained repository authority cleanup also failed",
+            action=repository_authority_owner.close,
+            complete=lambda: repository_authority_owner.closed,
+            retry_incomplete="cancellation",
+            incomplete_owner=repository_authority_owner,
+        ),
     )
     try:
         with _run_context_with_cleanup_actions(runtime_cleanup):
             with _run_context_with_cleanup_actions(storage_cleanup):
+                repository_authority = (
+                    None
+                    if repo_path is None
+                    else pin_repository_source_root(
+                        repo_path,
+                        _source_owner=repository_authority_owner.retain,
+                    )
+                )
                 base_provider = LocalWorkspaceProvider(workspace_root)
                 base_provider.require_support()
                 topology = topology_owner.acquire(
@@ -1007,6 +1028,8 @@ def _run_mcp_retained(args: argparse.Namespace) -> int:
                         cas_root,
                         workspace_root,
                         output,
+                        repo_path=repo_path,
+                        repository_authority=repository_authority,
                     )
                 )
                 provider = _RetainedTopologyWorkspaceProvider(
@@ -1035,6 +1058,7 @@ def _run_mcp_retained(args: argparse.Namespace) -> int:
                     topology.catalog_path,
                     topology.catalog_identity,
                 )
+                topology.verify()
                 if snapshot_id is None:
                     load_retained_server_context_ref(
                         repository,
@@ -1046,6 +1070,8 @@ def _run_mcp_retained(args: argparse.Namespace) -> int:
                         object_store=object_store,
                         workspace_provider=provider,
                         runtime_owner=runtime_owner,
+                        repo_path=topology.repo_path,
+                        expected_root_authority=topology.repository_authority,
                     )
                 else:
                     load_retained_server_context_snapshot(
@@ -1057,7 +1083,10 @@ def _run_mcp_retained(args: argparse.Namespace) -> int:
                         object_store=object_store,
                         workspace_provider=provider,
                         runtime_owner=runtime_owner,
+                        repo_path=topology.repo_path,
+                        expected_root_authority=topology.repository_authority,
                     )
+                topology.verify_bindings()
             serve_retained_context(
                 runtime_owner,
                 log_level=args.log_level,
@@ -1444,7 +1473,33 @@ def _lexical_cli_path(value: object, *, label: str) -> Path:
         raise CLIError(f"{label} path is invalid") from exc
 
 
-def _retained_materialization_paths(args: argparse.Namespace) -> tuple[Path, ...]:
+def _retained_mcp_repository_path(value: object) -> Path | None:
+    """Freeze one explicit retained source checkout before provider work."""
+
+    if value is None:
+        return None
+    path = _lexical_cli_path(value, label="repository source")
+    try:
+        metadata = path.lstat()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise CLIError(
+            "repository source must resolve to one existing real directory"
+        ) from exc
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or not metadata.st_dev
+        or not metadata.st_ino
+    ):
+        raise CLIError("repository source must resolve to one existing real directory")
+    return path
+
+
+def _retained_materialization_paths(
+    args: argparse.Namespace,
+    *,
+    repo_path: Path | None = None,
+) -> tuple[Path, ...]:
     """Freeze lexical paths without touching the destination namespace."""
 
     catalog_path = _lexical_cli_path(args.catalog, label="catalog")
@@ -1457,11 +1512,20 @@ def _retained_materialization_paths(args: argparse.Namespace) -> tuple[Path, ...
         raise CLIError("output must be below the workspace root") from exc
     if not output_relative.parts:
         raise CLIError("output must be a child of the workspace root")
-    for first, first_label, second, second_label in (
+    comparisons = (
         (catalog_path, "catalog", cas_root, "CAS root"),
         (catalog_path, "catalog", workspace_root, "workspace root"),
         (cas_root, "CAS root", workspace_root, "workspace root"),
-    ):
+    )
+    if repo_path is not None:
+        comparisons = (
+            *comparisons,
+            (repo_path, "repository source", catalog_path, "catalog"),
+            (repo_path, "repository source", cas_root, "CAS root"),
+            (repo_path, "repository source", output, "output"),
+            (repo_path, "repository source", workspace_root, "workspace root"),
+        )
+    for first, first_label, second, second_label in comparisons:
         if _paths_overlap(first, second):
             raise CLIError(f"{first_label} must not overlap the {second_label}")
     return catalog_path, cas_root, workspace_root, output
@@ -1750,6 +1814,87 @@ def _require_retained_mount_topology(
         raise CLIError("retained roots must not traverse a same-device mount alias")
 
 
+def _require_retained_repository_topology(
+    repo_path: Path,
+    catalog_path: Path,
+    cas_root: Path,
+    workspace_root: Path,
+    output: Path,
+) -> None:
+    """Deny lexical aliases, inode aliases, and mapped physical source aliases."""
+
+    for storage, storage_label in (
+        (catalog_path, "catalog"),
+        (cas_root, "CAS root"),
+        (output, "output"),
+        (workspace_root, "workspace root"),
+    ):
+        if _paths_overlap(repo_path, storage):
+            raise CLIError(
+                f"repository source must not physically overlap the {storage_label}"
+            )
+
+    repository_ancestry = _retained_directory_ancestry(
+        repo_path,
+        label="repository source",
+    )
+    for storage_ancestry, storage_label in (
+        (
+            _retained_directory_ancestry(
+                catalog_path.parent,
+                label="catalog parent",
+            ),
+            "catalog",
+        ),
+        (
+            _retained_directory_ancestry(cas_root, label="CAS root"),
+            "CAS root",
+        ),
+        (
+            _retained_directory_ancestry(
+                output.parent,
+                label="output parent",
+            ),
+            "output",
+        ),
+        (
+            _retained_directory_ancestry(
+                workspace_root,
+                label="workspace root",
+            ),
+            "workspace root",
+        ),
+    ):
+        _require_distinct_directory_ancestry(
+            repository_ancestry,
+            "repository source",
+            storage_ancestry,
+            storage_label,
+        )
+
+    mappings = _retained_linux_mount_mappings()
+    repository_physical = _retained_linux_physical_path(repo_path, mappings)
+    for storage, storage_label in (
+        (catalog_path, "catalog"),
+        (cas_root, "CAS root"),
+        (output, "output"),
+        (workspace_root, "workspace root"),
+    ):
+        storage_physical = _retained_linux_physical_path(storage, mappings)
+        if (
+            repository_physical is not None
+            and storage_physical is not None
+            and _retained_physical_paths_overlap(
+                repository_physical,
+                storage_physical,
+            )
+        ):
+            raise CLIError(
+                "repository source must not traverse a physical "
+                f"{storage_label} alias"
+            )
+
+
 @dataclass(slots=True)
 class _RetainedMaterializationTopology:
     catalog_path: Path
@@ -1760,6 +1905,12 @@ class _RetainedMaterializationTopology:
     cas_binding: _RetainedDirectoryBinding
     workspace_binding: _RetainedDirectoryBinding
     output_parent_binding: _RetainedDirectoryBinding
+    repo_path: Path | None = None
+    repository_identity: tuple[object, ...] | None = None
+    repository_authority: object | None = field(
+        default=None,
+        repr=False,
+    )
     _closed: bool = field(default=False, init=False, repr=False)
 
     @property
@@ -1801,6 +1952,63 @@ class _RetainedMaterializationTopology:
             self.workspace_binding,
             self.output_parent_binding,
         )
+        repository_values = (
+            self.repo_path,
+            self.repository_identity,
+            self.repository_authority,
+        )
+        if all(value is None for value in repository_values):
+            return
+        if any(value is None for value in repository_values):
+            raise CLIError("retained repository source topology is incomplete")
+        repo_path = self.repo_path
+        repository_identity = self.repository_identity
+        repository_authority = self.repository_authority
+        if (
+            repo_path is None
+            or repository_identity is None
+            or repository_authority is None
+        ):  # pragma: no cover - guarded above for type narrowing
+            raise CLIError("retained repository source topology is incomplete")
+        try:
+            repository_authority.verify()  # type: ignore[attr-defined]
+            observed_repository_path = repository_authority.root  # type: ignore[attr-defined]
+            observed_repository_identity = (  # type: ignore[attr-defined]
+                repository_authority.root_identity
+            )
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            raise CLIError("repository source authority changed") from exc
+        if observed_repository_path != repo_path:
+            raise CLIError("repository source authority path changed")
+        if observed_repository_identity != repository_identity:
+            raise CLIError("repository source authority identity changed")
+        for storage_identity, storage_label in (
+            (cas_identity, "CAS root"),
+            (workspace_identity, "workspace root"),
+            (output_parent_identity, "output parent"),
+        ):
+            if observed_repository_identity == tuple(storage_identity[:2]):
+                raise CLIError(
+                    f"repository source physically aliases the {storage_label}"
+                )
+        _require_retained_repository_topology(
+            repo_path,
+            self.catalog_path,
+            self.cas_root,
+            self.workspace_root,
+            self.output,
+        )
+        try:
+            repository_authority.verify()  # type: ignore[attr-defined]
+            if (  # type: ignore[attr-defined]
+                repository_authority.root != repo_path
+                or repository_authority.root_identity != repository_identity
+            ):
+                raise CLIError("repository source authority changed")
+        except CLIError:
+            raise
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            raise CLIError("repository source authority changed") from exc
 
     def verify(self) -> None:
         self.verify_bindings()
@@ -1969,6 +2177,9 @@ def _require_retained_materialization_topology(
     cas_root: Path,
     workspace_root: Path,
     output: Path,
+    *,
+    repo_path: Path | None = None,
+    repository_authority: object | None = None,
 ) -> _RetainedMaterializationTopology:
     """Open and retain physical authorities for every mutable storage root."""
 
@@ -1978,6 +2189,15 @@ def _require_retained_materialization_topology(
         _open_publication_authority,
         _PublicationAuthorityOwner,
     )
+    from .source_fingerprint import RepositorySourceRootAuthority
+
+    if (repo_path is None) != (repository_authority is None):
+        raise CLIError("retained repository source topology is incomplete")
+    if (
+        repository_authority is not None
+        and type(repository_authority) is not RepositorySourceRootAuthority
+    ):
+        raise CLIError("retained repository source authority has an invalid type")
 
     try:
         output.lstat()
@@ -2044,6 +2264,17 @@ def _require_retained_materialization_topology(
         raise CLIError("output must remain below the physical workspace root") from exc
     if not resolved_output_relative.parts:
         raise CLIError("output must be a child of the physical workspace root")
+    repository_identity: tuple[object, ...] | None = None
+    if repository_authority is not None:
+        try:
+            repository_authority.verify()
+            pinned_repo = repository_authority.root
+            repository_identity = repository_authority.root_identity
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            raise CLIError("repository source authority changed") from exc
+        if pinned_repo != repo_path:
+            raise CLIError("repository source authority differs from its path")
+        repo_path = pinned_repo
     for first, first_label, second, second_label in (
         (resolved_catalog, "catalog", resolved_cas, "CAS root"),
         (resolved_catalog, "catalog", resolved_workspace, "workspace root"),
@@ -2054,6 +2285,14 @@ def _require_retained_materialization_topology(
             raise CLIError(
                 f"{first_label} must not physically overlap the {second_label}"
             )
+    if repo_path is not None:
+        _require_retained_repository_topology(
+            repo_path,
+            resolved_catalog,
+            resolved_cas,
+            resolved_workspace,
+            resolved_output,
+        )
 
     owners = tuple(_PublicationAuthorityOwner() for _index in range(3))
 
@@ -2096,6 +2335,9 @@ def _require_retained_materialization_topology(
             cas_binding=cas_binding,
             workspace_binding=workspace_binding,
             output_parent_binding=output_parent_binding,
+            repo_path=repo_path,
+            repository_identity=repository_identity,
+            repository_authority=repository_authority,
         )
         topology.verify()
         return topology
@@ -5654,7 +5896,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     mcp_parser.add_argument(
         "--repo",
-        help="optional exact checkout bound to --artifact",
+        help="optional exact checkout bound to --artifact or retained startup",
     )
     mcp_parser.add_argument(
         "--repository",

--- a/codenib/compiler/manifest_source.py
+++ b/codenib/compiler/manifest_source.py
@@ -15,6 +15,7 @@ from ..repository_source_selection import RepositorySourceSelection
 from ..source_fingerprint import (
     RepositorySourceBinding,
     RepositorySourceIdentitySnapshot,
+    RepositorySourceRootAuthority,
     SourceFingerprint,
 )
 from .manifest import (
@@ -108,6 +109,7 @@ def capture_repository_source_for_manifest(
     *,
     exclude_roots: Iterable[str | Path] = (),
     _source_owner: Callable[[object], None] | None = None,
+    expected_root_authority: RepositorySourceRootAuthority | None = None,
 ) -> RepositorySourceBinding:
     """Capture retained reads using the manifest's persisted policy."""
 
@@ -117,12 +119,14 @@ def capture_repository_source_for_manifest(
             root,
             exclude_roots=exclude_roots,
             _source_owner=_source_owner,
+            expected_root_authority=expected_root_authority,
         )
     return source_fingerprint_module.capture_repository_source(
         root,
         exclude_roots=exclude_roots,
         selection=selection,
         _source_owner=_source_owner,
+        expected_root_authority=expected_root_authority,
     )
 
 

--- a/codenib/mcp/retained_context.py
+++ b/codenib/mcp/retained_context.py
@@ -59,7 +59,10 @@ from ..compiler.manifest_materialization import (
     materialize_retained_repo_manifest_snapshot,
 )
 from ..compiler.manifest_storage import DEFAULT_MAX_MANIFEST_BYTES
-from ..source_fingerprint import lexical_repository_path
+from ..source_fingerprint import (
+    RepositorySourceRootAuthority,
+    lexical_repository_path,
+)
 from ..storage.models import NamespaceIdentity
 from ..storage.protocols import ReceiptRetainingObjectStore, RetainedSnapshotCatalog
 from ..storage.view_bundle import (
@@ -600,6 +603,7 @@ def _cross_check_binding(
     *,
     repo_path: str | Path | None,
     source_cleanup_owner: SourceBindingCleanupOwner,
+    expected_root_authority: RepositorySourceRootAuthority | None,
 ) -> ContextArtifactBinding:
     """Verify and cross-bind every data and authority projection."""
 
@@ -663,6 +667,7 @@ def _cross_check_binding(
             expected_root=root,
             expected_ownership=ownership,
             source_cleanup_owner=source_cleanup_owner,
+            expected_root_authority=expected_root_authority,
             expected_repository=artifact_result.repository,
             expected_commit=artifact_result.commit,
         )
@@ -704,6 +709,7 @@ def _activate_materialization(
     runtime_owner: RetainedServerContextOwner,
     *,
     repo_path: str | Path | None,
+    expected_root_authority: RepositorySourceRootAuthority | None,
 ) -> RetainedServerContextResult:
     """Consume one publication reader and activate its selected runtime."""
 
@@ -719,6 +725,7 @@ def _activate_materialization(
             publication,
             repo_path=repo_path,
             source_cleanup_owner=runtime_owner._source_owner,
+            expected_root_authority=expected_root_authority,
         )
         if "bm25" not in artifact_result.views:
             raise ValueError("retained MCP contexts require a selected BM25 view")
@@ -794,6 +801,7 @@ def _load_retained_server_context(
     snapshot_id: str | None,
     expected_generation: int | None,
     repo_path: str | Path | None,
+    expected_root_authority: RepositorySourceRootAuthority | None,
 ) -> RetainedServerContextResult:
     if type(runtime_owner) is not RetainedServerContextOwner:
         raise TypeError("runtime_owner must be a RetainedServerContextOwner")
@@ -802,6 +810,16 @@ def _load_retained_server_context(
     # Fail before catalog/object-store/provider work, while leaving the actual
     # source capture inside the authenticated publication-reader callback.
     resolved_repo_path = _optional_lexical_repository_path(repo_path)
+    if expected_root_authority is not None:
+        if type(expected_root_authority) is not RepositorySourceRootAuthority:
+            raise TypeError(
+                "expected_root_authority must be a RepositorySourceRootAuthority"
+            )
+        if resolved_repo_path is None:
+            raise ValueError("expected_root_authority requires repo_path")
+        expected_root_authority.verify()
+        if expected_root_authority.root != resolved_repo_path:
+            raise ValueError("expected_root_authority differs from repo_path")
 
     reservation = object()
     cleanup = (
@@ -831,6 +849,7 @@ def _load_retained_server_context(
                 receipt_owner,
                 runtime_owner,
                 repo_path=resolved_repo_path,
+                expected_root_authority=expected_root_authority,
             ),
         )
 
@@ -847,6 +866,7 @@ def load_retained_server_context_ref(
     ref_name: str = DEFAULT_REF_NAME,
     expected_generation: int | None = None,
     repo_path: str | Path | None = None,
+    expected_root_authority: RepositorySourceRootAuthority | None = None,
     max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
     max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
     max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
@@ -886,6 +906,7 @@ def load_retained_server_context_ref(
         snapshot_id=None,
         expected_generation=expected_generation,
         repo_path=repo_path,
+        expected_root_authority=expected_root_authority,
     )
 
 
@@ -900,6 +921,7 @@ def load_retained_server_context_snapshot(
     runtime_owner: RetainedServerContextOwner,
     namespace_name: str = DEFAULT_NAMESPACE_NAME,
     repo_path: str | Path | None = None,
+    expected_root_authority: RepositorySourceRootAuthority | None = None,
     max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
     max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
     max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
@@ -938,6 +960,7 @@ def load_retained_server_context_snapshot(
         snapshot_id=snapshot_id,
         expected_generation=None,
         repo_path=repo_path,
+        expected_root_authority=expected_root_authority,
     )
 
 

--- a/codenib/source_fingerprint.py
+++ b/codenib/source_fingerprint.py
@@ -51,7 +51,9 @@ from ._windows_fs_authority import WindowsDirectoryEntry as _WindowsDirectoryEnt
 from ._windows_fs_authority import WindowsHandleMetadata as _WindowsHandleMetadata
 from ._windows_fs_authority import WindowsKernelApi as _WindowsKernelApi
 from ._windows_fs_authority import WindowsReparsePoint as _WindowsReparsePoint
-from ._windows_fs_authority import _WindowsHandleCleanup
+from ._windows_fs_authority import (
+    _WindowsHandleCleanup,
+)
 from .repository_filters import (
     REPOSITORY_FILTER_POLICY_VERSION,
     repository_path_is_visible,
@@ -2207,7 +2209,7 @@ class _PosixRepositoryRootAuthority:
         return self._closed
 
     def verify(self, expected_root_identity: tuple[int, ...]) -> None:
-        if self._closed:
+        if self._closed or not self._resources:
             raise ValueError("repository root authority is closed")
         anchor = self._resources[0]
         if _binding_identity(os.fstat(anchor)) != self._anchor_identity:
@@ -2224,6 +2226,35 @@ class _PosixRepositoryRootAuthority:
                 raise ValueError("repository root path changed")
         if _version_identity(os.fstat(self.descriptor)) != expected_root_identity:
             raise ValueError("repository root changed while it was retained")
+
+    def verify_binding(self) -> None:
+        """Verify only the live lexical object chain, not directory versions."""
+
+        if self._closed or not self._resources:
+            raise ValueError("repository root authority is closed")
+        anchor = self._resources[0]
+        opened_anchor = os.fstat(anchor)
+        if (
+            _descriptor_ownership_identity(opened_anchor)
+            != self._resource_identities.get(anchor)
+            or _binding_identity(opened_anchor)[:2] != self._anchor_identity[:2]
+        ):
+            raise ValueError("repository root anchor binding changed")
+        for parent, name, child, expected_binding in self._bindings:
+            opened_parent = os.fstat(parent)
+            observed = os.stat(name, dir_fd=parent, follow_symlinks=False)
+            opened = os.fstat(child)
+            if (
+                _descriptor_ownership_identity(opened_parent)
+                != self._resource_identities.get(parent)
+                or _descriptor_ownership_identity(opened)
+                != self._resource_identities.get(child)
+                or _is_link_or_reparse(observed)
+                or not stat.S_ISDIR(observed.st_mode)
+                or _binding_identity(observed)[:2] != expected_binding[:2]
+                or _binding_identity(opened)[:2] != expected_binding[:2]
+            ):
+                raise ValueError("repository root path binding changed")
 
     def close(self) -> None:
         if self._closed:
@@ -2658,6 +2689,374 @@ def _verify_pinned_repository_root(
     authority.verify(expected_identity)
 
 
+class RepositorySourceRootAuthority:
+    """Pre-pinned lexical hierarchy used to authenticate a later source capture."""
+
+    __slots__ = (
+        "_root",
+        "_root_identity",
+        "_posix_authority",
+        "_windows_api",
+        "_windows_authority",
+        "_pid",
+        "_lock",
+        "_process_locks",
+    )
+
+    def __init__(
+        self,
+        *,
+        root: Path,
+        root_identity: tuple[object, ...],
+        posix_authority: _PosixRepositoryRootAuthority | None = None,
+        windows_api: _WindowsKernelApi | None = None,
+        windows_authority: object | None = None,
+    ) -> None:
+        if type(root) is not type(Path()) or type(root_identity) is not tuple:
+            raise TypeError("repository root authority fields must use exact types")
+        if not root_identity:
+            raise ValueError("repository root authority identity is empty")
+        posix = posix_authority is not None
+        windows = windows_api is not None or windows_authority is not None
+        if posix == windows or (
+            windows and (windows_api is None or windows_authority is None)
+        ):
+            raise ValueError("repository root authority backend is invalid")
+        self._root = type(root)(os.fspath(root))
+        self._root_identity = tuple(root_identity)
+        self._posix_authority = posix_authority
+        self._windows_api = windows_api
+        self._windows_authority = windows_authority
+        self._pid = os.getpid()
+        self._lock = _SourceLifecycleRLock()
+        self._process_locks = {self._pid: self._lock}
+
+    @property
+    def root(self) -> Path:
+        self._require_owner_pid()
+        with _SourceLockLease(self._lock) as acquisition_failure:
+            if acquisition_failure is not None:
+                raise acquisition_failure
+            self._verify_unlocked()
+            return type(self._root)(os.fspath(self._root))
+
+    @property
+    def root_identity(self) -> tuple[object, ...]:
+        self._require_owner_pid()
+        with _SourceLockLease(self._lock) as acquisition_failure:
+            if acquisition_failure is not None:
+                raise acquisition_failure
+            self._verify_unlocked()
+            posix = self._posix_authority
+            if posix is not None:
+                observed = tuple(_binding_identity(os.fstat(posix.descriptor))[:2])
+            else:
+                authority = self._windows_authority
+                if authority is None:  # pragma: no cover - constructor invariant
+                    raise RuntimeError("repository root authority backend changed")
+                observed = tuple(authority.identity[:2])  # type: ignore[attr-defined]
+            expected = tuple(self._root_identity[:2])
+            if observed != expected:
+                raise RuntimeError("repository root authority identity changed")
+            return expected
+
+    @property
+    def closed(self) -> bool:
+        if os.getpid() != self._pid:
+            return bool(self._authority.closed)  # type: ignore[attr-defined]
+        with _SourceLockLease(self._lock) as acquisition_failure:
+            if acquisition_failure is not None:
+                raise acquisition_failure
+            return bool(self._authority.closed)  # type: ignore[attr-defined]
+
+    @property
+    def _authority(self) -> object:
+        authority = self._posix_authority or self._windows_authority
+        if authority is None:  # pragma: no cover - constructor invariant
+            raise RuntimeError("repository root authority has no backend")
+        return authority
+
+    def _require_owner_pid(self) -> None:
+        if os.getpid() != self._pid:
+            raise RuntimeError("repository root authority cannot cross processes")
+
+    def _verify_unlocked(self) -> None:
+        if self.closed:
+            raise RuntimeError("repository root authority is closed")
+        posix = self._posix_authority
+        if posix is not None:
+            if posix.root != self._root:
+                raise RuntimeError("repository root authority path changed")
+            posix.verify_binding()
+            return
+        api = self._windows_api
+        authority = self._windows_authority
+        if api is None or authority is None:  # pragma: no cover - invariant
+            raise RuntimeError("repository root authority backend changed")
+        if authority.path != self._root:  # type: ignore[attr-defined]
+            raise RuntimeError("repository root authority path changed")
+        authority.verify_binding()  # type: ignore[attr-defined]
+
+    def verify(self) -> None:
+        self._require_owner_pid()
+        with _SourceLockLease(self._lock) as acquisition_failure:
+            if acquisition_failure is not None:
+                raise acquisition_failure
+            self._verify_unlocked()
+
+    @contextmanager
+    def capture_lease(self) -> Iterator["RepositorySourceRootAuthority"]:
+        """Borrow this exact expected hierarchy across one independent capture."""
+
+        self._require_owner_pid()
+        with _SourceLockLease(self._lock) as acquisition_failure:
+            if acquisition_failure is not None:
+                raise acquisition_failure
+            self._verify_unlocked()
+            yield self
+
+    def _hierarchy_identity(self) -> tuple[object, ...]:
+        """Return the verified anchor-to-root object chain for exact handoff."""
+
+        self.verify()
+        posix = self._posix_authority
+        if posix is not None:
+            return (
+                "posix",
+                os.fspath(self._root),
+                tuple(posix._anchor_identity[:2]),
+                tuple(
+                    (name, tuple(identity[:2]))
+                    for _parent, name, _child, identity in posix._bindings
+                ),
+            )
+        authority = self._windows_authority
+        if authority is None:  # pragma: no cover - constructor invariant
+            raise RuntimeError("repository root authority backend changed")
+        return (
+            "windows",
+            os.fspath(self._root).casefold(),
+            tuple(authority.anchor_identity[:2]),  # type: ignore[attr-defined]
+            tuple(
+                (
+                    observation.name.casefold(),
+                    tuple(observation.child_identity[:2]),
+                )
+                for observation in authority.observations  # type: ignore[attr-defined]
+            ),
+        )
+
+    def _close_with_lock(self, lock: _SourceLifecycleRLock) -> None:
+        with _SourceLockLease(lock) as first_failure:
+            if not self.closed:
+                try:
+                    self._authority.close()  # type: ignore[attr-defined]
+                except BaseException as exc:  # noqa: B036 - retryable owner
+                    first_failure = _remember_interruption(first_failure, exc)
+            if first_failure is not None:
+                raise first_failure
+
+    def close(self) -> None:
+        current_pid = os.getpid()
+        if current_pid == self._pid:
+            self._close_with_lock(self._lock)
+            return
+        child_lock = self._process_locks.setdefault(
+            current_pid,
+            _SourceLifecycleRLock(),
+        )
+        cleanup_failure: BaseException | None = None
+        try:
+            self._close_with_lock(child_lock)
+        except BaseException as exc:  # noqa: B036 - report boundary after cleanup
+            cleanup_failure = exc
+        if current_pid != self._pid:
+            boundary = RuntimeError("repository root authority cannot cross processes")
+            if cleanup_failure is not None:
+                raise boundary from cleanup_failure
+            raise boundary
+
+    def __enter__(self) -> "RepositorySourceRootAuthority":
+        self.verify()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+
+def pin_repository_source_root(
+    root: str | Path,
+    *,
+    _source_owner: Callable[[object], None] | None = None,
+) -> RepositorySourceRootAuthority:
+    """Pin a full lexical root hierarchy for a later exact capture handoff."""
+
+    if _source_owner is not None and not callable(_source_owner):
+        raise TypeError("source owner must be callable")
+    cleanup_slot = _SourceCleanupSlot()
+    if _source_owner is not None:
+        _source_owner(cleanup_slot)
+    try:
+        if sys.platform == "win32":
+            root_path = _lexical_windows_repository_path(root)
+            api, authority, root_identity = _open_windows_pinned_repository_root(
+                root_path,
+                cleanup_slot=cleanup_slot,
+            )
+            expected = RepositorySourceRootAuthority(
+                root=root_path,
+                root_identity=root_identity,
+                windows_api=api,
+                windows_authority=authority,
+            )
+        else:
+            root_path = lexical_repository_path(root)
+            authority = _open_pinned_repository_root(
+                root_path,
+                cleanup_slot=cleanup_slot,
+            )
+            expected = RepositorySourceRootAuthority(
+                root=root_path,
+                root_identity=authority.root_identity,
+                posix_authority=authority,
+            )
+        cleanup_slot.own(expected)
+        expected.verify()
+        return expected
+    except BaseException as primary:  # noqa: B036 - preserve acquisition primary
+        cleanup_failure: BaseException | None = None
+        try:
+            cleanup_slot.close()
+        except BaseException as exc:  # noqa: B036 - retain retryable cleanup
+            cleanup_failure = exc
+        _attach_source_cleanup_owner(primary, cleanup_slot)
+        if cleanup_failure is not None:
+            raise primary from cleanup_failure
+        raise
+
+
+def _require_expected_repository_root_authority(
+    expected: RepositorySourceRootAuthority | None,
+    root: Path,
+) -> RepositorySourceRootAuthority | None:
+    if expected is None:
+        return None
+    if type(expected) is not RepositorySourceRootAuthority:
+        raise TypeError(
+            "expected_root_authority must be a RepositorySourceRootAuthority"
+        )
+    try:
+        expected.verify()
+        expected_root = expected.root
+    except RepositoryChangedError:
+        raise
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RepositoryChangedError(
+            "expected repository root authority changed during capture"
+        ) from exc
+    same_root = (
+        os.fspath(expected_root).casefold() == os.fspath(root).casefold()
+        if sys.platform == "win32"
+        else expected_root == root
+    )
+    if not same_root:
+        raise ValueError("expected repository root authority differs from root")
+    return expected
+
+
+def _posix_root_hierarchy_identity(
+    root: Path,
+    authority: _PosixRepositoryRootAuthority,
+    root_identity: tuple[int, ...],
+) -> tuple[object, ...]:
+    authority.verify(root_identity)
+    return (
+        "posix",
+        os.fspath(root),
+        tuple(authority._anchor_identity[:2]),
+        tuple(
+            (name, tuple(identity[:2]))
+            for _parent, name, _child, identity in authority._bindings
+        ),
+    )
+
+
+def _windows_root_hierarchy_identity(
+    root: Path,
+    api: _WindowsKernelApi,
+    authority: object,
+    root_identity: tuple[object, ...],
+) -> tuple[object, ...]:
+    _verify_windows_pinned_repository_root(
+        api,
+        authority,  # type: ignore[arg-type]
+        root_identity,
+    )
+    return (
+        "windows",
+        os.fspath(root).casefold(),
+        tuple(authority.anchor_identity[:2]),  # type: ignore[attr-defined]
+        tuple(
+            (
+                observation.name.casefold(),
+                tuple(observation.child_identity[:2]),
+            )
+            for observation in authority.observations  # type: ignore[attr-defined]
+        ),
+    )
+
+
+def _require_repository_root_authority_handoff(
+    expected: RepositorySourceRootAuthority | None,
+    observed_identity: Callable[[], tuple[object, ...]],
+    verify_observed: Callable[[], None],
+) -> None:
+    if expected is None:
+        return
+    try:
+        expected.verify()
+        verify_observed()
+        matches = expected._hierarchy_identity() == observed_identity()
+        expected.verify()
+        verify_observed()
+    except RepositoryChangedError:
+        raise
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RepositoryChangedError(
+            "repository root authority changed during capture"
+        ) from exc
+    if not matches:
+        raise RepositoryChangedError(
+            "repository root hierarchy differs from its expected authority"
+        )
+
+
+@contextmanager
+def _expected_repository_root_capture_lease(
+    expected: RepositorySourceRootAuthority | None,
+) -> Iterator[None]:
+    if expected is None:
+        yield
+        return
+    if type(expected) is not RepositorySourceRootAuthority:
+        raise TypeError(
+            "expected_root_authority must be a RepositorySourceRootAuthority"
+        )
+    entered = False
+    try:
+        with expected.capture_lease():
+            entered = True
+            yield
+    except RepositoryChangedError:
+        raise
+    except (OSError, RuntimeError, ValueError) as exc:
+        if entered:
+            raise
+        raise RepositoryChangedError(
+            "expected repository root authority changed during capture"
+        ) from exc
+
+
 def _fingerprint_windows_repository(
     root: str | Path,
     *,
@@ -2669,6 +3068,7 @@ def _fingerprint_windows_repository(
     source_owner: Callable[[object], None] | None = None,
     cleanup_slot: _SourceCleanupSlot | None = None,
     identity_policy: object = _CURRENT_SOURCE_IDENTITY_POLICY,
+    expected_root_authority: RepositorySourceRootAuthority | None = None,
 ) -> SourceFingerprint | RepositorySourceBinding:
     """Hash a Windows repository through one retained HANDLE authority."""
 
@@ -2678,6 +3078,10 @@ def _fingerprint_windows_repository(
             source_owner(cleanup_slot)
     selected_source = _snapshot_repository_source_selection(selection)
     root_path = _lexical_windows_repository_path(root)
+    expected_root_authority = _require_expected_repository_root_authority(
+        expected_root_authority,
+        root_path,
+    )
     hasher = _new_source_fingerprint_hasher(
         version,
         selected_source,
@@ -2695,6 +3099,27 @@ def _fingerprint_windows_repository(
             root_path,
             api=api,
             cleanup_slot=cleanup_slot,
+        )
+
+        def observed_hierarchy() -> tuple[object, ...]:
+            return _windows_root_hierarchy_identity(
+                root_path,
+                selected,  # type: ignore[arg-type]
+                root_authority,
+                root_identity,
+            )
+
+        def verify_observed() -> None:
+            _verify_windows_pinned_repository_root(
+                selected,  # type: ignore[arg-type]
+                root_authority,
+                root_identity,
+            )
+
+        _require_repository_root_authority_handoff(
+            expected_root_authority,
+            observed_hierarchy,
+            verify_observed,
         )
         initial_scan = _scan_pinned_windows_repository(
             selected,
@@ -2840,6 +3265,11 @@ def _fingerprint_windows_repository(
                 hasher.update(b"\0")
             file_count += 1
 
+        _require_repository_root_authority_handoff(
+            expected_root_authority,
+            observed_hierarchy,
+            verify_observed,
+        )
         final_scan = _scan_pinned_windows_repository(
             selected,
             root_authority.handle,
@@ -2858,6 +3288,11 @@ def _fingerprint_windows_repository(
             selected,
             root_authority,
             root_identity,
+        )
+        _require_repository_root_authority_handoff(
+            expected_root_authority,
+            observed_hierarchy,
+            verify_observed,
         )
         _verify_windows_repository_links(
             root_path,
@@ -2954,6 +3389,7 @@ def _fingerprint_repository(
     retain_binding: bool = False,
     source_owner: Callable[[object], None] | None = None,
     identity_policy: object = _CURRENT_SOURCE_IDENTITY_POLICY,
+    expected_root_authority: RepositorySourceRootAuthority | None = None,
 ) -> SourceFingerprint | RepositorySourceBinding:
     """Hash visible repository contents with v2 or the diagnostic v1 format."""
 
@@ -2974,6 +3410,7 @@ def _fingerprint_repository(
             retain_binding=retain_binding,
             cleanup_slot=cleanup_slot,
             identity_policy=identity_policy,
+            expected_root_authority=expected_root_authority,
         )
 
     # Do not call Path.resolve() here. A reversible root-to-symlink swap during
@@ -2981,6 +3418,10 @@ def _fingerprint_repository(
     # foreign tree. The lexical path remains the rebind target for the pinned
     # no-follow descriptor throughout the operation.
     root_path = lexical_repository_path(root)
+    expected_root_authority = _require_expected_repository_root_authority(
+        expected_root_authority,
+        root_path,
+    )
 
     hasher = _new_source_fingerprint_hasher(
         version,
@@ -3001,6 +3442,25 @@ def _fingerprint_repository(
         )
         root_descriptor = root_authority.descriptor
         root_identity = root_authority.root_identity
+
+        def observed_hierarchy() -> tuple[object, ...]:
+            return _posix_root_hierarchy_identity(
+                root_path,
+                root_authority,
+                root_identity,
+            )
+
+        def verify_observed() -> None:
+            _verify_pinned_repository_root(
+                root_authority,
+                root_identity,
+            )
+
+        _require_repository_root_authority_handoff(
+            expected_root_authority,
+            observed_hierarchy,
+            verify_observed,
+        )
         initial_scan = _scan_pinned_repository(
             root_descriptor,
             excluded=excluded,
@@ -3145,6 +3605,11 @@ def _fingerprint_repository(
                 hasher.update(b"\0")
             file_count += 1
 
+        _require_repository_root_authority_handoff(
+            expected_root_authority,
+            observed_hierarchy,
+            verify_observed,
+        )
         final_scan = _scan_pinned_repository(
             root_descriptor,
             excluded=excluded,
@@ -3159,6 +3624,11 @@ def _fingerprint_repository(
                 "repository entries changed while they were being fingerprinted"
             )
         _verify_pinned_repository_root(root_authority, root_identity)
+        _require_repository_root_authority_handoff(
+            expected_root_authority,
+            observed_hierarchy,
+            verify_observed,
+        )
         _verify_posix_repository_links(
             root_path,
             root_descriptor,
@@ -3301,18 +3771,21 @@ def _capture_repository_source_legacy_manifest_v11(
     *,
     exclude_roots: Iterable[str | Path] = (),
     _source_owner: Callable[[object], None] | None = None,
+    expected_root_authority: RepositorySourceRootAuthority | None = None,
 ) -> RepositorySourceBinding:
     """Retain reads for an exact policy-3 manifest-v1.1 source identity."""
 
-    result = _fingerprint_repository(
-        root,
-        exclude_roots=exclude_roots,
-        selection=DEFAULT_REPOSITORY_SOURCE_SELECTION,
-        version=SOURCE_FINGERPRINT_VERSION,
-        retain_binding=True,
-        source_owner=_source_owner,
-        identity_policy=_LEGACY_MANIFEST_V11_SOURCE_IDENTITY_POLICY,
-    )
+    with _expected_repository_root_capture_lease(expected_root_authority):
+        result = _fingerprint_repository(
+            root,
+            exclude_roots=exclude_roots,
+            selection=DEFAULT_REPOSITORY_SOURCE_SELECTION,
+            version=SOURCE_FINGERPRINT_VERSION,
+            retain_binding=True,
+            source_owner=_source_owner,
+            identity_policy=_LEGACY_MANIFEST_V11_SOURCE_IDENTITY_POLICY,
+            expected_root_authority=expected_root_authority,
+        )
     if not isinstance(result, RepositorySourceBinding):  # pragma: no cover
         raise AssertionError("legacy source capture did not retain read authority")
     return result
@@ -3324,22 +3797,26 @@ def capture_repository_source(
     exclude_roots: Iterable[str | Path] = (),
     selection: RepositorySourceSelection = DEFAULT_REPOSITORY_SOURCE_SELECTION,
     _source_owner: Callable[[object], None] | None = None,
+    expected_root_authority: RepositorySourceRootAuthority | None = None,
 ) -> RepositorySourceBinding:
     """Capture source fingerprint v2 and retain its exact read authority.
 
     ``_source_owner`` is an internal handoff sink used by callers that must own
     a stable cleanup slot before acquisition and the completed binding before
-    this Python frame returns.
+    this Python frame returns. ``expected_root_authority`` requires the newly
+    pinned hierarchy to be the same live object chain as an earlier preflight.
     """
 
-    result = _fingerprint_repository(
-        root,
-        exclude_roots=exclude_roots,
-        selection=selection,
-        version=SOURCE_FINGERPRINT_VERSION,
-        retain_binding=True,
-        source_owner=_source_owner,
-    )
+    with _expected_repository_root_capture_lease(expected_root_authority):
+        result = _fingerprint_repository(
+            root,
+            exclude_roots=exclude_roots,
+            selection=selection,
+            version=SOURCE_FINGERPRINT_VERSION,
+            retain_binding=True,
+            source_owner=_source_owner,
+            expected_root_authority=expected_root_authority,
+        )
     if not isinstance(result, RepositorySourceBinding):  # pragma: no cover
         raise AssertionError("source capture did not retain repository authority")
     return result
@@ -3438,6 +3915,7 @@ __all__ = [
     "RepositorySourceFileRecord",
     "RepositorySourceIdentitySnapshot",
     "RepositorySourceReader",
+    "RepositorySourceRootAuthority",
     "SOURCE_FINGERPRINT_VERSION",
     "SourceFingerprint",
     "capture_repository_source",
@@ -3446,6 +3924,7 @@ __all__ = [
     "is_legacy_source_fingerprint_v1",
     "is_secure_source_fingerprint_v2",
     "lexical_repository_path",
+    "pin_repository_source_root",
     "repository_source_is_dirty",
     "source_fingerprint_version",
 ]

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -286,6 +286,7 @@ codenib mcp \
   --catalog /var/lib/codenib/catalog.sqlite3 \
   --cas-root /var/lib/codenib/cas \
   --workspace-root /var/lib/codenib/workspaces \
+  --repo /srv/checkouts/repository \
   --repository owner/repository \
   --ref main \
   --expected-generation 7 \
@@ -295,10 +296,12 @@ codenib mcp \
 Omit `--ref` to resolve `main` once at startup, or use `--snapshot
 <snapshot-id>`. `--expected-generation` is ref-only. These storage arguments
 form one all-or-none mode and cannot be combined with a positional manifest,
-`--artifact`, or `--repo`. The catalog must already be initialized, the strict
-CAS preprovisioned, the workspace private and exact `0700`, and the output
-missing under that workspace; this command does not provision or replace any
-of them.
+or `--artifact`. `--repo` is optional: when supplied it must name one existing
+real checkout whose lexical hierarchy is free of links and physically disjoint
+from the catalog, CAS, workspace, and output. The catalog must already be
+initialized, the strict CAS preprovisioned, the workspace private and exact
+`0700`, and the output missing under that workspace; this command does not
+provision or replace any of them.
 
 During startup CodeNib materializes the selected immutable generation, builds
 the query binding through the active publication receipt's authenticated
@@ -310,25 +313,35 @@ the runtime context, and only after that releases the receipt. The materialized
 output persists after normal shutdown and after receipt cleanup; a failure
 after publication warns about the existing path rather than deleting it.
 
-This is a source-disabled, query-only cold start. It currently requires a BM25
-view, which loads from canonical persisted documents. A selected portable
-vector remains native-parser inert and reports its authorization error; the
-route never treats cache hashes as permission to parse FAISS, and vector-only
-snapshots are rejected for this runtime. The ref is not polled or re-resolved,
-the receipt is not a catalog/CAS GC pin, and no live context replacement occurs.
-Those in-flight request pins and atomic swaps remain M3 work; durable evidence
-retention and reclamation remain M5 work.
+Omit `--repo` for the existing source-disabled, query-only cold start. With
+`--repo`, CodeNib pins the checkout's lexical anchor, every ancestor, and root
+before provider or storage work, then requires the source capture opened inside
+the artifact-reader callback to match that same live object chain. The CLI
+rejects lexical, object-identity, ancestry, bind-mount, and mapped-physical
+source/storage aliases. The preflight pin closes before `mcp.run`; the
+independent authenticated source binding remains active through serving and
+enables BM25 result content plus `read_source` with verification scope
+`content-bytes`.
 
-The library also provides a preparatory source-bound seam for future manifest
-compatibility. `bind_context_artifact_reader` captures a source-fingerprint-v2
-checkout inside the active publication-reader callback, and the retained
-ref/snapshot loaders accept an optional `repo_path`. Their one-shot owner keeps
+Both forms require a BM25 view, which loads from canonical persisted documents.
+A selected portable vector remains native-parser inert and reports its
+authorization error; adding source does not authorize native LSP state, attest
+the mutable Git commit, or make the portable context fully equivalent to an
+ordinary manifest startup. The route never treats cache hashes as permission to
+parse FAISS, and vector-only snapshots are rejected for this runtime. The ref
+is not polled or re-resolved, the receipt is not a catalog/CAS GC pin, and no
+live context replacement occurs. Those in-flight request pins and atomic swaps
+remain M3 work; durable evidence retention and reclamation remain M5 work.
+
+The source-bound route uses `bind_context_artifact_reader` inside the active
+publication-reader callback and passes a separately owned preflight root
+authority through the retained ref/snapshot loader. Their one-shot owner keeps
 the captured source reachable through cancellation, closes context, source,
 then publication receipt in the parent, and revokes source before receipt in a
-forked child without acquiring the copied context lock. This does not change
-the command above: retained `codenib mcp` still cannot be combined with
-`--repo`. A later slice must add the source/storage topology gate, CLI wiring,
-and compatibility E2E before the manifest runtime track can advance.
+forked child without acquiring the copied context lock. The explicit CLI route
+and compatibility E2E establish this lifecycle, but a separate benchmark
+protocol update and canonical source-bound receipts are still required before
+the manifest runtime track can advance.
 
 These retained-read routes and the explicit BM25/vector ingress above do not
 complete the hybrid-storage M1 milestone. Benchmark-backed promotion of the

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -679,34 +679,48 @@ generation, and creates the query binding through the publication receipt's
 synchronous authenticated reader rather than reopening an unbound path. The
 complete `ServerContext` is installed in a caller-precreated, PID-bound,
 one-shot runtime owner while that reader is active. Catalog, CAS, and retained
-path authorities close before stdio serving begins; the workspace receipt stays
-active for the entire `mcp.run` lifetime. Shutdown first detaches the global
-context, then closes the runtime context and only then releases the receipt.
-Receipt closure does not delete the materialized output.
+path authorities close before stdio serving begins; the workspace receipt and
+any selected repository-source binding stay active for the entire `mcp.run`
+lifetime. Shutdown first detaches the global context, then closes the runtime
+context, source authority, and receipt in that order. A forked child revokes
+source before receipt without entering an inherited context lock. Receipt
+closure does not delete the materialized output.
 
-This startup is query-only and source-disabled. A selected BM25 view loads from
-persisted canonical documents; a selected portable vector remains FAISS-parser
-inert and reports its existing authorization error, so the current cold-start
-route requires BM25 and does not advertise a vector-only runtime. It never
-mints native vector authorization from cache-ingress hashes. The selected
-receipt fixes one local generation but is not a catalog snapshot lease or CAS
-GC pin. The route does not poll or re-resolve a ref, replace a live context,
-hold storage connections while serving, provision storage, delete output, or
-add request-level pins. Those replacement and in-flight lifetime contracts
-remain M3 work, while durable retention and reclamation remain M5 work.
+Without `--repo`, this startup remains query-only and source-disabled. With an
+explicit `--repo <checkout>`, the CLI pins the checkout's lexical anchor, every
+ancestor, and root before provider or storage work. It rejects lexical,
+same-object, ancestry, and Linux mapped-physical overlap with the catalog, CAS,
+workspace, or output. Source capture then opens its independent retained read
+authority while the artifact publication reader is active and proves that the
+new anchor-to-root chain is the same still-live chain as the preflight pin
+before scanning. The preflight pin closes before serving; the independently
+captured source authority supplies authenticated BM25 content and `read_source`
+for the server lifetime.
 
-A preparatory library seam can now bind an exact checkout without reopening the
-materialized artifact path. `bind_context_artifact_reader` captures and verifies
+A selected BM25 view loads from persisted canonical documents. A selected
+portable vector remains FAISS-parser inert and reports its existing
+authorization error, and a source-bound portable context still does not gain
+native LSP authorization or commit attestation. The route therefore requires
+BM25 and does not advertise a vector-only runtime or full ordinary-manifest
+equivalence. It never mints native vector authorization from cache-ingress
+hashes. The selected receipt fixes one local generation but is not a catalog
+snapshot lease or CAS GC pin. The route does not poll or re-resolve a ref,
+replace a live context, hold storage connections while serving, provision
+storage, delete output, or add request-level pins. Those replacement and
+in-flight lifetime contracts remain M3 work, while durable retention and
+reclamation remain M5 work.
+
+The reader-native source seam is now exposed by the explicit retained
+`codenib mcp --repo` route. `bind_context_artifact_reader` captures and verifies
 source fingerprint v2 while the publication receipt's authenticated reader is
-active, and the retained ref/snapshot loaders accept an optional `repo_path`
-for callers that already own the surrounding topology. The one-shot runtime
-owner retains source authority across cancellation, closes context, source, and
-receipt in that order in the parent, and revokes source before receipt in a
-forked child without taking an inherited context lock. Portable vector payloads
-remain native-parser inert. This is not yet exposed by `codenib mcp`: the CLI
-still rejects retained storage combined with `--repo`, and the production
-source-versus-storage topology gate and route-level compatibility evidence are
-still missing. The explicit command above therefore remains source-disabled.
+active, and the retained ref/snapshot loaders accept the live preflight root
+authority in addition to its lexical path. The one-shot runtime owner retains
+source authority across cancellation, closes context, source, and receipt in
+that order in the parent, and revokes source before receipt in a forked child
+without taking an inherited context lock. Portable vector payloads remain
+native-parser inert. Route-level source-bound benchmark evidence and any
+decision about full ordinary-manifest compatibility are still missing; this
+explicit route does not change a default.
 
 The standalone materialization command and retained MCP cold start do not
 initialize or populate the control plane, import a legacy cache, build views,
@@ -726,7 +740,7 @@ that collecting a fast result cannot silently approve a production route:
 | A1 | Run the fixed, report-only retained storage harness and preserve each route's complete public and authority parity. | Implemented as a four-cell v2 evidence protocol; it cannot promote a route. |
 | A2 compiler | Record canonical compiler receipts for the approved subject/media matrix and ratify numeric compiler policy from measured results. | Pending real measurements. |
 | A2 query-only runtime | Record canonical direct-artifact versus retained receipts and ratify numeric query-only runtime policy. | Pending real measurements. |
-| A2 manifest compatibility | Preserve ordinary manifest MCP public behavior and authority when selecting retained storage. | Reader-native source binding is implemented at the library boundary; explicit CLI topology, end-to-end routing, and compatibility evidence remain pending. |
+| A2 manifest compatibility | Preserve ordinary manifest MCP public behavior and authority when selecting retained storage. | The explicit source-bound CLI route and lifecycle are implemented; source-bound benchmark evidence is pending, and portable provenance/native-LSP differences still keep full manifest replacement blocked. |
 | B1 | Promote BM25 compiler publication to a configured default. | Pending A2 compiler. |
 | B2 | Promote query-only BM25 retained cold start to a configured default. | Pending A2 query-only runtime; this does not replace source-bound manifest MCP. |
 | C | Supply the `provider-bound-exact` strict BM25 native provider. | Independent work, but required before M1 closes. |

--- a/test/artifacts/test_runtime.py
+++ b/test/artifacts/test_runtime.py
@@ -63,6 +63,7 @@ from codenib.source_fingerprint import (
     RepositoryChangedError,
     capture_repository_source,
     fingerprint_repository,
+    pin_repository_source_root,
 )
 
 
@@ -1190,6 +1191,54 @@ def test_bind_context_artifact_reader_loads_source_without_path_reopen(
         source_owner.close()
     assert source.closed
     assert source_owner.closed
+
+
+def test_bind_context_artifact_reader_threads_expected_root_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    ownership = capture_directory_ownership(artifact)
+    receipt = _receipt_stub(artifact, ownership)
+    source_owner = SourceBindingCleanupOwner()
+    expected = pin_repository_source_root(repo)
+    real_capture = runtime_module.capture_repository_source
+    observed: list[object] = []
+
+    def capture(*args: object, **kwargs: object):
+        observed.append(kwargs.get("expected_root_authority"))
+        return real_capture(*args, **kwargs)
+
+    monkeypatch.setattr(runtime_module, "capture_repository_source", capture)
+
+    def consume(publication: PublicationDirectoryReader):
+        return bind_context_artifact_reader(
+            receipt,
+            publication,
+            repo,
+            expected_root=artifact,
+            expected_ownership=ownership,
+            source_cleanup_owner=source_owner,
+            expected_root_authority=expected,
+            expected_repository="example/project",
+            expected_commit=commit,
+        )
+
+    try:
+        binding = reopen_authenticated_directory(
+            artifact,
+            ownership,
+            consume,
+        )
+        source = binding.source_binding
+        assert source is not None
+        assert observed == [expected]
+        expected.close()
+        assert source.read_bytes("sample.py", max_bytes=1024) == b"VALUE = 1\n"
+    finally:
+        if not expected.closed:
+            expected.close()
+        source_owner.close()
 
 
 def test_bind_context_artifact_reader_requires_exact_empty_cleanup_owner(

--- a/test/compiler/test_retained_context.py
+++ b/test/compiler/test_retained_context.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 
 import pytest
 
+import codenib.artifacts.runtime as runtime_module
 import codenib.mcp.retained_context as retained_context_module
 from codenib.compiler.manifest import RepoManifest
 from codenib.mcp.context import ServerContext
@@ -23,6 +24,7 @@ from codenib.mcp.retained_context import (
     load_retained_server_context_ref,
     load_retained_server_context_snapshot,
 )
+from codenib.source_fingerprint import pin_repository_source_root
 from codenib.storage import PublishConflict
 from codenib.storage.models import NamespaceIdentity, RepositoryIdentity
 
@@ -161,6 +163,52 @@ def test_loads_retained_ref_with_reader_bound_source(
         assert owner.closed
         assert owner._source_owner.closed
         assert captured_sources and captured_sources[0].closed
+
+
+def test_retained_loader_threads_expected_root_authority_to_capture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (fixture, imported, object_store, catalog):
+        owner = RetainedServerContextOwner()
+        destination = tmp_path / "context"
+        expected = pin_repository_source_root(fixture.repository)
+        real_capture = runtime_module.capture_repository_source
+        observed: list[object] = []
+
+        def capture(*args: object, **kwargs: object):
+            observed.append(kwargs.get("expected_root_authority"))
+            return real_capture(*args, **kwargs)
+
+        monkeypatch.setattr(runtime_module, "capture_repository_source", capture)
+        try:
+            load_retained_server_context_ref(
+                "owner/repo",
+                destination,
+                catalog=catalog,
+                object_store=object_store,
+                workspace_provider=_TestWorkspaceProvider(),
+                runtime_owner=owner,
+                expected_generation=imported.generation,
+                repo_path=fixture.repository,
+                expected_root_authority=expected,
+            )
+
+            assert observed == [expected]
+            expected.close()
+            assert (
+                owner.context.read_source_bytes("sample.py", max_bytes=1024)
+                == b"VALUE = 1\n"
+            )
+        finally:
+            if not expected.closed:
+                expected.close()
+            owner.close()
+        assert owner.closed
+        assert owner._source_owner.closed
 
 
 def test_loads_retained_snapshot_with_vector_native_inert(
@@ -346,6 +394,95 @@ def test_invalid_source_repo_path_fails_before_materialization(
     materialize.assert_not_called()
     assert owner.state == "empty"
     owner.close()
+    assert owner.closed
+
+
+@pytest.mark.parametrize(
+    ("failure", "error_type", "message"),
+    [
+        ("wrong-type", TypeError, "RepositorySourceRootAuthority"),
+        ("closed", RuntimeError, "closed"),
+        ("wrong-root", ValueError, "differs from repo_path"),
+    ],
+)
+def test_invalid_expected_root_authority_fails_before_materialization(
+    tmp_path: Path,
+    failure: str,
+    error_type: type[BaseException],
+    message: str,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    authority: object
+    if failure == "wrong-type":
+        authority = object()
+    elif failure == "closed":
+        authority = pin_repository_source_root(repo)
+        authority.close()  # type: ignore[attr-defined]
+    else:
+        authority = pin_repository_source_root(foreign)
+
+    owner = RetainedServerContextOwner()
+    try:
+        with (
+            patch.object(
+                retained_context_module,
+                "materialize_retained_repo_manifest_ref",
+            ) as materialize,
+            pytest.raises(error_type, match=message),
+        ):
+            load_retained_server_context_ref(
+                "owner/repo",
+                tmp_path / "context",
+                catalog=object(),  # type: ignore[arg-type]
+                object_store=object(),  # type: ignore[arg-type]
+                workspace_provider=object(),  # type: ignore[arg-type]
+                runtime_owner=owner,
+                repo_path=repo,
+                expected_root_authority=authority,  # type: ignore[arg-type]
+            )
+
+        materialize.assert_not_called()
+        assert owner.state == "empty"
+    finally:
+        close = getattr(authority, "close", None)
+        closed = bool(getattr(authority, "closed", True))
+        if callable(close) and not closed:
+            close()
+        owner.close()
+    assert owner.closed
+
+
+def test_source_repo_without_expected_authority_reaches_materializer(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    owner = RetainedServerContextOwner()
+    failure = RuntimeError("materializer reached")
+
+    with (
+        patch.object(
+            retained_context_module,
+            "materialize_retained_repo_manifest_ref",
+            side_effect=failure,
+        ) as materialize,
+        pytest.raises(RuntimeError, match="materializer reached") as caught,
+    ):
+        load_retained_server_context_ref(
+            "owner/repo",
+            tmp_path / "context",
+            catalog=object(),  # type: ignore[arg-type]
+            object_store=object(),  # type: ignore[arg-type]
+            workspace_provider=object(),  # type: ignore[arg-type]
+            runtime_owner=owner,
+            repo_path=repo,
+        )
+
+    assert caught.value is failure
+    materialize.assert_called_once()
     assert owner.closed
 
 

--- a/test/compiler/test_retained_mcp_cli_e2e.py
+++ b/test/compiler/test_retained_mcp_cli_e2e.py
@@ -21,11 +21,13 @@ from codenib.mcp import server as server_module
 from codenib.mcp.context import ServerContext
 from codenib.mcp.retained_context import RetainedServerContextOwner
 from codenib.mcp.tools.search import search_bm25_impl
+from codenib.mcp.tools.source import read_source_impl
 from codenib.paths import repo_index_dir
 from codenib.storage import LocalCAS, SQLiteCatalog, StorageIntegrityError
 
 _REPOSITORY_KEY = "owner/retained-mcp-route"
 _MARKER = "PRODUCTION_RETAINED_MCP_ROUTE"
+_SOURCE_TEXT = f"def retained_mcp_marker():\n    return {_MARKER!r}\n"
 
 
 def _git_commit(repository: Path) -> str:
@@ -76,6 +78,7 @@ def _capture_retained_mcp_cli_state() -> dict[str, object]:
 
     required = (
         "runtime_owner",
+        "repository_authority_owner",
         "topology_owner",
         "object_store_owner",
         "catalog_owner",
@@ -101,10 +104,16 @@ def _capture_retained_mcp_cli_state() -> dict[str, object]:
     return captured
 
 
+@pytest.mark.parametrize(
+    "source_bound",
+    (False, True),
+    ids=("query-only", "source-bound"),
+)
 def test_index_publish_retained_then_mcp_cold_starts_real_bm25(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    source_bound: bool,
 ) -> None:
     # Other MCP tests exercise the legacy module-global startup path.  Keep
     # this cold-start lifecycle isolated while still requiring the retained
@@ -112,10 +121,7 @@ def test_index_publish_retained_then_mcp_cold_starts_real_bm25(
     monkeypatch.setattr(server_module, "_ctx", None)
     repository = tmp_path / "repository"
     repository.mkdir(mode=0o700)
-    (repository / "sample.py").write_text(
-        f"def retained_mcp_marker():\n    return {_MARKER!r}\n",
-        encoding="utf-8",
-    )
+    (repository / "sample.py").write_text(_SOURCE_TEXT, encoding="utf-8")
     commit = _git_commit(repository)
 
     workspace = tmp_path / "workspace"
@@ -169,6 +175,7 @@ def test_index_publish_retained_then_mcp_cold_starts_real_bm25(
     materialized_output = workspace / "retained-mcp-context"
     captured: dict[str, object] = {}
     installed_contexts: list[ServerContext] = []
+    installed_sources: list[object] = []
 
     def run_stdio(*, transport: str) -> None:
         assert transport == "stdio"
@@ -180,12 +187,24 @@ def test_index_publish_retained_then_mcp_cold_starts_real_bm25(
         assert context.errors == {}
         assert context.artifact is not None
         assert context.artifact["verified"] is True
+        assert context.source_verified is source_bound
+        assert context.source_verification_scope == (
+            "content-bytes" if source_bound else None
+        )
+        assert context.commit_verified is False
 
         run_state = _capture_retained_mcp_cli_state()
         captured.update(run_state)
         for name in ("topology_owner", "object_store_owner", "catalog_owner"):
             assert run_state[name].closed  # type: ignore[attr-defined]
+        assert run_state["repository_authority_owner"].closed  # type: ignore[attr-defined]
         assert run_state["topology"].closed  # type: ignore[attr-defined]
+        repository_authority = run_state["topology"].repository_authority  # type: ignore[attr-defined]
+        if source_bound:
+            assert repository_authority is not None
+            assert repository_authority.closed
+        else:
+            assert repository_authority is None
         with pytest.raises(StorageIntegrityError, match="closed"):
             run_state["object_store"].has("0" * 64)  # type: ignore[attr-defined]
         with pytest.raises(sqlite3.ProgrammingError):
@@ -197,9 +216,20 @@ def test_index_publish_retained_then_mcp_cold_starts_real_bm25(
         assert type(runtime_owner) is RetainedServerContextOwner
         assert runtime_owner.state == "active"
         assert runtime_owner.context is context
+        assert runtime_owner._source_owner.closed is (not source_bound)  # noqa: SLF001
+        if source_bound:
+            assert context._source_binding is not None  # noqa: SLF001
+            assert not context._source_binding.closed  # noqa: SLF001
+            installed_sources.append(context._source_binding)  # noqa: SLF001
+        else:
+            assert context._source_binding is None  # noqa: SLF001
         results = search_bm25_impl(context, _MARKER, top_k=5)
         assert results
         assert results[0]["file"] == "sample.py"
+        if source_bound:
+            assert results[0]["content"] == _SOURCE_TEXT
+        else:
+            assert results[0].get("content") is None
         assert context.bm25 is not None
         normalized_marker = _MARKER.lower().replace("_", " ")
         assert any(
@@ -207,6 +237,22 @@ def test_index_publish_retained_then_mcp_cold_starts_real_bm25(
             for document in context.bm25.documents
         )
         assert search_bm25_impl(context, "retained_mcp_marker", top_k=1)
+        if source_bound:
+            source = read_source_impl(context, "sample.py", 1, 2)
+            assert source["file"] == "sample.py"
+            assert source["content"] == _SOURCE_TEXT
+            assert source["source"] == {
+                "repository": _REPOSITORY_KEY,
+                "commit": commit,
+                "source_fingerprint": context.manifest.source_fingerprint,
+                "verified": True,
+                "verification_scope": "content-bytes",
+                "commit_verified": False,
+                "checkout_state": "not-attested",
+            }
+        else:
+            with pytest.raises(RuntimeError, match="source reads are unavailable"):
+                read_source_impl(context, "sample.py", 1, 2)
         assert server_module.get_context() is context
         assert runtime_owner.state == "active"
         assert runtime_owner.context is context
@@ -215,25 +261,26 @@ def test_index_publish_retained_then_mcp_cold_starts_real_bm25(
 
     monkeypatch.setattr(server_module.mcp, "run", run_stdio)
     assert server_module._ctx is None
-    mcp_args = parser.parse_args(
-        [
-            "mcp",
-            "--catalog",
-            os.fspath(catalog_path),
-            "--cas-root",
-            os.fspath(cas_root),
-            "--workspace-root",
-            os.fspath(workspace),
-            "--repository",
-            _REPOSITORY_KEY,
-            "--ref",
-            "main",
-            "--expected-generation",
-            "1",
-            "--output",
-            os.fspath(materialized_output),
-        ]
-    )
+    mcp_command = [
+        "mcp",
+        "--catalog",
+        os.fspath(catalog_path),
+        "--cas-root",
+        os.fspath(cas_root),
+        "--workspace-root",
+        os.fspath(workspace),
+        "--repository",
+        _REPOSITORY_KEY,
+        "--ref",
+        "main",
+        "--expected-generation",
+        "1",
+        "--output",
+        os.fspath(materialized_output),
+    ]
+    if source_bound:
+        mcp_command.extend(("--repo", os.fspath(repository)))
+    mcp_args = parser.parse_args(mcp_command)
     assert mcp_args.handler is cli_module._run_mcp
     assert mcp_args.handler(mcp_args) == 0
 
@@ -246,7 +293,10 @@ def test_index_publish_retained_then_mcp_cold_starts_real_bm25(
     assert type(runtime_owner) is RetainedServerContextOwner
     assert runtime_owner.closed
     assert runtime_owner._context_close_complete  # noqa: SLF001
+    assert runtime_owner._source_owner.closed  # noqa: SLF001
     assert runtime_owner._receipt_owner.closed  # noqa: SLF001
+    assert len(installed_sources) == int(source_bound)
+    assert all(source.closed for source in installed_sources)  # type: ignore[attr-defined]
     with pytest.raises(RuntimeError, match="closed"):
         runtime_owner.context
 
@@ -254,6 +304,7 @@ def test_index_publish_retained_then_mcp_cold_starts_real_bm25(
         owner = captured[name]
         assert type(owner) is cli_module._RetainedMaterializationResourceOwner
         assert owner.closed
+    assert captured["repository_authority_owner"].closed  # type: ignore[attr-defined]
     assert captured["topology"].closed  # type: ignore[attr-defined]
 
     object_store = captured["object_store"]

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3879,8 +3879,12 @@ def test_mcp_parser_limits_tool_surface_and_defaults_to_full() -> None:
     assert exc_info.value.code == 2
 
 
-def _retained_mcp_argv(tmp_path: Path) -> list[str]:
-    return [
+def _retained_mcp_argv(
+    tmp_path: Path,
+    *,
+    repo: Path | None = None,
+) -> list[str]:
+    arguments = [
         "mcp",
         "--catalog",
         str(tmp_path / "catalog.sqlite3"),
@@ -3893,6 +3897,9 @@ def _retained_mcp_argv(tmp_path: Path) -> list[str]:
         "--repository",
         "owner/repo",
     ]
+    if repo is not None:
+        arguments.extend(("--repo", str(repo)))
+    return arguments
 
 
 def test_mcp_retained_parser_exposes_ref_and_snapshot_selection(
@@ -3927,6 +3934,42 @@ def test_mcp_retained_parser_exposes_ref_and_snapshot_selection(
     assert both.value.code == 2
 
 
+def test_mcp_retained_mode_accepts_only_an_explicit_source_checkout(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    parser = cli.build_parser()
+    retained = parser.parse_args(_retained_mcp_argv(tmp_path, repo=repo))
+    artifact = parser.parse_args(
+        ["mcp", "--artifact", "/tmp/context", "--repo", str(repo)]
+    )
+
+    assert cli._mcp_context_mode(retained) == "retained"
+    assert retained.repo == str(repo)
+    assert cli._mcp_context_mode(artifact) == "artifact"
+
+    for context_input in ((".",), ("--artifact", "/tmp/context")):
+        mixed = parser.parse_args(
+            [*_retained_mcp_argv(tmp_path, repo=repo), *context_input]
+        )
+        with pytest.raises(cli.CLIError, match="manifest|--artifact"):
+            cli._mcp_context_mode(mixed)
+
+
+def test_mcp_repo_without_artifact_or_retained_selection_is_rejected() -> None:
+    args = cli.build_parser().parse_args(["mcp", "--repo", "/src/repo"])
+
+    with pytest.raises(cli.CLIError, match="requires --artifact or retained MCP"):
+        cli._mcp_context_mode(args)
+
+
+def test_mcp_repo_cannot_bind_a_positional_manifest() -> None:
+    args = cli.build_parser().parse_args(["mcp", ".", "--repo", "/src/repo"])
+
+    with pytest.raises(cli.CLIError, match="requires --artifact or retained MCP"):
+        cli._mcp_context_mode(args)
+
+
 @pytest.mark.parametrize(
     ("arguments", "message"),
     (
@@ -3934,6 +3977,10 @@ def test_mcp_retained_parser_exposes_ref_and_snapshot_selection(
         (("--repository", "owner/repo"), "require --artifact"),
         (
             ("--runtime-probe", "--catalog", "catalog.sqlite3"),
+            "--runtime-probe cannot be combined",
+        ),
+        (
+            ("--runtime-probe", "--repo", "/src/repo"),
             "--runtime-probe cannot be combined",
         ),
     ),
@@ -3972,6 +4019,24 @@ def test_mcp_retained_rejects_mixed_context_and_snapshot_generation(
     assert "requires retained ref selection" in capsys.readouterr().err
 
 
+def test_mcp_retained_source_still_requires_a_repository_key_before_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        cli,
+        "_require_modules",
+        lambda *_args, **_kwargs: pytest.fail("dependency probe must not run"),
+    )
+    arguments = _retained_mcp_argv(tmp_path, repo=tmp_path / "repo")
+    repository_option = arguments.index("--repository")
+    del arguments[repository_option : repository_option + 2]
+
+    assert cli.run(arguments) == 2
+    assert "--repository" in capsys.readouterr().err
+
+
 def test_mcp_retained_dispatches_only_after_dependency_probe(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -3991,6 +4056,792 @@ def test_mcp_retained_dispatches_only_after_dependency_probe(
 
     assert cli._run_mcp(args) == 0
     assert calls == [("mcp",), args]
+
+
+@pytest.mark.parametrize(
+    ("case", "message"),
+    (
+        ("empty", "repository source path is required"),
+        ("nul", "repository source path is invalid"),
+        ("missing", "repository source must resolve to one existing real directory"),
+        ("file", "repository source must resolve to one existing real directory"),
+        ("symlink", "repository source must resolve to one existing real directory"),
+    ),
+)
+def test_mcp_retained_rejects_invalid_source_before_any_mutation(
+    tmp_path: Path,
+    case: str,
+    message: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.mcp.retained_context as retained_context_module
+
+    target = tmp_path / "repository"
+    target.mkdir()
+    if case == "empty":
+        value = ""
+    elif case == "nul":
+        value = "bad\x00repository"
+    elif case == "missing":
+        value = str(tmp_path / "missing")
+    elif case == "file":
+        source_file = tmp_path / "source.py"
+        source_file.touch()
+        value = str(source_file)
+    else:
+        source_link = tmp_path / "repository-link"
+        source_link.symlink_to(target, target_is_directory=True)
+        value = str(source_link)
+
+    args = cli.build_parser().parse_args(
+        [*_retained_mcp_argv(tmp_path), "--repo", value]
+    )
+
+    def unexpected(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("invalid source preflight must precede retained mutation")
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", unexpected)
+    monkeypatch.setattr(
+        cli,
+        "_require_retained_materialization_topology",
+        unexpected,
+    )
+    monkeypatch.setattr(storage_module, "LocalCAS", unexpected)
+    monkeypatch.setattr(storage_module, "SQLiteCatalog", unexpected)
+    monkeypatch.setattr(
+        retained_context_module,
+        "load_retained_server_context_ref",
+        unexpected,
+    )
+    monkeypatch.setattr(
+        retained_context_module,
+        "load_retained_server_context_snapshot",
+        unexpected,
+    )
+
+    with pytest.raises(cli.CLIError, match=message):
+        cli._run_mcp_retained(args)
+
+
+def _retained_source_topology_paths(
+    tmp_path: Path,
+) -> tuple[Path, Path, Path, Path, Path]:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    catalog_parent = tmp_path / "catalog-state"
+    catalog_parent.mkdir()
+    catalog = catalog_parent / "catalog.sqlite3"
+    catalog.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    output = workspace_root / "runtime"
+    return repository, catalog, cas_root, workspace_root, output
+
+
+@pytest.mark.parametrize(
+    "protected",
+    ("catalog", "CAS root", "workspace root", "output"),
+)
+def test_mcp_retained_rejects_lexical_source_storage_aliases(
+    tmp_path: Path,
+    protected: str,
+) -> None:
+    repository, catalog, cas_root, workspace_root, output = (
+        _retained_source_topology_paths(tmp_path)
+    )
+    repository.rmdir()
+    repository = {
+        "catalog": catalog.parent,
+        "CAS root": cas_root,
+        "workspace root": workspace_root / "source",
+        "output": output,
+    }[protected]
+    args = SimpleNamespace(
+        catalog=str(catalog),
+        cas_root=str(cas_root),
+        workspace_root=str(workspace_root),
+        output=str(output),
+    )
+
+    with pytest.raises(
+        cli.CLIError,
+        match=rf"repository source must not overlap the {protected}",
+    ):
+        cli._retained_materialization_paths(args, repo_path=repository)
+
+
+def test_mcp_retained_rejects_lexical_source_alias_before_pin_or_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.mcp.retained_context as retained_context_module
+
+    catalog_path = tmp_path / "catalog.sqlite3"
+    catalog_path.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    args = cli.build_parser().parse_args(_retained_mcp_argv(tmp_path, repo=cas_root))
+
+    def unexpected(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("lexical source alias must fail before authority or provider work")
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "pin_repository_source_root",
+        unexpected,
+    )
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", unexpected)
+    monkeypatch.setattr(
+        cli,
+        "_require_retained_materialization_topology",
+        unexpected,
+    )
+    monkeypatch.setattr(storage_module, "LocalCAS", unexpected)
+    monkeypatch.setattr(storage_module, "SQLiteCatalog", unexpected)
+    monkeypatch.setattr(
+        retained_context_module,
+        "load_retained_server_context_ref",
+        unexpected,
+    )
+
+    with pytest.raises(
+        cli.CLIError,
+        match="repository source must not overlap the CAS root",
+    ):
+        cli._run_mcp_retained(args)
+
+
+@pytest.mark.parametrize(
+    "protected",
+    ("catalog", "CAS root", "workspace root", "output"),
+)
+def test_mcp_retained_rejects_resolved_source_storage_aliases(
+    tmp_path: Path,
+    protected: str,
+) -> None:
+    repository, catalog, cas_root, workspace_root, output = (
+        _retained_source_topology_paths(tmp_path)
+    )
+    if protected == "catalog":
+        catalog.unlink()
+        physical_catalog = repository / "catalog.sqlite3"
+        physical_catalog.touch()
+        catalog.symlink_to(physical_catalog)
+    elif protected == "CAS root":
+        cas_root.rmdir()
+        cas_root.symlink_to(repository, target_is_directory=True)
+    else:
+        physical_workspace = tmp_path / "physical-workspace"
+        physical_workspace.mkdir()
+        workspace_root.rmdir()
+        workspace_root.symlink_to(physical_workspace, target_is_directory=True)
+        if protected == "workspace root":
+            repository.rmdir()
+            repository = physical_workspace / "source"
+            repository.mkdir()
+        else:
+            repository.rmdir()
+            repository = physical_workspace
+
+    with pytest.raises(
+        cli.CLIError,
+        match=rf"repository source must not physically overlap the {protected}",
+    ):
+        with source_fingerprint_module.pin_repository_source_root(
+            repository
+        ) as repository_authority:
+            cli._require_retained_materialization_topology(
+                catalog,
+                cas_root,
+                workspace_root,
+                output,
+                repo_path=repository,
+                repository_authority=repository_authority,
+            )
+
+
+@pytest.mark.parametrize(
+    ("protected", "ancestry_label"),
+    (
+        ("catalog", "catalog parent"),
+        ("CAS root", "CAS root"),
+        ("workspace root", "workspace root"),
+        ("output", "output parent"),
+    ),
+)
+def test_mcp_retained_rejects_directory_identity_source_aliases(
+    tmp_path: Path,
+    protected: str,
+    ancestry_label: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository, catalog, cas_root, workspace_root, output = (
+        _retained_source_topology_paths(tmp_path)
+    )
+    real_ancestry = cli._retained_directory_ancestry
+    repository_ancestry = real_ancestry(
+        repository,
+        label="repository source",
+    )
+    repository_identity = repository_ancestry[0][1]
+
+    def aliased_ancestry(
+        path: Path,
+        *,
+        label: str,
+    ) -> tuple[tuple[Path, tuple[int, int]], ...]:
+        observed = list(real_ancestry(path, label=label))
+        if label == ancestry_label:
+            observed[0] = (observed[0][0], repository_identity)
+        return tuple(observed)
+
+    monkeypatch.setattr(cli, "_retained_directory_ancestry", aliased_ancestry)
+
+    with pytest.raises(
+        cli.CLIError,
+        match=rf"repository source must not physically alias the {protected}",
+    ):
+        cli._require_retained_repository_topology(
+            repository,
+            catalog,
+            cas_root,
+            workspace_root,
+            output,
+        )
+
+
+@pytest.mark.parametrize(
+    "protected",
+    ("catalog", "CAS root", "workspace root", "output"),
+)
+def test_mcp_retained_rejects_linux_mapped_source_bind_aliases(
+    tmp_path: Path,
+    protected: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository, catalog, cas_root, workspace_root, output = (
+        _retained_source_topology_paths(tmp_path)
+    )
+    protected_paths = {
+        "catalog": catalog,
+        "CAS root": cas_root,
+        "workspace root": workspace_root,
+        "output": output,
+    }
+    mappings = [
+        cli._RetainedLinuxMountMapping(
+            mount_id=1,
+            device="0:1",
+            root=PurePosixPath("/host"),
+            mount_point=Path("/"),
+        ),
+        cli._RetainedLinuxMountMapping(
+            mount_id=2,
+            device="8:1",
+            root=PurePosixPath("/shared/source"),
+            mount_point=repository,
+        ),
+    ]
+    for index, (label, path) in enumerate(protected_paths.items(), start=3):
+        is_alias = label == protected
+        mappings.append(
+            cli._RetainedLinuxMountMapping(
+                mount_id=index,
+                device="8:1" if is_alias else f"9:{index}",
+                root=(
+                    PurePosixPath("/shared/source")
+                    if is_alias
+                    else PurePosixPath(f"/protected/{index}")
+                ),
+                mount_point=path,
+            )
+        )
+    monkeypatch.setattr(
+        cli,
+        "_retained_linux_mount_mappings",
+        lambda: tuple(mappings),
+    )
+
+    with pytest.raises(
+        cli.CLIError,
+        match=rf"repository source must not traverse a physical {protected} alias",
+    ):
+        cli._require_retained_repository_topology(
+            repository,
+            catalog,
+            cas_root,
+            workspace_root,
+            output,
+        )
+
+
+@pytest.mark.parametrize(
+    ("selector", "loader_name"),
+    (
+        (("--ref", "release", "--expected-generation", "4"), "ref"),
+        (("--snapshot", "snapshot-4"), "snapshot"),
+    ),
+)
+@pytest.mark.parametrize("source_bound", (False, True))
+def test_mcp_retained_passes_only_the_topology_frozen_source_to_loaders(
+    tmp_path: Path,
+    selector: tuple[str, ...],
+    loader_name: str,
+    source_bound: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.mcp.retained_context as retained_context_module
+    import codenib.mcp.server as server_module
+
+    catalog_path = tmp_path / "catalog.sqlite3"
+    catalog_path.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    output = workspace_root / "runtime"
+    arguments = [
+        "mcp",
+        "--catalog",
+        str(catalog_path),
+        "--cas-root",
+        str(cas_root),
+        "--workspace-root",
+        str(workspace_root),
+        "--output",
+        str(output),
+        "--repository",
+        "owner/repo",
+        *selector,
+    ]
+    if source_bound:
+        arguments.extend(("--repo", str(repository / ".")))
+    args = cli.build_parser().parse_args(arguments)
+
+    class Provider:
+        def __init__(self, root: Path) -> None:
+            assert root == workspace_root
+
+        def require_support(self) -> None:
+            pass
+
+    class Resource:
+        def __init__(self, label: str) -> None:
+            self.label = label
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    object_store = Resource("CAS")
+    catalog = Resource("catalog")
+    calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+    authority_roots: list[Path | None] = []
+
+    def record_loader(
+        name: str,
+        values: tuple[object, ...],
+        kwargs: dict[str, object],
+    ) -> None:
+        expected = kwargs["expected_root_authority"]
+        if source_bound:
+            assert expected is not None
+            assert not expected.closed  # type: ignore[attr-defined]
+            authority_roots.append(expected.root)  # type: ignore[attr-defined]
+        else:
+            assert expected is None
+            authority_roots.append(None)
+        calls.append((name, values, kwargs))
+
+    def ref_loader(*values: object, **kwargs: object) -> None:
+        record_loader("ref", values, kwargs)
+
+    def snapshot_loader(*values: object, **kwargs: object) -> None:
+        record_loader("snapshot", values, kwargs)
+
+    served: list[object] = []
+
+    def serve(owner: object, **kwargs: object) -> None:
+        assert object_store.closed
+        assert catalog.closed
+        assert kwargs == {"log_level": "INFO", "tool_surface": "full"}
+        served.append(owner)
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(
+        storage_module, "LocalCAS", lambda *_args, **_kwargs: object_store
+    )
+    monkeypatch.setattr(
+        storage_module, "SQLiteCatalog", lambda *_args, **_kwargs: catalog
+    )
+    monkeypatch.setattr(
+        retained_context_module,
+        "load_retained_server_context_ref",
+        ref_loader,
+    )
+    monkeypatch.setattr(
+        retained_context_module,
+        "load_retained_server_context_snapshot",
+        snapshot_loader,
+    )
+    monkeypatch.setattr(server_module, "serve_retained_context", serve)
+
+    assert cli._run_mcp_retained(args) == 0
+
+    assert len(calls) == 1
+    selected, positional, kwargs = calls[0]
+    assert selected == loader_name
+    common_keys = {
+        "namespace_name",
+        "catalog",
+        "object_store",
+        "workspace_provider",
+        "runtime_owner",
+        "repo_path",
+        "expected_root_authority",
+    }
+    if loader_name == "ref":
+        assert positional == ("owner/repo", output)
+        assert set(kwargs) == common_keys | {"ref_name", "expected_generation"}
+        assert kwargs["ref_name"] == "release"
+        assert kwargs["expected_generation"] == 4
+    else:
+        assert positional == ("owner/repo", "snapshot-4", output)
+        assert set(kwargs) == common_keys
+    expected_repo = (
+        Path(os.path.abspath(os.fspath(repository))) if source_bound else None
+    )
+    assert kwargs["repo_path"] == expected_repo
+    provider = kwargs["workspace_provider"]
+    assert type(provider) is cli._RetainedTopologyWorkspaceProvider
+    expected_authority = provider.topology.repository_authority
+    assert kwargs["expected_root_authority"] is expected_authority
+    if source_bound:
+        assert expected_authority is not None
+        assert expected_authority.closed
+    else:
+        assert expected_authority is None
+    assert authority_roots == [expected_repo]
+    assert kwargs["namespace_name"] == "default"
+    assert kwargs["catalog"] is catalog
+    assert kwargs["object_store"] is object_store
+    assert provider.topology.repo_path == expected_repo
+    assert provider.topology.closed
+    assert kwargs["runtime_owner"] is served[0]
+    assert object_store.closed
+    assert catalog.closed
+
+
+@pytest.mark.parametrize("replacement", ("root", "ancestor"))
+def test_mcp_retained_rejects_identical_source_replacement_before_capture(
+    tmp_path: Path,
+    replacement: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.mcp.retained_context as retained_context_module
+    import codenib.mcp.server as server_module
+
+    catalog_path = tmp_path / "catalog.sqlite3"
+    catalog_path.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+
+    if replacement == "root":
+        repository = tmp_path / "repository"
+        repository.mkdir()
+        candidate = tmp_path / "candidate-repository"
+        candidate.mkdir()
+        displaced = tmp_path / "displaced-repository"
+
+        def replace_repository() -> None:
+            repository.rename(displaced)
+            candidate.rename(repository)
+
+    else:
+        source_parent = tmp_path / "source-parent"
+        source_parent.mkdir()
+        repository = source_parent / "repository"
+        repository.mkdir()
+        candidate_parent = tmp_path / "candidate-parent"
+        candidate_parent.mkdir()
+        displaced_parent = tmp_path / "displaced-parent"
+
+        def replace_repository() -> None:
+            source_parent.rename(displaced_parent)
+            candidate_parent.rename(source_parent)
+            (displaced_parent / "repository").rename(repository)
+
+    source_text = "VALUE = 'IDENTICAL_SOURCE_REPLACEMENT'\n"
+    (repository / "sample.py").write_text(source_text, encoding="utf-8")
+    if replacement == "root":
+        (candidate / "sample.py").write_text(source_text, encoding="utf-8")
+
+    args = cli.build_parser().parse_args(_retained_mcp_argv(tmp_path, repo=repository))
+
+    class Provider:
+        def __init__(self, root: Path) -> None:
+            assert root == workspace_root
+
+        def require_support(self) -> None:
+            pass
+
+    class Resource:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    object_store = Resource()
+    catalog = Resource()
+    authorities: list[object] = []
+    topologies: list[object] = []
+    real_topology = cli._require_retained_materialization_topology
+    replacement_complete = False
+
+    def capture_topology(*values: object, **kwargs: object):
+        topology = real_topology(*values, **kwargs)
+        topologies.append(topology)
+        return topology
+
+    def load_after_replacement(*_args: object, **kwargs: object) -> None:
+        nonlocal replacement_complete
+        expected = kwargs["expected_root_authority"]
+        assert expected is not None
+        assert not expected.closed
+        assert kwargs["repo_path"] == repository
+        authorities.append(expected)
+        replace_repository()
+        replacement_complete = True
+        binding = source_fingerprint_module.capture_repository_source(
+            kwargs["repo_path"],
+            expected_root_authority=expected,
+        )
+        try:
+            pytest.fail("replacement source capture unexpectedly succeeded")
+        finally:
+            binding.close()
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(
+        cli,
+        "_require_retained_materialization_topology",
+        capture_topology,
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "LocalCAS",
+        lambda *_args, **_kwargs: object_store,
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "SQLiteCatalog",
+        lambda *_args, **_kwargs: catalog,
+    )
+    monkeypatch.setattr(
+        retained_context_module,
+        "load_retained_server_context_ref",
+        load_after_replacement,
+    )
+    monkeypatch.setattr(
+        retained_context_module,
+        "load_retained_server_context_snapshot",
+        lambda *_args, **_kwargs: pytest.fail("snapshot loader must not run"),
+    )
+    monkeypatch.setattr(
+        server_module,
+        "serve_retained_context",
+        lambda *_args, **_kwargs: pytest.fail("replaced source must not be served"),
+    )
+
+    with pytest.raises(
+        cli.CLIError,
+        match="expected repository root authority changed during capture",
+    ):
+        cli._run_mcp_retained(args)
+
+    assert replacement_complete
+    assert len(authorities) == 1
+    assert authorities[0].closed  # type: ignore[attr-defined]
+    assert object_store.closed
+    assert catalog.closed
+    assert len(topologies) == 1
+    assert topologies[0].closed  # type: ignore[attr-defined]
+    assert topologies[0].repository_authority.closed  # type: ignore[attr-defined]
+
+
+def test_mcp_retained_source_replacement_during_provider_probe_blocks_storage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.mcp.retained_context as retained_context_module
+    import codenib.mcp.server as server_module
+
+    catalog_path = tmp_path / "catalog.sqlite3"
+    catalog_path.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    candidate = tmp_path / "candidate-repository"
+    candidate.mkdir()
+    displaced = tmp_path / "displaced-repository"
+    source_text = "VALUE = 'IDENTICAL_PROVIDER_REPLACEMENT'\n"
+    (repository / "sample.py").write_text(source_text, encoding="utf-8")
+    (candidate / "sample.py").write_text(source_text, encoding="utf-8")
+    args = cli.build_parser().parse_args(_retained_mcp_argv(tmp_path, repo=repository))
+    captured_authorities: list[object] = []
+    real_pin = source_fingerprint_module.pin_repository_source_root
+
+    def capture_pin(*values: object, **kwargs: object):
+        authority = real_pin(*values, **kwargs)
+        captured_authorities.append(authority)
+        return authority
+
+    class Provider:
+        def __init__(self, root: Path) -> None:
+            assert root == workspace_root
+
+        def require_support(self) -> None:
+            repository.rename(displaced)
+            candidate.rename(repository)
+
+    def unexpected(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("replaced repository must fail before retained storage or loading")
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "pin_repository_source_root",
+        capture_pin,
+    )
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(storage_module, "LocalCAS", unexpected)
+    monkeypatch.setattr(storage_module, "SQLiteCatalog", unexpected)
+    monkeypatch.setattr(
+        retained_context_module,
+        "load_retained_server_context_ref",
+        unexpected,
+    )
+    monkeypatch.setattr(
+        retained_context_module,
+        "load_retained_server_context_snapshot",
+        unexpected,
+    )
+    monkeypatch.setattr(server_module, "serve_retained_context", unexpected)
+
+    with pytest.raises(
+        cli.CLIError,
+        match="repository source authority changed",
+    ):
+        cli._run_mcp_retained(args)
+
+    assert len(captured_authorities) == 1
+    assert captured_authorities[0].closed  # type: ignore[attr-defined]
+
+
+def test_mcp_retained_cancellation_closes_source_storage_and_topology(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.mcp.retained_context as retained_context_module
+    import codenib.mcp.server as server_module
+
+    catalog_path = tmp_path / "catalog.sqlite3"
+    catalog_path.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    args = cli.build_parser().parse_args(_retained_mcp_argv(tmp_path, repo=repository))
+    primary = KeyboardInterrupt("retained MCP load cancelled")
+
+    class Provider:
+        def __init__(self, root: Path) -> None:
+            assert root == workspace_root
+
+        def require_support(self) -> None:
+            pass
+
+    class Resource:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class Source(Resource):
+        pass
+
+    object_store = Resource()
+    catalog = Resource()
+    source = Source()
+    owners: list[object] = []
+    topologies: list[object] = []
+    real_topology = cli._require_retained_materialization_topology
+
+    def capture_topology(*values: object, **kwargs: object):
+        topology = real_topology(*values, **kwargs)
+        topologies.append(topology)
+        return topology
+
+    def cancel_load(*_args: object, **kwargs: object) -> None:
+        owner = kwargs["runtime_owner"]
+        owners.append(owner)
+        owner._source_owner.retain(source)  # type: ignore[attr-defined]  # noqa: SLF001
+        raise primary
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(
+        cli,
+        "_require_retained_materialization_topology",
+        capture_topology,
+    )
+    monkeypatch.setattr(
+        storage_module, "LocalCAS", lambda *_args, **_kwargs: object_store
+    )
+    monkeypatch.setattr(
+        storage_module, "SQLiteCatalog", lambda *_args, **_kwargs: catalog
+    )
+    monkeypatch.setattr(
+        retained_context_module,
+        "load_retained_server_context_ref",
+        cancel_load,
+    )
+    monkeypatch.setattr(
+        retained_context_module,
+        "load_retained_server_context_snapshot",
+        lambda *_args, **_kwargs: pytest.fail("snapshot loader must not run"),
+    )
+    monkeypatch.setattr(
+        server_module,
+        "serve_retained_context",
+        lambda *_args, **_kwargs: pytest.fail("cancelled context must not be served"),
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        cli._run_mcp_retained(args)
+
+    assert caught.value is primary
+    assert len(owners) == 1
+    assert owners[0].closed  # type: ignore[attr-defined]
+    assert source.closed
+    assert object_store.closed
+    assert catalog.closed
+    assert len(topologies) == 1
+    assert topologies[0].closed  # type: ignore[attr-defined]
+    assert topologies[0].repository_authority.closed  # type: ignore[attr-defined]
 
 
 def test_mcp_runtime_probe_checks_the_complete_codegraph_runtime(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -2744,11 +2744,15 @@ def test_artifact_materialize_resource_store_interruption_closes_authorities(
     # A line event at the next source line is the portable trace boundary after
     # STORE_ATTR and before acquire() returns.  Some supported CPython builds do
     # not emit the optional per-opcode trace events.
-    post_store_line = next(
-        instruction.starts_line
+    post_store_instruction = next(
+        instruction
         for instruction in instructions[store_index + 1 :]
-        if instruction.starts_line is not None
+        if instruction.starts_line
     )
+    post_store_line = getattr(post_store_instruction, "line_number", None)
+    if type(post_store_line) is not int:
+        post_store_line = post_store_instruction.starts_line
+    assert type(post_store_line) is int
     injected = False
     previous_trace = sys.gettrace()
 

--- a/test/test_source_fingerprint.py
+++ b/test/test_source_fingerprint.py
@@ -36,11 +36,13 @@ from codenib.source_fingerprint import (
     SOURCE_FINGERPRINT_VERSION,
     RepositoryChangedError,
     RepositorySourceBinding,
+    RepositorySourceRootAuthority,
     capture_repository_source,
     fingerprint_repository,
     fingerprint_repository_v1_for_diagnostics,
     is_legacy_source_fingerprint_v1,
     is_secure_source_fingerprint_v2,
+    pin_repository_source_root,
     repository_source_is_dirty,
     source_fingerprint_version,
 )
@@ -2320,16 +2322,21 @@ def test_legacy_manifest_v11_compat_identity_is_exact_and_explicit(
     assert legacy.file_count == current.file_count == 1
     assert legacy.value != current.value
 
+    expected = pin_repository_source_root(tmp_path)
     binding = source_fingerprint_module._capture_repository_source_legacy_manifest_v11(
-        tmp_path
+        tmp_path,
+        expected_root_authority=expected,
     )
     try:
         snapshot = binding.authenticated_identity_snapshot()
         assert snapshot.fingerprint == legacy.value
         assert snapshot.source_selection is None
+        expected.close()
         assert binding.read_bytes("module.py", max_bytes=64) == b"VALUE = 1\n"
     finally:
         binding.close()
+        if not expected.closed:
+            expected.close()
 
 
 def test_fingerprint_rejects_non_selection_policy(tmp_path: Path) -> None:
@@ -2339,6 +2346,77 @@ def test_fingerprint_rejects_non_selection_policy(tmp_path: Path) -> None:
         fingerprint_repository(tmp_path, selection=None)  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="RepositorySourceSelection"):
         capture_repository_source(tmp_path, selection=None)  # type: ignore[arg-type]
+
+
+def test_windows_expected_root_authority_uses_binding_only_casefolded_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    real_open_relative = api.open_relative
+
+    def casefold_open_relative(
+        parent_handle: int,
+        name: str,
+        **kwargs: object,
+    ) -> int:
+        parent_id = api.handles[parent_handle]
+        matches = [
+            candidate
+            for candidate in api._children(parent_id)
+            if candidate.casefold() == name.casefold()
+        ]
+        assert len(matches) == 1
+        return real_open_relative(parent_handle, matches[0], **kwargs)
+
+    def open_fake_root(
+        root: Path,
+        *,
+        api: object | None = None,
+        cleanup_slot: object | None = None,
+    ):
+        selected = api if api is not None else fake_api
+        return contained_source_module._open_windows_pinned_repository_root(
+            root,
+            api=selected,
+            cleanup_slot=cleanup_slot,
+        )
+
+    fake_api = api
+    monkeypatch.setattr(api, "open_relative", casefold_open_relative)
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_open_windows_pinned_repository_root",
+        open_fake_root,
+    )
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "sys",
+        SimpleNamespace(platform="win32", exc_info=sys.exc_info),
+    )
+
+    expected = pin_repository_source_root(Path(r"C:\REPO"))
+    api.nodes[api.root_id]["version"] = 2
+    binding = capture_repository_source(
+        Path(r"c:\repo"),
+        expected_root_authority=expected,
+    )
+    try:
+        assert binding.read_bytes("source.py", max_bytes=1024) == b"VALUE = 1\n"
+    finally:
+        binding.close()
+
+    replacement = api.add_directory()
+    api.add_file(replacement, "source.py", b"VALUE = 1\n")
+    api._children(api.volume_id)["repo"] = replacement
+    try:
+        with pytest.raises(RepositoryChangedError, match="authority changed"):
+            capture_repository_source(
+                Path(r"c:\repo"),
+                expected_root_authority=expected,
+            )
+    finally:
+        expected.close()
 
 
 def test_windows_fake_regular_tree_matches_posix_v1_and_v2(
@@ -4971,3 +5049,302 @@ def test_windows_real_source_failure_closes_all_handles_node(
     after = handle_count()
 
     assert after <= before + 2
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="exercises POSIX directory fds")
+def test_expected_root_authority_handoff_is_independent_and_binding_only(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "parent"
+    repo = parent / "repo"
+    repo.mkdir(parents=True)
+    (repo / "source.py").write_bytes(b"VALUE = 1\n")
+    expected = pin_repository_source_root(repo)
+
+    parent_before = parent.stat()
+    root_before = repo.stat()
+    os.utime(
+        parent,
+        ns=(parent_before.st_atime_ns, parent_before.st_mtime_ns + 1_000_000),
+    )
+    os.utime(
+        repo,
+        ns=(root_before.st_atime_ns, root_before.st_mtime_ns + 1_000_000),
+    )
+
+    binding = capture_repository_source(
+        repo,
+        expected_root_authority=expected,
+    )
+    try:
+        assert type(expected) is RepositorySourceRootAuthority
+        assert binding._posix_authority is not expected._posix_authority
+        expected.close()
+        assert binding.read_bytes("source.py", max_bytes=1024) == b"VALUE = 1\n"
+    finally:
+        if not expected.closed:
+            expected.close()
+        binding.close()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="exercises POSIX directory fds")
+@pytest.mark.parametrize("replacement", ["root", "ancestor"])
+def test_expected_root_authority_rejects_identical_replacement(
+    tmp_path: Path,
+    replacement: str,
+) -> None:
+    parent = tmp_path / "parent"
+    repo = parent / "repo"
+    repo.mkdir(parents=True)
+    payload = b"VALUE = 1\n"
+    (repo / "source.py").write_bytes(payload)
+    expected = pin_repository_source_root(repo)
+
+    if replacement == "root":
+        parked = parent / "parked-repo"
+        repo.rename(parked)
+        repo.mkdir()
+    else:
+        parked = tmp_path / "parked-parent"
+        parent.rename(parked)
+        repo.mkdir(parents=True)
+    (repo / "source.py").write_bytes(payload)
+
+    try:
+        with pytest.raises(RepositoryChangedError, match="authority changed"):
+            capture_repository_source(
+                repo,
+                expected_root_authority=expected,
+            )
+    finally:
+        expected.close()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="exercises POSIX directory fds")
+def test_expected_root_authority_validates_type_root_and_closed_state(
+    tmp_path: Path,
+) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "source.py").write_bytes(b"FIRST\n")
+    (second / "source.py").write_bytes(b"SECOND\n")
+
+    with pytest.raises(TypeError, match="RepositorySourceRootAuthority"):
+        capture_repository_source(
+            first,
+            expected_root_authority=object(),  # type: ignore[arg-type]
+        )
+
+    foreign = pin_repository_source_root(second)
+    try:
+        with pytest.raises(ValueError, match="differs from root"):
+            capture_repository_source(first, expected_root_authority=foreign)
+    finally:
+        foreign.close()
+
+    closed = pin_repository_source_root(first)
+    closed.close()
+    with pytest.raises(RepositoryChangedError, match="authority changed"):
+        capture_repository_source(first, expected_root_authority=closed)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="exercises POSIX directory fds")
+def test_pin_root_installs_cleanup_slot_before_open_and_preserves_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    owner = SourceBindingCleanupOwner()
+    interruption = KeyboardInterrupt("injected root pin cancellation")
+
+    def interrupt_open(*_args: object, **_kwargs: object) -> int:
+        assert not owner.closed
+        assert len(owner._sources) == 1
+        raise interruption
+
+    monkeypatch.setattr(source_fingerprint_module.os, "open", interrupt_open)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        pin_repository_source_root(repo, _source_owner=owner.retain)
+
+    assert caught.value is interruption
+    assert not owner.closed
+    assert len(owner._sources) == 1
+    owner.close()
+    assert owner.closed
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="exercises POSIX directory fds")
+def test_pin_root_cancellation_retains_acquired_authority_for_cleanup_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    owner = SourceBindingCleanupOwner()
+    interruption = KeyboardInterrupt("injected completed root pin")
+    cleanup_failure = OSError(errno.EIO, "injected root authority close failure")
+    real_close = RepositorySourceRootAuthority.close
+
+    def interrupt_verify(_authority: RepositorySourceRootAuthority) -> None:
+        raise interruption
+
+    def fail_close(_authority: RepositorySourceRootAuthority) -> None:
+        raise cleanup_failure
+
+    monkeypatch.setattr(RepositorySourceRootAuthority, "verify", interrupt_verify)
+    monkeypatch.setattr(RepositorySourceRootAuthority, "close", fail_close)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        pin_repository_source_root(repo, _source_owner=owner.retain)
+
+    assert caught.value is interruption
+    assert caught.value.__cause__ is cleanup_failure
+    assert not owner.closed
+    assert len(owner.pending_sources) == 1
+    assert type(owner.pending_sources[0]) is RepositorySourceRootAuthority
+    assert caught.value.source_cleanup_owner is owner._sources[0]
+
+    monkeypatch.setattr(RepositorySourceRootAuthority, "close", real_close)
+    owner.close()
+    assert owner.closed
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="exercises POSIX directory fds")
+def test_expected_root_capture_lease_serializes_close(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_bytes(b"VALUE = 1\n")
+    expected = pin_repository_source_root(repo)
+    scan_entered = threading.Event()
+    allow_scan = threading.Event()
+    close_finished = threading.Event()
+    real_scan = source_fingerprint_module._scan_pinned_repository
+    bindings: list[RepositorySourceBinding] = []
+    failures: list[BaseException] = []
+    scan_calls = 0
+
+    def blocking_scan(*args: object, **kwargs: object):
+        nonlocal scan_calls
+        scan_calls += 1
+        if scan_calls == 1:
+            scan_entered.set()
+            if not allow_scan.wait(timeout=5):
+                raise AssertionError("timed out waiting to finish repository scan")
+        return real_scan(*args, **kwargs)
+
+    def capture() -> None:
+        try:
+            bindings.append(
+                capture_repository_source(
+                    repo,
+                    expected_root_authority=expected,
+                )
+            )
+        except BaseException as exc:  # noqa: B036 - report thread failure
+            failures.append(exc)
+
+    def close() -> None:
+        try:
+            expected.close()
+        except BaseException as exc:  # noqa: B036 - report thread failure
+            failures.append(exc)
+        finally:
+            close_finished.set()
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_scan_pinned_repository",
+        blocking_scan,
+    )
+    capture_thread = threading.Thread(target=capture)
+    close_thread = threading.Thread(target=close)
+    capture_thread.start()
+    assert scan_entered.wait(timeout=2)
+    close_thread.start()
+    assert not close_finished.wait(timeout=0.1)
+    allow_scan.set()
+    capture_thread.join(timeout=5)
+    close_thread.join(timeout=5)
+
+    try:
+        assert not capture_thread.is_alive()
+        assert not close_thread.is_alive()
+        assert failures == []
+        assert len(bindings) == 1
+        assert expected.closed
+        assert bindings[0].read_bytes("source.py", max_bytes=1024) == b"VALUE = 1\n"
+    finally:
+        allow_scan.set()
+        if capture_thread.is_alive():
+            capture_thread.join(timeout=5)
+        if close_thread.is_alive():
+            close_thread.join(timeout=5)
+        if not expected.closed:
+            expected.close()
+        for binding in bindings:
+            binding.close()
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "fork") or sys.platform == "win32",
+    reason="requires POSIX fork and directory fds",
+)
+def test_expected_root_child_close_revokes_without_inherited_lock(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_bytes(b"VALUE = 1\n")
+    expected = pin_repository_source_root(repo)
+    held = threading.Event()
+    release = threading.Event()
+
+    def hold_lock() -> None:
+        expected._lock.acquire()
+        held.set()
+        release.wait(timeout=10)
+        expected._lock.release()
+
+    thread = threading.Thread(target=hold_lock)
+    thread.start()
+    assert held.wait(timeout=2)
+    read_descriptor, write_descriptor = os.pipe()
+    child = os.fork()
+    if child == 0:  # pragma: no cover - child reports through the pipe
+        try:
+            os.close(read_descriptor)
+            try:
+                expected.close()
+            except RuntimeError as exc:
+                if "cannot cross processes" not in str(exc):
+                    raise
+            resources = expected._posix_authority._resources
+            os.write(
+                write_descriptor,
+                b"1" if expected.closed and not resources else b"0",
+            )
+        except BaseException:  # noqa: B036 - report child failure through pipe
+            os.write(write_descriptor, b"E")
+        finally:
+            os.close(write_descriptor)
+            os._exit(0)
+
+    os.close(write_descriptor)
+    try:
+        ready, _, _ = select.select([read_descriptor], [], [], 3)
+        if not ready:
+            os.kill(child, signal.SIGKILL)
+            pytest.fail("fork child deadlocked on inherited root authority lock")
+        assert os.read(read_descriptor, 1) == b"1"
+    finally:
+        os.close(read_descriptor)
+        release.set()
+        thread.join(timeout=2)
+        os.waitpid(child, 0)
+        expected.verify()
+        expected.close()


### PR DESCRIPTION
## Summary

Allow retained MCP ref or snapshot startup to opt into an authenticated live
repository with `--repo`, while preserving the existing source-disabled
query-only route when the option is omitted.

This builds on the reader-native source-binding seam merged in #660. It does
not promote retained startup to the default route, authorize portable-vector
native parsing, attest a commit, or complete the A2 compatibility gate.

Related to #199.

## Changes

- pin the lexical repository anchor, ancestor chain, and root before provider or
  storage work, and require an exact object-chain handoff to source capture
- reject repository/storage overlap through lexical, ancestry, inode, and
  mapped-mount aliases before materialization
- thread the borrowed preflight authority through artifact-reader binding and
  retained ref/snapshot activation without transferring ownership
- release the preflight pin before serving while retaining the independent
  source binding for BM25 content and `read_source`
- preserve source-disabled retained startup when `--repo` is omitted
- cover replacement, alias, cancellation, close/fork, query-only, and real
  source-bound E2E behavior
- support Python 3.14 instruction line metadata in CLI test tracing
- update the storage roadmap and operator documentation without claiming
  default-route or full manifest-compatibility promotion

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/test_source_fingerprint.py test/artifacts/test_runtime.py test/compiler/test_retained_context.py test/test_cli.py test/compiler/test_retained_mcp_cli_e2e.py --tb=short` — 495 passed, 5 skipped
- unit marker tier — 6,897 passed, 71 skipped, 190 deselected in a fresh read-only namespace; two expected pytest-cache warnings
- the direct host run reached 3,655 passes before the known host-only `/usr/bin/docker` absence; the isolated full run above completed successfully
- Black on 10 Python files, isort with the Black profile, flake8, `py_compile`, and `git diff --check`
- `python -m mkdocs build --strict`
- `python scripts/check_public_docs.py`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
