### PR TITLE
perf(storage): add source-bound retained route benchmark

### DIFF
--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -339,9 +339,10 @@ authority through the retained ref/snapshot loader. Their one-shot owner keeps
 the captured source reachable through cancellation, closes context, source,
 then publication receipt in the parent, and revokes source before receipt in a
 forked child without acquiring the copied context lock. The explicit CLI route
-and compatibility E2E establish this lifecycle, but a separate benchmark
-protocol update and canonical source-bound receipts are still required before
-the manifest runtime track can advance.
+and compatibility E2E establish this lifecycle. The v3 report-only protocol
+now measures its narrow BM25/content-authority and full-runtime projections
+separately, but canonical source-bound receipts and ratified budgets are still
+required before either policy track can advance.
 
 These retained-read routes and the explicit BM25/vector ingress above do not
 complete the hybrid-storage M1 milestone. Benchmark-backed promotion of the
@@ -404,7 +405,7 @@ authorities. The worker then launches a fresh inner route process. Those
 locations are therefore not controller flags, and provisioning is excluded
 from the timed inner route.
 
-The v2 harness compares four pairs and alternates AB/BA order for every pair:
+The v3 harness compares five pairs and alternates AB/BA order for every pair:
 
 - Compiler cold: A runs ordinary `codenib index --preset fast` from an empty
   cache; B runs the same command with retained publication.
@@ -420,12 +421,19 @@ The v2 harness compares four pairs and alternates AB/BA order for every pair:
   stopwatch, A runs `codenib mcp --artifact` without `--repo`, while B resolves
   and materializes the retained ref. Both are source-disabled and use the real
   parser and command handler.
+- Runtime cold source-bound: A starts the ordinary manifest MCP route and B
+  resolves and materializes the retained ref with the same explicit `--repo`
+  checkout. Both have content-byte source authority. The report judges their
+  BM25/content-authority projection separately from full runtime compatibility.
 
 Only `mcp.run` is replaced by a ready callback that executes the same fixed
-BM25 queries. With three subjects, two media classes, four cells, two arms,
-four warmups, and 20 measured rounds, a canonical v2 run contains 1,152 fresh
-inner route processes. The query-only pair adds 288 samples, or 33.3 percent,
-to the original three-cell protocol.
+BM25 queries, captures public `get_manifest`, and attempts one fixed public
+`read_source` probe. Source-bound arms must return the authenticated window;
+query-only arms must return the exact source-unavailable response. Those probes
+and normal context cleanup are inside the runtime stopwatch. With three
+subjects, two media classes, five cells, two arms, four warmups, and 20 measured
+rounds, a canonical v3 run contains 1,440 fresh inner route processes. The
+source-bound pair adds 288 samples, or 25 percent, over v2.
 
 Here, compiler cold means an empty CodeNib compiler cache, and runtime cold
 means a fresh process and unloaded context. The harness does not flush or
@@ -440,31 +448,47 @@ receipt records `route_wall_seconds`, `process_wall_seconds`, `cpu_seconds`,
 `/proc/self/io`. The report summarizes measured samples with median p50 and
 nearest-rank p95.
 
-Runtime parity hashes the complete public BM25 result, including optional
-source `content`, ordering, scores, and locations, and binds the observed source
-authority contract. The manifest compatibility cell therefore stays red even
-if a particular query omits content: its legacy arm has authenticated live
-source while retained startup is source-disabled. The query-only cell requires
-both arms to remain source-disabled and to produce identical complete payloads.
-A1 never erases `content`, narrows the projection, or encodes a particular
-digest as an expected failure.
+The normalized BM25 plan digest is explicitly artifact evidence, not a public
+manifest-equivalence claim. Runtime receipts hash the complete ordered public
+BM25 results, including optional source `content`, scores, and locations. Both
+query-only arms must reject `read_source`. Both source-bound arms execute the
+same source window: its file/range/content projection feeds the narrow
+content-authority comparison, while its complete public response, including
+repository provenance, remains in the full-runtime comparison. Public manifest
+state, artifact origin, loaded views/errors, LSP policy, native authorization,
+and commit-attestation state remain explicit full-runtime evidence. The
+controller first validates the exact public response, then masks only
+authenticated per-sample paths and finite build timestamps before hashing; it
+does not remove artifact or runtime fields. A1 never erases `content`, hides
+provenance, or encodes a particular digest as an expected failure.
 
-Reports aggregate compiler, query-only runtime, and manifest runtime
-compatibility as independent tracks. A parity-red compatibility sentinel still
-allows a complete, reviewable report with `failure=null`; worker, schema,
-source, isolation, cleanup, safety, or postflight faults instead make the
-measurement fail. All tracks remain report-only and promotion-ineligible.
-The controller exits zero for a complete report even when top-level `passed`
-is false; a nonzero exit means the measurement itself failed, not merely that
-a compatibility track remained red.
+Reports aggregate compiler, query-only runtime, the original source-disabled
+sentinel, source-bound BM25/content-authority, and source-bound full-runtime
+compatibility as independent projection-aware tracks. Each projection reports
+within-arm stability and pair equality, so two stable but different arms stay
+red. Both compatibility tracks also keep `scope_complete=false`; even future
+pair equality cannot authorize ordinary-manifest replacement without broader
+view and tool coverage. A parity-red compatibility sentinel still allows a
+complete, reviewable report with `failure=null`; worker, schema, source,
+isolation, cleanup, safety, or postflight faults instead make the measurement
+fail. All tracks remain report-only and promotion-ineligible.
+The controller exits zero after successfully writing a complete report, even
+when top-level `passed` is false. It exits one after successfully writing a
+failed measurement report. Exit two is reserved for hidden-worker failures and
+command/report-output failures that cannot be represented by a successfully
+written report. Red parity or incomplete compatibility scope alone therefore
+remains exit zero.
 
 Do not infer promotion thresholds from one A1 run. A2 must execute the approved
-fixed subject/media matrix and retain its canonical receipts. The compiler and
-query-only runtime tracks may ratify their own numeric policies independently;
-B1 requires the former and query-only B2 requires the latter. Replacing the
-ordinary source-bound manifest MCP path remains blocked until the reader-native
-source seam is exposed through a topology-safe production route and preserves
-the same public behavior and authority. The independent gate C
+fixed subject/media matrix and retain its canonical receipts. The compiler,
+query-only runtime, and narrowly scoped source-bound BM25 tracks may ratify
+their own numeric policies independently; B1 requires the first and query-only
+B2 requires the second. The reader-native source seam and topology-safe
+explicit route now exist, but replacing the ordinary source-bound manifest MCP
+path remains blocked on equal public behavior, artifact provenance, native
+capability policy, and required view coverage. A future source-bound BM25
+default requires its own A2 decision and does not satisfy that full
+compatibility gate. The independent gate C
 `provider-bound-exact` native provider is still required before M1 closes.
 This harness does not add M2 generic generation publication or fenced jobs, M3
 hot switching or request pins, or M5 retention and garbage collection.

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -718,9 +718,10 @@ authority in addition to its lexical path. The one-shot runtime owner retains
 source authority across cancellation, closes context, source, and receipt in
 that order in the parent, and revokes source before receipt in a forked child
 without taking an inherited context lock. Portable vector payloads remain
-native-parser inert. Route-level source-bound benchmark evidence and any
-decision about full ordinary-manifest compatibility are still missing; this
-explicit route does not change a default.
+native-parser inert. The v3 report-only protocol now records source-bound BM25
+and full-runtime compatibility projections separately. Canonical source-bound
+measurements, ratified budgets, and any decision about full ordinary-manifest
+compatibility are still missing; this explicit route does not change a default.
 
 The standalone materialization command and retained MCP cold start do not
 initialize or populate the control plane, import a legacy cache, build views,
@@ -737,12 +738,14 @@ that collecting a fast result cannot silently approve a production route:
 
 | Gate | Required result | Current status |
 | --- | --- | --- |
-| A1 | Run the fixed, report-only retained storage harness and preserve each route's complete public and authority parity. | Implemented as a four-cell v2 evidence protocol; it cannot promote a route. |
+| A1 | Run the fixed, report-only retained storage harness and record route-specific BM25-plan, public-query, source-read, and runtime-authority projections without conflating their scopes. | Implemented as a five-cell v3 evidence protocol; it cannot promote a route. |
 | A2 compiler | Record canonical compiler receipts for the approved subject/media matrix and ratify numeric compiler policy from measured results. | Pending real measurements. |
 | A2 query-only runtime | Record canonical direct-artifact versus retained receipts and ratify numeric query-only runtime policy. | Pending real measurements. |
-| A2 manifest compatibility | Preserve ordinary manifest MCP public behavior and authority when selecting retained storage. | The explicit source-bound CLI route and lifecycle are implemented; source-bound benchmark evidence is pending, and portable provenance/native-LSP differences still keep full manifest replacement blocked. |
+| A2 source-bound BM25 runtime | Record canonical ordinary-manifest versus retained-with-source receipts and ratify a narrowly scoped source-bound BM25 policy. | Pending v3 canonical measurements; this scope is narrower than ordinary-manifest equivalence. |
+| A2 manifest compatibility | Preserve ordinary manifest MCP public behavior, provenance, and authority when selecting retained storage. | The explicit source-bound CLI route is implemented, but portable provenance, native-LSP policy, and incomplete non-BM25 coverage keep full manifest replacement blocked. |
 | B1 | Promote BM25 compiler publication to a configured default. | Pending A2 compiler. |
 | B2 | Promote query-only BM25 retained cold start to a configured default. | Pending A2 query-only runtime; this does not replace source-bound manifest MCP. |
+| B2 source-bound | Promote a specifically scoped source-bound BM25 retained cold start. | Pending A2 source-bound BM25 runtime; it cannot satisfy the full manifest-compatibility gate. |
 | C | Supply the `provider-bound-exact` strict BM25 native provider. | Independent work, but required before M1 closes. |
 
 The A1 harness fixes the BM25 `fast` compiler/runtime comparison rather than
@@ -752,15 +755,21 @@ with retained publication; storage provisioning is outside the measured route.
 For compiler current-cache behavior, both arms start from equivalent verified
 current caches: A measures the ordinary update and B measures the retained
 exact retry with its original expected ref generation, which must not advance
-the ref again. Runtime cold start deliberately has two cells. The
-manifest-compatibility cell keeps arm A on the ordinary source-bound manifest
-MCP context and arm B on the source-disabled retained context. It is an honest
-compatibility sentinel, not a performance waiver. The query-only cell prepares
-a direct portable context artifact outside the stopwatch, then compares its
-source-disabled MCP startup with the same retained ref resolution and
-materialization. Both cells use the real parser and command handler. The
-harness replaces only `mcp.run` with a ready callback that executes the same
-fixed BM25 queries.
+the ref again. Runtime cold start deliberately has three cells. The original
+source-disabled sentinel keeps arm A on the ordinary source-bound manifest MCP
+context and arm B on the source-disabled retained context. The query-only cell
+prepares a direct portable context artifact outside the stopwatch, then
+compares its source-disabled MCP startup with retained ref resolution and
+materialization. The source-bound cell keeps arm A on ordinary manifest MCP
+startup and gives arm B the retained ref plus the same explicit repository
+checkout. It measures the end-to-end source-bound replacement question, but
+reports narrow BM25/content-authority parity separately from full runtime
+compatibility. All three cells use the real parser and command handler. The
+harness replaces only `mcp.run` with a ready callback that executes the fixed
+BM25 queries, captures public `get_manifest`, and attempts one fixed public
+source-read probe. Source-bound arms must return the authenticated window;
+query-only arms must return the exact source-unavailable response. All of this
+work and normal context cleanup remain inside the runtime stopwatch.
 
 Every paired round alternates AB/BA order. For each arm, the controller starts
 a short-lived outer sample worker. Every arm receives a fresh `CODENIB_HOME`
@@ -770,9 +779,10 @@ touch those retained authorities. The worker then launches a fresh inner route
 process. The canonical matrix fixes one small, medium, and large subject plus
 exactly two approved, physically distinct media classes, with four warmups
 followed by 20 measured rounds.
-Four cells, two arms, three subjects, and two media classes therefore require
-1,152 fresh inner route processes; the query-only runtime cell adds 288
-samples, or 33.3 percent, over the original three-cell protocol.
+Five cells, two arms, three subjects, and two media classes therefore require
+1,440 fresh inner route processes. The source-bound cell adds 288 samples, or
+25 percent, over v2; the query-only and source-bound cells together add 576
+samples over the original three-cell protocol.
 Each route receipt records
 `route_wall_seconds`, `process_wall_seconds`, `cpu_seconds`, `peak_rss_bytes`,
 `io_read_bytes`, `io_write_bytes`, `payload_bytes`, and `payload_files`.
@@ -786,37 +796,55 @@ or control filesystem page-cache state. AB/BA ordering balances that nuisance,
 and the report records it as `uncontrolled`; A2 must assess its receipts with
 that limitation intact.
 
-Runtime parity covers the complete public BM25 result, including optional
-source content, ordering, scores, and locations. It also includes the source
-authority contract, so the manifest-compatibility cell remains blocked even
-when a particular query happens not to return content. Its source-verified
-legacy arm and source-disabled retained arm are not interchangeable. The
-query-only cell instead requires both direct-artifact and retained arms to stay
-source-disabled and to return identical full payloads. The harness never drops
-`content`, narrows the projection, or hard-codes an expected mismatch.
+The normalized BM25 plan identity is artifact evidence, not a claim that the
+public manifest payloads are equal. Runtime receipts separately preserve the
+complete ordered BM25 results, including optional source `content`, scores,
+and locations. Query-only arms must both reject `read_source`; source-bound
+arms execute the same bounded public source-read probe. Its content window is
+part of the narrow content-authority projection, while the complete public
+response, including repository provenance, remains in the full-runtime
+projection. Public manifest state, artifact origin, source authority, loaded
+views and errors, LSP policy, native authorization, and commit-attestation
+state likewise remain explicit full-runtime evidence. Before hashing, the
+controller validates the exact public response and masks only authenticated
+per-sample paths and finite build timestamps; it does not remove artifact or
+runtime fields. The harness never drops `content`, hides delivery provenance,
+or hard-codes a particular mismatch.
 
-The v2 report aggregates three independent tracks: compiler, query-only
-runtime, and manifest runtime compatibility. Completing all samples safely
-produces a complete report even when a parity track is red; operational,
-schema, isolation, cleanup, source, or postflight failures still fail the
-measurement. A complete report is not a passing compatibility decision and
-never authorizes promotion. This separation lets A2 compiler and A2
-query-only runtime use their own canonical green receipts without laundering
-the blocked manifest-replacement track.
-The controller therefore exits zero when the report status is `complete`, even
-if top-level `passed` is false, and exits nonzero only when the measurement
-status is `failed`.
+The v3 report aggregates compiler, query-only runtime, the original
+source-disabled manifest sentinel, source-bound BM25/content-authority, and
+source-bound full-runtime compatibility as independent projection-aware
+tracks. Each projection reports within-arm stability and pair equality; stable
+but different arms remain red. Both compatibility tracks also keep
+`scope_complete=false`, so even future pair equality cannot authorize
+ordinary-manifest replacement without broader view and tool coverage.
+Completing all samples safely produces a complete report even when a
+compatibility track is red. Operational, schema, isolation, cleanup, source,
+or postflight failures instead fail the measurement. A complete report is not
+a passing compatibility decision and never authorizes promotion. This
+separation lets A2 compiler, query-only runtime, and narrowly scoped
+source-bound BM25 evidence advance independently without laundering the
+blocked full-runtime replacement track.
+The controller therefore exits zero after successfully writing a report whose
+status is `complete`, even if top-level `passed` is false. It exits one after
+successfully writing a `failed` measurement report. Exit two is reserved for
+hidden-worker failures and command/report-output failures that cannot be
+represented by a successfully written report. Red parity or incomplete
+compatibility scope alone remains exit zero.
 
 A1 intentionally has no approved numeric thresholds or threshold override.
 Its policy is unratified and every report sets `promotion_eligible=false`, even
 when a track passes and all measurements complete. Only A2 measurements over
 the fixed approved subject/media matrix may establish canonical receipts and
 ratify numeric thresholds. B1 requires the compiler track; query-only B2
-requires the query-only runtime track. Replacing ordinary source-bound manifest
-MCP remains blocked until the reader-native source seam is exposed through a
-topology-safe production route and preserves the same public and authority
-behavior in compatibility evidence. None of these promotions is approved by
-landing either the seam or the harness. This leaves M1 in progress.
+requires the query-only runtime track. A future source-bound BM25 default
+requires its own A2 policy and remains narrower than ordinary-manifest
+equivalence. The reader-native source seam and topology-safe explicit route now
+exist, but replacing ordinary source-bound manifest MCP remains blocked until
+retained startup preserves the same public behavior, artifact provenance,
+native capability policy, and required view coverage in compatibility
+evidence. Landing either the route or the harness does not approve a default.
+This leaves M1 in progress.
 
 These gates do not move the existing milestone boundaries. Generic generation
 publication and fenced jobs remain M2, live bundle replacement and in-flight

--- a/scripts/profiling/profile_retained_storage_gate.py
+++ b/scripts/profiling/profile_retained_storage_gate.py
@@ -21,12 +21,17 @@ The manifest-backed ``runtime-cold`` cell is intentionally retained as a
 compatibility sentinel: its live-source legacy arm and source-disabled retained
 arm are not authority-equivalent.  ``runtime-cold-query-only`` is the comparable
 runtime cost cell; it measures a direct portable artifact without ``--repo``
-against the retained portable-artifact route.
+against the retained portable-artifact route.  Its v3 timed workload includes
+the public manifest and the canonical source-read refusal.  The source-bound
+cell compares the ordinary manifest route with retained ``--repo`` delivery.
+Its narrow content-authority projection is the performance comparison; its
+full runtime projection preserves public-manifest and delivery differences.
 """
 
 from __future__ import annotations
 
 import argparse
+import asyncio
 import contextlib
 import hashlib
 import io
@@ -50,18 +55,18 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _DEFAULT_MANIFEST = Path(__file__).with_name("retained_storage_subjects.json")
 _DEFAULT_OUTPUT = Path(tempfile.gettempdir()) / "codenib-retained-storage-gate.json"
 
-BENCHMARK_ID = "retained_storage_explicit_route_gate_v2"
-MANIFEST_SCHEMA_VERSION = 2
-REPORT_SCHEMA_VERSION = 2
+BENCHMARK_ID = "retained_storage_explicit_route_gate_v3"
+MANIFEST_SCHEMA_VERSION = 3
+REPORT_SCHEMA_VERSION = 3
 DEFAULT_ITERATIONS = 20
 DEFAULT_WARMUPS = 4
 DEFAULT_WORKER_TIMEOUT_SECONDS = 1800.0
 CANONICAL_PEAK_RSS_SOURCE = "proc-self-status-vmhwm-kib-v1"
 CANONICAL_IO_SOURCE = "proc-self-io-v1"
 _CANONICAL_MANIFEST_SHA256 = (
-    "sha256:2d7f95489567ef17993bd1f87b46864931645719e172731a68d15d7e7e6913cb"
+    "sha256:22e01bd5acd133186a039df5a8e383308687fd8c9f8fd0554ce9592087ede6f8"
 )
-_CANONICAL_MANIFEST_SIZE = 3164
+_CANONICAL_MANIFEST_SIZE = 3197
 
 ARMS = ("legacy", "candidate")
 CELLS = (
@@ -69,31 +74,101 @@ CELLS = (
     "compiler-current",
     "runtime-cold",
     "runtime-cold-query-only",
+    "runtime-cold-source-bound",
 )
 TRACKS = {
-    "compiler": ("compiler-cold", "compiler-current"),
-    "query-only-runtime": ("runtime-cold-query-only",),
-    "manifest-runtime-compatibility": ("runtime-cold",),
+    "compiler": {
+        "cells": ("compiler-cold", "compiler-current"),
+        "projection": "compiler",
+    },
+    "query-only-runtime": {
+        "cells": ("runtime-cold-query-only",),
+        "projection": "full-runtime",
+    },
+    "manifest-runtime-compatibility": {
+        "cells": ("runtime-cold",),
+        "projection": "full-runtime",
+    },
+    "source-bound-runtime": {
+        "cells": ("runtime-cold-source-bound",),
+        "projection": "content-authority",
+    },
+    "source-bound-manifest-compatibility": {
+        "cells": ("runtime-cold-source-bound",),
+        "projection": "full-runtime",
+    },
 }
-CELL_AUTHORITY_CONTRACTS = {
+PARITY_PROJECTIONS = ("compiler", "content-authority", "full-runtime")
+CELL_PRIMARY_PROJECTIONS = {
+    "compiler-cold": "compiler",
+    "compiler-current": "compiler",
+    "runtime-cold": "full-runtime",
+    "runtime-cold-query-only": "full-runtime",
+    "runtime-cold-source-bound": "content-authority",
+}
+CELL_ROUTE_CONTRACTS = {
     "compiler-cold": {
-        "legacy": "compiler-cache-index",
-        "candidate": "compiler-cache-index-and-retained-publication",
+        "legacy": {
+            "route": "compiler-cache-index",
+            "context_provenance": "compiler-cache-manifest",
+            "source": "not-exercised",
+        },
+        "candidate": {
+            "route": "compiler-cache-index-and-retained-publication",
+            "context_provenance": "compiler-cache-manifest",
+            "source": "not-exercised",
+        },
     },
     "compiler-current": {
-        "legacy": "compiler-cache-index",
-        "candidate": "compiler-cache-index-and-retained-publication",
+        "legacy": {
+            "route": "compiler-cache-index",
+            "context_provenance": "compiler-cache-manifest",
+            "source": "not-exercised",
+        },
+        "candidate": {
+            "route": "compiler-cache-index-and-retained-publication",
+            "context_provenance": "compiler-cache-manifest",
+            "source": "not-exercised",
+        },
     },
     "runtime-cold": {
-        "legacy": "manifest-live-source",
-        "candidate": "retained-portable-artifact-query-only",
+        "legacy": {
+            "route": "manifest-path",
+            "context_provenance": "ordinary-manifest",
+            "source": "content-bytes-v2",
+        },
+        "candidate": {
+            "route": "retained-ref",
+            "context_provenance": "portable-context-artifact",
+            "source": "source-disabled",
+        },
     },
     "runtime-cold-query-only": {
-        "legacy": "direct-portable-artifact-query-only-no-repo",
-        "candidate": "retained-portable-artifact-query-only",
+        "legacy": {
+            "route": "direct-artifact",
+            "context_provenance": "portable-context-artifact",
+            "source": "source-disabled",
+        },
+        "candidate": {
+            "route": "retained-ref",
+            "context_provenance": "portable-context-artifact",
+            "source": "source-disabled",
+        },
+    },
+    "runtime-cold-source-bound": {
+        "legacy": {
+            "route": "manifest-path",
+            "context_provenance": "ordinary-manifest",
+            "source": "content-bytes-v2",
+        },
+        "candidate": {
+            "route": "retained-ref",
+            "context_provenance": "portable-context-artifact",
+            "source": "content-bytes-v2",
+        },
     },
 }
-CANONICAL_SAMPLE_COUNT = 1152
+CANONICAL_SAMPLE_COUNT = 1440
 PHASES = ("warmup", "measured")
 PAYLOAD_CLASSES = ("small", "medium", "large")
 VIEW_SET_ID = "bm25-fast"
@@ -141,7 +216,7 @@ _INNER_SAMPLE_FIELDS = frozenset(
         "view_set_id",
         "process_id",
         "metrics",
-        "parity_identity",
+        "parity_identities",
         "result",
         "safety",
     }
@@ -181,14 +256,24 @@ _SAFETY_FIELDS = frozenset(
         "cleanup_complete",
         "storage_closed",
         "context_closed",
+        "source_closed",
         "ref_stable",
         "retained_matches_raw",
     }
 )
 _RESULT_FIELDS = frozenset(
-    {"manifest", "view", "retained_view", "queries", "snapshot", "authority"}
+    {
+        "bm25_plan",
+        "public_manifest",
+        "view",
+        "retained_view",
+        "queries",
+        "source_read",
+        "snapshot",
+        "runtime",
+    }
 )
-_MANIFEST_IDENTITY_FIELDS = frozenset(
+_BM25_PLAN_IDENTITY_FIELDS = frozenset(
     {
         "commit",
         "source_fingerprint",
@@ -208,15 +293,101 @@ _VIEW_IDENTITY_FIELDS = frozenset(
 )
 _QUERY_IDENTITY_FIELDS = frozenset({"sha256", "count", "nonempty"})
 _SNAPSHOT_FIELDS = frozenset({"snapshot_id", "ref_name", "generation", "changed"})
-_PARITY_FIELDS = frozenset({"manifest", "view", "queries", "authority"})
-_AUTHORITY_IDENTITY_FIELDS = frozenset(
+_PARITY_IDENTITIES_FIELDS = frozenset(PARITY_PROJECTIONS)
+_COMPILER_PARITY_FIELDS = frozenset({"bm25_plan", "view", "queries"})
+_CONTENT_AUTHORITY_PARITY_FIELDS = frozenset(
+    {"compiler", "source_read", "source_authority", "source_capabilities"}
+)
+_FULL_RUNTIME_PARITY_FIELDS = frozenset(
     {
-        "context_kind",
+        "content_authority",
+        "public_manifest",
+        "source_read",
+        "context_provenance",
         "artifact",
-        "source_verified",
-        "source_verification_scope",
+        "capabilities",
     }
 )
+_PUBLIC_MANIFEST_EVIDENCE_FIELDS = frozenset(
+    {"raw_sha256", "parity_sha256", "parity_schema"}
+)
+_PUBLIC_MANIFEST_PARITY_SCHEMA = "codenib.retained-storage-public-manifest-parity.v1"
+_PUBLIC_MANIFEST_RUNTIME_FIELDS = frozenset(
+    {
+        "loaded_views",
+        "view_errors",
+        "tool_surface",
+        "explore_session",
+        "source_read",
+        "lsp_provider",
+    }
+)
+_PUBLIC_MANIFEST_SOURCE_FIELDS = frozenset(
+    {
+        "verified",
+        "error",
+        "verification_scope",
+        "commit_verified",
+        "checkout_state",
+    }
+)
+_PUBLIC_MANIFEST_EXPLORE_FIELDS = frozenset(
+    {"calls", "ranges", "max_ranges", "evictions"}
+)
+_SOURCE_READ_EVIDENCE_FIELDS = frozenset(
+    {"status", "payload_sha256", "content_sha256", "error_sha256", "count"}
+)
+_SOURCE_READ_CONTENT_FIELDS = frozenset({"status", "content_sha256", "count"})
+_SOURCE_READ_PAYLOAD_FIELDS = frozenset(
+    {"file", "start_line", "end_line", "content", "content_projection", "source"}
+)
+_SOURCE_READ_PROVENANCE_FIELDS = frozenset(
+    {
+        "repository",
+        "commit",
+        "source_fingerprint",
+        "verified",
+        "verification_scope",
+        "commit_verified",
+        "checkout_state",
+    }
+)
+_SOURCE_CONTENT_PROJECTION_FIELDS = frozenset(
+    {"truncated", "original_chars", "returned_chars", "strategy"}
+)
+_RUNTIME_IDENTITY_FIELDS = frozenset(
+    {"delivery", "artifact", "source_authority", "capabilities"}
+)
+_PORTABLE_ARTIFACT_FIELDS = frozenset(
+    {"verified", "schema", "repository", "commit", "views"}
+)
+_DELIVERY_IDENTITY_FIELDS = frozenset({"route", "context_provenance"})
+_SOURCE_AUTHORITY_FIELDS = frozenset({"kind", "verified", "verification_scope"})
+_RUNTIME_CAPABILITY_FIELDS = frozenset(
+    {
+        "loaded_views",
+        "view_errors",
+        "read_source",
+        "native_vector_authorized",
+        "native_lsp_allowed",
+        "lsp_provider",
+        "commit_verified",
+        "checkout_state",
+    }
+)
+_LSP_PROVIDER_REQUIRED_FIELDS = frozenset(
+    {
+        "provider",
+        "backend",
+        "status",
+        "capabilities",
+    }
+)
+_LSP_PROVIDER_ALLOWED_FIELDS = _LSP_PROVIDER_REQUIRED_FIELDS | {
+    "index_snapshot",
+    "fallback_reason",
+}
+_LSP_CAPABILITY_FIELDS = frozenset({"definition", "references", "route"})
 _SOURCE_SELECTION_FIELDS = frozenset(
     {"schema", "repository_filter_policy", "exclude_subtrees"}
 )
@@ -608,7 +779,7 @@ def load_subject_manifest(path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
         or receipt["size"] != _CANONICAL_MANIFEST_SIZE
     ):
         raise ValueError(
-            "checked-in subject manifest differs from the v2 canonical anchor"
+            "checked-in subject manifest differs from the v3 canonical anchor"
         )
     if payload_bytes.startswith(b"\xef\xbb\xbf"):
         raise ValueError("subject manifest must not use a UTF-8 BOM")
@@ -990,15 +1161,18 @@ def _io_source() -> str:
 def _empty_tracks() -> dict[str, dict[str, Any]]:
     return {
         track: {
-            "cells": list(cells),
+            "cells": list(specification["cells"]),
+            "projection": specification["projection"],
             "measurement_complete": False,
             "parity_passed": False,
             "safety_passed": False,
+            "scope_complete": False,
+            "decision": "blocked",
             "passed": False,
             "policy_status": "unratified",
             "promotion_eligible": False,
         }
-        for track, cells in TRACKS.items()
+        for track, specification in TRACKS.items()
     }
 
 
@@ -1058,12 +1232,18 @@ def _base_report(
                 ),
                 "runtime-cold": (
                     "fresh-inner-import-parser-handler-through-ready-callback-"
-                    "fixed-queries-and-normal-cleanup-return"
+                    "fixed-queries-public-manifest-source-read-probe-or-refusal-"
+                    "and-normal-cleanup-return"
                 ),
                 "runtime-cold-query-only": (
                     "fresh-inner-import-parser-direct-or-retained-portable-"
-                    "artifact-handler-through-ready-callback-fixed-queries-and-"
-                    "normal-cleanup-return"
+                    "artifact-handler-through-ready-callback-fixed-queries-"
+                    "public-manifest-source-read-refusal-and-normal-cleanup-return"
+                ),
+                "runtime-cold-source-bound": (
+                    "fresh-inner-import-parser-ordinary-manifest-or-retained-"
+                    "source-bound-handler-through-ready-callback-fixed-queries-"
+                    "public-manifest-source-read-probe-and-normal-cleanup-return"
                 ),
             },
             "process_wall_boundary": (
@@ -1072,10 +1252,21 @@ def _base_report(
             "filesystem_page_cache": "uncontrolled",
             "cold_definitions": {
                 "compiler-cold": "empty-codenib-cache",
-                "runtime-cold": "fresh-process-and-context",
-                "runtime-cold-query-only": "fresh-process-and-context",
+                "runtime-cold": (
+                    "fresh-process-and-context-with-public-manifest-and-"
+                    "source-read-probe-or-refusal"
+                ),
+                "runtime-cold-query-only": (
+                    "fresh-process-and-context-with-public-manifest-and-"
+                    "source-read-refusal"
+                ),
+                "runtime-cold-source-bound": (
+                    "fresh-process-and-context-with-public-manifest-and-"
+                    "source-read-probe"
+                ),
             },
-            "cell_authority_contracts": _json_snapshot(CELL_AUTHORITY_CONTRACTS),
+            "cell_route_contracts": _json_snapshot(CELL_ROUTE_CONTRACTS),
+            "parity_projections": list(PARITY_PROJECTIONS),
         },
         "benchmark_receipts": {
             "before": None,
@@ -1172,8 +1363,15 @@ def _protocol(
         "iterations_per_arm": DEFAULT_ITERATIONS,
         "warmups_per_arm": DEFAULT_WARMUPS,
         "cells": list(CELLS),
-        "tracks": {track: list(cells) for track, cells in TRACKS.items()},
-        "cell_authority_contracts": _json_snapshot(CELL_AUTHORITY_CONTRACTS),
+        "tracks": {
+            track: {
+                "cells": list(specification["cells"]),
+                "projection": specification["projection"],
+            }
+            for track, specification in TRACKS.items()
+        },
+        "cell_route_contracts": _json_snapshot(CELL_ROUTE_CONTRACTS),
+        "parity_projections": list(PARITY_PROJECTIONS),
         "canonical_sample_count": CANONICAL_SAMPLE_COUNT,
         "view_set_ids": [VIEW_SET_ID],
         "payload_classes": list(PAYLOAD_CLASSES),
@@ -1199,8 +1397,15 @@ def _protocol(
         "iterations_per_arm": iterations,
         "warmups_per_arm": warmups,
         "cells": list(manifest["cells"]),
-        "tracks": {track: list(cells) for track, cells in TRACKS.items()},
-        "cell_authority_contracts": _json_snapshot(CELL_AUTHORITY_CONTRACTS),
+        "tracks": {
+            track: {
+                "cells": list(specification["cells"]),
+                "projection": specification["projection"],
+            }
+            for track, specification in TRACKS.items()
+        },
+        "cell_route_contracts": _json_snapshot(CELL_ROUTE_CONTRACTS),
+        "parity_projections": list(PARITY_PROJECTIONS),
         "canonical_sample_count": (
             len(manifest["subjects"])
             * len(media)
@@ -1230,13 +1435,13 @@ def _protocol(
     }
 
 
-def _validate_manifest_identity(
+def _validate_bm25_plan_identity(
     value: object,
     *,
     subject: Mapping[str, Any],
     label: str,
 ) -> dict[str, Any]:
-    identity = _require_exact_dict(value, _MANIFEST_IDENTITY_FIELDS, label=label)
+    identity = _require_exact_dict(value, _BM25_PLAN_IDENTITY_FIELDS, label=label)
     commit = _required_text(identity["commit"], label=f"{label} commit", maximum=40)
     if commit != subject["revision"]:
         raise RuntimeError(f"{label} commit differs from the fixed subject")
@@ -1330,42 +1535,280 @@ def _portable_artifact_identity(subject: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
-def _expected_authority_identity(request: Mapping[str, Any]) -> dict[str, Any]:
+def _runtime_source_enabled(request: Mapping[str, Any]) -> bool | None:
     cell = request["cell"]
-    arm = request["arm"]
     if cell in {"compiler-cold", "compiler-current"}:
+        return None
+    return (request["arm"] == "legacy" and cell != "runtime-cold-query-only") or (
+        request["arm"] == "candidate" and cell == "runtime-cold-source-bound"
+    )
+
+
+def _runtime_uses_portable_artifact(request: Mapping[str, Any]) -> bool:
+    if request["cell"] in {"compiler-cold", "compiler-current"}:
+        return False
+    return request["arm"] == "candidate" or (
+        request["arm"] == "legacy" and request["cell"] == "runtime-cold-query-only"
+    )
+
+
+def _expected_runtime_identity(request: Mapping[str, Any]) -> dict[str, Any]:
+    route = CELL_ROUTE_CONTRACTS[request["cell"]][request["arm"]]
+    source_enabled = _runtime_source_enabled(request)
+    if source_enabled is None:
         return {
-            "context_kind": "compiler-portable-plan",
+            "delivery": {
+                "route": route["route"],
+                "context_provenance": route["context_provenance"],
+            },
             "artifact": None,
-            "source_verified": None,
-            "source_verification_scope": None,
+            "source_authority": None,
+            "capabilities": None,
         }
-    if cell == "runtime-cold" and arm == "legacy":
-        return {
-            "context_kind": "manifest-live-source",
-            "artifact": None,
-            "source_verified": True,
-            "source_verification_scope": "content-bytes",
-        }
+    portable = _runtime_uses_portable_artifact(request)
     return {
-        "context_kind": "portable-artifact-query-only",
-        "artifact": _portable_artifact_identity(request["subject"]),
-        "source_verified": False,
-        "source_verification_scope": None,
+        "delivery": {
+            "route": route["route"],
+            "context_provenance": route["context_provenance"],
+        },
+        "artifact": (
+            _portable_artifact_identity(request["subject"]) if portable else None
+        ),
+        "source_authority": {
+            "kind": "content-bytes-v2" if source_enabled else "source-disabled",
+            "verified": source_enabled,
+            "verification_scope": "content-bytes" if source_enabled else None,
+        },
+        "capabilities": {
+            "loaded_views": ["bm25"],
+            "view_errors": {},
+            "read_source": source_enabled,
+            "native_vector_authorized": False,
+            "native_lsp_allowed": not portable,
+            # Provider selection is host-observed evidence, not a fixed gate
+            # input.  The validator below enforces the route policy while the
+            # full-runtime projection retains the exact public selection.
+            "lsp_provider": None,
+            "commit_verified": False,
+            "checkout_state": "not-attested",
+        },
     }
 
 
-def _validate_authority_identity(
+def _validate_lsp_provider(value: object, *, label: str) -> dict[str, Any]:
+    if type(value) is not dict:
+        raise ValueError(f"{label} must be an exact JSON object")
+    observed_fields = set(value)
+    if not _LSP_PROVIDER_REQUIRED_FIELDS <= observed_fields or not observed_fields <= (
+        _LSP_PROVIDER_ALLOWED_FIELDS
+    ):
+        raise ValueError(f"{label} has invalid fields")
+    provider = value
+    capabilities = _require_exact_dict(
+        provider["capabilities"],
+        _LSP_CAPABILITY_FIELDS,
+        label=f"{label} capabilities",
+    )
+    if any(type(capabilities[field]) is not bool for field in capabilities):
+        raise RuntimeError(f"{label} capabilities must be exact booleans")
+    normalized = {
+        "provider": _required_text(
+            provider["provider"], label=f"{label} provider", maximum=128
+        ),
+        "backend": _required_text(
+            provider["backend"], label=f"{label} backend", maximum=128
+        ),
+        "status": _required_text(
+            provider["status"], label=f"{label} status", maximum=128
+        ),
+        "index_snapshot": provider.get("index_snapshot"),
+        "capabilities": dict(capabilities),
+    }
+    if "fallback_reason" in provider:
+        normalized["fallback_reason"] = _required_text(
+            provider["fallback_reason"],
+            label=f"{label} fallback reason",
+            maximum=256,
+        )
+    if normalized["index_snapshot"] is not None:
+        _required_text(
+            normalized["index_snapshot"],
+            label=f"{label} index snapshot",
+            maximum=512,
+        )
+    return normalized
+
+
+def _validate_runtime_identity(
     value: object,
     *,
     request: Mapping[str, Any],
     label: str,
 ) -> dict[str, Any]:
-    identity = _require_exact_dict(value, _AUTHORITY_IDENTITY_FIELDS, label=label)
-    expected = _expected_authority_identity(request)
-    if identity != expected:
+    identity = _require_exact_dict(value, _RUNTIME_IDENTITY_FIELDS, label=label)
+    delivery = _require_exact_dict(
+        identity["delivery"], _DELIVERY_IDENTITY_FIELDS, label=f"{label} delivery"
+    )
+    delivery = {
+        field: _required_text(
+            delivery[field],
+            label=f"{label} delivery {field}",
+            maximum=128,
+        )
+        for field in _DELIVERY_IDENTITY_FIELDS
+    }
+    artifact = identity["artifact"]
+    if artifact is not None:
+        artifact = _require_exact_dict(
+            artifact,
+            _PORTABLE_ARTIFACT_FIELDS,
+            label=f"{label} artifact",
+        )
+        if type(artifact["verified"]) is not bool:
+            raise RuntimeError(f"{label} artifact verification flag is malformed")
+        for field in ("schema", "repository", "commit"):
+            _required_text(
+                artifact[field],
+                label=f"{label} artifact {field}",
+                maximum=512,
+            )
+        if type(artifact["views"]) is not list or any(
+            type(view) is not str for view in artifact["views"]
+        ):
+            raise RuntimeError(f"{label} artifact views are malformed")
+    source = identity["source_authority"]
+    if source is not None:
+        source = _require_exact_dict(
+            source,
+            _SOURCE_AUTHORITY_FIELDS,
+            label=f"{label} source authority",
+        )
+        _required_text(
+            source["kind"],
+            label=f"{label} source authority kind",
+            maximum=128,
+        )
+        if type(source["verified"]) is not bool:
+            raise RuntimeError(f"{label} source authority flag is malformed")
+        if source["verification_scope"] is not None:
+            _required_text(
+                source["verification_scope"],
+                label=f"{label} source authority verification scope",
+                maximum=128,
+            )
+    capabilities = identity["capabilities"]
+    if capabilities is not None:
+        capabilities = _require_exact_dict(
+            capabilities,
+            _RUNTIME_CAPABILITY_FIELDS,
+            label=f"{label} capabilities",
+        )
+        for field in (
+            "read_source",
+            "native_vector_authorized",
+            "native_lsp_allowed",
+            "commit_verified",
+        ):
+            if type(capabilities[field]) is not bool:
+                raise RuntimeError(f"{label} capability flags are malformed")
+        if type(capabilities["loaded_views"]) is not list or any(
+            type(view) is not str for view in capabilities["loaded_views"]
+        ):
+            raise RuntimeError(f"{label} loaded views are malformed")
+        if type(capabilities["view_errors"]) is not dict:
+            raise RuntimeError(f"{label} view errors are malformed")
+        _required_text(
+            capabilities["checkout_state"],
+            label=f"{label} checkout state",
+            maximum=128,
+        )
+        capabilities = {
+            **capabilities,
+            "lsp_provider": _validate_lsp_provider(
+                capabilities["lsp_provider"],
+                label=f"{label} LSP provider",
+            ),
+        }
+    normalized = {
+        "delivery": delivery,
+        "artifact": None if artifact is None else _json_snapshot(artifact),
+        "source_authority": None if source is None else dict(source),
+        "capabilities": None if capabilities is None else dict(capabilities),
+    }
+    expected = _expected_runtime_identity(request)
+    observed_lsp = None
+    if expected["capabilities"] is not None:
+        expected["capabilities"].pop("lsp_provider")
+        observed_lsp = normalized["capabilities"].pop("lsp_provider")
+    matches_contract = normalized == expected
+    if expected["capabilities"] is not None:
+        normalized["capabilities"]["lsp_provider"] = observed_lsp
+    if not matches_contract:
         raise RuntimeError(f"{label} differs from its exact per-cell contract")
-    return _json_snapshot(expected)
+    if _runtime_uses_portable_artifact(request) and (
+        type(observed_lsp) is not dict
+        or observed_lsp.get("fallback_reason")
+        != "portable_artifact_uses_persisted_graph"
+    ):
+        raise RuntimeError(f"{label} portable LSP policy changed")
+    return _json_snapshot(normalized)
+
+
+def _validate_public_manifest_evidence(
+    value: object,
+    *,
+    runtime_expected: bool,
+    label: str,
+) -> dict[str, Any] | None:
+    if not runtime_expected:
+        if value is not None:
+            raise RuntimeError(f"{label} must be absent for compiler samples")
+        return None
+    evidence = _require_exact_dict(value, _PUBLIC_MANIFEST_EVIDENCE_FIELDS, label=label)
+    raw = _required_text(evidence["raw_sha256"], label=f"{label} raw", maximum=80)
+    parity = _required_text(
+        evidence["parity_sha256"], label=f"{label} parity", maximum=80
+    )
+    if not _SHA256_RE.fullmatch(raw) or not _SHA256_RE.fullmatch(parity):
+        raise RuntimeError(f"{label} digests are malformed")
+    if evidence["parity_schema"] != _PUBLIC_MANIFEST_PARITY_SCHEMA:
+        raise RuntimeError(f"{label} parity schema changed")
+    return {
+        "raw_sha256": raw,
+        "parity_sha256": parity,
+        "parity_schema": _PUBLIC_MANIFEST_PARITY_SCHEMA,
+    }
+
+
+def _validate_source_read_evidence(
+    value: object,
+    *,
+    expected_status: str,
+    label: str,
+) -> dict[str, Any]:
+    evidence = _require_exact_dict(value, _SOURCE_READ_EVIDENCE_FIELDS, label=label)
+    if evidence["status"] != expected_status:
+        raise RuntimeError(f"{label} status differs from its route contract")
+    count = _nonnegative_int(evidence["count"], label=f"{label} count")
+    expected_count = 0 if expected_status == "not-exercised" else 1
+    if count != expected_count:
+        raise RuntimeError(f"{label} count differs from its route contract")
+    digests: dict[str, str | None] = {}
+    for field in ("payload_sha256", "content_sha256", "error_sha256"):
+        digest = evidence[field]
+        if digest is not None:
+            digest = _required_text(digest, label=f"{label} {field}", maximum=80)
+            if not _SHA256_RE.fullmatch(digest):
+                raise RuntimeError(f"{label} contains a malformed digest")
+        digests[field] = digest
+    expected_presence = {
+        "not-exercised": (False, False, False),
+        "verified": (True, True, False),
+        "source-disabled": (False, False, True),
+    }[expected_status]
+    if tuple(digests[field] is not None for field in digests) != expected_presence:
+        raise RuntimeError(f"{label} digest presence differs from its route contract")
+    return {"status": expected_status, **digests, "count": count}
 
 
 def _validate_snapshot(
@@ -1394,6 +1837,7 @@ def _validate_snapshot(
         "compiler-current": False,
         "runtime-cold": None,
         "runtime-cold-query-only": None,
+        "runtime-cold-source-bound": None,
     }[cell]
     if snapshot["changed"] is not expected_changed:
         raise RuntimeError("candidate sample changed flag violates its cell contract")
@@ -1403,6 +1847,101 @@ def _validate_snapshot(
         "generation": generation,
         "changed": expected_changed,
     }
+
+
+def _source_read_status(request: Mapping[str, Any]) -> str:
+    source_enabled = _runtime_source_enabled(request)
+    if source_enabled is None:
+        return "not-exercised"
+    return "verified" if source_enabled else "source-disabled"
+
+
+def _parity_identities_from_result(result: Mapping[str, Any]) -> dict[str, Any]:
+    view = result["view"]
+    runtime = result["runtime"]
+    source_read = result["source_read"]
+    compiler = {
+        "bm25_plan": _json_snapshot(result["bm25_plan"]),
+        "view": {
+            "documents_sha256": view["documents_sha256"],
+            "metadata_sha256": view["metadata_sha256"],
+        },
+        "queries": _json_snapshot(result["queries"]),
+    }
+    content_authority = {
+        "compiler": _json_snapshot(compiler),
+        "source_read": {
+            "status": source_read["status"],
+            "content_sha256": source_read["content_sha256"],
+            "count": source_read["count"],
+        },
+        "source_authority": _json_snapshot(runtime["source_authority"]),
+        "source_capabilities": (
+            None
+            if runtime["capabilities"] is None
+            else {
+                field: _json_snapshot(runtime["capabilities"][field])
+                for field in (
+                    "loaded_views",
+                    "read_source",
+                    "commit_verified",
+                    "checkout_state",
+                )
+            }
+        ),
+    }
+    public_manifest = result["public_manifest"]
+    public_manifest_parity = (
+        None
+        if public_manifest is None
+        else {
+            "parity_schema": public_manifest["parity_schema"],
+            "parity_sha256": public_manifest["parity_sha256"],
+        }
+    )
+    full_runtime = {
+        "content_authority": _json_snapshot(content_authority),
+        "public_manifest": public_manifest_parity,
+        "source_read": _json_snapshot(source_read),
+        "context_provenance": runtime["delivery"]["context_provenance"],
+        "artifact": _json_snapshot(runtime["artifact"]),
+        "capabilities": _json_snapshot(runtime["capabilities"]),
+    }
+    return {
+        "compiler": compiler,
+        "content-authority": content_authority,
+        "full-runtime": full_runtime,
+    }
+
+
+def _validate_parity_identities(
+    value: object,
+    *,
+    expected: Mapping[str, Any],
+) -> dict[str, Any]:
+    identities = _require_exact_dict(
+        value,
+        _PARITY_IDENTITIES_FIELDS,
+        label="sample parity identities",
+    )
+    _require_exact_dict(
+        identities["compiler"],
+        _COMPILER_PARITY_FIELDS,
+        label="sample compiler parity identity",
+    )
+    _require_exact_dict(
+        identities["content-authority"],
+        _CONTENT_AUTHORITY_PARITY_FIELDS,
+        label="sample content-authority parity identity",
+    )
+    _require_exact_dict(
+        identities["full-runtime"],
+        _FULL_RUNTIME_PARITY_FIELDS,
+        label="sample full-runtime parity identity",
+    )
+    if identities != expected:
+        raise RuntimeError("sample parity projections differ from their result")
+    return _json_snapshot(expected)
 
 
 def _validate_sample_receipt(
@@ -1447,17 +1986,28 @@ def _validate_sample_receipt(
     result = _require_exact_dict(
         receipt["result"], _RESULT_FIELDS, label="sample result"
     )
-    manifest = _validate_manifest_identity(
-        result["manifest"], subject=subject, label="sample manifest identity"
+    bm25_plan = _validate_bm25_plan_identity(
+        result["bm25_plan"], subject=subject, label="sample BM25 plan identity"
     )
     view = _validate_view_identity(result["view"], label="sample BM25 identity")
     queries = _validate_query_identity(
         result["queries"], subject=subject, label="sample query identity"
     )
-    authority = _validate_authority_identity(
-        result["authority"],
+    runtime = _validate_runtime_identity(
+        result["runtime"],
         request=request,
-        label="sample authority identity",
+        label="sample runtime identity",
+    )
+    runtime_expected = _runtime_source_enabled(request) is not None
+    public_manifest = _validate_public_manifest_evidence(
+        result["public_manifest"],
+        runtime_expected=runtime_expected,
+        label="sample public manifest evidence",
+    )
+    source_read = _validate_source_read_evidence(
+        result["source_read"],
+        expected_status=_source_read_status(request),
+        label="sample source-read evidence",
     )
     retained_view = result["retained_view"]
     if retained_view is not None:
@@ -1478,20 +2028,20 @@ def _validate_sample_receipt(
         raise RuntimeError("sample payload byte metric differs from its BM25 identity")
     if normalized_metrics["payload_files"] != view["payload_files"]:
         raise RuntimeError("sample payload file metric differs from its BM25 identity")
-    parity = _require_exact_dict(
-        receipt["parity_identity"], _PARITY_FIELDS, label="sample parity identity"
-    )
-    expected_parity = {
-        "manifest": manifest,
-        "view": {
-            "documents_sha256": view["documents_sha256"],
-            "metadata_sha256": view["metadata_sha256"],
-        },
+    normalized_result = {
+        "bm25_plan": bm25_plan,
+        "public_manifest": public_manifest,
+        "view": view,
+        "retained_view": retained_view,
         "queries": queries,
-        "authority": authority,
+        "source_read": source_read,
+        "snapshot": snapshot,
+        "runtime": runtime,
     }
-    if parity != expected_parity:
-        raise RuntimeError("sample parity projection differs from its result")
+    expected_parity = _parity_identities_from_result(normalized_result)
+    parity_identities = _validate_parity_identities(
+        receipt["parity_identities"], expected=expected_parity
+    )
     safety = _require_exact_dict(
         receipt["safety"], _SAFETY_FIELDS, label="sample safety"
     )
@@ -1513,15 +2063,8 @@ def _validate_sample_receipt(
         "view_set_id": receipt["view_set_id"],
         "process_id": process_id,
         "metrics": normalized_metrics,
-        "parity_identity": expected_parity,
-        "result": {
-            "manifest": manifest,
-            "view": view,
-            "retained_view": retained_view,
-            "queries": queries,
-            "snapshot": snapshot,
-            "authority": authority,
-        },
+        "parity_identities": parity_identities,
+        "result": normalized_result,
         "safety": dict(safety),
     }
 
@@ -1582,7 +2125,7 @@ def _run_cell(
         "candidate": [],
     }
     all_samples: list[dict[str, Any]] = []
-    every_pair = True
+    every_pair = {projection: True for projection in PARITY_PROJECTIONS}
     for phase, rounds, report_phase in (
         ("warmup", warmups, "warmups"),
         ("measured", iterations, "measured"),
@@ -1618,8 +2161,15 @@ def _run_cell(
                 process_ids.append(receipt["process_id"])
                 if phase == "measured":
                     measured_by_arm[arm].append(receipt)
-            pair_equal = pair[0]["parity_identity"] == pair[1]["parity_identity"]
-            every_pair = every_pair and pair_equal
+            pair_equal = {
+                projection: (
+                    pair[0]["parity_identities"][projection]
+                    == pair[1]["parity_identities"][projection]
+                )
+                for projection in PARITY_PROJECTIONS
+            }
+            for projection, equal in pair_equal.items():
+                every_pair[projection] = every_pair[projection] and equal
             runs[report_phase].append(
                 {
                     "round_index": round_index,
@@ -1628,28 +2178,48 @@ def _run_cell(
                     "samples": pair,
                 }
             )
-    identities = {_json_digest(sample["parity_identity"]) for sample in all_samples}
-    stable = len(identities) == 1
+    identities = {
+        projection: {
+            arm: {
+                _json_digest(sample["parity_identities"][projection])
+                for sample in all_samples
+                if sample["arm"] == arm
+            }
+            for arm in ARMS
+        }
+        for projection in PARITY_PROJECTIONS
+    }
+    parity = {
+        projection: {
+            "every_pair_equal": every_pair[projection],
+            "stable_within_arm": {
+                arm: len(identities[projection][arm]) == 1 for arm in ARMS
+            },
+            "identity_sha256": {
+                arm: sorted(identities[projection][arm]) for arm in ARMS
+            },
+            "passed": every_pair[projection]
+            and all(len(identities[projection][arm]) == 1 for arm in ARMS),
+        }
+        for projection in PARITY_PROJECTIONS
+    }
     summary = {arm: _summarize_arm(measured_by_arm[arm]) for arm in ARMS}
     safety_checks = {
         field: all(sample["safety"][field] for sample in all_samples)
         for field in sorted(_SAFETY_FIELDS)
     }
-    passed = every_pair and stable and all(safety_checks.values())
+    primary_projection = CELL_PRIMARY_PROJECTIONS[cell]
+    passed = parity[primary_projection]["passed"] and all(safety_checks.values())
     return {
         "subject_id": frozen_subject["id"],
         "media_id": media_id,
         "view_set_id": frozen_view_set["id"],
         "cell": cell,
+        "primary_projection": primary_projection,
         "passed": passed,
         "runs": runs,
         "summary": summary,
-        "parity": {
-            "every_pair": every_pair,
-            "stable_across_runs": stable,
-            "identity_sha256": sorted(identities),
-            "passed": every_pair and stable,
-        },
+        "parity": parity,
         "safety": {
             "checks": safety_checks,
             "passed": all(safety_checks.values()),
@@ -1708,12 +2278,43 @@ def _cell_measurement_complete(
             if (
                 pair.get("round_index") != round_index
                 or pair.get("arm_order") != order
-                or type(pair.get("parity")) is not bool
+                or type(pair.get("parity")) is not dict
+                or set(pair["parity"]) != set(PARITY_PROJECTIONS)
+                or any(type(value) is not bool for value in pair["parity"].values())
                 or type(samples) is not list
                 or len(samples) != len(ARMS)
                 or [sample.get("arm") for sample in samples] != order
             ):
                 return False
+    primary_projection = cell.get("primary_projection")
+    if primary_projection != CELL_PRIMARY_PROJECTIONS.get(cell.get("cell")):
+        return False
+    parity = cell.get("parity")
+    if type(parity) is not dict or set(parity) != set(PARITY_PROJECTIONS):
+        return False
+    for projection in PARITY_PROJECTIONS:
+        projection_parity = parity[projection]
+        if (
+            type(projection_parity) is not dict
+            or set(projection_parity)
+            != {
+                "every_pair_equal",
+                "stable_within_arm",
+                "identity_sha256",
+                "passed",
+            }
+            or type(projection_parity["every_pair_equal"]) is not bool
+            or type(projection_parity["passed"]) is not bool
+            or type(projection_parity["stable_within_arm"]) is not dict
+            or set(projection_parity["stable_within_arm"]) != set(ARMS)
+            or any(
+                type(value) is not bool
+                for value in projection_parity["stable_within_arm"].values()
+            )
+            or type(projection_parity["identity_sha256"]) is not dict
+            or set(projection_parity["identity_sha256"]) != set(ARMS)
+        ):
+            return False
     summary = cell.get("summary")
     if type(summary) is not dict or set(summary) != set(ARMS):
         return False
@@ -1754,7 +2355,13 @@ def _aggregate_tracks(
         by_cell[str(value["cell"])].append(value)
 
     tracks: dict[str, dict[str, Any]] = {}
-    for track, track_cells in TRACKS.items():
+    incomplete_scope_tracks = {
+        "manifest-runtime-compatibility",
+        "source-bound-manifest-compatibility",
+    }
+    for track, specification in TRACKS.items():
+        track_cells = specification["cells"]
+        projection = specification["projection"]
         instances = [item for cell in track_cells for item in by_cell[cell]]
         expected_count = expected_instances * len(track_cells)
         identities = {
@@ -1780,19 +2387,32 @@ def _aggregate_tracks(
             )
         )
         parity_passed = measurement_complete and all(
-            type(item.get("parity")) is dict and item["parity"].get("passed") is True
+            type(item.get("parity")) is dict
+            and type(item["parity"].get(projection)) is dict
+            and item["parity"][projection].get("passed") is True
             for item in instances
         )
         safety_passed = measurement_complete and all(
             type(item.get("safety")) is dict and item["safety"].get("passed") is True
             for item in instances
         )
+        scope_complete = (
+            track not in incomplete_scope_tracks
+            and measurement_complete
+            and safety_passed
+        )
+        passed = (
+            measurement_complete and parity_passed and safety_passed and scope_complete
+        )
         tracks[track] = {
             "cells": list(track_cells),
+            "projection": projection,
             "measurement_complete": measurement_complete,
             "parity_passed": parity_passed,
             "safety_passed": safety_passed,
-            "passed": measurement_complete and parity_passed and safety_passed,
+            "scope_complete": scope_complete,
+            "decision": "passed" if passed else "blocked",
+            "passed": passed,
             "policy_status": "unratified",
             "promotion_eligible": False,
         }
@@ -2045,7 +2665,7 @@ def profile_retained_storage_gate(
         return _failure(
             report,
             "protocol",
-            RuntimeError("measurement protocol is not canonical v2"),
+            RuntimeError("measurement protocol is not canonical v3"),
         )
 
     tracks_passed = all(
@@ -2056,12 +2676,23 @@ def profile_retained_storage_gate(
     report["promotion_eligible"] = False
     report["failure"] = None
     if not tracks_passed:
+        blocked_causes: list[str] = []
+        if any(
+            aggregate["parity_passed"] is not True
+            for aggregate in report["tracks"].values()
+        ):
+            blocked_causes.append("one or more track parity projections are red")
+        if any(
+            aggregate["scope_complete"] is not True
+            for aggregate in report["tracks"].values()
+        ):
+            blocked_causes.append("one or more compatibility scopes remain incomplete")
         report["decision"] = {
             "policy_status": "unratified",
             "report_only": True,
             "promotion_eligible": False,
             "recommendation": "retain-explicit-routes",
-            "reason": "one or more compatibility tracks are parity red",
+            "reason": "; ".join(blocked_causes),
         }
     return report
 
@@ -2446,7 +3077,11 @@ def _prepare_sample(request: Mapping[str, Any], paths: Mapping[str, str]) -> Non
         _provision_storage(paths)
     if cell == "compiler-current":
         _invoke_cli(_index_arguments(request, paths, candidate=arm == "candidate"))
-    elif cell in {"runtime-cold", "runtime-cold-query-only"}:
+    elif cell in {
+        "runtime-cold",
+        "runtime-cold-query-only",
+        "runtime-cold-source-bound",
+    }:
         _invoke_cli(_index_arguments(request, paths, candidate=arm == "candidate"))
         if cell == "runtime-cold-query-only" and arm == "legacy":
             _invoke_cli(
@@ -2503,24 +3138,48 @@ def _normalize_manifest_measurement_metadata(
 ) -> dict[str, Any]:
     if type(normalized) is not dict or set(normalized.get("indexes", {})) != {"bm25"}:
         raise RuntimeError("BM25 gate manifest has an unexpected view set")
-    normalized["compiled_at"] = "<measurement-metadata>"
-    normalized["compiled_at_epoch"] = 0
+    if "compiled_at" not in normalized or "compiled_at_epoch" not in normalized:
+        raise RuntimeError("BM25 gate manifest compilation timestamps are missing")
+    _required_text(
+        normalized["compiled_at"],
+        label="BM25 gate manifest compiled_at",
+        maximum=256,
+    )
+    _finite_nonnegative(
+        normalized["compiled_at_epoch"],
+        label="BM25 gate manifest compiled_at_epoch",
+    )
     entry = normalized["indexes"]["bm25"]
     if type(entry) is not dict:
         raise RuntimeError("BM25 gate manifest entry is malformed")
     raw_entry_path = entry.get("path")
     if type(raw_entry_path) is not str:
         raise RuntimeError("BM25 gate manifest path is malformed")
-    entry["path"] = "<isolated-bm25-view>"
-    entry["built_at"] = "<measurement-metadata>"
-    entry["built_at_epoch"] = 0
+    if "built_at" not in entry or "built_at_epoch" not in entry:
+        raise RuntimeError("BM25 gate manifest build timestamps are missing")
+    _required_text(
+        entry["built_at"],
+        label="BM25 gate manifest built_at",
+        maximum=256,
+    )
+    _finite_nonnegative(
+        entry["built_at_epoch"],
+        label="BM25 gate manifest built_at_epoch",
+    )
     metadata = entry.get("metadata")
     if type(metadata) is not dict:
         raise RuntimeError("BM25 gate manifest metadata is malformed")
     if "build_duration_seconds" in metadata:
-        if type(metadata["build_duration_seconds"]) not in {int, float}:
-            raise RuntimeError("BM25 build duration metadata is malformed")
+        _finite_nonnegative(
+            metadata["build_duration_seconds"],
+            label="BM25 build duration metadata",
+        )
         metadata["build_duration_seconds"] = "<measurement-metadata>"
+    normalized["compiled_at"] = "<measurement-metadata>"
+    normalized["compiled_at_epoch"] = 0
+    entry["path"] = "<isolated-bm25-view>"
+    entry["built_at"] = "<measurement-metadata>"
+    entry["built_at_epoch"] = 0
     return normalized
 
 
@@ -2581,6 +3240,390 @@ def _normalized_portable_manifest_semantics(manifest: Any) -> dict[str, Any]:
         raise RuntimeError("portable BM25 plan paths are not canonical")
     repo["path"] = "<isolated-source>"
     return _normalize_manifest_measurement_metadata(normalized)
+
+
+def _normalized_public_manifest_payload(
+    value: Mapping[str, Any],
+    *,
+    request: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Mask only per-sample paths and times in the real public response."""
+
+    normalized = _json_snapshot(dict(value))
+    indexes = normalized.get("indexes")
+    repo = normalized.get("repo")
+    if type(indexes) is not dict or set(indexes) != {"bm25"}:
+        raise RuntimeError("public manifest has an unexpected view set")
+    if type(repo) is not dict or type(repo.get("path")) is not str:
+        raise RuntimeError("public manifest repository path is malformed")
+    entry = indexes["bm25"]
+    if type(entry) is not dict or type(entry.get("path")) is not str:
+        raise RuntimeError("public manifest BM25 path is malformed")
+
+    portable_query_context = (
+        _runtime_uses_portable_artifact(request)
+        and _runtime_source_enabled(request) is False
+    )
+    if portable_query_context:
+        if repo["path"] != "source" or entry["path"] != "views/bm25":
+            raise RuntimeError("portable public manifest paths are not canonical")
+        repository_path = "source"
+        view_path = "views/bm25"
+    else:
+        subject_root = Path(request["subject_root"])
+        raw_repository = Path(repo["path"])
+        raw_view = Path(entry["path"])
+        if (
+            not raw_repository.is_absolute()
+            or Path(os.path.abspath(os.fspath(raw_repository))) != subject_root
+            or not raw_view.is_absolute()
+        ):
+            raise RuntimeError("ordinary public manifest paths changed")
+        repository_path = "<authenticated-benchmark-subject>"
+        view_path = "<isolated-bm25-view>"
+
+    normalized = _normalize_manifest_measurement_metadata(normalized)
+    normalized["repo"]["path"] = repository_path
+    normalized["indexes"]["bm25"]["path"] = view_path
+    return normalized
+
+
+def _validated_public_manifest_payload(
+    value: Mapping[str, Any],
+    *,
+    request: Mapping[str, Any],
+    context_manifest: Mapping[str, Any],
+    context_state: Mapping[str, Any],
+    tool_surface: str,
+) -> dict[str, Any]:
+    if type(value) is not dict:
+        raise RuntimeError("public get_manifest response must be an exact object")
+    raw = _json_snapshot(value)
+    typed = dict(raw)
+    runtime_value = typed.pop("runtime", None)
+    runtime = _require_exact_dict(
+        runtime_value,
+        _PUBLIC_MANIFEST_RUNTIME_FIELDS,
+        label="public get_manifest runtime",
+    )
+
+    portable = _runtime_uses_portable_artifact(request)
+    if portable:
+        if "artifact" not in typed:
+            raise RuntimeError("portable public get_manifest omitted its artifact")
+        artifact = typed.pop("artifact")
+        if artifact != context_state["artifact"] or artifact is None:
+            raise RuntimeError("public get_manifest artifact changed")
+    elif "artifact" in typed or context_state["artifact"] is not None:
+        raise RuntimeError("ordinary public get_manifest claimed an artifact")
+    if typed != context_manifest:
+        raise RuntimeError("public get_manifest differs from its active manifest")
+
+    explore = _require_exact_dict(
+        runtime["explore_session"],
+        _PUBLIC_MANIFEST_EXPLORE_FIELDS,
+        label="public get_manifest explore session",
+    )
+    for field in _PUBLIC_MANIFEST_EXPLORE_FIELDS:
+        _nonnegative_int(
+            explore[field], label=f"public get_manifest explore session {field}"
+        )
+    if explore["max_ranges"] == 0:
+        raise RuntimeError("public get_manifest explore capacity must be positive")
+
+    source = _require_exact_dict(
+        runtime["source_read"],
+        _PUBLIC_MANIFEST_SOURCE_FIELDS,
+        label="public get_manifest source-read state",
+    )
+    if (
+        type(source["verified"]) is not bool
+        or type(source["commit_verified"]) is not bool
+    ):
+        raise RuntimeError("public get_manifest source flags are malformed")
+    if source["error"] is not None:
+        _required_text(
+            source["error"],
+            label="public get_manifest source error",
+        )
+    if source["verification_scope"] is not None:
+        _required_text(
+            source["verification_scope"],
+            label="public get_manifest source verification scope",
+            maximum=128,
+        )
+    _required_text(
+        source["checkout_state"],
+        label="public get_manifest source checkout state",
+        maximum=128,
+    )
+    expected_source = {
+        "verified": context_state["source_verified"],
+        "error": context_state["source_error"],
+        "verification_scope": context_state["source_verification_scope"],
+        "commit_verified": context_state["commit_verified"],
+        "checkout_state": "not-attested",
+    }
+    if source != expected_source:
+        raise RuntimeError("public get_manifest source-read state changed")
+    expected_surface = _required_text(
+        tool_surface,
+        label="active MCP tool surface",
+        maximum=64,
+    )
+    if expected_surface != "full" or runtime["tool_surface"] != expected_surface:
+        raise RuntimeError("public get_manifest tool surface changed")
+    if (
+        runtime["loaded_views"] != context_state["loaded_views"]
+        or runtime["view_errors"] != context_state["errors"]
+        or runtime["lsp_provider"] != context_state["lsp_provider"]
+    ):
+        raise RuntimeError("public get_manifest runtime state changed")
+    return raw
+
+
+def _public_manifest_evidence(
+    value: Mapping[str, Any],
+    *,
+    request: Mapping[str, Any],
+    context_manifest: Mapping[str, Any],
+    context_state: Mapping[str, Any],
+    tool_surface: str,
+) -> dict[str, Any]:
+    raw = _validated_public_manifest_payload(
+        value,
+        request=request,
+        context_manifest=context_manifest,
+        context_state=context_state,
+        tool_surface=tool_surface,
+    )
+    parity = _normalized_public_manifest_payload(raw, request=request)
+    return {
+        "raw_sha256": _json_digest(raw),
+        "parity_sha256": _json_digest(parity),
+        "parity_schema": _PUBLIC_MANIFEST_PARITY_SCHEMA,
+    }
+
+
+def _source_probe_coordinates(
+    query_payload: Sequence[Mapping[str, Any]],
+) -> tuple[str, int]:
+    if not query_payload:
+        raise RuntimeError("source probe requires one BM25 query payload")
+    results = query_payload[0].get("results")
+    if type(results) is not list or not results or type(results[0]) is not dict:
+        raise RuntimeError("source probe requires one BM25 result")
+    first = results[0]
+    file_path = _required_text(
+        first.get("file"), label="source probe file", maximum=4096
+    )
+    start_line = _positive_int(first.get("start_line"), label="source probe line")
+    return file_path, start_line
+
+
+def _validate_source_content_projection(
+    value: object,
+    *,
+    content: str,
+) -> dict[str, Any]:
+    if type(value) is not dict:
+        raise RuntimeError("public source content projection must be an exact object")
+    fields = frozenset(value)
+    base_fields = _SOURCE_CONTENT_PROJECTION_FIELDS
+    if fields not in {
+        base_fields,
+        base_fields | {"line_truncated"},
+        base_fields | {"next_start_line"},
+    }:
+        raise RuntimeError("public source content projection fields changed")
+    if type(value["truncated"]) is not bool:
+        raise RuntimeError("public source content truncation flag is malformed")
+    original = _nonnegative_int(
+        value["original_chars"],
+        label="public source original character count",
+    )
+    returned = _nonnegative_int(
+        value["returned_chars"],
+        label="public source returned character count",
+    )
+    strategy = _required_text(
+        value["strategy"],
+        label="public source content strategy",
+        maximum=64,
+    )
+    if returned != len(content) or original < returned:
+        raise RuntimeError("public source content projection counts changed")
+    if value["truncated"] is False:
+        if fields != base_fields or strategy != "complete" or original != returned:
+            raise RuntimeError("complete public source projection is malformed")
+    else:
+        if strategy != "sequential_window" or original <= returned:
+            raise RuntimeError("truncated public source projection is malformed")
+        if "line_truncated" in value:
+            if value["line_truncated"] is not True:
+                raise RuntimeError("public source line truncation flag is malformed")
+        elif "next_start_line" in value:
+            _positive_int(
+                value["next_start_line"],
+                label="public source next start line",
+            )
+        else:
+            raise RuntimeError("truncated public source projection lacks continuation")
+    return _json_snapshot(value)
+
+
+def _validated_public_source_payload(
+    value: object,
+    *,
+    request: Mapping[str, Any],
+    file_path: str,
+    start_line: int,
+    source_fingerprint: str,
+) -> dict[str, Any]:
+    payload = _require_exact_dict(
+        value,
+        _SOURCE_READ_PAYLOAD_FIELDS,
+        label="public source-read payload",
+    )
+    observed_file = _required_text(
+        payload["file"],
+        label="public source-read file",
+        maximum=4096,
+    )
+    observed_start = _positive_int(
+        payload["start_line"],
+        label="public source-read start line",
+    )
+    observed_end = _positive_int(
+        payload["end_line"],
+        label="public source-read end line",
+    )
+    if (
+        observed_file != file_path
+        or observed_start != start_line
+        or observed_end != start_line
+    ):
+        raise RuntimeError("public source-read coordinates changed")
+    if type(payload["content"]) is not str:
+        raise RuntimeError("public source-read content is malformed")
+    payload["content_projection"] = _validate_source_content_projection(
+        payload["content_projection"],
+        content=payload["content"],
+    )
+    provenance = _require_exact_dict(
+        payload["source"],
+        _SOURCE_READ_PROVENANCE_FIELDS,
+        label="public source-read provenance",
+    )
+    for field in (
+        "repository",
+        "commit",
+        "source_fingerprint",
+        "verification_scope",
+        "checkout_state",
+    ):
+        _required_text(
+            provenance[field],
+            label=f"public source-read provenance {field}",
+            maximum=4096,
+        )
+    if (
+        type(provenance["verified"]) is not bool
+        or type(provenance["commit_verified"]) is not bool
+    ):
+        raise RuntimeError("public source-read provenance flags are malformed")
+    expected_fingerprint = _required_text(
+        source_fingerprint,
+        label="active context source fingerprint",
+        maximum=80,
+    )
+    if not _SOURCE_V2_RE.fullmatch(expected_fingerprint):
+        raise RuntimeError("active context source fingerprint is not secure v2")
+    expected_repository = (
+        request["subject"]["repository_key"]
+        if _runtime_uses_portable_artifact(request)
+        else request["subject_root"]
+    )
+    expected_provenance = {
+        "repository": expected_repository,
+        "commit": request["subject"]["revision"],
+        "source_fingerprint": expected_fingerprint,
+        "verified": True,
+        "verification_scope": "content-bytes",
+        "commit_verified": False,
+        "checkout_state": "not-attested",
+    }
+    if provenance != expected_provenance:
+        raise RuntimeError("public source-read provenance changed")
+    return _json_snapshot(payload)
+
+
+def _source_read_evidence(
+    server_module: Any,
+    context: Any,
+    query_payload: Sequence[Mapping[str, Any]],
+    *,
+    request: Mapping[str, Any],
+) -> dict[str, Any]:
+    file_path, start_line = _source_probe_coordinates(query_payload)
+    source_enabled = _runtime_source_enabled(request)
+    if source_enabled is None:
+        raise RuntimeError("compiler samples must not execute a source probe")
+    if server_module.get_context() is not context:
+        raise RuntimeError("public source probe lost its active MCP context")
+    try:
+        payload = asyncio.run(
+            server_module.read_source(file_path, start_line, start_line)
+        )
+    except RuntimeError as exc:
+        expected_error = "source reads are unavailable: " + (
+            context.source_error or "source binding is unverified"
+        )
+        if (
+            source_enabled
+            or type(exc) is not RuntimeError
+            or str(exc) != expected_error
+        ):
+            raise
+        if server_module.get_context() is not context:
+            raise RuntimeError(
+                "public source probe changed its active MCP context"
+            ) from exc
+        return {
+            "status": "source-disabled",
+            "payload_sha256": None,
+            "content_sha256": None,
+            "error_sha256": _json_digest(
+                {"error_type": type(exc).__name__, "message": str(exc)}
+            ),
+            "count": 1,
+        }
+    if not source_enabled:
+        raise RuntimeError("source-disabled runtime unexpectedly served source bytes")
+    if server_module.get_context() is not context:
+        raise RuntimeError("public source probe changed its active MCP context")
+    payload = _validated_public_source_payload(
+        _json_snapshot(payload),
+        request=request,
+        file_path=file_path,
+        start_line=start_line,
+        source_fingerprint=context.manifest.source_fingerprint,
+    )
+    content_fields = (
+        "file",
+        "start_line",
+        "end_line",
+        "content",
+        "content_projection",
+    )
+    content = {field: payload[field] for field in content_fields}
+    return {
+        "status": "verified",
+        "payload_sha256": _json_digest(payload),
+        "content_sha256": _json_digest(content),
+        "error_sha256": None,
+        "count": 1,
+    }
 
 
 def _view_inventory_receipts(view_root: Path) -> dict[str, dict[str, Any]]:
@@ -2787,6 +3830,45 @@ def _canonical_cache_identity(
     return manifest_identity, view_identity
 
 
+def _validate_runtime_context_manifest(
+    value: object,
+    *,
+    persisted: Mapping[str, Any],
+    request: Mapping[str, Any],
+    paths: Mapping[str, str],
+) -> dict[str, Any]:
+    if type(value) is not dict or type(persisted) is not dict:
+        raise RuntimeError("runtime context manifests must be exact objects")
+    expected = _json_snapshot(persisted)
+    source_bound_retained = (
+        request["cell"] == "runtime-cold-source-bound" and request["arm"] == "candidate"
+    )
+    if source_bound_retained:
+        repo = expected.get("repo")
+        indexes = expected.get("indexes")
+        if (
+            type(repo) is not dict
+            or repo.get("path") != "source"
+            or type(indexes) is not dict
+            or set(indexes) != {"bm25"}
+            or type(indexes["bm25"]) is not dict
+            or indexes["bm25"].get("path") != "views/bm25"
+        ):
+            raise RuntimeError(
+                "source-bound retained manifest is not canonically portable"
+            )
+        runtime_view = (Path(paths["runtime_output"]) / "views" / "bm25").resolve(
+            strict=True
+        )
+        repo["path"] = request["subject_root"]
+        indexes["bm25"]["path"] = os.fspath(runtime_view)
+    if value != expected:
+        raise RuntimeError(
+            "runtime context manifest differs from its exact persisted binding"
+        )
+    return expected
+
+
 def _query_payload(context: Any, subject: Mapping[str, Any]) -> list[dict[str, Any]]:
     from codenib.mcp.tools.search import search_bm25_impl
 
@@ -2830,7 +3912,7 @@ def _route_result_from_manifest(
     *,
     request: Mapping[str, Any],
     subject: Mapping[str, Any],
-    manifest_identity: Mapping[str, Any],
+    bm25_plan_identity: Mapping[str, Any],
     view_identity: Mapping[str, Any],
 ) -> tuple[dict[str, Any], bool]:
     from codenib.mcp.context import ServerContext
@@ -2854,12 +3936,20 @@ def _route_result_from_manifest(
             active_context.close()
             closed = True
     result = {
-        "manifest": dict(manifest_identity),
+        "bm25_plan": dict(bm25_plan_identity),
+        "public_manifest": None,
         "view": dict(view_identity),
         "retained_view": None,
         "queries": queries,
+        "source_read": {
+            "status": "not-exercised",
+            "payload_sha256": None,
+            "content_sha256": None,
+            "error_sha256": None,
+            "count": 0,
+        },
         "snapshot": {field: None for field in _SNAPSHOT_FIELDS},
-        "authority": _expected_authority_identity(request),
+        "runtime": _expected_runtime_identity(request),
     }
     return result, closed
 
@@ -2870,8 +3960,12 @@ def _runtime_context_state(context: Any) -> dict[str, Any]:
         "errors": dict(context.errors),
         "artifact": None if context.artifact is None else dict(context.artifact),
         "source_verified": context.source_verified,
+        "source_error": context.source_error,
         "source_verification_scope": context.source_verification_scope,
-        "vector_loaded": context.vector is not None,
+        "native_vector_authorized": context._native_index_authorization is not None,
+        "native_lsp_allowed": context._lsp_allow_native,
+        "lsp_provider": _json_snapshot(context.lsp_provider_selection),
+        "commit_verified": context.commit_verified,
     }
 
 
@@ -2886,31 +3980,65 @@ def _validate_runtime_context_state(
             "errors",
             "artifact",
             "source_verified",
+            "source_error",
             "source_verification_scope",
-            "vector_loaded",
+            "native_vector_authorized",
+            "native_lsp_allowed",
+            "lsp_provider",
+            "commit_verified",
         }
     )
     state = _require_exact_dict(value, fields, label="runtime context state")
     if (
+        type(state["source_verified"]) is not bool
+        or type(state["native_vector_authorized"]) is not bool
+        or type(state["native_lsp_allowed"]) is not bool
+        or type(state["commit_verified"]) is not bool
+    ):
+        raise RuntimeError("MCP runtime capability flags are malformed")
+    if state["source_verified"]:
+        if state["source_error"] is not None:
+            raise RuntimeError("verified MCP source context retained an error")
+    else:
+        _required_text(
+            state["source_error"],
+            label="unverified MCP source error",
+        )
+    if (
         state["loaded_views"] != ["bm25"]
         or state["errors"] != {}
-        or state["vector_loaded"] is not False
+        or state["native_vector_authorized"] is not False
+        or state["commit_verified"] is not False
     ):
         raise RuntimeError("MCP route is not an exact clean BM25 context")
+    route = CELL_ROUTE_CONTRACTS[request["cell"]][request["arm"]]
+    source_verified = state["source_verified"]
     observed = {
-        "context_kind": (
-            "manifest-live-source"
-            if state["artifact"] is None
-            else "portable-artifact-query-only"
-        ),
+        "delivery": {
+            "route": route["route"],
+            "context_provenance": route["context_provenance"],
+        },
         "artifact": state["artifact"],
-        "source_verified": state["source_verified"],
-        "source_verification_scope": state["source_verification_scope"],
+        "source_authority": {
+            "kind": ("content-bytes-v2" if source_verified else "source-disabled"),
+            "verified": source_verified,
+            "verification_scope": state["source_verification_scope"],
+        },
+        "capabilities": {
+            "loaded_views": list(state["loaded_views"]),
+            "view_errors": dict(state["errors"]),
+            "read_source": source_verified,
+            "native_vector_authorized": state["native_vector_authorized"],
+            "native_lsp_allowed": state["native_lsp_allowed"],
+            "lsp_provider": state["lsp_provider"],
+            "commit_verified": state["commit_verified"],
+            "checkout_state": "not-attested",
+        },
     }
-    return _validate_authority_identity(
+    return _validate_runtime_identity(
         observed,
         request=request,
-        label="runtime context authority",
+        label="runtime context contract",
     )
 
 
@@ -2999,7 +4127,7 @@ def _runtime_arguments(
         return ["mcp", os.fspath(_cache_manifest_path(Path(request["subject_root"])))]
     if generation is None:
         raise RuntimeError("candidate runtime route requires a retained ref")
-    return [
+    arguments = [
         "mcp",
         "--catalog",
         paths["catalog"],
@@ -3016,6 +4144,9 @@ def _runtime_arguments(
         "--output",
         paths["runtime_output"],
     ]
+    if request["cell"] == "runtime-cold-source-bound":
+        arguments.extend(("--repo", request["subject_root"]))
+    return arguments
 
 
 def _validate_route_config(value: object) -> tuple[dict[str, Any], dict[str, str]]:
@@ -3076,6 +4207,7 @@ def _route_worker(value: object) -> dict[str, Any]:
     cpu_started = time.process_time()
     wall_started = time.perf_counter()
     context_closed = False
+    source_closed = False
     route_result: dict[str, Any] | None = None
     metrics: dict[str, float | int] | None = None
     with _sample_environment(paths):
@@ -3100,9 +4232,10 @@ def _route_worker(value: object) -> dict[str, Any]:
                 _cache_manifest_path(Path(request["subject_root"])),
                 request=request,
                 subject=request["subject"],
-                manifest_identity=canonical_manifest,
+                bm25_plan_identity=canonical_manifest,
                 view_identity=canonical_view,
             )
+            source_closed = True
         else:
             from codenib.compiler.manifest import MANIFEST_FILENAME
             from codenib.mcp import server as server_module
@@ -3122,12 +4255,26 @@ def _route_worker(value: object) -> dict[str, Any]:
                 if transport != "stdio":
                     raise RuntimeError("MCP route selected a non-stdio transport")
                 context = server_module.get_context()
+                if server_module.get_context() is not context:
+                    raise RuntimeError("MCP ready callback changed its context")
+                captured["source_binding"] = context._source_binding
+                captured["tool_surface"] = server_module.mcp.tool_surface
                 captured["context_manifest"] = context.manifest.to_dict()
-                captured["context_state"] = _runtime_context_state(context)
-                captured["query_payload"] = _query_payload(
+                query_payload = _query_payload(
                     context,
                     request["subject"],
                 )
+                captured["query_payload"] = query_payload
+                captured["public_manifest"] = asyncio.run(server_module.get_manifest())
+                captured["source_read"] = _source_read_evidence(
+                    server_module,
+                    context,
+                    query_payload,
+                    request=request,
+                )
+                if server_module.get_context() is not context:
+                    raise RuntimeError("MCP public probes changed their context")
+                captured["context_state"] = _runtime_context_state(context)
 
             server_module.mcp.run = run_stdio
             try:
@@ -3152,16 +4299,31 @@ def _route_worker(value: object) -> dict[str, Any]:
             context_manifest = captured.get("context_manifest")
             context_state = captured.get("context_state")
             query_payload = captured.get("query_payload")
+            public_manifest = captured.get("public_manifest")
+            source_read = captured.get("source_read")
+            tool_surface = captured.get("tool_surface")
             if (
                 type(context_manifest) is not dict
                 or type(context_state) is not dict
                 or type(query_payload) is not list
+                or type(public_manifest) is not dict
+                or type(source_read) is not dict
+                or type(tool_surface) is not str
+                or "source_binding" not in captured
             ):
                 raise RuntimeError("MCP benchmark callback did not observe a context")
-            authority = _validate_runtime_context_state(
+            runtime = _validate_runtime_context_state(
                 context_state,
                 request=request,
             )
+            source_binding = captured["source_binding"]
+            if _runtime_source_enabled(request):
+                source_closed = (
+                    source_binding is not None
+                    and getattr(source_binding, "closed", False) is True
+                )
+            else:
+                source_closed = source_binding is None
             canonical_manifest, canonical_view = _canonical_cache_identity(
                 request,
                 paths,
@@ -3188,20 +4350,30 @@ def _route_worker(value: object) -> dict[str, Any]:
 
                 manifest = RepoManifest.load(runtime_manifest)
                 actual_view = None
-            if context_manifest != manifest.to_dict():
-                raise RuntimeError(
-                    "runtime context manifest differs from its persisted manifest"
-                )
+            _validate_runtime_context_manifest(
+                context_manifest,
+                persisted=manifest.to_dict(),
+                request=request,
+                paths=paths,
+            )
             route_result = {
-                "manifest": canonical_manifest,
+                "bm25_plan": canonical_manifest,
+                "public_manifest": _public_manifest_evidence(
+                    public_manifest,
+                    request=request,
+                    context_manifest=context_manifest,
+                    context_state=context_state,
+                    tool_surface=tool_surface,
+                ),
                 "view": canonical_view,
                 "retained_view": None,
                 "queries": _query_identity_from_payload(
                     query_payload,
                     subject=request["subject"],
                 ),
+                "source_read": source_read,
                 "snapshot": {field: None for field in _SNAPSHOT_FIELDS},
-                "authority": authority,
+                "runtime": runtime,
             }
             if request["arm"] == "candidate":
                 route_result["retained_view"] = actual_view
@@ -3220,6 +4392,7 @@ def _route_worker(value: object) -> dict[str, Any]:
         "metrics": metrics,
         "result": route_result,
         "context_closed": context_closed,
+        "source_closed": source_closed,
     }
 
 
@@ -3253,7 +4426,16 @@ def _invoke_materialize(
 def _validate_route_result(value: object) -> dict[str, Any]:
     route = _require_exact_dict(
         value,
-        frozenset({"operation", "process_id", "metrics", "result", "context_closed"}),
+        frozenset(
+            {
+                "operation",
+                "process_id",
+                "metrics",
+                "result",
+                "context_closed",
+                "source_closed",
+            }
+        ),
         label="inner route result",
     )
     if route["operation"] != "route":
@@ -3265,6 +4447,8 @@ def _validate_route_result(value: object) -> dict[str, Any]:
         raise RuntimeError("inner route result shape changed")
     if type(route["context_closed"]) is not bool:
         raise RuntimeError("inner route context cleanup flag is malformed")
+    if type(route["source_closed"]) is not bool:
+        raise RuntimeError("inner route source cleanup flag is malformed")
     return route
 
 
@@ -3359,7 +4543,7 @@ def _sample_worker(value: object) -> dict[str, Any]:
                         )
                     )
                     retained_matches_raw = (
-                        retained_manifest == result["manifest"]
+                        retained_manifest == result["bm25_plan"]
                         and retained_view == result["view"]
                     )
                     result["retained_view"] = retained_view
@@ -3369,7 +4553,7 @@ def _sample_worker(value: object) -> dict[str, Any]:
                         paths,
                     )
                     retained_matches_raw = (
-                        raw_manifest == result["manifest"]
+                        raw_manifest == result["bm25_plan"]
                         and raw_view == result["view"]
                         and result["retained_view"] == result["view"]
                     )
@@ -3383,16 +4567,7 @@ def _sample_worker(value: object) -> dict[str, Any]:
             subject_unchanged = before == after
             if not subject_unchanged:
                 raise RuntimeError("benchmark subject changed during a sample")
-            view = result["view"]
-            parity = {
-                "manifest": dict(result["manifest"]),
-                "view": {
-                    "documents_sha256": view["documents_sha256"],
-                    "metadata_sha256": view["metadata_sha256"],
-                },
-                "queries": dict(result["queries"]),
-                "authority": _json_snapshot(result["authority"]),
-            }
+            parity_identities = _parity_identities_from_result(result)
             receipt = {
                 "schema_version": REPORT_SCHEMA_VERSION,
                 "operation": "sample",
@@ -3406,7 +4581,7 @@ def _sample_worker(value: object) -> dict[str, Any]:
                 "view_set_id": request["view_set"]["id"],
                 "process_id": route["process_id"],
                 "metrics": dict(route["metrics"]),
-                "parity_identity": parity,
+                "parity_identities": parity_identities,
                 "result": result,
                 "safety": {
                     "subject_unchanged": subject_unchanged,
@@ -3414,6 +4589,7 @@ def _sample_worker(value: object) -> dict[str, Any]:
                     "cleanup_complete": False,
                     "storage_closed": True,
                     "context_closed": route["context_closed"],
+                    "source_closed": route["source_closed"],
                     "ref_stable": ref_stable,
                     "retained_matches_raw": retained_matches_raw,
                 },

--- a/scripts/profiling/retained_storage_subjects.json
+++ b/scripts/profiling/retained_storage_subjects.json
@@ -1,6 +1,6 @@
 {
-  "schema_version": 2,
-  "benchmark": "retained_storage_explicit_route_gate_v2",
+  "schema_version": 3,
+  "benchmark": "retained_storage_explicit_route_gate_v3",
   "policy": {
     "status": "unratified",
     "canonical_iterations": 20,
@@ -16,7 +16,8 @@
     "compiler-cold",
     "compiler-current",
     "runtime-cold",
-    "runtime-cold-query-only"
+    "runtime-cold-query-only",
+    "runtime-cold-source-bound"
   ],
   "view_sets": [
     {

--- a/test/scripts/test_profile_retained_storage_gate.py
+++ b/test/scripts/test_profile_retained_storage_gate.py
@@ -10,6 +10,7 @@ import math
 import os
 import signal
 import subprocess
+import sys
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, Mapping
@@ -178,73 +179,111 @@ def _use_distinct_media_classes(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(profiler, "_media_identity", distinct)
 
 
-def _parity_identity(request: Mapping[str, Any]) -> dict[str, Any]:
+def _bm25_plan_identity(request: Mapping[str, Any]) -> dict[str, Any]:
     subject = request["subject"]
+    return {
+        "commit": subject["revision"],
+        "source_fingerprint": _SOURCE_V2,
+        "source_selection_digest": _json_digest(subject["source_selection"]),
+        "semantic_sha256": _SHA_B,
+        "languages": list(subject["languages"]),
+        "file_count": 1,
+    }
+
+
+def _public_manifest_evidence(request: Mapping[str, Any]) -> dict[str, Any] | None:
+    if request["cell"] in {"compiler-cold", "compiler-current"}:
+        return None
+    portable = request["arm"] == "candidate" or (
+        request["arm"] == "legacy" and request["cell"] == "runtime-cold-query-only"
+    )
+    return {
+        "raw_sha256": _SHA_D if portable else _SHA_C,
+        "parity_sha256": _SHA_D if portable else _SHA_C,
+        "parity_schema": "codenib.retained-storage-public-manifest-parity.v1",
+    }
+
+
+def _source_read_evidence(request: Mapping[str, Any]) -> dict[str, Any]:
+    cell = request["cell"]
+    if cell in {"compiler-cold", "compiler-current"}:
+        return {
+            "status": "not-exercised",
+            "payload_sha256": None,
+            "content_sha256": None,
+            "error_sha256": None,
+            "count": 0,
+        }
+    source_enabled = (
+        request["arm"] == "legacy" and cell != "runtime-cold-query-only"
+    ) or (request["arm"] == "candidate" and cell == "runtime-cold-source-bound")
+    if source_enabled:
+        return {
+            "status": "verified",
+            "payload_sha256": _SHA_C,
+            "content_sha256": _SHA_D,
+            "error_sha256": None,
+            "count": 1,
+        }
+    return {
+        "status": "source-disabled",
+        "payload_sha256": None,
+        "content_sha256": None,
+        "error_sha256": _SHA_C,
+        "count": 1,
+    }
+
+
+def _runtime_identity(request: Mapping[str, Any]) -> dict[str, Any]:
+    runtime = profiler._expected_runtime_identity(request)  # noqa: SLF001
+    capabilities = runtime["capabilities"]
+    if capabilities is None:
+        return runtime
+    portable = request["arm"] == "candidate" or (
+        request["arm"] == "legacy" and request["cell"] == "runtime-cold-query-only"
+    )
+    capabilities["lsp_provider"] = {
+        "provider": "codenib_static_index",
+        "backend": "unavailable",
+        "status": "unavailable",
+        "index_snapshot": None,
+        "fallback_reason": (
+            "portable_artifact_uses_persisted_graph"
+            if portable
+            else "repository_source_policy_requires_persisted_graph"
+        ),
+        "capabilities": {
+            "definition": False,
+            "references": False,
+            "route": False,
+        },
+    }
+    return runtime
+
+
+def _sample_receipt(request: Mapping[str, Any], *, process_id: int) -> dict[str, Any]:
     queries_sha256 = (
         _SHA_B
         if request["cell"] == "runtime-cold" and request["arm"] == "candidate"
         else _SHA_A
     )
-    return {
-        "manifest": {
-            "commit": subject["revision"],
-            "source_fingerprint": _SOURCE_V2,
-            "source_selection_digest": _json_digest(subject["source_selection"]),
-            "semantic_sha256": _SHA_B,
-            "languages": list(subject["languages"]),
-            "file_count": 1,
-        },
+    result = {
+        "bm25_plan": _bm25_plan_identity(request),
+        "public_manifest": _public_manifest_evidence(request),
         "view": {
             "documents_sha256": _SHA_C,
             "metadata_sha256": _SHA_D,
+            "payload_bytes": 128,
+            "payload_files": 2,
         },
         "queries": {
             "sha256": queries_sha256,
-            "count": len(subject["queries"]),
+            "count": len(request["subject"]["queries"]),
             "nonempty": True,
         },
-        "authority": _authority_identity(request),
+        "source_read": _source_read_evidence(request),
+        "runtime": _runtime_identity(request),
     }
-
-
-def _authority_identity(request: Mapping[str, Any]) -> dict[str, Any]:
-    cell = request["cell"]
-    arm = request["arm"]
-    if cell in {"compiler-cold", "compiler-current"}:
-        return {
-            "context_kind": "compiler-portable-plan",
-            "artifact": None,
-            "source_verified": None,
-            "source_verification_scope": None,
-        }
-    if cell == "runtime-cold" and arm == "legacy":
-        return {
-            "context_kind": "manifest-live-source",
-            "artifact": None,
-            "source_verified": True,
-            "source_verification_scope": "content-bytes",
-        }
-
-    from codenib.artifacts.context import CONTEXT_ARTIFACT_SCHEMA
-
-    return {
-        "context_kind": "portable-artifact-query-only",
-        "artifact": {
-            "verified": True,
-            "schema": CONTEXT_ARTIFACT_SCHEMA,
-            "repository": request["subject"]["repository_key"],
-            "commit": request["subject"]["revision"],
-            "views": ["bm25"],
-        },
-        "source_verified": False,
-        "source_verification_scope": None,
-    }
-
-
-def _sample_receipt(request: Mapping[str, Any], *, process_id: int) -> dict[str, Any]:
-    parity = _parity_identity(request)
-    result = deepcopy(parity)
-    result["view"].update({"payload_bytes": 128, "payload_files": 2})
     result["retained_view"] = (
         deepcopy(result["view"]) if request["arm"] == "candidate" else None
     )
@@ -261,6 +300,7 @@ def _sample_receipt(request: Mapping[str, Any], *, process_id: int) -> dict[str,
             "compiler-current": False,
             "runtime-cold": None,
             "runtime-cold-query-only": None,
+            "runtime-cold-source-bound": None,
         }[request["cell"]]
         result["snapshot"] = {
             "snapshot_id": _SNAPSHOT_ID,
@@ -268,6 +308,7 @@ def _sample_receipt(request: Mapping[str, Any], *, process_id: int) -> dict[str,
             "generation": 1,
             "changed": changed,
         }
+    parity = profiler._parity_identities_from_result(result)  # noqa: SLF001
     return {
         "schema_version": profiler.REPORT_SCHEMA_VERSION,
         "operation": request["operation"],
@@ -290,7 +331,7 @@ def _sample_receipt(request: Mapping[str, Any], *, process_id: int) -> dict[str,
             "payload_bytes": 128,
             "payload_files": 2,
         },
-        "parity_identity": parity,
+        "parity_identities": parity,
         "result": result,
         "safety": {
             "subject_unchanged": True,
@@ -298,6 +339,7 @@ def _sample_receipt(request: Mapping[str, Any], *, process_id: int) -> dict[str,
             "cleanup_complete": True,
             "storage_closed": True,
             "context_closed": True,
+            "source_closed": True,
             "ref_stable": True,
             "retained_matches_raw": True,
         },
@@ -327,6 +369,8 @@ def _run_fake_cell(
     media_roots: Mapping[str, Path],
     cell: str,
     sample_runner: Callable[[Mapping[str, Any]], Mapping[str, Any]],
+    iterations: int = 1,
+    warmups: int = 0,
 ) -> dict[str, Any]:
     manifest, _receipt = profiler.load_subject_manifest(manifest_path)
     subject = manifest["subjects"][0]
@@ -340,30 +384,81 @@ def _run_fake_cell(
         media_identity=profiler._media_identity(media_root),
         view_set=manifest["view_sets"][0],
         cell=cell,
-        iterations=1,
-        warmups=0,
+        iterations=iterations,
+        warmups=warmups,
         sample_runner=sample_runner,
         process_ids=process_ids,
     )
-    assert len(process_ids) == 2
-    assert len(set(process_ids)) == 2
+    expected_samples = (iterations + warmups) * len(profiler.ARMS)
+    assert len(process_ids) == expected_samples
+    assert len(set(process_ids)) == expected_samples
     return result
 
 
-def test_public_v2_contract_and_deterministic_paired_order() -> None:
+def test_public_v3_contract_and_deterministic_paired_order() -> None:
     assert profiler.ARMS == ("legacy", "candidate")
     assert profiler.CELLS == (
         "compiler-cold",
         "compiler-current",
         "runtime-cold",
         "runtime-cold-query-only",
+        "runtime-cold-source-bound",
     )
     assert profiler.TRACKS == {
-        "compiler": ("compiler-cold", "compiler-current"),
-        "query-only-runtime": ("runtime-cold-query-only",),
-        "manifest-runtime-compatibility": ("runtime-cold",),
+        "compiler": {
+            "cells": ("compiler-cold", "compiler-current"),
+            "projection": "compiler",
+        },
+        "query-only-runtime": {
+            "cells": ("runtime-cold-query-only",),
+            "projection": "full-runtime",
+        },
+        "manifest-runtime-compatibility": {
+            "cells": ("runtime-cold",),
+            "projection": "full-runtime",
+        },
+        "source-bound-runtime": {
+            "cells": ("runtime-cold-source-bound",),
+            "projection": "content-authority",
+        },
+        "source-bound-manifest-compatibility": {
+            "cells": ("runtime-cold-source-bound",),
+            "projection": "full-runtime",
+        },
     }
-    assert profiler.CANONICAL_SAMPLE_COUNT == 1152
+    assert profiler.PARITY_PROJECTIONS == (
+        "compiler",
+        "content-authority",
+        "full-runtime",
+    )
+    assert profiler.CELL_PRIMARY_PROJECTIONS == {
+        "compiler-cold": "compiler",
+        "compiler-current": "compiler",
+        "runtime-cold": "full-runtime",
+        "runtime-cold-query-only": "full-runtime",
+        "runtime-cold-source-bound": "content-authority",
+    }
+    expected_compiler_delivery = {
+        "legacy": {
+            "route": "compiler-cache-index",
+            "context_provenance": "compiler-cache-manifest",
+        },
+        "candidate": {
+            "route": "compiler-cache-index-and-retained-publication",
+            "context_provenance": "compiler-cache-manifest",
+        },
+    }
+    for cell in ("compiler-cold", "compiler-current"):
+        assert {
+            arm: {
+                "route": contract["route"],
+                "context_provenance": contract["context_provenance"],
+            }
+            for arm, contract in profiler.CELL_ROUTE_CONTRACTS[cell].items()
+        } == expected_compiler_delivery
+        for arm, delivery in expected_compiler_delivery.items():
+            assert _runtime_identity({"cell": cell, "arm": arm})["delivery"] == delivery
+    assert profiler.CANONICAL_SAMPLE_COUNT == 1440
     assert [profiler.paired_arm_order(index) for index in range(4)] == [
         ("legacy", "candidate"),
         ("candidate", "legacy"),
@@ -396,22 +491,46 @@ def test_runtime_manifest_sentinel_is_negative_but_query_only_is_exact(
 
     sentinel_pair = sentinel["runs"]["measured"][0]
     legacy_sentinel, candidate_sentinel = sentinel_pair["samples"]
-    assert sentinel_pair["parity"] is False
-    assert sentinel["parity"]["every_pair"] is False
-    assert sentinel["parity"]["stable_across_runs"] is False
-    assert sentinel["parity"]["passed"] is False
-    assert len(sentinel["parity"]["identity_sha256"]) == 2
+    assert sentinel_pair["parity"] == {
+        "compiler": False,
+        "content-authority": False,
+        "full-runtime": False,
+    }
+    assert sentinel["primary_projection"] == "full-runtime"
+    assert sentinel["parity"]["full-runtime"]["every_pair_equal"] is False
+    assert sentinel["parity"]["full-runtime"]["stable_within_arm"] == {
+        "legacy": True,
+        "candidate": True,
+    }
+    assert sentinel["parity"]["full-runtime"]["passed"] is False
+    assert sentinel["parity"]["full-runtime"]["identity_sha256"].keys() == {
+        "legacy",
+        "candidate",
+    }
     assert (
         legacy_sentinel["result"]["queries"]["sha256"]
         != candidate_sentinel["result"]["queries"]["sha256"]
     )
-    assert legacy_sentinel["result"]["authority"] == {
-        "context_kind": "manifest-live-source",
+    assert legacy_sentinel["result"]["runtime"] == {
+        "delivery": {
+            "route": "manifest-path",
+            "context_provenance": "ordinary-manifest",
+        },
         "artifact": None,
-        "source_verified": True,
-        "source_verification_scope": "content-bytes",
+        "source_authority": {
+            "kind": "content-bytes-v2",
+            "verified": True,
+            "verification_scope": "content-bytes",
+        },
+        "capabilities": _runtime_identity(
+            {
+                "cell": "runtime-cold",
+                "arm": "legacy",
+                "subject": subject,
+            }
+        )["capabilities"],
     }
-    assert candidate_sentinel["result"]["authority"] == _authority_identity(
+    assert candidate_sentinel["result"]["runtime"] == _runtime_identity(
         {
             "cell": "runtime-cold",
             "arm": "candidate",
@@ -420,12 +539,246 @@ def test_runtime_manifest_sentinel_is_negative_but_query_only_is_exact(
     )
 
     query_only_pair = query_only["runs"]["measured"][0]
-    assert query_only_pair["parity"] is True
-    assert query_only["parity"]["passed"] is True
+    assert query_only_pair["parity"] == {
+        "compiler": True,
+        "content-authority": True,
+        "full-runtime": True,
+    }
+    assert query_only["parity"]["full-runtime"]["passed"] is True
     assert (
-        query_only_pair["samples"][0]["parity_identity"]
-        == query_only_pair["samples"][1]["parity_identity"]
+        query_only_pair["samples"][0]["parity_identities"]
+        == query_only_pair["samples"][1]["parity_identities"]
     )
+
+
+def test_source_bound_runtime_has_content_authority_parity_not_manifest_parity(
+    tmp_path: Path,
+) -> None:
+    manifest_path, subject_roots, media_roots = _fixture(tmp_path)
+
+    source_bound = _run_fake_cell(
+        manifest_path=manifest_path,
+        subject_roots=subject_roots,
+        media_roots=media_roots,
+        cell="runtime-cold-source-bound",
+        sample_runner=_fake_sample_runner(),
+    )
+
+    pair = source_bound["runs"]["measured"][0]
+    legacy, candidate = pair["samples"]
+    assert source_bound["primary_projection"] == "content-authority"
+    assert pair["parity"] == {
+        "compiler": True,
+        "content-authority": True,
+        "full-runtime": False,
+    }
+    assert source_bound["parity"]["content-authority"] == {
+        "every_pair_equal": True,
+        "stable_within_arm": {"legacy": True, "candidate": True},
+        "identity_sha256": {
+            "legacy": [_json_digest(legacy["parity_identities"]["content-authority"])],
+            "candidate": [
+                _json_digest(candidate["parity_identities"]["content-authority"])
+            ],
+        },
+        "passed": True,
+    }
+    assert source_bound["parity"]["full-runtime"]["every_pair_equal"] is False
+    assert source_bound["parity"]["full-runtime"]["stable_within_arm"] == {
+        "legacy": True,
+        "candidate": True,
+    }
+    assert source_bound["passed"] is True
+    assert legacy["result"]["source_read"] == candidate["result"]["source_read"]
+    assert (
+        legacy["result"]["runtime"]["source_authority"]
+        == candidate["result"]["runtime"]["source_authority"]
+    )
+    assert legacy["result"]["public_manifest"] != candidate["result"]["public_manifest"]
+    assert legacy["result"]["runtime"]["delivery"] == {
+        "route": "manifest-path",
+        "context_provenance": "ordinary-manifest",
+    }
+    assert candidate["result"]["runtime"]["delivery"] == {
+        "route": "retained-ref",
+        "context_provenance": "portable-context-artifact",
+    }
+
+
+def test_content_authority_projection_keeps_only_source_capability_evidence(
+    tmp_path: Path,
+) -> None:
+    manifest_path, subject_roots, media_roots = _fixture(tmp_path)
+    manifest, _receipt = profiler.load_subject_manifest(manifest_path)
+    subject = manifest["subjects"][0]
+    media_id, media_root = next(iter(media_roots.items()))
+
+    def result(arm: str) -> dict[str, Any]:
+        request = {
+            "operation": "sample",
+            "arm": arm,
+            "phase": "measured",
+            "round_index": 0,
+            "cell": "runtime-cold-source-bound",
+            "subject": subject,
+            "subject_root": os.fspath(subject_roots[subject["id"]]),
+            "media_id": media_id,
+            "media_root": os.fspath(media_root),
+            "media_identity": profiler._media_identity(media_root),
+            "view_set": manifest["view_sets"][0],
+            "run_id": "1" * 32,
+        }
+        return _sample_receipt(request, process_id=1234)["result"]
+
+    legacy = profiler._parity_identities_from_result(result("legacy"))  # noqa: SLF001
+    candidate_result = result("candidate")
+    candidate = profiler._parity_identities_from_result(  # noqa: SLF001
+        candidate_result
+    )
+    assert set(candidate["content-authority"]) == {
+        "compiler",
+        "source_read",
+        "source_authority",
+        "source_capabilities",
+    }
+    assert (
+        legacy["content-authority"]["source_capabilities"]
+        == candidate["content-authority"]["source_capabilities"]
+        == {
+            "loaded_views": ["bm25"],
+            "read_source": True,
+            "commit_verified": False,
+            "checkout_state": "not-attested",
+        }
+    )
+    assert legacy["content-authority"] == candidate["content-authority"]
+    compiler_result = deepcopy(candidate_result)
+    compiler_result["runtime"] = _runtime_identity(
+        {"cell": "compiler-cold", "arm": "legacy", "subject": subject}
+    )
+    compiler_result["source_read"] = {
+        "status": "not-exercised",
+        "payload_sha256": None,
+        "content_sha256": None,
+        "error_sha256": None,
+        "count": 0,
+    }
+    assert (
+        profiler._parity_identities_from_result(compiler_result)[  # noqa: SLF001
+            "content-authority"
+        ]["source_capabilities"]
+        is None
+    )
+
+    for field, replacement in (
+        ("loaded_views", []),
+        ("read_source", False),
+        ("commit_verified", True),
+        ("checkout_state", "attested"),
+    ):
+        changed = deepcopy(candidate_result)
+        changed["runtime"]["capabilities"][field] = replacement
+        projection = profiler._parity_identities_from_result(changed)  # noqa: SLF001
+        assert projection["content-authority"] != candidate["content-authority"]
+        assert projection["full-runtime"] != candidate["full-runtime"]
+
+    excluded_changes: list[tuple[Callable[[dict[str, Any]], None], bool]] = [
+        (
+            lambda changed: changed["runtime"]["capabilities"].__setitem__(
+                "native_vector_authorized", True
+            ),
+            True,
+        ),
+        (
+            lambda changed: changed["runtime"]["capabilities"].__setitem__(
+                "native_lsp_allowed", True
+            ),
+            True,
+        ),
+        (
+            lambda changed: changed["runtime"]["capabilities"][
+                "lsp_provider"
+            ].__setitem__("status", "changed"),
+            True,
+        ),
+        (
+            lambda changed: changed["runtime"]["delivery"].__setitem__(
+                "route", "treatment-route"
+            ),
+            False,
+        ),
+        (
+            lambda changed: changed["runtime"]["delivery"].__setitem__(
+                "context_provenance", "changed-provenance"
+            ),
+            True,
+        ),
+        (
+            lambda changed: changed["runtime"]["artifact"].__setitem__(
+                "commit", "b" * 40
+            ),
+            True,
+        ),
+    ]
+    for mutate, full_changes in excluded_changes:
+        changed = deepcopy(candidate_result)
+        mutate(changed)
+        projection = profiler._parity_identities_from_result(changed)  # noqa: SLF001
+        assert projection["content-authority"] == candidate["content-authority"]
+        assert (projection["full-runtime"] != candidate["full-runtime"]) is full_changes
+
+
+def test_each_projection_reports_pair_equality_and_per_arm_stability(
+    tmp_path: Path,
+) -> None:
+    manifest_path, subject_roots, media_roots = _fixture(tmp_path)
+
+    def vary_only_full_runtime(
+        receipt: dict[str, Any], request: Mapping[str, Any], call: int
+    ) -> None:
+        if request["arm"] == "candidate" and call == 3:
+            receipt["result"]["source_read"]["error_sha256"] = _SHA_D
+            receipt["parity_identities"] = (
+                profiler._parity_identities_from_result(  # noqa: SLF001
+                    receipt["result"]
+                )
+            )
+
+    query_only = _run_fake_cell(
+        manifest_path=manifest_path,
+        subject_roots=subject_roots,
+        media_roots=media_roots,
+        cell="runtime-cold-query-only",
+        sample_runner=_fake_sample_runner(vary_only_full_runtime),
+        iterations=2,
+    )
+
+    for projection in ("compiler", "content-authority"):
+        assert query_only["parity"][projection] == {
+            "every_pair_equal": True,
+            "stable_within_arm": {"legacy": True, "candidate": True},
+            "identity_sha256": {
+                "legacy": query_only["parity"][projection]["identity_sha256"]["legacy"],
+                "candidate": query_only["parity"][projection]["identity_sha256"][
+                    "candidate"
+                ],
+            },
+            "passed": True,
+        }
+        assert all(
+            len(query_only["parity"][projection]["identity_sha256"][arm]) == 1
+            for arm in profiler.ARMS
+        )
+    assert query_only["parity"]["full-runtime"]["every_pair_equal"] is False
+    assert query_only["parity"]["full-runtime"]["stable_within_arm"] == {
+        "legacy": True,
+        "candidate": False,
+    }
+    assert {
+        arm: len(query_only["parity"]["full-runtime"]["identity_sha256"][arm])
+        for arm in profiler.ARMS
+    } == {"legacy": 1, "candidate": 2}
+    assert query_only["parity"]["full-runtime"]["passed"] is False
 
 
 def test_runtime_manifest_authority_mismatch_blocks_equal_query_digest(
@@ -438,7 +791,11 @@ def test_runtime_manifest_authority_mismatch_blocks_equal_query_digest(
     ) -> None:
         if request["cell"] == "runtime-cold" and request["arm"] == "candidate":
             receipt["result"]["queries"]["sha256"] = _SHA_A
-            receipt["parity_identity"]["queries"]["sha256"] = _SHA_A
+            receipt["parity_identities"] = (
+                profiler._parity_identities_from_result(  # noqa: SLF001
+                    receipt["result"]
+                )
+            )
 
     sentinel = _run_fake_cell(
         manifest_path=manifest_path,
@@ -451,9 +808,11 @@ def test_runtime_manifest_authority_mismatch_blocks_equal_query_digest(
     pair = sentinel["runs"]["measured"][0]
     legacy, candidate = pair["samples"]
     assert legacy["result"]["queries"] == candidate["result"]["queries"]
-    assert legacy["result"]["authority"] != candidate["result"]["authority"]
-    assert pair["parity"] is False
-    assert sentinel["parity"]["passed"] is False
+    assert legacy["result"]["runtime"] != candidate["result"]["runtime"]
+    assert pair["parity"]["compiler"] is True
+    assert pair["parity"]["content-authority"] is False
+    assert pair["parity"]["full-runtime"] is False
+    assert sentinel["parity"]["full-runtime"]["passed"] is False
 
 
 def test_track_aggregation_isolates_parity_and_completeness(
@@ -481,11 +840,60 @@ def test_track_aggregation_isolates_parity_and_completeness(
         "compiler": True,
         "query-only-runtime": True,
         "manifest-runtime-compatibility": False,
+        "source-bound-runtime": True,
+        "source-bound-manifest-compatibility": False,
     }
     assert all(track["measurement_complete"] for track in baseline.values())
+    assert baseline["source-bound-runtime"] == {
+        "cells": ["runtime-cold-source-bound"],
+        "projection": "content-authority",
+        "measurement_complete": True,
+        "parity_passed": True,
+        "safety_passed": True,
+        "scope_complete": True,
+        "decision": "passed",
+        "passed": True,
+        "policy_status": "unratified",
+        "promotion_eligible": False,
+    }
+    assert baseline["source-bound-manifest-compatibility"] == {
+        "cells": ["runtime-cold-source-bound"],
+        "projection": "full-runtime",
+        "measurement_complete": True,
+        "parity_passed": False,
+        "safety_passed": True,
+        "scope_complete": False,
+        "decision": "blocked",
+        "passed": False,
+        "policy_status": "unratified",
+        "promotion_eligible": False,
+    }
+
+    parity_laundered = deepcopy(cells)
+    parity_laundered["runtime-cold"]["parity"]["full-runtime"]["passed"] = True
+    parity_laundered["runtime-cold-source-bound"]["parity"]["full-runtime"][
+        "passed"
+    ] = True
+    laundered_tracks = profiler._aggregate_tracks(
+        parity_laundered,
+        expected_instances_per_cell=1,
+        iterations=1,
+        warmups=0,
+    )
+    for track in (
+        "manifest-runtime-compatibility",
+        "source-bound-manifest-compatibility",
+    ):
+        assert laundered_tracks[track]["parity_passed"] is True
+        assert laundered_tracks[track]["scope_complete"] is False
+        assert laundered_tracks[track]["decision"] == "blocked"
+        assert laundered_tracks[track]["passed"] is False
+    assert all(track["passed"] for track in laundered_tracks.values()) is False
 
     query_parity_red = deepcopy(cells)
-    query_parity_red["runtime-cold-query-only"]["parity"]["passed"] = False
+    query_parity_red["runtime-cold-query-only"]["parity"]["full-runtime"][
+        "passed"
+    ] = False
     query_tracks = profiler._aggregate_tracks(
         query_parity_red,
         expected_instances_per_cell=1,
@@ -500,6 +908,11 @@ def test_track_aggregation_isolates_parity_and_completeness(
     assert (
         query_tracks["manifest-runtime-compatibility"]
         == baseline["manifest-runtime-compatibility"]
+    )
+    assert query_tracks["source-bound-runtime"] == baseline["source-bound-runtime"]
+    assert (
+        query_tracks["source-bound-manifest-compatibility"]
+        == baseline["source-bound-manifest-compatibility"]
     )
 
     missing_query_cell = {
@@ -516,9 +929,12 @@ def test_track_aggregation_isolates_parity_and_completeness(
     assert incomplete_tracks["compiler"] == baseline["compiler"]
     assert incomplete_tracks["query-only-runtime"] == {
         "cells": ["runtime-cold-query-only"],
+        "projection": "full-runtime",
         "measurement_complete": False,
         "parity_passed": False,
         "safety_passed": False,
+        "scope_complete": False,
+        "decision": "blocked",
         "passed": False,
         "policy_status": "unratified",
         "promotion_eligible": False,
@@ -527,6 +943,7 @@ def test_track_aggregation_isolates_parity_and_completeness(
         incomplete_tracks["manifest-runtime-compatibility"]
         == baseline["manifest-runtime-compatibility"]
     )
+    assert incomplete_tracks["source-bound-runtime"] == baseline["source-bound-runtime"]
 
 
 def test_summary_uses_median_and_nearest_rank_p95() -> None:
@@ -576,6 +993,645 @@ def test_full_public_query_payload_keeps_optional_content_in_the_digest() -> Non
     )
 
 
+def test_public_manifest_normalizer_masks_only_times_and_isolated_paths(
+    tmp_path: Path,
+) -> None:
+    subject_root = tmp_path / "subject"
+    ordinary = {
+        "schema_version": 3,
+        "repo": {
+            "path": os.fspath(subject_root),
+            "commit": "a" * 40,
+            "source_fingerprint": _SOURCE_V2,
+        },
+        "compiled_at": "2026-08-24T10:11:12Z",
+        "compiled_at_epoch": 1234.5,
+        "indexes": {
+            "bm25": {
+                "path": os.fspath(tmp_path / "isolated-bm25"),
+                "built_at": "2026-08-24T10:11:13Z",
+                "built_at_epoch": 1235.5,
+                "metadata": {
+                    "build_duration_seconds": 9.25,
+                    "content_authority": "must-survive",
+                },
+            }
+        },
+        "runtime": {
+            "source_read": {
+                "verified": True,
+                "verification_scope": "content-bytes",
+            },
+            "lsp_provider": {"provider": "codenib_static_index"},
+        },
+        "artifact": None,
+    }
+    request = {
+        "cell": "runtime-cold-source-bound",
+        "arm": "legacy",
+        "subject_root": os.fspath(subject_root),
+    }
+
+    normalized = profiler._normalized_public_manifest_payload(  # noqa: SLF001
+        ordinary,
+        request=request,
+    )
+
+    expected = deepcopy(ordinary)
+    expected["repo"]["path"] = "<authenticated-benchmark-subject>"
+    expected["compiled_at"] = "<measurement-metadata>"
+    expected["compiled_at_epoch"] = 0
+    expected["indexes"]["bm25"]["path"] = "<isolated-bm25-view>"
+    expected["indexes"]["bm25"]["built_at"] = "<measurement-metadata>"
+    expected["indexes"]["bm25"]["built_at_epoch"] = 0
+    expected["indexes"]["bm25"]["metadata"][
+        "build_duration_seconds"
+    ] = "<measurement-metadata>"
+    assert normalized == expected
+    assert ordinary["compiled_at"] == "2026-08-24T10:11:12Z"
+
+    authority_changed = deepcopy(ordinary)
+    authority_changed["runtime"]["source_read"]["verified"] = False
+    assert _json_digest(
+        profiler._normalized_public_manifest_payload(  # noqa: SLF001
+            ordinary,
+            request=request,
+        )
+    ) != _json_digest(
+        profiler._normalized_public_manifest_payload(  # noqa: SLF001
+            authority_changed,
+            request=request,
+        )
+    )
+
+    portable = deepcopy(ordinary)
+    portable["repo"]["path"] = "source"
+    portable["indexes"]["bm25"]["path"] = "views/bm25"
+    portable["artifact"] = {"verified": True, "schema": "portable"}
+    portable_request = {
+        **request,
+        "cell": "runtime-cold-query-only",
+        "arm": "candidate",
+    }
+    portable_normalized = profiler._normalized_public_manifest_payload(  # noqa: SLF001
+        portable,
+        request=portable_request,
+    )
+    assert portable_normalized["repo"]["path"] == "source"
+    assert portable_normalized["indexes"]["bm25"]["path"] == "views/bm25"
+    assert portable_normalized["artifact"] == portable["artifact"]
+    assert (
+        portable_normalized["runtime"]["lsp_provider"]
+        == portable["runtime"]["lsp_provider"]
+    )
+    assert _json_digest(normalized) != _json_digest(portable_normalized)
+
+
+def test_public_manifest_receipt_is_exactly_bound_to_the_active_context(
+    tmp_path: Path,
+) -> None:
+    subject_root = tmp_path / "subject"
+
+    def contract(
+        *, portable: bool
+    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+        artifact = (
+            {
+                "verified": True,
+                "schema": "codenib.context-artifact.v1",
+                "repository": "benchmark/fixture",
+                "commit": "a" * 40,
+                "views": ["bm25"],
+            }
+            if portable
+            else None
+        )
+        context_manifest = {
+            "schema_version": 3,
+            "repo": {
+                "path": os.fspath(subject_root),
+                "commit": "a" * 40,
+                "source_fingerprint": _SOURCE_V2,
+            },
+            "compiled_at": "2026-08-24T10:11:12Z",
+            "compiled_at_epoch": 1234.5,
+            "indexes": {
+                "bm25": {
+                    "path": (os.fspath(tmp_path / "isolated-bm25")),
+                    "built_at": "2026-08-24T10:11:13Z",
+                    "built_at_epoch": 1235.5,
+                    "metadata": {"build_duration_seconds": 0.25},
+                }
+            },
+        }
+        lsp_provider = {"provider": "codenib_static_index", "status": "unavailable"}
+        context_state = {
+            "loaded_views": ["bm25"],
+            "errors": {},
+            "artifact": artifact,
+            "source_verified": True,
+            "source_error": None,
+            "source_verification_scope": "content-bytes",
+            "lsp_provider": lsp_provider,
+            "commit_verified": False,
+        }
+        public = {
+            **deepcopy(context_manifest),
+            "runtime": {
+                "loaded_views": ["bm25"],
+                "view_errors": {},
+                "tool_surface": "full",
+                "explore_session": {
+                    "calls": 0,
+                    "ranges": 0,
+                    "max_ranges": 256,
+                    "evictions": 0,
+                },
+                "source_read": {
+                    "verified": True,
+                    "error": None,
+                    "verification_scope": "content-bytes",
+                    "commit_verified": False,
+                    "checkout_state": "not-attested",
+                },
+                "lsp_provider": deepcopy(lsp_provider),
+            },
+        }
+        if portable:
+            public["artifact"] = deepcopy(artifact)
+        request = {
+            "cell": "runtime-cold-source-bound",
+            "arm": "candidate" if portable else "legacy",
+            "subject_root": os.fspath(subject_root),
+        }
+        return request, context_manifest, context_state, public
+
+    for portable in (False, True):
+        request, context_manifest, context_state, public = contract(portable=portable)
+        assert (
+            profiler._validated_public_manifest_payload(  # noqa: SLF001
+                public,
+                request=request,
+                context_manifest=context_manifest,
+                context_state=context_state,
+                tool_surface="full",
+            )
+            == public
+        )
+        assert profiler._public_manifest_evidence(  # noqa: SLF001
+            public,
+            request=request,
+            context_manifest=context_manifest,
+            context_state=context_state,
+            tool_surface="full",
+        ) == {
+            "raw_sha256": _json_digest(public),
+            "parity_sha256": _json_digest(
+                profiler._normalized_public_manifest_payload(  # noqa: SLF001
+                    public,
+                    request=request,
+                )
+            ),
+            "parity_schema": "codenib.retained-storage-public-manifest-parity.v1",
+        }
+
+    request, context_manifest, context_state, public = contract(portable=False)
+    invalid_ordinary: list[dict[str, Any]] = []
+    missing_runtime = deepcopy(public)
+    missing_runtime["runtime"].pop("loaded_views")
+    invalid_ordinary.append(missing_runtime)
+    extra_runtime = deepcopy(public)
+    extra_runtime["runtime"]["unexpected"] = True
+    invalid_ordinary.append(extra_runtime)
+    manifest_drift = deepcopy(public)
+    manifest_drift["repo"]["commit"] = "b" * 40
+    invalid_ordinary.append(manifest_drift)
+    extra_artifact = deepcopy(public)
+    extra_artifact["artifact"] = {"verified": True}
+    invalid_ordinary.append(extra_artifact)
+    source_drift = deepcopy(public)
+    source_drift["runtime"]["source_read"]["verified"] = False
+    invalid_ordinary.append(source_drift)
+    lsp_drift = deepcopy(public)
+    lsp_drift["runtime"]["lsp_provider"]["status"] = "ready"
+    invalid_ordinary.append(lsp_drift)
+    view_drift = deepcopy(public)
+    view_drift["runtime"]["loaded_views"] = []
+    invalid_ordinary.append(view_drift)
+    view_error_drift = deepcopy(public)
+    view_error_drift["runtime"]["view_errors"] = {"bm25": "broken"}
+    invalid_ordinary.append(view_error_drift)
+    for invalid in invalid_ordinary:
+        with pytest.raises((RuntimeError, ValueError)):
+            profiler._validated_public_manifest_payload(  # noqa: SLF001
+                invalid,
+                request=request,
+                context_manifest=context_manifest,
+                context_state=context_state,
+                tool_surface="full",
+            )
+
+    request, context_manifest, context_state, public = contract(portable=True)
+    missing_artifact = deepcopy(public)
+    missing_artifact.pop("artifact")
+    artifact_drift = deepcopy(public)
+    artifact_drift["artifact"]["commit"] = "b" * 40
+    for invalid in (missing_artifact, artifact_drift):
+        with pytest.raises((RuntimeError, ValueError)):
+            profiler._validated_public_manifest_payload(  # noqa: SLF001
+                invalid,
+                request=request,
+                context_manifest=context_manifest,
+                context_state=context_state,
+                tool_surface="full",
+            )
+
+
+def test_public_manifest_normalizer_masks_authority_differences_in_no_field(
+    tmp_path: Path,
+) -> None:
+    """Changing source, artifact, or LSP evidence must change parity."""
+
+    subject_root = tmp_path / "subject"
+    ordinary = {
+        "repo": {"path": os.fspath(subject_root)},
+        "compiled_at": "first",
+        "compiled_at_epoch": 1,
+        "indexes": {
+            "bm25": {
+                "path": os.fspath(tmp_path / "view"),
+                "built_at": "first",
+                "built_at_epoch": 1,
+                "metadata": {"build_duration_seconds": 1},
+            }
+        },
+        "runtime": {
+            "source_read": {"verified": True},
+            "lsp_provider": {"provider": "persisted"},
+        },
+        "artifact": None,
+    }
+    request = {
+        "cell": "runtime-cold-source-bound",
+        "arm": "legacy",
+        "subject_root": os.fspath(subject_root),
+    }
+    baseline = profiler._normalized_public_manifest_payload(  # noqa: SLF001
+        ordinary,
+        request=request,
+    )
+    for path, replacement in (
+        (("runtime", "source_read", "verified"), False),
+        (("runtime", "lsp_provider", "provider"), "native"),
+        (("artifact",), {"verified": True}),
+    ):
+        changed = deepcopy(ordinary)
+        target = changed
+        for component in path[:-1]:
+            target = target[component]
+        target[path[-1]] = replacement
+        assert (
+            profiler._normalized_public_manifest_payload(  # noqa: SLF001
+                changed,
+                request=request,
+            )
+            != baseline
+        )
+
+
+def test_public_manifest_normalizer_rejects_malformed_measurement_metadata(
+    tmp_path: Path,
+) -> None:
+    subject_root = tmp_path / "subject"
+    request = {
+        "cell": "runtime-cold-source-bound",
+        "arm": "legacy",
+        "subject_root": os.fspath(subject_root),
+    }
+
+    def payload() -> dict[str, Any]:
+        return {
+            "repo": {"path": os.fspath(subject_root)},
+            "compiled_at": "2026-08-24T10:11:12Z",
+            "compiled_at_epoch": 1234.5,
+            "indexes": {
+                "bm25": {
+                    "path": os.fspath(tmp_path / "isolated-bm25"),
+                    "built_at": "2026-08-24T10:11:13Z",
+                    "built_at_epoch": 1235.5,
+                    "metadata": {"build_duration_seconds": 0.25},
+                }
+            },
+        }
+
+    for container, field in (
+        ((), "compiled_at"),
+        ((), "compiled_at_epoch"),
+        (("indexes", "bm25"), "built_at"),
+        (("indexes", "bm25"), "built_at_epoch"),
+    ):
+        malformed = payload()
+        target = malformed
+        for component in container:
+            target = target[component]
+        target.pop(field)
+        with pytest.raises(RuntimeError):
+            profiler._normalized_public_manifest_payload(  # noqa: SLF001
+                malformed,
+                request=request,
+            )
+
+    for container, field in (
+        ((), "compiled_at"),
+        (("indexes", "bm25"), "built_at"),
+    ):
+        for invalid in (None, True, 1, 1.5):
+            malformed = payload()
+            target = malformed
+            for component in container:
+                target = target[component]
+            target[field] = invalid
+            with pytest.raises((RuntimeError, ValueError)):
+                profiler._normalized_public_manifest_payload(  # noqa: SLF001
+                    malformed,
+                    request=request,
+                )
+
+    for container, field in (
+        ((), "compiled_at_epoch"),
+        (("indexes", "bm25"), "built_at_epoch"),
+    ):
+        for invalid in (None, True, "1", math.nan, math.inf, -math.inf, -1):
+            malformed = payload()
+            target = malformed
+            for component in container:
+                target = target[component]
+            target[field] = invalid
+            with pytest.raises((RuntimeError, ValueError)):
+                profiler._normalized_public_manifest_payload(  # noqa: SLF001
+                    malformed,
+                    request=request,
+                )
+
+    for invalid in (None, True, "1", math.nan, math.inf, -math.inf, -1):
+        malformed = payload()
+        malformed["indexes"]["bm25"]["metadata"]["build_duration_seconds"] = invalid
+        with pytest.raises((RuntimeError, ValueError)):
+            profiler._normalized_public_manifest_payload(  # noqa: SLF001
+                malformed,
+                request=request,
+            )
+
+    first = payload()
+    second = payload()
+    second["compiled_at"] = "2027-01-02T03:04:05Z"
+    second["compiled_at_epoch"] = 9999
+    second["indexes"]["bm25"]["built_at"] = "2027-01-02T03:04:06Z"
+    second["indexes"]["bm25"]["built_at_epoch"] = 10_000
+    second["indexes"]["bm25"]["metadata"]["build_duration_seconds"] = 4.5
+    assert profiler._normalized_public_manifest_payload(  # noqa: SLF001
+        first,
+        request=request,
+    ) == profiler._normalized_public_manifest_payload(  # noqa: SLF001
+        second,
+        request=request,
+    )
+
+
+def test_public_server_source_probe_separates_payload_content_and_refusal_digests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.mcp import server as server_module
+
+    class Manifest:
+        repo_path = "benchmark/fixture"
+        commit = "a" * 40
+        source_fingerprint = _SOURCE_V2
+
+    class SourceContext:
+        source_verified = True
+        source_error = None
+        artifact = {"repository": "benchmark/fixture"}
+        manifest = Manifest()
+
+        def read_source_bytes(self, path: str, *, max_bytes: int) -> bytes:
+            assert path == "package.py"
+            assert max_bytes == 64 * 1024 * 1024
+            return b"first line\nsecond line\n"
+
+    context = SourceContext()
+    monkeypatch.setattr(server_module, "_ctx", context)
+    query_payload = [
+        {
+            "query": {"text": "package"},
+            "results": [{"file": "package.py", "start_line": 1}],
+        }
+    ]
+    request = {
+        "cell": "runtime-cold-source-bound",
+        "arm": "candidate",
+        "subject": {
+            "repository_key": "benchmark/fixture",
+            "revision": "a" * 40,
+        },
+        "subject_root": "/unused-benchmark-subject",
+    }
+
+    verified = profiler._source_read_evidence(  # noqa: SLF001
+        server_module,
+        context,
+        query_payload,
+        request=request,
+    )
+    content = {
+        "content": "first line\n",
+        "content_projection": {
+            "truncated": False,
+            "original_chars": 11,
+            "returned_chars": 11,
+            "strategy": "complete",
+        },
+        "end_line": 1,
+        "file": "package.py",
+        "start_line": 1,
+    }
+    payload = {
+        **content,
+        "source": {
+            "repository": "benchmark/fixture",
+            "commit": "a" * 40,
+            "source_fingerprint": _SOURCE_V2,
+            "verified": True,
+            "verification_scope": "content-bytes",
+            "commit_verified": False,
+            "checkout_state": "not-attested",
+        },
+    }
+    assert verified == {
+        "status": "verified",
+        "payload_sha256": _json_digest(payload),
+        "content_sha256": _json_digest(content),
+        "error_sha256": None,
+        "count": 1,
+    }
+    assert verified["payload_sha256"] != verified["content_sha256"]
+
+    class DisabledContext(SourceContext):
+        source_verified = False
+        source_error = "retained route has no repository source"
+
+        def read_source_bytes(self, path: str, *, max_bytes: int) -> bytes:
+            raise AssertionError("disabled public source route reached storage")
+
+    disabled_context = DisabledContext()
+    monkeypatch.setattr(server_module, "_ctx", disabled_context)
+    disabled_request = {
+        **request,
+        "cell": "runtime-cold-query-only",
+    }
+    message = "source reads are unavailable: retained route has no repository source"
+    assert profiler._source_read_evidence(  # noqa: SLF001
+        server_module,
+        disabled_context,
+        query_payload,
+        request=disabled_request,
+    ) == {
+        "status": "source-disabled",
+        "payload_sha256": None,
+        "content_sha256": None,
+        "error_sha256": _json_digest(
+            {"error_type": "RuntimeError", "message": message}
+        ),
+        "count": 1,
+    }
+
+
+def test_public_source_payload_validator_rejects_any_shape_or_authority_drift(
+    tmp_path: Path,
+) -> None:
+    subject_root = tmp_path / "subject"
+    subject = {
+        "repository_key": "benchmark/fixture",
+        "revision": "a" * 40,
+    }
+    portable_request = {
+        "cell": "runtime-cold-source-bound",
+        "arm": "candidate",
+        "subject": subject,
+        "subject_root": os.fspath(subject_root),
+    }
+
+    def payload(*, repository: str = "benchmark/fixture") -> dict[str, Any]:
+        return {
+            "file": "package.py",
+            "start_line": 1,
+            "end_line": 1,
+            "content": "first line\n",
+            "content_projection": {
+                "truncated": False,
+                "original_chars": 11,
+                "returned_chars": 11,
+                "strategy": "complete",
+            },
+            "source": {
+                "repository": repository,
+                "commit": "a" * 40,
+                "source_fingerprint": _SOURCE_V2,
+                "verified": True,
+                "verification_scope": "content-bytes",
+                "commit_verified": False,
+                "checkout_state": "not-attested",
+            },
+        }
+
+    valid = payload()
+    assert (
+        profiler._validated_public_source_payload(  # noqa: SLF001
+            valid,
+            request=portable_request,
+            file_path="package.py",
+            start_line=1,
+            source_fingerprint=_SOURCE_V2,
+        )
+        == valid
+    )
+    ordinary_request = {
+        **portable_request,
+        "arm": "legacy",
+    }
+    ordinary = payload(repository=os.fspath(subject_root))
+    assert (
+        profiler._validated_public_source_payload(  # noqa: SLF001
+            ordinary,
+            request=ordinary_request,
+            file_path="package.py",
+            start_line=1,
+            source_fingerprint=_SOURCE_V2,
+        )
+        == ordinary
+    )
+
+    invalid_payloads: list[dict[str, Any]] = []
+    for field in valid:
+        missing = deepcopy(valid)
+        missing.pop(field)
+        invalid_payloads.append(missing)
+    extra = deepcopy(valid)
+    extra["unexpected"] = True
+    invalid_payloads.append(extra)
+    for field in valid["source"]:
+        missing = deepcopy(valid)
+        missing["source"].pop(field)
+        invalid_payloads.append(missing)
+    extra_source = deepcopy(valid)
+    extra_source["source"]["unexpected"] = True
+    invalid_payloads.append(extra_source)
+
+    for field, replacement in (
+        ("repository", "wrong/repository"),
+        ("commit", "b" * 40),
+        ("source_fingerprint", "sha256-v2:" + "f" * 64),
+        ("verified", False),
+        ("verified", 1),
+        ("verification_scope", "commit"),
+        ("commit_verified", True),
+        ("commit_verified", 0),
+        ("checkout_state", "attested"),
+    ):
+        drift = deepcopy(valid)
+        drift["source"][field] = replacement
+        invalid_payloads.append(drift)
+
+    for field, replacement in (
+        ("file", None),
+        ("file", "other.py"),
+        ("start_line", True),
+        ("start_line", 0),
+        ("end_line", 2),
+        ("content", None),
+        ("content_projection", None),
+    ):
+        malformed = deepcopy(valid)
+        malformed[field] = replacement
+        invalid_payloads.append(malformed)
+    projection_extra = deepcopy(valid)
+    projection_extra["content_projection"]["unexpected"] = True
+    invalid_payloads.append(projection_extra)
+    projection_count_drift = deepcopy(valid)
+    projection_count_drift["content_projection"]["returned_chars"] = 10
+    invalid_payloads.append(projection_count_drift)
+
+    for invalid in invalid_payloads:
+        with pytest.raises((RuntimeError, ValueError)):
+            profiler._validated_public_source_payload(  # noqa: SLF001
+                invalid,
+                request=portable_request,
+                file_path="package.py",
+                start_line=1,
+                source_fingerprint=_SOURCE_V2,
+            )
+
+
 @pytest.mark.parametrize(
     "mutation",
     [
@@ -609,7 +1665,7 @@ def test_manifest_schema_is_exact_and_bm25_only(
         profiler.load_subject_manifest(path)
 
 
-def test_v2_manifest_accepts_only_the_frozen_four_cell_order(tmp_path: Path) -> None:
+def test_v3_manifest_accepts_only_the_frozen_five_cell_order(tmp_path: Path) -> None:
     subjects = [
         _subject_row(
             identifier=f"fixture-{payload_class}",
@@ -632,8 +1688,8 @@ def test_v2_manifest_accepts_only_the_frozen_four_cell_order(tmp_path: Path) -> 
         "view_sets",
         "subjects",
     }
-    assert manifest["schema_version"] == 2
-    assert manifest["benchmark"] == "retained_storage_explicit_route_gate_v2"
+    assert manifest["schema_version"] == 3
+    assert manifest["benchmark"] == "retained_storage_explicit_route_gate_v3"
     assert manifest["cells"] == list(profiler.CELLS)
     metadata = path.stat()
     assert receipt == {
@@ -667,7 +1723,7 @@ def test_atomic_writer_emits_canonical_json_and_preserves_old_report_on_nan(
     assert list(tmp_path.iterdir()) == [output]
 
 
-def test_canonical_v2_report_has_exact_shape_tracks_and_process_count(
+def test_canonical_v3_report_has_exact_shape_tracks_and_process_count(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     manifest_path, subject_roots, media_roots = _fixture(tmp_path)
@@ -732,7 +1788,8 @@ def test_canonical_v2_report_has_exact_shape_tracks_and_process_count(
         "warmups_per_arm",
         "cells",
         "tracks",
-        "cell_authority_contracts",
+        "cell_route_contracts",
+        "parity_projections",
         "canonical_sample_count",
         "view_set_ids",
         "payload_classes",
@@ -748,26 +1805,75 @@ def test_canonical_v2_report_has_exact_shape_tracks_and_process_count(
     }
     assert report["protocol"]["expected"]["cells"] == list(profiler.CELLS)
     assert report["protocol"]["expected"]["tracks"] == {
-        name: list(cells) for name, cells in profiler.TRACKS.items()
+        name: {
+            "cells": list(specification["cells"]),
+            "projection": specification["projection"],
+        }
+        for name, specification in profiler.TRACKS.items()
     }
-    assert report["protocol"]["expected"]["cell_authority_contracts"] == (
-        profiler.CELL_AUTHORITY_CONTRACTS
+    assert report["protocol"]["expected"]["cell_route_contracts"] == (
+        profiler.CELL_ROUTE_CONTRACTS
     )
-    assert report["protocol"]["expected"]["canonical_sample_count"] == 1152
-    assert report["configuration"]["cell_authority_contracts"] == (
-        profiler.CELL_AUTHORITY_CONTRACTS
+    assert report["protocol"]["expected"]["parity_projections"] == list(
+        profiler.PARITY_PROJECTIONS
     )
+    assert report["protocol"]["expected"]["canonical_sample_count"] == 1440
+    assert report["configuration"]["cell_route_contracts"] == (
+        profiler.CELL_ROUTE_CONTRACTS
+    )
+    assert report["configuration"]["parity_projections"] == list(
+        profiler.PARITY_PROJECTIONS
+    )
+    assert report["configuration"]["stopwatch_boundaries"] == {
+        "compiler-cold": (
+            "fresh-inner-codenib-cli-import-parser-index-handler-through-return"
+        ),
+        "compiler-current": (
+            "fresh-inner-codenib-cli-import-parser-index-handler-through-return"
+        ),
+        "runtime-cold": (
+            "fresh-inner-import-parser-handler-through-ready-callback-fixed-"
+            "queries-public-manifest-source-read-probe-or-refusal-and-normal-"
+            "cleanup-return"
+        ),
+        "runtime-cold-query-only": (
+            "fresh-inner-import-parser-direct-or-retained-portable-artifact-"
+            "handler-through-ready-callback-fixed-queries-public-manifest-"
+            "source-read-refusal-and-normal-cleanup-return"
+        ),
+        "runtime-cold-source-bound": (
+            "fresh-inner-import-parser-ordinary-manifest-or-retained-source-"
+            "bound-handler-through-ready-callback-fixed-queries-public-manifest-"
+            "source-read-probe-and-normal-cleanup-return"
+        ),
+    }
+    assert report["configuration"]["cold_definitions"] == {
+        "compiler-cold": "empty-codenib-cache",
+        "runtime-cold": (
+            "fresh-process-and-context-with-public-manifest-and-source-read-"
+            "probe-or-refusal"
+        ),
+        "runtime-cold-query-only": (
+            "fresh-process-and-context-with-public-manifest-and-source-read-refusal"
+        ),
+        "runtime-cold-source-bound": (
+            "fresh-process-and-context-with-public-manifest-and-source-read-probe"
+        ),
+    }
     assert report["decision"] == {
         "policy_status": "unratified",
         "report_only": True,
         "promotion_eligible": False,
         "recommendation": "retain-explicit-routes",
-        "reason": "one or more compatibility tracks are parity red",
+        "reason": (
+            "one or more track parity projections are red; one or more "
+            "compatibility scopes remain incomplete"
+        ),
     }
     assert report["benchmark_receipts"]["unchanged"] is True
     assert len(report["subjects"]) == 3
     assert len(report["media"]) == 2
-    assert len(report["cells"]) == 24
+    assert len(report["cells"]) == 30
     assert {
         cell: sum(item["cell"] == cell for item in report["cells"].values())
         for cell in profiler.CELLS
@@ -776,44 +1882,91 @@ def test_canonical_v2_report_has_exact_shape_tracks_and_process_count(
         "compiler",
         "query-only-runtime",
         "manifest-runtime-compatibility",
+        "source-bound-runtime",
+        "source-bound-manifest-compatibility",
     ]
     assert report["tracks"] == {
         "compiler": {
             "cells": ["compiler-cold", "compiler-current"],
+            "projection": "compiler",
             "measurement_complete": True,
             "parity_passed": True,
             "safety_passed": True,
+            "scope_complete": True,
+            "decision": "passed",
             "passed": True,
             "policy_status": "unratified",
             "promotion_eligible": False,
         },
         "query-only-runtime": {
             "cells": ["runtime-cold-query-only"],
+            "projection": "full-runtime",
             "measurement_complete": True,
             "parity_passed": True,
             "safety_passed": True,
+            "scope_complete": True,
+            "decision": "passed",
             "passed": True,
             "policy_status": "unratified",
             "promotion_eligible": False,
         },
         "manifest-runtime-compatibility": {
             "cells": ["runtime-cold"],
+            "projection": "full-runtime",
             "measurement_complete": True,
             "parity_passed": False,
             "safety_passed": True,
+            "scope_complete": False,
+            "decision": "blocked",
+            "passed": False,
+            "policy_status": "unratified",
+            "promotion_eligible": False,
+        },
+        "source-bound-runtime": {
+            "cells": ["runtime-cold-source-bound"],
+            "projection": "content-authority",
+            "measurement_complete": True,
+            "parity_passed": True,
+            "safety_passed": True,
+            "scope_complete": True,
+            "decision": "passed",
+            "passed": True,
+            "policy_status": "unratified",
+            "promotion_eligible": False,
+        },
+        "source-bound-manifest-compatibility": {
+            "cells": ["runtime-cold-source-bound"],
+            "projection": "full-runtime",
+            "measurement_complete": True,
+            "parity_passed": False,
+            "safety_passed": True,
+            "scope_complete": False,
+            "decision": "blocked",
             "passed": False,
             "policy_status": "unratified",
             "promotion_eligible": False,
         },
     }
     assert report["process_isolation"]["passed"] is True
-    assert report["process_isolation"]["expected_samples"] == 1152
-    assert report["process_isolation"]["observed_samples"] == 1152
-    assert len(report["process_isolation"]["inner_process_ids"]) == 1152
-    assert len(set(report["process_isolation"]["inner_process_ids"])) == 1152
+    assert report["process_isolation"]["expected_samples"] == 1440
+    assert report["process_isolation"]["observed_samples"] == 1440
+    assert len(report["process_isolation"]["inner_process_ids"]) == 1440
+    assert len(set(report["process_isolation"]["inner_process_ids"])) == 1440
     assert report["process_isolation"]["duplicate_process_ids"] == []
     for cell in report["cells"].values():
         assert {"runs", "summary", "parity", "safety", "performance"} <= set(cell)
+        assert (
+            cell["primary_projection"]
+            == profiler.CELL_PRIMARY_PROJECTIONS[cell["cell"]]
+        )
+        assert set(cell["parity"]) == set(profiler.PARITY_PROJECTIONS)
+        for projection in profiler.PARITY_PROJECTIONS:
+            assert set(cell["parity"][projection]) == {
+                "every_pair_equal",
+                "stable_within_arm",
+                "identity_sha256",
+                "passed",
+            }
         assert len(cell["runs"]["warmups"]) == profiler.DEFAULT_WARMUPS
         assert len(cell["runs"]["measured"]) == profiler.DEFAULT_ITERATIONS
 
@@ -923,7 +2076,7 @@ def test_override_protocol_is_an_operational_failure_after_measurement(
     assert report["status"] == "failed"
     assert report["passed"] is False
     assert report["failure"]["stage"] == "protocol"
-    assert report["process_isolation"]["observed_samples"] == 48
+    assert report["process_isolation"]["observed_samples"] == 60
     assert report["protocol"]["canonical"] is False
     assert report["protocol"]["observed"]["iterations_per_arm"] == 1
     assert report["protocol"]["observed"]["warmups_per_arm"] == 0
@@ -1043,11 +2196,13 @@ def test_worker_crash_and_timeout_produce_negative_reports(
         lambda receipt, _request, _call: receipt["safety"].__setitem__(
             "subject_unchanged", False
         ),
-        lambda receipt, _request, _call: receipt["result"]["manifest"].__setitem__(
+        lambda receipt, _request, _call: receipt["result"]["bm25_plan"].__setitem__(
             "source_fingerprint", _SHA_D
         ),
         lambda receipt, request, _call: (
-            receipt["parity_identity"]["view"].__setitem__("documents_sha256", _SHA_B)
+            receipt["parity_identities"]["compiler"]["view"].__setitem__(
+                "documents_sha256", _SHA_B
+            )
             if request["arm"] == "candidate"
             else None
         ),
@@ -1268,6 +2423,27 @@ def test_each_cell_uses_its_exact_prep_and_runtime_cli_contract(
                 ),
             ),
         ],
+        ("runtime-cold-source-bound", "legacy"): [
+            (
+                "cli",
+                profiler._index_arguments(
+                    request("runtime-cold-source-bound", "legacy"),
+                    paths,
+                    candidate=False,
+                ),
+            )
+        ],
+        ("runtime-cold-source-bound", "candidate"): [
+            ("provision", paths),
+            (
+                "cli",
+                profiler._index_arguments(
+                    request("runtime-cold-source-bound", "candidate"),
+                    paths,
+                    candidate=True,
+                ),
+            ),
+        ],
     }
 
     for cell in profiler.CELLS:
@@ -1310,6 +2486,102 @@ def test_each_cell_uses_its_exact_prep_and_runtime_cli_contract(
         paths["runtime_output"],
     ]
     assert "--repo" not in retained_arguments
+    source_bound_arguments = profiler._runtime_arguments(
+        request("runtime-cold-source-bound", "candidate"), paths, generation=1
+    )
+    assert source_bound_arguments == [
+        *retained_arguments,
+        "--repo",
+        os.fspath(subject_root.resolve()),
+    ]
+    assert profiler._runtime_arguments(
+        request("runtime-cold-source-bound", "legacy"), paths, generation=None
+    ) == ["mcp", os.fspath(profiler._cache_manifest_path(subject_root))]
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="the canonical profiler route requires Linux /proc accounting",
+)
+def test_real_local_runtime_route_matrix_uses_each_public_mcp_delivery(
+    tmp_path: Path,
+) -> None:
+    manifest_path, subject_roots, media_roots = _fixture(tmp_path)
+    manifest, _receipt = profiler.load_subject_manifest(manifest_path)
+    subject = manifest["subjects"][0]
+    subject_root = subject_roots[subject["id"]]
+    media_id, media_root = next(iter(media_roots.items()))
+    route_matrix = (
+        ("runtime-cold", "legacy", "manifest-path", "verified"),
+        (
+            "runtime-cold-query-only",
+            "legacy",
+            "direct-artifact",
+            "source-disabled",
+        ),
+        (
+            "runtime-cold-query-only",
+            "candidate",
+            "retained-ref",
+            "source-disabled",
+        ),
+        (
+            "runtime-cold-source-bound",
+            "candidate",
+            "retained-ref",
+            "verified",
+        ),
+    )
+    receipts: dict[tuple[str, str], dict[str, Any]] = {}
+
+    for index, (cell, arm, route, source_status) in enumerate(route_matrix, start=1):
+        request = {
+            "operation": "sample",
+            "arm": arm,
+            "phase": "measured",
+            "round_index": 0,
+            "cell": cell,
+            "subject": subject,
+            "subject_root": os.fspath(subject_root.resolve()),
+            "media_id": media_id,
+            "media_root": os.fspath(media_root.resolve()),
+            "media_identity": profiler._media_identity(media_root.resolve()),
+            "view_set": manifest["view_sets"][0],
+            "run_id": f"{index:032x}",
+        }
+
+        try:
+            receipt = profiler._sample_worker(request)  # noqa: SLF001
+        except Exception as exc:
+            raise AssertionError(f"real route failed for {cell}/{arm}") from exc
+        receipt = profiler._validate_sample_receipt(  # noqa: SLF001
+            receipt,
+            request=request,
+        )
+
+        assert receipt["result"]["runtime"]["delivery"]["route"] == route
+        assert receipt["result"]["source_read"]["status"] == source_status
+        assert receipt["result"]["public_manifest"] is not None
+        assert receipt["safety"]["context_closed"] is True
+        assert receipt["safety"]["source_closed"] is True
+        assert receipt["safety"]["cleanup_complete"] is True
+        receipts[(cell, arm)] = receipt
+
+    direct = receipts[("runtime-cold-query-only", "legacy")]
+    retained_query_only = receipts[("runtime-cold-query-only", "candidate")]
+    assert direct["parity_identities"] == retained_query_only["parity_identities"]
+
+    ordinary = receipts[("runtime-cold", "legacy")]
+    retained_source = receipts[("runtime-cold-source-bound", "candidate")]
+    assert (
+        ordinary["parity_identities"]["content-authority"]
+        == retained_source["parity_identities"]["content-authority"]
+    )
+    assert (
+        ordinary["parity_identities"]["full-runtime"]
+        != retained_source["parity_identities"]["full-runtime"]
+    )
+    assert not any(media_root.iterdir())
 
 
 def test_outer_sample_hides_prep_and_reports_the_inner_route_pid(
@@ -1362,6 +2634,7 @@ def test_outer_sample_hides_prep_and_reports_the_inner_route_pid(
                 },
                 "result": result,
                 "context_closed": True,
+                "source_closed": True,
             },
             1.25,
         )
@@ -1472,78 +2745,259 @@ def test_inner_route_requires_the_exact_derived_authority_paths(
             )
 
 
-def test_runtime_context_authority_contract_is_cell_and_arm_specific() -> None:
-    from codenib.artifacts.context import CONTEXT_ARTIFACT_SCHEMA
+def test_source_bound_runtime_manifest_allows_only_the_two_authenticated_rebinds(
+    tmp_path: Path,
+) -> None:
+    subject_root = tmp_path / "subject"
+    subject_root.mkdir()
+    runtime_output = tmp_path / "runtime-output"
+    runtime_view = runtime_output / "views" / "bm25"
+    runtime_view.mkdir(parents=True)
+    persisted = {
+        "version": "1.2",
+        "repo": {
+            "path": "source",
+            "commit": "a" * 40,
+            "source_fingerprint": _SOURCE_V2,
+        },
+        "indexes": {
+            "bm25": {
+                "path": "views/bm25",
+                "status": "fresh",
+                "metadata": {"builder_schema": 8},
+            }
+        },
+    }
+    request = {
+        "cell": "runtime-cold-source-bound",
+        "arm": "candidate",
+        "subject_root": os.fspath(subject_root),
+    }
+    expected = deepcopy(persisted)
+    expected["repo"]["path"] = os.fspath(subject_root)
+    expected["indexes"]["bm25"]["path"] = os.fspath(runtime_view.resolve())
 
+    assert (
+        profiler._validate_runtime_context_manifest(  # noqa: SLF001
+            expected,
+            persisted=persisted,
+            request=request,
+            paths={"runtime_output": os.fspath(runtime_output)},
+        )
+        == expected
+    )
+    assert persisted["repo"]["path"] == "source"
+    assert persisted["indexes"]["bm25"]["path"] == "views/bm25"
+
+    invalid_values: list[dict[str, Any]] = []
+    for mutate in (
+        lambda value: value["repo"].__setitem__("commit", "b" * 40),
+        lambda value: value["indexes"]["bm25"]["metadata"].__setitem__(
+            "builder_schema", 9
+        ),
+        lambda value: value.__setitem__("unexpected", True),
+        lambda value: value.pop("version"),
+        lambda value: value["repo"].__setitem__("path", "source"),
+        lambda value: value["indexes"]["bm25"].__setitem__(
+            "path", os.fspath(tmp_path / "other-view")
+        ),
+    ):
+        changed = deepcopy(expected)
+        mutate(changed)
+        invalid_values.append(changed)
+    for invalid in invalid_values:
+        with pytest.raises(RuntimeError, match="exact persisted binding"):
+            profiler._validate_runtime_context_manifest(  # noqa: SLF001
+                invalid,
+                persisted=persisted,
+                request=request,
+                paths={"runtime_output": os.fspath(runtime_output)},
+            )
+
+    malformed_persisted = deepcopy(persisted)
+    malformed_persisted["repo"]["path"] = os.fspath(subject_root)
+    malformed_view = deepcopy(persisted)
+    malformed_view["indexes"]["bm25"]["path"] = "views/other"
+    for malformed in (malformed_persisted, malformed_view):
+        with pytest.raises(RuntimeError, match="canonically portable"):
+            profiler._validate_runtime_context_manifest(  # noqa: SLF001
+                expected,
+                persisted=malformed,
+                request=request,
+                paths={"runtime_output": os.fspath(runtime_output)},
+            )
+
+
+def test_other_runtime_manifests_require_exact_persisted_identity(
+    tmp_path: Path,
+) -> None:
+    ordinary = {
+        "version": "1.2",
+        "repo": {"path": os.fspath(tmp_path / "subject"), "commit": "a" * 40},
+        "indexes": {
+            "bm25": {
+                "path": os.fspath(tmp_path / "ordinary-view"),
+                "status": "fresh",
+            }
+        },
+    }
+    portable = {
+        "version": "1.2",
+        "repo": {"path": "source", "commit": "a" * 40},
+        "indexes": {"bm25": {"path": "views/bm25", "status": "fresh"}},
+    }
+    routes = (
+        ({"cell": "runtime-cold", "arm": "legacy"}, ordinary),
+        ({"cell": "runtime-cold-query-only", "arm": "legacy"}, portable),
+        ({"cell": "runtime-cold-query-only", "arm": "candidate"}, portable),
+    )
+    paths = {"runtime_output": os.fspath(tmp_path / "unused-runtime")}
+    for request, persisted in routes:
+        assert (
+            profiler._validate_runtime_context_manifest(  # noqa: SLF001
+                persisted,
+                persisted=persisted,
+                request=request,
+                paths=paths,
+            )
+            == persisted
+        )
+        for mutation in (
+            lambda value: value["repo"].__setitem__("commit", "b" * 40),
+            lambda value: value["indexes"]["bm25"].__setitem__("status", "stale"),
+            lambda value: value.pop("version"),
+            lambda value: value.__setitem__("unexpected", True),
+        ):
+            changed = deepcopy(persisted)
+            mutation(changed)
+            with pytest.raises(RuntimeError, match="exact persisted binding"):
+                profiler._validate_runtime_context_manifest(  # noqa: SLF001
+                    changed,
+                    persisted=persisted,
+                    request=request,
+                    paths=paths,
+                )
+
+
+def test_runtime_context_authority_contract_is_cell_and_arm_specific() -> None:
     subject = {
         "repository_key": "benchmark/fixture",
         "revision": "a" * 40,
+    }
+    ordinary_request = {
+        "cell": "runtime-cold",
+        "arm": "legacy",
+        "subject": subject,
+    }
+    candidate_request = {
+        "cell": "runtime-cold",
+        "arm": "candidate",
+        "subject": subject,
+    }
+    direct_request = {
+        "cell": "runtime-cold-query-only",
+        "arm": "legacy",
+        "subject": subject,
     }
     legacy = {
         "loaded_views": ["bm25"],
         "errors": {},
         "artifact": None,
         "source_verified": True,
+        "source_error": None,
         "source_verification_scope": "content-bytes",
-        "vector_loaded": False,
+        "native_vector_authorized": False,
+        "native_lsp_allowed": True,
+        "lsp_provider": _runtime_identity(ordinary_request)["capabilities"][
+            "lsp_provider"
+        ],
+        "commit_verified": False,
     }
     candidate = {
         **legacy,
-        "artifact": {
-            "verified": True,
-            "schema": CONTEXT_ARTIFACT_SCHEMA,
-            "repository": subject["repository_key"],
-            "commit": subject["revision"],
-            "views": ["bm25"],
-        },
+        "artifact": _runtime_identity(candidate_request)["artifact"],
         "source_verified": False,
+        "source_error": "retained route has no repository source",
         "source_verification_scope": None,
+        "native_lsp_allowed": False,
+        "lsp_provider": _runtime_identity(candidate_request)["capabilities"][
+            "lsp_provider"
+        ],
     }
 
     legacy_authority = profiler._validate_runtime_context_state(
         legacy,
-        request={"cell": "runtime-cold", "arm": "legacy", "subject": subject},
+        request=ordinary_request,
     )
     candidate_authority = profiler._validate_runtime_context_state(
         candidate,
-        request={"cell": "runtime-cold", "arm": "candidate", "subject": subject},
+        request=candidate_request,
     )
     direct_authority = profiler._validate_runtime_context_state(
         candidate,
-        request={
-            "cell": "runtime-cold-query-only",
-            "arm": "legacy",
-            "subject": subject,
-        },
+        request=direct_request,
     )
 
-    assert legacy_authority == {
-        "context_kind": "manifest-live-source",
-        "artifact": None,
-        "source_verified": True,
-        "source_verification_scope": "content-bytes",
+    assert legacy_authority == _runtime_identity(ordinary_request)
+    assert direct_authority == _runtime_identity(direct_request)
+    assert candidate_authority == _runtime_identity(candidate_request)
+    assert direct_authority["delivery"] == {
+        "route": "direct-artifact",
+        "context_provenance": "portable-context-artifact",
     }
-    assert direct_authority == candidate_authority
-    assert candidate_authority["context_kind"] == "portable-artifact-query-only"
-    assert candidate_authority["source_verified"] is False
+    assert candidate_authority["delivery"] == {
+        "route": "retained-ref",
+        "context_provenance": "portable-context-artifact",
+    }
+    assert {
+        key: value for key, value in direct_authority.items() if key != "delivery"
+    } == {key: value for key, value in candidate_authority.items() if key != "delivery"}
+    assert candidate_authority["source_authority"] == {
+        "kind": "source-disabled",
+        "verified": False,
+        "verification_scope": None,
+    }
+    assert set(candidate_authority["capabilities"]) == {
+        "loaded_views",
+        "view_errors",
+        "read_source",
+        "native_vector_authorized",
+        "native_lsp_allowed",
+        "lsp_provider",
+        "commit_verified",
+        "checkout_state",
+    }
+    assert candidate_authority["capabilities"]["view_errors"] == {}
+
+    for invalid_view_errors in ([], {"bm25": "synthetic failure"}):
+        invalid_runtime = _runtime_identity(candidate_request)
+        invalid_runtime["capabilities"]["view_errors"] = invalid_view_errors
+        with pytest.raises((RuntimeError, ValueError)):
+            profiler._validate_runtime_identity(  # noqa: SLF001
+                invalid_runtime,
+                request=candidate_request,
+                label="synthetic runtime identity",
+            )
 
     with pytest.raises(RuntimeError, match="exact per-cell contract"):
         profiler._validate_runtime_context_state(
-            {**legacy, "source_verified": False},
-            request={
-                "cell": "runtime-cold",
-                "arm": "legacy",
-                "subject": subject,
+            {
+                **legacy,
+                "source_verified": False,
+                "source_error": "synthetic unverified source",
+                "source_verification_scope": None,
             },
+            request=ordinary_request,
         )
     with pytest.raises(RuntimeError, match="exact per-cell contract"):
         profiler._validate_runtime_context_state(
-            {**candidate, "source_verified": True},
-            request={
-                "cell": "runtime-cold-query-only",
-                "arm": "legacy",
-                "subject": subject,
+            {
+                **candidate,
+                "source_verified": True,
+                "source_error": None,
+                "source_verification_scope": "content-bytes",
             },
+            request=direct_request,
         )
 
 


### PR DESCRIPTION
## Summary

Extend the report-only retained-storage A1 benchmark to v3 with a source-bound cold-runtime comparison between ordinary manifest MCP and retained ref materialization with `--repo`.

The report separates narrow BM25/content-authority evidence from full ordinary-manifest compatibility. Portable artifact provenance, public-manifest differences, native capability policy, and incomplete view coverage remain explicit blockers, and every report remains promotion-ineligible.

Related to #199. This does not close the RFC or complete M1.

## Changes

- Add the fifth `runtime-cold-source-bound` cell while preserving the existing source-disabled compatibility sentinel and query-only portable-artifact comparison.
- Split compiler, content-authority, and full-runtime parity projections with independent per-arm stability and pair-equality receipts.
- Exercise public `get_manifest` and `read_source` success/refusal paths inside every runtime stopwatch.
- Validate the retained source-bound runtime against the canonical portable manifest with only the authenticated repository and BM25 view path rebinds allowed.
- Preserve artifact origin, source provenance, loaded-view errors, native authorization, observed LSP selection, commit-attestation state, cleanup, PID, and path-binding evidence.
- Raise the canonical matrix to five cells and 1,440 fresh inner route processes.
- Keep complete parity-red reports distinct from operational failures while leaving all tracks unratified and `promotion_eligible=false`.
- Document separate A2/B2 boundaries for query-only runtime, source-bound BM25 runtime, and full manifest replacement.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `pytest -q test/scripts/test_profile_retained_storage_gate.py -x --tb=short`: 55 passed, including the real four-delivery profiler matrix
- `pytest -q test/compiler/test_retained_mcp_cli_e2e.py`: 2 passed
- Full unit marker in a read-only bwrap namespace: 6902 passed, 78 skipped, 190 deselected
- `black --check`, `isort --check-only`, `flake8`, `py_compile`, and `git diff --check`
- `mkdocs build --strict`, namespace/capability checks, and the public-doc boundary check
- `make -n retained-storage-gate` with the canonical three-subject/two-media argument matrix

The full 1,440-process canonical A2 benchmark was not run; it requires the pinned detached subjects and two approved physical media classes. This PR adds the report-only harness and does not claim a performance or promotion result.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
