### PR TITLE
feat(storage): capture exact workspace destinations

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -117,7 +117,11 @@ jobs:
             import codenib._workspace_owner_impl as implementation;
             from codenib import _workspace_owner;
             assert platform.machine() == '${{ matrix.arch }}';
-            assert implementation.workspace_owner_protocol_version == 2;
+            assert implementation.workspace_owner_protocol_version == 3;
+            assert all(callable(getattr(implementation, name, None)) for name in
+            ('capture_owner_destination_exact',
+            'verify_owner_destination_binding_exact',
+            'borrow_owner_destination_descriptor_exact'));
             assert implementation.require_support() is None;
             _workspace_owner.require_support()"
 
@@ -345,7 +349,9 @@ jobs:
         run: |
           python - <<'PY'
           import hashlib
+          import os
           import stat
+          import time
           from pathlib import Path
           from tempfile import TemporaryDirectory
 
@@ -363,9 +369,21 @@ jobs:
           )
 
           assert Path(implementation.__file__).name == "_workspace_owner_impl.abi3.so"
-          assert implementation.workspace_owner_protocol_version == 2
+          assert implementation.workspace_owner_protocol_version == 3
+          capture_symbols = (
+              "capture_owner_destination_exact",
+              "verify_owner_destination_binding_exact",
+              "borrow_owner_destination_descriptor_exact",
+          )
+          assert all(
+              callable(getattr(implementation, name, None))
+              for name in capture_symbols
+          )
           assert implementation.require_support() is None
           assert _workspace_owner.require_support() is None
+          assert callable(_workspace_owner.capture_owner_destination)
+          assert callable(_workspace_owner.verify_owner_destination_binding)
+          assert callable(_workspace_owner.borrow_owner_destination_descriptor)
 
           payload = b'{"release-smoke":"ok"}'
           with TemporaryDirectory() as temporary:
@@ -418,6 +436,45 @@ jobs:
               receipt_owner.close()
 
               assert receipt_owner.closed
+              destination_identity = (destination.stat().st_dev, destination.stat().st_ino)
+              destination_names = tuple(path.name for path in root.iterdir())
+              captured_owner = _workspace_owner.create_owner()
+              try:
+                  _workspace_owner.capture_owner_destination(
+                      captured_owner,
+                      os.fsencode(root),
+                      b"published",
+                      time.monotonic_ns() + 10_000_000_000,
+                  )
+                  assert _workspace_owner.owner_state(captured_owner) == (
+                      "destination-captured"
+                  )
+                  assert (
+                      _workspace_owner.verify_owner_destination_binding(
+                          captured_owner
+                      )
+                      is None
+                  )
+                  destination_descriptor = (
+                      _workspace_owner.borrow_owner_destination_descriptor(
+                          captured_owner
+                      )
+                  )
+                  descriptor_metadata = os.fstat(destination_descriptor)
+                  assert stat.S_ISDIR(descriptor_metadata.st_mode)
+                  assert (
+                      descriptor_metadata.st_dev,
+                      descriptor_metadata.st_ino,
+                  ) == destination_identity
+                  assert not os.get_inheritable(destination_descriptor)
+              finally:
+                  _workspace_owner.close_owner_exact(captured_owner)
+
+              assert _workspace_owner.owner_closed(captured_owner)
+              assert tuple(path.name for path in root.iterdir()) == destination_names
+              assert (destination.stat().st_dev, destination.stat().st_ino) == (
+                  destination_identity
+              )
               assert output.read_bytes() == payload
           PY
 

--- a/codenib/_workspace_owner.py
+++ b/codenib/_workspace_owner.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-_EXPECTED_WORKSPACE_OWNER_PROTOCOL_VERSION = 2
+_EXPECTED_WORKSPACE_OWNER_PROTOCOL_VERSION = 3
 _IMPORT_ERROR: BaseException | None = None
 
 try:
@@ -39,17 +39,26 @@ _claim_owner_publish_permit_exact = _implementation_attribute(
 _require_owner_exact = _implementation_attribute("require_owner_exact")
 _close_owner_exact = _implementation_attribute("close_owner_exact")
 _provision_owner_exact = _implementation_attribute("provision_owner_exact")
+_capture_owner_destination_exact = _implementation_attribute(
+    "capture_owner_destination_exact"
+)
 _verify_owner_authority_exact = _implementation_attribute(
     "verify_owner_authority_exact"
 )
 _verify_owner_adoption_binding_exact = _implementation_attribute(
     "verify_owner_adoption_binding_exact"
 )
+_verify_owner_destination_binding_exact = _implementation_attribute(
+    "verify_owner_destination_binding_exact"
+)
 _borrow_owner_parent_descriptor_exact = _implementation_attribute(
     "borrow_owner_parent_descriptor_exact"
 )
 _borrow_owner_root_descriptor_exact = _implementation_attribute(
     "borrow_owner_root_descriptor_exact"
+)
+_borrow_owner_destination_descriptor_exact = _implementation_attribute(
+    "borrow_owner_destination_descriptor_exact"
 )
 _borrow_owner_directory_descriptor_exact = _implementation_attribute(
     "borrow_owner_directory_descriptor_exact"
@@ -84,10 +93,13 @@ _workspace_owner_protocol_available = (
             _require_owner_exact,
             _close_owner_exact,
             _provision_owner_exact,
+            _capture_owner_destination_exact,
             _verify_owner_authority_exact,
             _verify_owner_adoption_binding_exact,
+            _verify_owner_destination_binding_exact,
             _borrow_owner_parent_descriptor_exact,
             _borrow_owner_root_descriptor_exact,
+            _borrow_owner_destination_descriptor_exact,
             _borrow_owner_directory_descriptor_exact,
             _begin_owner_file_exact,
             _write_owner_file_exact,
@@ -113,10 +125,13 @@ if not _workspace_owner_protocol_available:
     _require_owner_exact = None
     _close_owner_exact = None
     _provision_owner_exact = None
+    _capture_owner_destination_exact = None
     _verify_owner_authority_exact = None
     _verify_owner_adoption_binding_exact = None
+    _verify_owner_destination_binding_exact = None
     _borrow_owner_parent_descriptor_exact = None
     _borrow_owner_root_descriptor_exact = None
+    _borrow_owner_destination_descriptor_exact = None
     _borrow_owner_directory_descriptor_exact = None
     _begin_owner_file_exact = None
     _write_owner_file_exact = None
@@ -238,10 +253,40 @@ def provision_owner(
     )
 
 
+def capture_owner_destination(
+    owner: object,
+    allowed_root: bytes,
+    destination: bytes,
+    deadline_ns: int,
+) -> None:
+    """Capture one exact existing destination without mutating its namespace."""
+
+    _require_protocol()
+    assert _capture_owner_destination_exact is not None
+    _require_none_result(
+        _capture_owner_destination_exact(
+            owner,
+            allowed_root,
+            destination,
+            deadline_ns,
+        ),
+        "destination-capture",
+    )
+
+
 def verify_owner_authority(owner: object) -> None:
     _require_protocol()
     assert _verify_owner_authority_exact is not None
     _require_none_result(_verify_owner_authority_exact(owner), "verify")
+
+
+def verify_owner_destination_binding(owner: object) -> None:
+    _require_protocol()
+    assert _verify_owner_destination_binding_exact is not None
+    _require_none_result(
+        _verify_owner_destination_binding_exact(owner),
+        "destination-binding verification",
+    )
 
 
 def verify_owner_adoption_binding(
@@ -284,6 +329,17 @@ def borrow_owner_root_descriptor(owner: object) -> int:
     return _require_descriptor(
         _borrow_owner_root_descriptor_exact(owner),
         "root-descriptor",
+    )
+
+
+def borrow_owner_destination_descriptor(owner: object) -> int:
+    """Borrow the owner-held destination FD; callers must not close it."""
+
+    _require_protocol()
+    assert _borrow_owner_destination_descriptor_exact is not None
+    return _require_descriptor(
+        _borrow_owner_destination_descriptor_exact(owner),
+        "destination-descriptor",
     )
 
 
@@ -409,10 +465,12 @@ __all__ = [
     "abort_owner",
     "abort_owner_file",
     "begin_owner_file",
+    "borrow_owner_destination_descriptor",
     "borrow_owner_directory_descriptor",
     "borrow_owner_parent_descriptor",
     "borrow_owner_root_descriptor",
     "claim_owner_publish_permit",
+    "capture_owner_destination",
     "close_owner_exact",
     "commit_owner_receipt",
     "create_owner",
@@ -429,5 +487,6 @@ __all__ = [
     "sync_owner_parent",
     "verify_owner_adoption_binding",
     "verify_owner_authority",
+    "verify_owner_destination_binding",
     "write_owner_file",
 ]

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -22,8 +22,22 @@ import-cache` recaptures an already existing selected cache, `codenib artifact
 materialize` publishes a retained catalog ref or immutable snapshot to a
 missing portable-artifact directory, and retained `codenib mcp` cold-start
 materializes and holds one such generation for a single stdio server lifetime.
-The strict BM25 replacement path still requires the unsupported
-`provider-bound-exact` destination mode.
+Protocol v3 also adds an internal, capture-only authority primitive for an
+existing destination directory. It moves an otherwise empty native owner into
+the distinct `destination-captured` state, where callers may verify the
+captured root plus destination name/device/inode binding, borrow its
+authenticated directory descriptor, and close or abort the owner. The internal
+native/facade primitive performs no namespace mutation, exposes neither the
+destination-parent nor staged-workspace-root descriptor, and performs no
+publication, rename, exchange, or replacement. The borrowed destination
+descriptor remains owner-owned and valid only for the owner's lifetime;
+trusted internal callers must not close it and could still use it as a
+capability, so capture is an authority boundary rather than a Python sandbox.
+
+`LocalWorkspaceProvider` remains missing-only and still rejects the strict
+BM25 producer's `provider-bound-exact` destination mode. Completing that Gate C
+provider requires an atomic exchange/replacement protocol v4, or a separately
+advertised capability; protocol v3 preparation does not close the gate.
 
 ## Publish a normal index build
 
@@ -348,8 +362,10 @@ These retained-read routes and the explicit BM25/vector ingress above do not
 complete the hybrid-storage M1 milestone. Benchmark-backed promotion of the
 opt-in compiler and runtime routes is still missing, as is a production
 provider for the strict BM25 replacement producer's `provider-bound-exact`
-destination contract. Graph and Zoekt ingress remain M2 or later work; fenced
-jobs and runtime hot switching remain separate milestones.
+destination contract. The capture-only protocol-v3 root authority does not
+change that provider rejection and cannot exchange or replace the captured
+directory. Graph and Zoekt ingress remain M2 or later work; fenced jobs and
+runtime hot switching remain separate milestones.
 
 ## Measure the retained storage gate
 
@@ -490,8 +506,11 @@ capability policy, and required view coverage. A future source-bound BM25
 default requires its own A2 decision and does not satisfy that full
 compatibility gate. The independent gate C
 `provider-bound-exact` native provider is still required before M1 closes.
-This harness does not add M2 generic generation publication or fenced jobs, M3
-hot switching or request pins, or M5 retention and garbage collection.
+Protocol v3 supplies only its non-mutating capture preparation; the later
+exchange/replacement operation must use protocol v4 or an explicit independent
+capability. This harness does not add M2 generic generation publication or
+fenced jobs, M3 hot switching or request pins, or M5 retention and garbage
+collection.
 
 ## Lifecycle
 
@@ -542,7 +561,7 @@ The provider deliberately has a narrow first release:
 - One absolute authority root owned by the current effective UID, with exact
   mode `0700`. The root must be a private, quiescent namespace rather than a
   directory another same-UID process actively mutates.
-- A complete protocol-v2 native extension and a successful Linux ownership
+- A complete protocol-v3 native extension and a successful Linux ownership
   support probe before the first namespace mutation.
 - A plan small enough for the process descriptor limit. The format permits up
   to 100,000 directories, but the native `RLIMIT_NOFILE` preflight may reject a
@@ -566,11 +585,12 @@ policy permits cleanup; discarding it forfeits recoverability.
 
 ## Publication guarantees
 
-The protocol-v2 native aggregate owns the namespace and file descriptors for
-the whole operation. It creates and writes files without returning raw file
-descriptors to Python, pins the root and planned directory identities, and
-performs one no-replace forward rename under a one-shot permit. The caller's
-receipt-slot store is the authority linearization point:
+The protocol-v3 native aggregate preserves the protocol-v2 missing-destination
+publication contract. In that publication mode it owns the namespace and file
+descriptors for the whole operation, creates and writes files without returning
+raw file descriptors to Python, pins the root and planned directory identities,
+and performs one no-replace forward rename under a one-shot permit. The
+caller's receipt-slot store is the authority linearization point:
 
 - before the store, failure quarantines the exact candidate;
 - after the store, recovery commits the same native receipt token
@@ -581,3 +601,18 @@ receipt-slot store is the authority linearization point:
 Staged and published validators run inside that transaction. The returned
 receipt therefore names one exact, durably published generation rather than a
 path checked after the fact.
+
+Protocol v3's additive capture mode instead binds the private allowed root,
+destination-parent chain, existing destination directory, and exact
+name/device/inode without mutating any of them. A `destination-captured` owner
+permits only destination verification, an owner-owned borrowed destination
+descriptor, and owner close or abort; legacy destination-parent,
+staged-workspace-root, and planned-directory borrows plus file, publication,
+quarantine, and rename operations fail closed. The borrowed descriptor is valid
+only for the owner lifetime and callers must not close it. The native capture
+operation itself makes no namespace change. Trusted internal code could still
+use the destination descriptor with `*at` syscalls, so this is an authority
+boundary rather than a Python sandbox. It is root-authority evidence for future
+Gate C work, not full `_TreeOwnership` and not a `provider-bound-exact`
+provider. Atomic exchange or replacement remains a protocol-v4 or separately
+advertised capability.

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -282,16 +282,26 @@ authenticated reader pinned through synchronous consumption. The contract
 remains provider-neutral, and a concrete `LocalWorkspaceProvider` now supplies
 it on Linux for missing destinations below one private, quiescent root owned by
 the current effective UID with exact mode `0700`. Native workspace-owner
-protocol v2 pins the namespace
-and owns every file descriptor, acquires and writes files without exposing raw
-file descriptors to Python, and gates the only forward rename with a one-shot
-publish permit. The caller-owned receipt slot is the publication-authority
+protocol v3 preserves the v2 publication contract: it pins the namespace and
+owns every file descriptor, acquires and writes files without exposing raw file
+descriptors to Python, and gates the only forward rename with a one-shot publish
+permit. The caller-owned receipt slot is the publication-authority
 linearization point: unreceipted same-process failures quarantine the exact
 candidate, while a fork child authenticates and closes only its inherited
-descriptor pairs. The provider is an authority boundary for trusted callbacks,
-not an in-process Python sandbox. The explicit retained workflows construct it
-for operator-requested publication and cold start; no compiler or runtime route
-constructs it by default yet.
+descriptor pairs. V3 also adds a non-mutating capture-only mode for an existing
+destination. It enters the distinct `destination-captured` state, authenticates
+the private root and exact destination name/device/inode binding, and permits
+only verification, an owner-owned borrowed destination descriptor, and owner
+close or abort. Legacy destination-parent, staged-workspace-root, and
+planned-directory borrows reject this state, so capture creates no accidental
+parent or staged-workspace-root capability. The borrowed descriptor is valid
+only for the owner lifetime and callers must not close it. The native primitive
+performs no namespace mutation and cannot publish, exchange, or replace the
+directory. Trusted internal code could still use the descriptor with `*at`
+syscalls, so capture is not full `_TreeOwnership`. The provider remains an
+authority boundary for trusted callbacks, not an in-process Python sandbox.
+The explicit retained workflows construct it for operator-requested publication
+and cold start; no compiler or runtime route constructs it by default yet.
 
 Callback-scoped directory results are likewise provisional until ordered
 reader-validity, exact-ownership, child-namespace, and parent-authority
@@ -377,11 +387,15 @@ materialization APIs are now available as injectable library producers. The
 Linux local provider deliberately accepts only missing destinations, so
 whole-context retained materialization can use it explicitly, while strict BM25
 replacement requests `provider-bound-exact` and still lacks a concrete
-production provider. The explicit retained workflows can now construct the
-whole-context producer for one existing catalog selection, publish normal
-compiler output, and load one selected generation at MCP cold start, but no
-default compiler/runtime route constructs them. M1 remains in progress and the
-M2 BM25 profile adapter is still outstanding.
+production provider. Protocol v3 now supplies its capture-only,
+root-authority-preparation half, but `LocalWorkspaceProvider` still rejects the
+request and no exchange/replacement operation exists. That mutation boundary
+must be protocol v4 or a separately advertised capability. The explicit
+retained workflows can now construct the whole-context producer for one
+existing catalog selection, publish normal compiler output, and load one
+selected generation at MCP cold start, but no default compiler/runtime route
+constructs them. M1 remains in progress and the M2 BM25 profile adapter is still
+outstanding.
 
 Strict whole-context publication can now aggregate already-normalized BM25 and
 vector generations retained by active workspace receipt owners. The plan binds
@@ -729,7 +743,10 @@ advance refs, or make retained storage the default. Benchmark-backed promotion
 of the explicit compiler and runtime routes remains outstanding M1 work; graph
 and Zoekt cache ingress and fenced job publication remain M2 or later work.
 Strict BM25 replacement also still lacks the `provider-bound-exact` production
-provider.
+provider. Protocol-v3 destination capture is non-mutating preparation only;
+`LocalWorkspaceProvider` continues to reject that expectation, and atomic
+exchange/replacement remains a protocol-v4 or separately advertised
+capability.
 
 #### Retained storage promotion protocol
 
@@ -746,7 +763,7 @@ that collecting a fast result cannot silently approve a production route:
 | B1 | Promote BM25 compiler publication to a configured default. | Pending A2 compiler. |
 | B2 | Promote query-only BM25 retained cold start to a configured default. | Pending A2 query-only runtime; this does not replace source-bound manifest MCP. |
 | B2 source-bound | Promote a specifically scoped source-bound BM25 retained cold start. | Pending A2 source-bound BM25 runtime; it cannot satisfy the full manifest-compatibility gate. |
-| C | Supply the `provider-bound-exact` strict BM25 native provider. | Independent work, but required before M1 closes. |
+| C | Supply the `provider-bound-exact` strict BM25 native provider. | Capture-only protocol-v3 root authority is implemented as non-mutating preparation, but `LocalWorkspaceProvider` still rejects this expectation. Exchange/replacement requires protocol v4 or a separately advertised capability, so Gate C remains pending and required before M1 closes. |
 
 The A1 harness fixes the BM25 `fast` compiler/runtime comparison rather than
 accepting arbitrary route substitutions. For compiler cold start, arm A runs

--- a/native/workspace_owner.c
+++ b/native/workspace_owner.c
@@ -69,6 +69,7 @@ enum workspace_namespace_state {
   WORKSPACE_PUBLISHED_UNRECEIPTED = 4,
   WORKSPACE_RECEIPTED = 5,
   WORKSPACE_QUARANTINED = 6,
+  WORKSPACE_DESTINATION_CAPTURED = 7,
 };
 
 typedef struct {
@@ -88,6 +89,7 @@ typedef struct WorkspaceOwner {
   int allowed_root_policy_known;
   int closed;
   int provision_started;
+  int destination_capture_started;
   int namespace_created;
   int namespace_sync_pending;
   enum workspace_namespace_state namespace_state;
@@ -99,6 +101,9 @@ typedef struct WorkspaceOwner {
   int root_fd;
   int root_guard_fd;
   int root_exposed;
+  int captured_destination_fd;
+  int captured_destination_guard_fd;
+  int captured_destination_exposed;
   dev_t anchor_device;
   ino_t anchor_inode;
   int anchor_identity_known;
@@ -108,6 +113,9 @@ typedef struct WorkspaceOwner {
   dev_t root_device;
   ino_t root_inode;
   int root_identity_known;
+  dev_t captured_destination_device;
+  ino_t captured_destination_inode;
+  int captured_destination_identity_known;
   char *destination_name;
   char *destination_path;
   char *initial_stage_name;
@@ -201,6 +209,8 @@ static int check_deadline(long long deadline_ns) {
 
 static int verify_parent_binding(WorkspaceOwner *self);
 static int verify_owner_authority(WorkspaceOwner *self);
+static int verify_descriptor(int descriptor, int guard, dev_t device,
+                             ino_t inode);
 static int verify_hidden_directory(int descriptor, dev_t device, ino_t inode);
 static int quarantine_namespace_internal(WorkspaceOwner *self);
 
@@ -729,6 +739,15 @@ static int close_inherited_descriptors(WorkspaceOwner *self) {
       first_error = error;
     }
   }
+  error = close_one(self, &self->captured_destination_fd,
+                    &self->captured_destination_guard_fd,
+                    &self->captured_destination_device,
+                    &self->captured_destination_inode,
+                    &self->captured_destination_identity_known,
+                    self->captured_destination_exposed);
+  if (first_error == 0 && error != 0) {
+    first_error = error;
+  }
   error = close_one(self, &self->root_fd, &self->root_guard_fd,
                     &self->root_device, &self->root_inode,
                     &self->root_identity_known, self->root_exposed);
@@ -756,9 +775,11 @@ static int close_inherited_descriptors(WorkspaceOwner *self) {
       first_error = error;
     }
   }
-  self->closed = self->root_fd < 0 && self->root_guard_fd < 0 &&
-                 self->parent_fd < 0 && self->parent_guard_fd < 0 &&
-                 self->anchor_fd < 0 && self->anchor_guard_fd < 0;
+  self->closed = self->captured_destination_fd < 0 &&
+                 self->captured_destination_guard_fd < 0 && self->root_fd < 0 &&
+                 self->root_guard_fd < 0 && self->parent_fd < 0 &&
+                 self->parent_guard_fd < 0 && self->anchor_fd < 0 &&
+                 self->anchor_guard_fd < 0;
   for (index = 0; index < self->directory_count; ++index) {
     if (self->directories[index].fd >= 0 ||
         self->directories[index].guard_fd >= 0) {
@@ -806,6 +827,15 @@ static int close_all(WorkspaceOwner *self) {
       first_error = error;
     }
   }
+  error = close_one(self, &self->captured_destination_fd,
+                    &self->captured_destination_guard_fd,
+                    &self->captured_destination_device,
+                    &self->captured_destination_inode,
+                    &self->captured_destination_identity_known,
+                    self->captured_destination_exposed);
+  if (first_error == 0 && error != 0) {
+    first_error = error;
+  }
   error = close_one(self, &self->root_fd, &self->root_guard_fd,
                     &self->root_device, &self->root_inode,
                     &self->root_identity_known, self->root_exposed);
@@ -833,9 +863,11 @@ static int close_all(WorkspaceOwner *self) {
       first_error = error;
     }
   }
-  self->closed = self->root_fd < 0 && self->root_guard_fd < 0 &&
-                 self->parent_fd < 0 && self->parent_guard_fd < 0 &&
-                 self->anchor_fd < 0 && self->anchor_guard_fd < 0;
+  self->closed = self->captured_destination_fd < 0 &&
+                 self->captured_destination_guard_fd < 0 && self->root_fd < 0 &&
+                 self->root_guard_fd < 0 && self->parent_fd < 0 &&
+                 self->parent_guard_fd < 0 && self->anchor_fd < 0 &&
+                 self->anchor_guard_fd < 0;
   for (index = 0; index < self->directory_count; ++index) {
     if (self->directories[index].fd >= 0 ||
         self->directories[index].guard_fd >= 0) {
@@ -1577,6 +1609,7 @@ static PyObject *WorkspaceOwner_new(PyTypeObject *type, PyObject *args,
   self->allowed_root_policy_known = 0;
   self->closed = 0;
   self->provision_started = 0;
+  self->destination_capture_started = 0;
   self->namespace_created = 0;
   self->namespace_sync_pending = 0;
   self->namespace_state = WORKSPACE_EMPTY;
@@ -1588,9 +1621,13 @@ static PyObject *WorkspaceOwner_new(PyTypeObject *type, PyObject *args,
   self->root_fd = -1;
   self->root_guard_fd = -1;
   self->root_exposed = 0;
+  self->captured_destination_fd = -1;
+  self->captured_destination_guard_fd = -1;
+  self->captured_destination_exposed = 0;
   self->anchor_identity_known = 0;
   self->parent_identity_known = 0;
   self->root_identity_known = 0;
+  self->captured_destination_identity_known = 0;
   self->destination_name = NULL;
   self->destination_path = NULL;
   self->initial_stage_name = NULL;
@@ -2064,6 +2101,260 @@ error:
   return NULL;
 }
 
+static PyObject *WorkspaceOwner_capture_destination(WorkspaceOwner *self,
+                                                    PyObject *args) {
+  PyObject *allowed_root_object;
+  PyObject *destination_object;
+  PyObject *deadline_object;
+  char *allowed_root = NULL;
+  char *destination = NULL;
+  char *parent_path = NULL;
+  char *destination_name = NULL;
+  char *destination_path = NULL;
+  long long deadline_ns;
+  struct stat linked_metadata;
+  dev_t opened_device;
+  ino_t opened_inode;
+  int acquisition_started = 0;
+
+  if (require_linux() < 0 || require_owner_pid(self) < 0) {
+    return NULL;
+  }
+#if !defined(SYS_fstat) || !defined(SYS_newfstatat) || !defined(SYS_kcmp) ||   \
+    !defined(SYS_close)
+  PyErr_SetString(PyExc_RuntimeError,
+                  "native strict destination capture requires Linux "
+                  "descriptor and OFD-comparison syscalls");
+  return NULL;
+#else
+  if (probe_kcmp_support() < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native strict destination capture requires permitted "
+                    "same-process kcmp OFD comparison");
+    return NULL;
+  }
+#endif
+  if (self->closed || self->provision_started ||
+      self->destination_capture_started || self->namespace_created ||
+      self->namespace_sync_pending ||
+      self->namespace_state != WORKSPACE_EMPTY ||
+      self->publish_permit_claimed || self->publish_permit_active ||
+      self->anchor_fd >= 0 || self->anchor_guard_fd >= 0 ||
+      self->parent_fd >= 0 || self->parent_guard_fd >= 0 ||
+      self->root_fd >= 0 || self->root_guard_fd >= 0 ||
+      self->captured_destination_fd >= 0 ||
+      self->captured_destination_guard_fd >= 0 || self->directories != NULL ||
+      self->directory_count != 0 || self->scratch_count != 0 ||
+      self->absolute_chain_count != 0 || self->relative_chain_count != 0 ||
+      self->destination_name != NULL || self->destination_path != NULL ||
+      self->initial_stage_name != NULL || self->stage_name != NULL ||
+      self->plan_digest != NULL || self->orphan_name != NULL ||
+      self->file_fd >= 0 || self->file_guard_fd >= 0 ||
+      self->file_name != NULL || self->file_active || self->file_failed ||
+      self->receipt_generation != 0 || self->allowed_root_policy_known ||
+      self->anchor_identity_known || self->parent_identity_known ||
+      self->root_identity_known || self->captured_destination_identity_known) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace owner is not empty for destination "
+                    "capture");
+    return NULL;
+  }
+  if (!PyArg_UnpackTuple(args, "capture_destination", 3, 3,
+                         &allowed_root_object, &destination_object,
+                         &deadline_object)) {
+    return NULL;
+  }
+  if (!PyLong_CheckExact(deadline_object)) {
+    PyErr_SetString(PyExc_TypeError,
+                    "workspace capture deadline must be an exact integer");
+    return NULL;
+  }
+  deadline_ns = PyLong_AsLongLong(deadline_object);
+  if (deadline_ns == -1 && PyErr_Occurred()) {
+    return NULL;
+  }
+  if (deadline_ns <= 0) {
+    PyErr_SetString(PyExc_ValueError, "workspace capture deadline is invalid");
+    return NULL;
+  }
+  if (check_deadline(deadline_ns) < 0) {
+    return NULL;
+  }
+  allowed_root = copy_exact_bytes(allowed_root_object, "allowed root",
+                                  CODENIB_MAX_PATH_BYTES);
+  destination = copy_exact_bytes(destination_object, "workspace destination",
+                                 CODENIB_MAX_PATH_BYTES);
+  if (allowed_root == NULL || destination == NULL) {
+    goto error;
+  }
+  if (allowed_root[0] != '/') {
+    PyErr_SetString(PyExc_ValueError,
+                    "workspace allowed root must be an absolute path");
+    goto error;
+  }
+  if (split_destination(destination, &parent_path, &destination_name) < 0 ||
+      preflight_descriptor_budget(self, allowed_root, parent_path) < 0) {
+    goto error;
+  }
+  destination_path = join_destination_path(allowed_root, destination);
+  if (destination_path == NULL || check_deadline(deadline_ns) < 0) {
+    goto error;
+  }
+
+  self->destination_name = destination_name;
+  destination_name = NULL;
+  self->destination_path = destination_path;
+  destination_path = NULL;
+  acquisition_started = 1;
+  self->provision_started = 1;
+  self->destination_capture_started = 1;
+
+  self->anchor_fd = open_absolute_directory(self, allowed_root);
+  self->absolute_chain_count = self->scratch_count;
+  if (self->anchor_fd >= 0) {
+    self->anchor_fd = transfer_scratch_descriptor(
+        self, self->anchor_fd, &self->anchor_guard_fd, &self->anchor_device,
+        &self->anchor_inode);
+    if (self->anchor_fd >= 0) {
+      self->anchor_identity_known = 1;
+    }
+  }
+  if (self->anchor_fd < 0 ||
+      record_identity(self->anchor_fd, &self->anchor_device,
+                      &self->anchor_inode, S_IFDIR) < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  self->allowed_root_euid = geteuid();
+  self->allowed_root_policy_known = 1;
+  if (verify_allowed_root_policy(self) < 0) {
+    if (errno == EPERM) {
+      PyErr_SetString(PyExc_PermissionError,
+                      "workspace allowed root must be owned by the current "
+                      "effective user with exact mode 0700");
+    } else {
+      PyErr_SetFromErrno(PyExc_OSError);
+    }
+    goto error;
+  }
+  if (check_deadline(deadline_ns) < 0) {
+    goto error;
+  }
+  self->relative_chain_start = self->scratch_count;
+  self->parent_fd = walk_relative_directory(self, self->anchor_fd, parent_path);
+  self->relative_chain_count = self->scratch_count - self->relative_chain_start;
+  if (self->parent_fd >= 0) {
+    self->parent_fd = transfer_scratch_descriptor(
+        self, self->parent_fd, &self->parent_guard_fd, &self->parent_device,
+        &self->parent_inode);
+    if (self->parent_fd >= 0) {
+      self->parent_identity_known = 1;
+    }
+  }
+  if (self->parent_fd < 0 ||
+      record_identity(self->parent_fd, &self->parent_device,
+                      &self->parent_inode, S_IFDIR) < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  if (self->parent_device != self->anchor_device) {
+    PyErr_SetString(PyExc_ValueError,
+                    "workspace destination crosses the allowed-root device");
+    goto error;
+  }
+  if (verify_parent_binding(self) < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "workspace allowed-root binding changed during destination "
+                    "capture");
+    goto error;
+  }
+  if (native_fstatat_retry(self->parent_guard_fd, self->destination_name,
+                           &linked_metadata, AT_SYMLINK_NOFOLLOW) < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  if (!S_ISDIR(linked_metadata.st_mode) || linked_metadata.st_dev == 0 ||
+      linked_metadata.st_ino == 0) {
+    PyErr_SetString(PyExc_ValueError,
+                    "workspace capture destination is not a directory");
+    goto error;
+  }
+  if (linked_metadata.st_dev != self->parent_device) {
+    PyErr_SetString(PyExc_ValueError,
+                    "workspace capture destination crosses the parent device");
+    goto error;
+  }
+  self->captured_destination_device = linked_metadata.st_dev;
+  self->captured_destination_inode = linked_metadata.st_ino;
+  self->captured_destination_fd =
+      open_directory_at(self->parent_guard_fd, self->destination_name);
+  if (self->captured_destination_fd < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  self->captured_destination_guard_fd =
+      duplicate_cloexec(self->captured_destination_fd);
+  if (self->captured_destination_guard_fd < 0) {
+    int error_number = errno;
+    discard_uncommitted_pair(&self->captured_destination_fd,
+                             &self->captured_destination_guard_fd,
+                             error_number);
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  if (record_identity(self->captured_destination_fd, &opened_device,
+                      &opened_inode, S_IFDIR) < 0) {
+    int error_number = errno;
+    discard_uncommitted_pair(&self->captured_destination_fd,
+                             &self->captured_destination_guard_fd,
+                             error_number);
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  if (opened_device != self->captured_destination_device ||
+      opened_inode != self->captured_destination_inode ||
+      opened_device != self->parent_device) {
+    errno = ESTALE;
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  self->captured_destination_identity_known = 1;
+  if (check_deadline(deadline_ns) < 0 || verify_parent_binding(self) < 0 ||
+      verify_descriptor(self->captured_destination_fd,
+                        self->captured_destination_guard_fd,
+                        self->captured_destination_device,
+                        self->captured_destination_inode) < 0 ||
+      same_identity_at(self->parent_guard_fd, self->destination_name,
+                       self->captured_destination_device,
+                       self->captured_destination_inode) < 0 ||
+      verify_allowed_root_policy(self) < 0) {
+    if (!PyErr_Occurred()) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "workspace destination binding changed before capture "
+                      "commit");
+    }
+    goto error;
+  }
+  self->namespace_created = 0;
+  self->namespace_sync_pending = 0;
+  self->namespace_state = WORKSPACE_DESTINATION_CAPTURED;
+  free(allowed_root);
+  free(destination);
+  free(parent_path);
+  Py_RETURN_NONE;
+
+error:
+  if (!acquisition_started) {
+    free_configuration(self);
+  }
+  free(allowed_root);
+  free(destination);
+  free(parent_path);
+  free(destination_name);
+  free(destination_path);
+  return NULL;
+}
+
 static int verify_descriptor(int descriptor, int guard, dev_t device,
                              ino_t inode) {
   struct stat metadata;
@@ -2206,8 +2497,43 @@ static int verify_parent_binding(WorkspaceOwner *self) {
   return 0;
 }
 
+static int verify_captured_destination_binding(WorkspaceOwner *self) {
+  if (self->namespace_state != WORKSPACE_DESTINATION_CAPTURED || self->closed ||
+      !self->provision_started || !self->destination_capture_started ||
+      self->namespace_created || self->namespace_sync_pending ||
+      self->publish_permit_claimed || self->publish_permit_active ||
+      self->destination_name == NULL || self->destination_path == NULL ||
+      !self->captured_destination_identity_known ||
+      self->captured_destination_device == 0 ||
+      self->captured_destination_inode == 0 || self->root_fd >= 0 ||
+      self->root_guard_fd >= 0 || self->root_identity_known ||
+      self->directories != NULL || self->directory_count != 0 ||
+      self->file_fd >= 0 || self->file_guard_fd >= 0 || self->file_active ||
+      self->file_failed || self->file_name != NULL ||
+      self->initial_stage_name != NULL || self->stage_name != NULL ||
+      self->plan_digest != NULL || self->orphan_name != NULL ||
+      self->receipt_generation != 0 ||
+      self->parent_device != self->anchor_device ||
+      self->captured_destination_device != self->parent_device ||
+      verify_parent_binding(self) < 0 ||
+      verify_descriptor(self->captured_destination_fd,
+                        self->captured_destination_guard_fd,
+                        self->captured_destination_device,
+                        self->captured_destination_inode) < 0 ||
+      same_identity_at(self->parent_guard_fd, self->destination_name,
+                       self->captured_destination_device,
+                       self->captured_destination_inode) < 0) {
+    errno = ESTALE;
+    return -1;
+  }
+  return 0;
+}
+
 static int verify_owner_authority(WorkspaceOwner *self) {
   Py_ssize_t index;
+  if (self->destination_capture_started) {
+    return verify_captured_destination_binding(self);
+  }
   if (verify_parent_binding(self) < 0 || !self->root_identity_known ||
       verify_descriptor(self->root_fd, self->root_guard_fd, self->root_device,
                         self->root_inode) < 0 ||
@@ -2235,6 +2561,20 @@ static int verify_owner_authority(WorkspaceOwner *self) {
     }
   }
   return 0;
+}
+
+static PyObject *
+WorkspaceOwner_verify_destination_binding(WorkspaceOwner *self,
+                                          PyObject *Py_UNUSED(ignored)) {
+  if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (verify_captured_destination_binding(self) < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace destination binding changed");
+    return NULL;
+  }
+  Py_RETURN_NONE;
 }
 
 static PyObject *WorkspaceOwner_verify(WorkspaceOwner *self,
@@ -2581,6 +2921,11 @@ static PyObject *WorkspaceOwner_write_file(WorkspaceOwner *self,
   if (require_owner_pid(self) < 0) {
     return NULL;
   }
+  if (self->destination_capture_started) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "captured destination owner cannot write a file");
+    return NULL;
+  }
   if (!PyBytes_CheckExact(payload) ||
       PyBytes_AsStringAndSize(payload, &data, &size) < 0) {
     if (self->file_active) {
@@ -2650,6 +2995,11 @@ static PyObject *WorkspaceOwner_finish_file(WorkspaceOwner *self,
   PyObject *result;
 
   if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (self->destination_capture_started) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "captured destination owner cannot finish a file");
     return NULL;
   }
   if (exact_file_mode(mode_object, "workspace file final mode", &final_mode) <
@@ -2735,6 +3085,11 @@ static PyObject *WorkspaceOwner_abort_file(WorkspaceOwner *self,
   if (require_owner_pid(self) < 0) {
     return NULL;
   }
+  if (self->destination_capture_started) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "captured destination owner cannot abort a file");
+    return NULL;
+  }
   if (!self->file_active && self->file_fd < 0 && self->file_guard_fd < 0) {
     Py_RETURN_NONE;
   }
@@ -2783,6 +3138,11 @@ static PyObject *
 WorkspaceOwner_sync_parent_method(WorkspaceOwner *self,
                                   PyObject *Py_UNUSED(ignored)) {
   if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (self->destination_capture_started) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "captured destination owner cannot sync its parent");
     return NULL;
   }
   if (self->closed || verify_parent_binding(self) < 0 ||
@@ -3098,6 +3458,11 @@ static PyObject *WorkspaceOwner_quarantine(WorkspaceOwner *self,
   if (require_owner_pid(self) < 0) {
     return NULL;
   }
+  if (self->destination_capture_started) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "captured destination owner cannot be quarantined");
+    return NULL;
+  }
   if (quarantine_namespace_internal(self) < 0) {
     if (errno == ENOMEM) {
       PyErr_NoMemory();
@@ -3190,7 +3555,7 @@ static PyObject *WorkspaceOwner_directory_descriptor(WorkspaceOwner *self,
   Py_ssize_t index;
 
   if (require_owner_pid(self) < 0 || self->closed ||
-      verify_owner_authority(self) < 0) {
+      self->destination_capture_started || verify_owner_authority(self) < 0) {
     if (!PyErr_Occurred()) {
       PyErr_SetString(PyExc_RuntimeError, "native workspace owner is closed");
     }
@@ -3222,7 +3587,8 @@ static PyObject *WorkspaceOwner_directory_descriptor(WorkspaceOwner *self,
 static PyObject *WorkspaceOwner_get_parent_descriptor(WorkspaceOwner *self,
                                                       void *closure) {
   (void)closure;
-  if (require_owner_pid(self) < 0 || self->closed || self->parent_fd < 0 ||
+  if (require_owner_pid(self) < 0 || self->closed ||
+      self->destination_capture_started || self->parent_fd < 0 ||
       verify_parent_binding(self) < 0) {
     if (!PyErr_Occurred()) {
       PyErr_SetString(PyExc_RuntimeError,
@@ -3247,6 +3613,21 @@ static PyObject *WorkspaceOwner_get_root_descriptor(WorkspaceOwner *self,
   }
   self->root_exposed = 1;
   return PyLong_FromLong(self->root_fd);
+}
+
+static PyObject *WorkspaceOwner_get_destination_descriptor(WorkspaceOwner *self,
+                                                           void *closure) {
+  (void)closure;
+  if (require_owner_pid(self) < 0 ||
+      verify_captured_destination_binding(self) < 0) {
+    if (!PyErr_Occurred()) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "native workspace destination descriptor is unavailable");
+    }
+    return NULL;
+  }
+  self->captured_destination_exposed = 1;
+  return PyLong_FromLong(self->captured_destination_fd);
 }
 
 static PyObject *WorkspaceOwner_get_closed(WorkspaceOwner *self,
@@ -3282,6 +3663,9 @@ static PyObject *WorkspaceOwner_get_state(WorkspaceOwner *self, void *closure) {
       break;
     case WORKSPACE_QUARANTINED:
       state = "quarantined";
+      break;
+    case WORKSPACE_DESTINATION_CAPTURED:
+      state = "destination-captured";
       break;
     default:
       state = "invalid";
@@ -3537,6 +3921,14 @@ static PyObject *module_provision_owner_exact(PyObject *module,
                                       WorkspaceOwner_provision);
 }
 
+static PyObject *module_capture_owner_destination_exact(PyObject *module,
+                                                        PyObject *args) {
+  (void)module;
+  return dispatch_owner_varargs_exact(args, 4,
+                                      "capture_owner_destination_exact",
+                                      WorkspaceOwner_capture_destination);
+}
+
 static PyObject *module_claim_owner_publish_permit_exact(PyObject *module,
                                                          PyObject *owner) {
   (void)module;
@@ -3548,6 +3940,14 @@ static PyObject *module_verify_owner_authority_exact(PyObject *module,
                                                      PyObject *owner) {
   (void)module;
   return dispatch_owner_noargs_exact(owner, WorkspaceOwner_verify);
+}
+
+static PyObject *
+module_verify_owner_destination_binding_exact(PyObject *module,
+                                              PyObject *owner) {
+  (void)module;
+  return dispatch_owner_noargs_exact(owner,
+                                     WorkspaceOwner_verify_destination_binding);
 }
 
 static PyObject *module_verify_owner_adoption_binding_exact(PyObject *module,
@@ -3578,6 +3978,18 @@ static PyObject *module_borrow_owner_root_descriptor_exact(PyObject *module,
     return NULL;
   }
   return WorkspaceOwner_get_root_descriptor(exact_owner, NULL);
+}
+
+static PyObject *
+module_borrow_owner_destination_descriptor_exact(PyObject *module,
+                                                 PyObject *owner) {
+  WorkspaceOwner *exact_owner;
+  (void)module;
+  exact_owner = require_workspace_owner_exact(owner);
+  if (exact_owner == NULL) {
+    return NULL;
+  }
+  return WorkspaceOwner_get_destination_descriptor(exact_owner, NULL);
 }
 
 static PyObject *
@@ -3733,7 +4145,7 @@ static PyObject *module_require_owner_exact(PyObject *module, PyObject *owner) {
   return owner;
 }
 
-#define CODENIB_WORKSPACE_OWNER_PROTOCOL_VERSION 2
+#define CODENIB_WORKSPACE_OWNER_PROTOCOL_VERSION 3
 
 static PyObject *module_require_support(PyObject *module,
                                         PyObject *Py_UNUSED(ignored)) {
@@ -3775,12 +4187,18 @@ static PyMethodDef workspace_module_methods[] = {
      "Authenticate against the internally pinned native owner type."},
     {"provision_owner_exact", (PyCFunction)module_provision_owner_exact,
      METH_VARARGS, "Provision through exact native-owner dispatch."},
+    {"capture_owner_destination_exact",
+     (PyCFunction)module_capture_owner_destination_exact, METH_VARARGS,
+     "Capture one existing destination through exact native-owner dispatch."},
     {"claim_owner_publish_permit_exact",
      (PyCFunction)module_claim_owner_publish_permit_exact, METH_O,
      "Claim the exact owner's private one-shot publication capability."},
     {"verify_owner_authority_exact",
      (PyCFunction)module_verify_owner_authority_exact, METH_O,
      "Verify authority through exact native-owner dispatch."},
+    {"verify_owner_destination_binding_exact",
+     (PyCFunction)module_verify_owner_destination_binding_exact, METH_O,
+     "Verify one exact captured destination binding."},
     {"verify_owner_adoption_binding_exact",
      (PyCFunction)module_verify_owner_adoption_binding_exact, METH_VARARGS,
      "Verify adoption binding through exact native-owner dispatch."},
@@ -3790,6 +4208,9 @@ static PyMethodDef workspace_module_methods[] = {
     {"borrow_owner_root_descriptor_exact",
      (PyCFunction)module_borrow_owner_root_descriptor_exact, METH_O,
      "Borrow the exact owner's workspace-root descriptor."},
+    {"borrow_owner_destination_descriptor_exact",
+     (PyCFunction)module_borrow_owner_destination_descriptor_exact, METH_O,
+     "Borrow the exact owner's captured-destination descriptor."},
     {"borrow_owner_directory_descriptor_exact",
      (PyCFunction)module_borrow_owner_directory_descriptor_exact, METH_VARARGS,
      "Borrow one planned directory through exact native-owner dispatch."},

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -631,7 +631,13 @@ def test_registry_publishers_use_separate_workflows() -> None:
         in wheel_env["CIBW_REPAIR_WHEEL_COMMAND_LINUX"]
     )
     wheel_smoke = wheel_env["CIBW_TEST_COMMAND"]
-    assert "workspace_owner_protocol_version == 2" in wheel_smoke
+    assert "workspace_owner_protocol_version == 3" in wheel_smoke
+    for symbol in (
+        "capture_owner_destination_exact",
+        "verify_owner_destination_binding_exact",
+        "borrow_owner_destination_descriptor_exact",
+    ):
+        assert symbol in wheel_smoke
     assert "implementation.require_support() is None" in wheel_smoke
     assert "_workspace_owner.require_support()" in wheel_smoke
 
@@ -700,7 +706,13 @@ def test_registry_publishers_use_separate_workflows() -> None:
         "run"
     ]
     assert 'name == "_workspace_owner_impl.abi3.so"' in abi3_exercise
-    assert "workspace_owner_protocol_version == 2" in abi3_exercise
+    assert "workspace_owner_protocol_version == 3" in abi3_exercise
+    for symbol in (
+        "capture_owner_destination_exact",
+        "verify_owner_destination_binding_exact",
+        "borrow_owner_destination_descriptor_exact",
+    ):
+        assert symbol in abi3_exercise
     assert "implementation.require_support() is None" in abi3_exercise
     assert "_workspace_owner.require_support() is None" in abi3_exercise
     assert "LocalWorkspaceProvider(root)" in abi3_exercise
@@ -711,6 +723,18 @@ def test_registry_publishers_use_separate_workflows() -> None:
     assert "receipt_owner.active" in abi3_exercise
     assert "receipt_owner.close()" in abi3_exercise
     assert "receipt_owner.closed" in abi3_exercise
+    assert "_workspace_owner.capture_owner_destination(" in abi3_exercise
+    assert "destination-captured" in abi3_exercise
+    assert "_workspace_owner.verify_owner_destination_binding(" in abi3_exercise
+    assert "_workspace_owner.borrow_owner_destination_descriptor(" in abi3_exercise
+    assert "stat.S_ISDIR(descriptor_metadata.st_mode)" in abi3_exercise
+    assert "not os.get_inheritable(destination_descriptor)" in abi3_exercise
+    assert "os.close(destination_descriptor)" not in abi3_exercise
+    assert "_workspace_owner.close_owner_exact(captured_owner)" in abi3_exercise
+    assert "_workspace_owner.owner_closed(captured_owner)" in abi3_exercise
+    assert "tuple(path.name for path in root.iterdir()) == destination_names" in (
+        abi3_exercise
+    )
     assert abi3_exercise.count("assert output.read_bytes() == payload") == 2
 
     compatible_install_steps = {

--- a/test/test_workspace_owner.py
+++ b/test/test_workspace_owner.py
@@ -5,9 +5,11 @@
 from __future__ import annotations
 
 import ctypes.util
+import fcntl
 import gc
 import hashlib
 import os
+import shutil
 import stat
 import subprocess
 import sys
@@ -94,6 +96,46 @@ def _provision(
     return owner, selected_plan, publication_permit
 
 
+def _capture_existing_destination(root: Path, destination: bytes) -> object:
+    owner = _require_native_owner()
+    assert (
+        workspace_owner.capture_owner_destination(
+            owner,
+            os.fsencode(root),
+            destination,
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        is None
+    )
+    return owner
+
+
+def _tree_fingerprint(root: Path) -> tuple[tuple[object, ...], ...]:
+    entries: list[tuple[object, ...]] = []
+    for path in (root, *sorted(root.rglob("*"))):
+        metadata = path.lstat()
+        payload: bytes | str | None = None
+        if stat.S_ISREG(metadata.st_mode):
+            payload = path.read_bytes()
+        elif stat.S_ISLNK(metadata.st_mode):
+            payload = os.readlink(path)
+        entries.append(
+            (
+                os.fspath(path.relative_to(root.parent)),
+                stat.S_IFMT(metadata.st_mode),
+                stat.S_IMODE(metadata.st_mode),
+                metadata.st_dev,
+                metadata.st_ino,
+                metadata.st_nlink,
+                metadata.st_size,
+                metadata.st_mtime_ns,
+                metadata.st_ctime_ns,
+                payload,
+            )
+        )
+    return tuple(entries)
+
+
 def test_workspace_owner_facade_rejects_an_incomplete_abi(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -108,7 +150,7 @@ def test_workspace_owner_facade_rejects_an_incomplete_abi(
         workspace_owner.require_support()
 
 
-def test_workspace_owner_facade_rejects_symbol_complete_protocol_v1() -> None:
+def test_workspace_owner_facade_rejects_symbol_complete_protocol_v2() -> None:
     required_symbols = (
         "require_support",
         "create_owner_exact",
@@ -141,7 +183,7 @@ def test_workspace_owner_facade_rejects_symbol_complete_protocol_v1() -> None:
         import types
 
         implementation = types.ModuleType("codenib._workspace_owner_impl")
-        implementation.workspace_owner_protocol_version = 1
+        implementation.workspace_owner_protocol_version = 2
         for name in {required_symbols!r}:
             setattr(implementation, name, lambda *args, **kwargs: None)
         sys.modules[implementation.__name__] = implementation
@@ -154,7 +196,90 @@ def test_workspace_owner_facade_rejects_symbol_complete_protocol_v1() -> None:
         except RuntimeError as error:
             assert "workspace-owner extension" in str(error)
         else:
-            raise AssertionError("protocol-v1 implementation was accepted")
+            raise AssertionError("protocol-v2 implementation was accepted")
+        """
+    )
+    repository_root = Path(__file__).resolve().parents[1]
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (str(repository_root), environment.get("PYTHONPATH", ""))
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repository_root,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_workspace_owner_facade_rejects_each_incomplete_protocol_v3_abi() -> None:
+    required_symbols = (
+        "require_support",
+        "create_owner_exact",
+        "claim_owner_publish_permit_exact",
+        "require_owner_exact",
+        "close_owner_exact",
+        "provision_owner_exact",
+        "capture_owner_destination_exact",
+        "verify_owner_authority_exact",
+        "verify_owner_adoption_binding_exact",
+        "verify_owner_destination_binding_exact",
+        "borrow_owner_parent_descriptor_exact",
+        "borrow_owner_root_descriptor_exact",
+        "borrow_owner_destination_descriptor_exact",
+        "borrow_owner_directory_descriptor_exact",
+        "begin_owner_file_exact",
+        "write_owner_file_exact",
+        "finish_owner_file_exact",
+        "abort_owner_file_exact",
+        "seal_owner_directories_exact",
+        "sync_owner_parent_exact",
+        "mark_owner_adopted_exact",
+        "rename_owner_child_noreplace_exact",
+        "commit_owner_receipt_exact",
+        "abort_owner_exact",
+        "quarantine_owner_exact",
+        "owner_state_exact",
+        "owner_closed_exact",
+    )
+    script = textwrap.dedent(
+        f"""
+        import importlib
+        import sys
+        import types
+
+        import codenib
+
+        required = {required_symbols!r}
+        cached = tuple(
+            "_require_support_exact" if name == "require_support" else f"_{{name}}"
+            for name in required
+        )
+        for missing in required:
+            implementation = types.ModuleType("codenib._workspace_owner_impl")
+            implementation.workspace_owner_protocol_version = 3
+            for name in required:
+                if name != missing:
+                    setattr(implementation, name, lambda *args, **kwargs: None)
+            sys.modules[implementation.__name__] = implementation
+            setattr(codenib, "_workspace_owner_impl", implementation)
+            sys.modules.pop("codenib._workspace_owner", None)
+            if hasattr(codenib, "_workspace_owner"):
+                delattr(codenib, "_workspace_owner")
+
+            facade = importlib.import_module("codenib._workspace_owner")
+            assert not facade._workspace_owner_protocol_available, missing
+            for cached_name in cached:
+                assert getattr(facade, cached_name) is None, (missing, cached_name)
+            try:
+                facade.require_support()
+            except RuntimeError as error:
+                assert "workspace-owner extension" in str(error)
+            else:
+                raise AssertionError(f"incomplete protocol-v3 ABI accepted: {{missing}}")
         """
     )
     repository_root = Path(__file__).resolve().parents[1]
@@ -1096,3 +1221,642 @@ def test_native_owner_child_cleanup_does_not_close_reused_foreign_fds(
     assert (tmp_path / ".stage").is_dir()
     workspace_owner.abort_owner(owner)
     assert workspace_owner.owner_closed(owner)
+
+
+@pytest.mark.parametrize("cleanup", ("close", "abort"))
+def test_native_owner_captures_existing_destination_without_mutation(
+    tmp_path: Path,
+    cleanup: str,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "nested" / "published"
+    destination.mkdir(mode=0o750, parents=True)
+    root.chmod(0o700)
+    (destination / "payload.txt").write_bytes(b"retained")
+    before = _tree_fingerprint(root)
+    expected = destination.stat()
+
+    owner = _capture_existing_destination(root, b"nested/published")
+
+    assert workspace_owner.owner_state(owner) == "destination-captured"
+    assert not workspace_owner.owner_closed(owner)
+    assert workspace_owner.require_exact_owner(owner) is owner
+    assert workspace_owner.verify_owner_authority(owner) is None
+    assert workspace_owner.verify_owner_destination_binding(owner) is None
+    descriptor = workspace_owner.borrow_owner_destination_descriptor(owner)
+    assert workspace_owner.borrow_owner_destination_descriptor(owner) == descriptor
+    observed = os.fstat(descriptor)
+    assert stat.S_ISDIR(observed.st_mode)
+    assert (observed.st_dev, observed.st_ino) == (
+        expected.st_dev,
+        expected.st_ino,
+    )
+    assert fcntl.fcntl(descriptor, fcntl.F_GETFD) & fcntl.FD_CLOEXEC
+    assert _tree_fingerprint(root) == before
+
+    if cleanup == "close":
+        assert workspace_owner.close_owner_exact(owner) is None
+        assert workspace_owner.close_owner_exact(owner) is None
+    else:
+        assert workspace_owner.abort_owner(owner) is None
+        assert workspace_owner.abort_owner(owner) is None
+    assert workspace_owner.owner_closed(owner)
+    assert _tree_fingerprint(root) == before
+
+
+def test_native_destination_capture_return_interruption_preserves_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "payload.txt").write_bytes(b"preserved")
+    before = _tree_fingerprint(root)
+    owner = _require_native_owner()
+    interruption = KeyboardInterrupt("after native destination capture")
+
+    def interrupt_after_capture(result: object, label: str) -> None:
+        assert result is None
+        assert label == "destination-capture"
+        assert workspace_owner.owner_state(owner) == "destination-captured"
+        raise interruption
+
+    with monkeypatch.context() as context:
+        context.setattr(
+            workspace_owner,
+            "_require_none_result",
+            interrupt_after_capture,
+        )
+        with pytest.raises(KeyboardInterrupt) as captured:
+            workspace_owner.capture_owner_destination(
+                owner,
+                os.fsencode(root),
+                b"published",
+                time.monotonic_ns() + 10_000_000_000,
+            )
+
+    assert captured.value is interruption
+    assert workspace_owner.verify_owner_destination_binding(owner) is None
+    assert _tree_fingerprint(root) == before
+    workspace_owner.abort_owner(owner)
+    assert workspace_owner.owner_closed(owner)
+    assert _tree_fingerprint(root) == before
+
+
+def test_native_destination_capture_symbols_require_the_exact_owner_type(
+    tmp_path: Path,
+) -> None:
+    probe = _require_native_owner()
+    workspace_owner.close_owner_exact(probe)
+    candidate = object()
+
+    with pytest.raises(TypeError, match="invalid native type"):
+        workspace_owner.capture_owner_destination(
+            candidate,
+            os.fsencode(tmp_path),
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+    with pytest.raises(TypeError, match="invalid native type"):
+        workspace_owner.verify_owner_destination_binding(candidate)
+    with pytest.raises(TypeError, match="invalid native type"):
+        workspace_owner.borrow_owner_destination_descriptor(candidate)
+
+
+def test_native_captured_destination_rejects_every_legacy_owner_operation(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "payload.txt").write_bytes(b"immutable")
+    before = _tree_fingerprint(root)
+    owner = _capture_existing_destination(root, b"published")
+
+    rejected = (
+        lambda: workspace_owner.claim_owner_publish_permit(owner),
+        lambda: workspace_owner.provision_owner(
+            owner,
+            os.fsencode(root),
+            b"other",
+            b".stage",
+            b"0" * 64,
+            0o700,
+            (),
+            time.monotonic_ns() + 10_000_000_000,
+        ),
+        lambda: workspace_owner.capture_owner_destination(
+            owner,
+            os.fsencode(root),
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        ),
+        lambda: workspace_owner.verify_owner_adoption_binding(
+            owner,
+            os.fsencode(destination),
+            b".stage",
+            b"0" * 64,
+        ),
+        lambda: workspace_owner.borrow_owner_parent_descriptor(owner),
+        lambda: workspace_owner.borrow_owner_root_descriptor(owner),
+        lambda: workspace_owner.borrow_owner_directory_descriptor(owner, b"views"),
+        lambda: workspace_owner.begin_owner_file(owner, b"", b"new", 0o600),
+        lambda: workspace_owner.write_owner_file(owner, b"new"),
+        lambda: workspace_owner.finish_owner_file(owner, 0o600),
+        lambda: workspace_owner.abort_owner_file(owner),
+        lambda: workspace_owner.seal_owner_directories(owner),
+        lambda: workspace_owner.sync_owner_parent(owner),
+        lambda: workspace_owner.mark_owner_adopted(owner),
+        lambda: workspace_owner.rename_owner_child_noreplace(
+            owner,
+            b"published",
+            b"other",
+        ),
+        lambda: workspace_owner.commit_owner_receipt(owner),
+        lambda: workspace_owner.quarantine_owner(owner),
+    )
+    for operation in rejected:
+        with pytest.raises((RuntimeError, TypeError)):
+            operation()
+        assert workspace_owner.owner_state(owner) == "destination-captured"
+        assert workspace_owner.verify_owner_destination_binding(owner) is None
+        assert _tree_fingerprint(root) == before
+
+    workspace_owner.abort_owner(owner)
+    assert workspace_owner.owner_closed(owner)
+    assert _tree_fingerprint(root) == before
+
+
+def test_native_destination_capture_requires_exact_bounded_arguments(
+    tmp_path: Path,
+) -> None:
+    class BytesSubclass(bytes):
+        pass
+
+    root = tmp_path / "authority"
+    (root / "published").mkdir(parents=True)
+    root.chmod(0o700)
+    valid_root = os.fsencode(root)
+    valid_destination = b"published"
+    valid_deadline = time.monotonic_ns() + 10_000_000_000
+    invalid_arguments = (
+        (os.fspath(root), valid_destination, valid_deadline, TypeError),
+        (BytesSubclass(valid_root), valid_destination, valid_deadline, TypeError),
+        (valid_root, "published", valid_deadline, TypeError),
+        (valid_root, BytesSubclass(valid_destination), valid_deadline, TypeError),
+        (valid_root, valid_destination, True, TypeError),
+        (valid_root, valid_destination, 1.0, TypeError),
+        (valid_root, valid_destination, 0, ValueError),
+        (valid_root, valid_destination, -1, ValueError),
+        (b"relative", valid_destination, valid_deadline, ValueError),
+        (valid_root, b"", valid_deadline, ValueError),
+        (valid_root, b"/published", valid_deadline, ValueError),
+        (valid_root, b"./published", valid_deadline, ValueError),
+        (valid_root, b"nested/../published", valid_deadline, ValueError),
+        (valid_root, b"published/", valid_deadline, ValueError),
+        (valid_root, b"published\x00other", valid_deadline, ValueError),
+    )
+
+    for allowed_root, destination, deadline, error_type in invalid_arguments:
+        owner = _require_native_owner()
+        with pytest.raises(error_type):
+            workspace_owner.capture_owner_destination(
+                owner,
+                allowed_root,  # type: ignore[arg-type]
+                destination,  # type: ignore[arg-type]
+                deadline,  # type: ignore[arg-type]
+            )
+        assert workspace_owner.owner_state(owner) == "empty"
+        workspace_owner.close_owner_exact(owner)
+        assert workspace_owner.owner_closed(owner)
+
+
+def test_native_expired_capture_deadline_is_retryable_before_acquisition(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    (root / "published").mkdir(parents=True)
+    root.chmod(0o700)
+    owner = _require_native_owner()
+
+    with pytest.raises(TimeoutError):
+        workspace_owner.capture_owner_destination(
+            owner,
+            os.fsencode(root),
+            b"published",
+            time.monotonic_ns() - 1,
+        )
+
+    assert workspace_owner.owner_state(owner) == "empty"
+    assert (
+        workspace_owner.capture_owner_destination(
+            owner,
+            os.fsencode(root),
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        is None
+    )
+    workspace_owner.abort_owner(owner)
+    assert (root / "published").is_dir()
+
+
+@pytest.mark.parametrize(
+    "destination_kind",
+    ("missing", "file", "symlink", "symlink-parent"),
+)
+def test_native_capture_rejects_non_directory_or_unpinned_destinations_and_poison_closes(
+    tmp_path: Path,
+    destination_kind: str,
+) -> None:
+    root = tmp_path / "authority"
+    root.mkdir(mode=0o700)
+    root.chmod(0o700)
+    relative = b"published"
+    if destination_kind == "file":
+        (root / "published").write_bytes(b"not-a-directory")
+    elif destination_kind == "symlink":
+        (root / "real").mkdir()
+        (root / "published").symlink_to("real", target_is_directory=True)
+    elif destination_kind == "symlink-parent":
+        (root / "real-parent" / "published").mkdir(parents=True)
+        (root / "alias").symlink_to("real-parent", target_is_directory=True)
+        relative = b"alias/published"
+    before = _tree_fingerprint(root)
+    owner = _require_native_owner()
+
+    with pytest.raises((OSError, ValueError)):
+        workspace_owner.capture_owner_destination(
+            owner,
+            os.fsencode(root),
+            relative,
+            time.monotonic_ns() + 10_000_000_000,
+        )
+
+    assert workspace_owner.owner_state(owner) == "empty"
+    for operation in (
+        lambda: workspace_owner.claim_owner_publish_permit(owner),
+        lambda: workspace_owner.capture_owner_destination(
+            owner,
+            os.fsencode(root),
+            relative,
+            time.monotonic_ns() + 10_000_000_000,
+        ),
+        lambda: workspace_owner.borrow_owner_parent_descriptor(owner),
+        lambda: workspace_owner.abort_owner_file(owner),
+        lambda: workspace_owner.sync_owner_parent(owner),
+        lambda: workspace_owner.quarantine_owner(owner),
+    ):
+        with pytest.raises(RuntimeError):
+            operation()
+    assert _tree_fingerprint(root) == before
+    workspace_owner.abort_owner(owner)
+    assert workspace_owner.owner_closed(owner)
+    assert _tree_fingerprint(root) == before
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="requires Linux")
+def test_native_capture_rejects_destination_exchanged_between_stat_and_open(
+    tmp_path: Path,
+) -> None:
+    probe = _require_native_owner()
+    workspace_owner.close_owner_exact(probe)
+    compiler = shutil.which("cc")
+    if compiler is None:
+        pytest.skip("a C compiler is required for the deterministic race shim")
+    source = tmp_path / "capture_race.c"
+    library = tmp_path / "capture_race.so"
+    source.write_text(
+        textwrap.dedent(
+            r"""
+            #define _GNU_SOURCE
+            #include <dlfcn.h>
+            #include <errno.h>
+            #include <fcntl.h>
+            #include <stdarg.h>
+            #include <stdlib.h>
+            #include <string.h>
+            #include <sys/syscall.h>
+            #include <sys/types.h>
+            #include <unistd.h>
+
+            #ifndef RENAME_EXCHANGE
+            #define RENAME_EXCHANGE (1U << 1)
+            #endif
+
+            typedef int (*openat64_function)(int, const char *, int, ...);
+
+            int openat64(int parent, const char *name, int flags, ...) {
+              static openat64_function real_openat64 = NULL;
+              static int injected = 0;
+              mode_t mode = 0;
+              va_list arguments;
+
+              if (real_openat64 == NULL) {
+                real_openat64 =
+                    (openat64_function)dlsym(RTLD_NEXT, "openat64");
+                if (real_openat64 == NULL) {
+                  errno = ENOSYS;
+                  return -1;
+                }
+              }
+              if (!injected && name != NULL &&
+                  strcmp(name, "published") == 0 &&
+                  (flags & O_DIRECTORY) != 0 &&
+                  getenv("CODENIB_CAPTURE_RACE") != NULL) {
+                injected = 1;
+                if (syscall(SYS_renameat2, parent, "published", parent,
+                            "alternate", RENAME_EXCHANGE) != 0) {
+                  return -1;
+                }
+              }
+              if ((flags & O_CREAT) != 0) {
+                va_start(arguments, flags);
+                mode = va_arg(arguments, mode_t);
+                va_end(arguments);
+                return real_openat64(parent, name, flags, mode);
+              }
+              return real_openat64(parent, name, flags);
+            }
+            """
+        ),
+        encoding="utf-8",
+    )
+    subprocess.run(
+        [compiler, "-shared", "-fPIC", "-O2", "-Wall", "-o", library, source, "-ldl"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    root = tmp_path / "authority"
+    published = root / "published"
+    alternate = root / "alternate"
+    published.mkdir(parents=True)
+    alternate.mkdir()
+    root.chmod(0o700)
+    (published / "identity.txt").write_bytes(b"published-before-race")
+    (alternate / "identity.txt").write_bytes(b"alternate-before-race")
+    script = textwrap.dedent(
+        """
+        import os
+        import sys
+        import time
+        from pathlib import Path
+
+        import codenib._workspace_owner as workspace_owner
+
+        root = Path(sys.argv[1])
+        owner = workspace_owner.create_owner()
+        try:
+            workspace_owner.capture_owner_destination(
+                owner,
+                os.fsencode(root),
+                b"published",
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        except OSError:
+            pass
+        else:
+            raise AssertionError("capture accepted a stat/open destination exchange")
+        assert workspace_owner.owner_state(owner) == "empty"
+        assert (root / "published" / "identity.txt").read_bytes() == (
+            b"alternate-before-race"
+        )
+        assert (root / "alternate" / "identity.txt").read_bytes() == (
+            b"published-before-race"
+        )
+        after_failure = tuple(
+            sorted(
+                (path.relative_to(root).as_posix(), path.read_bytes())
+                for path in root.glob("*/identity.txt")
+            )
+        )
+        for operation in (
+            lambda: workspace_owner.borrow_owner_parent_descriptor(owner),
+            lambda: workspace_owner.verify_owner_destination_binding(owner),
+            lambda: workspace_owner.quarantine_owner(owner),
+        ):
+            try:
+                operation()
+            except RuntimeError:
+                pass
+            else:
+                raise AssertionError("poisoned capture owner remained usable")
+        workspace_owner.abort_owner(owner)
+        assert workspace_owner.owner_closed(owner)
+        after_cleanup = tuple(
+            sorted(
+                (path.relative_to(root).as_posix(), path.read_bytes())
+                for path in root.glob("*/identity.txt")
+            )
+        )
+        assert after_cleanup == after_failure
+        """
+    )
+    repository_root = Path(__file__).resolve().parents[1]
+    environment = dict(os.environ)
+    existing_preload = environment.get("LD_PRELOAD")
+    environment["LD_PRELOAD"] = os.pathsep.join(
+        value for value in (os.fspath(library), existing_preload) if value
+    )
+    environment["CODENIB_CAPTURE_RACE"] = "1"
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (str(repository_root), environment.get("PYTHONPATH", ""))
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script, os.fspath(root)],
+        cwd=repository_root,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.parametrize("rebind", ("destination", "parent", "allowed-root"))
+def test_native_captured_destination_detects_every_lexical_rebind(
+    tmp_path: Path,
+    rebind: str,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "nested" / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "payload.txt").write_bytes(b"original")
+    owner = _capture_existing_destination(root, b"nested/published")
+
+    if rebind == "destination":
+        destination.rename(root / "nested" / "captured-original")
+        destination.mkdir()
+    elif rebind == "parent":
+        (root / "nested").rename(root / "captured-parent")
+        destination.mkdir(parents=True)
+    else:
+        root.rename(tmp_path / "captured-root")
+        destination.mkdir(parents=True)
+        root.chmod(0o700)
+    before_cleanup = _tree_fingerprint(tmp_path)
+
+    with pytest.raises(RuntimeError, match="changed"):
+        workspace_owner.verify_owner_destination_binding(owner)
+    with pytest.raises(RuntimeError, match="changed"):
+        workspace_owner.verify_owner_authority(owner)
+    with pytest.raises(RuntimeError, match="unavailable"):
+        workspace_owner.borrow_owner_destination_descriptor(owner)
+
+    workspace_owner.abort_owner(owner)
+    assert workspace_owner.owner_closed(owner)
+    assert _tree_fingerprint(tmp_path) == before_cleanup
+
+
+def test_native_captured_destination_cleanup_does_not_close_reused_foreign_fd(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    before = _tree_fingerprint(root)
+    owner = _capture_existing_destination(root, b"published")
+    descriptor = workspace_owner.borrow_owner_destination_descriptor(owner)
+    os.close(descriptor)
+    foreign_source = os.open(
+        destination,
+        os.O_RDONLY
+        | os.O_DIRECTORY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_CLOEXEC", 0),
+    )
+    if foreign_source != descriptor:
+        os.dup2(foreign_source, descriptor, inheritable=False)
+
+    try:
+        with pytest.raises(RuntimeError, match="changed"):
+            workspace_owner.verify_owner_destination_binding(owner)
+        with pytest.raises(OSError):
+            workspace_owner.abort_owner(owner)
+        assert workspace_owner.owner_closed(owner)
+        replacement = os.fstat(descriptor)
+        expected = destination.stat()
+        assert stat.S_ISDIR(replacement.st_mode)
+        assert (replacement.st_dev, replacement.st_ino) == (
+            expected.st_dev,
+            expected.st_ino,
+        )
+        assert _tree_fingerprint(root) == before
+        assert workspace_owner.abort_owner(owner) is None
+    finally:
+        os.close(descriptor)
+        if foreign_source != descriptor:
+            os.close(foreign_source)
+
+
+def test_native_captured_destination_deallocation_only_closes_descriptors(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "payload.txt").write_bytes(b"preserved")
+    before = _tree_fingerprint(root)
+    owner = _capture_existing_destination(root, b"published")
+    workspace_owner.borrow_owner_destination_descriptor(owner)
+
+    del owner
+    gc.collect()
+
+    owned_targets = []
+    for name in os.listdir("/proc/self/fd"):
+        try:
+            target = os.readlink(f"/proc/self/fd/{name}")
+        except OSError:
+            continue
+        if os.fspath(root) in target:
+            owned_targets.append(target)
+    assert owned_targets == []
+    assert _tree_fingerprint(root) == before
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
+def test_native_captured_destination_child_revokes_inherited_fds_without_mutation(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "payload.txt").write_bytes(b"preserved")
+    before = _tree_fingerprint(root)
+    owner = _capture_existing_destination(root, b"published")
+    borrowed = workspace_owner.borrow_owner_destination_descriptor(owner)
+    read_descriptor, write_descriptor = os.pipe()
+    child_pid = os.fork()
+    if child_pid == 0:
+        os.close(read_descriptor)
+        foreign_source = -1
+        try:
+            for operation in (
+                lambda: workspace_owner.verify_owner_destination_binding(owner),
+                lambda: workspace_owner.borrow_owner_destination_descriptor(owner),
+                lambda: workspace_owner.abort_owner(owner),
+            ):
+                try:
+                    operation()
+                except RuntimeError as error:
+                    assert "PID boundary" in str(error)
+                else:
+                    raise AssertionError("cross-PID owner operation succeeded")
+            os.close(borrowed)
+            foreign_source = os.open(
+                "/dev/null",
+                os.O_RDONLY | getattr(os, "O_CLOEXEC", 0),
+            )
+            if foreign_source != borrowed:
+                os.dup2(foreign_source, borrowed, inheritable=False)
+            try:
+                workspace_owner.close_owner_exact(owner)
+            except RuntimeError as error:
+                assert "PID boundary" in str(error)
+            else:
+                raise AssertionError("cross-PID close did not report its boundary")
+            assert stat.S_ISCHR(os.fstat(borrowed).st_mode)
+            owned_targets = []
+            for name in os.listdir("/proc/self/fd"):
+                try:
+                    target = os.readlink(f"/proc/self/fd/{name}")
+                except OSError:
+                    continue
+                if os.fspath(root) in target:
+                    owned_targets.append(target)
+            assert owned_targets == []
+            os.write(write_descriptor, b"ok")
+        except BaseException as error:  # noqa: B036 - report child failure
+            os.write(write_descriptor, repr(error).encode("utf-8"))
+        finally:
+            try:
+                os.close(borrowed)
+            except OSError:
+                pass
+            if foreign_source >= 0 and foreign_source != borrowed:
+                os.close(foreign_source)
+            os.close(write_descriptor)
+            os._exit(0)
+
+    os.close(write_descriptor)
+    report = os.read(read_descriptor, 4096)
+    os.close(read_descriptor)
+    waited_pid, status = os.waitpid(child_pid, 0)
+    assert waited_pid == child_pid
+    assert os.waitstatus_to_exitcode(status) == 0
+    assert report == b"ok"
+    assert workspace_owner.verify_owner_destination_binding(owner) is None
+    assert _tree_fingerprint(root) == before
+    workspace_owner.abort_owner(owner)
+    assert workspace_owner.owner_closed(owner)
+    assert _tree_fingerprint(root) == before


### PR DESCRIPTION
## Summary

Add protocol-v3 native authority for capturing one existing Linux workspace
destination while pinning the exact allowed-root chain, parent/name binding,
directory device/inode identity, and same-open-file-description descriptor pair.

This primitive is capture-only: it creates no stage, performs no namespace
mutation or sync, transfers no descriptor ownership, and changes neither
`LocalWorkspaceProvider` nor any compiler/runtime route. The
`provider-bound-exact` Gate C and M1 remain open; atomic exchange or replacement
requires protocol v4 or a separately advertised capability.

Related to #199. This does not close the RFC or complete M1.

## Changes

- Add the distinct native `destination-captured` state and exact capture,
  verification, and borrowed-destination-descriptor symbols.
- Require an empty owner with no claimed publication permit, exact bounded byte
  paths, an exact positive deadline, an existing real directory, and one
  same-device destination binding.
- Permit only binding verification, the owner-held borrowed destination
  descriptor, and descriptor-only close, abort, or deallocation after capture.
- Reject staging, publication, file mutation, parent/root/directory borrows,
  receipt, rename, sync, and quarantine operations from the captured state.
- Preserve cleanup safety across descriptor reuse, failed acquisition,
  post-native-return interruption, deallocation, and fork-child revocation
  without mutating or syncing the captured namespace.
- Bump the private native protocol to v3 and make the Python facade reject both
  symbol-complete v2 implementations and every incomplete v3 implementation.
- Extend source, wheel, limited-ABI, and multi-Python release verification for
  the v3 symbols and capture-only lifecycle.
- Document the owner-held descriptor boundary and keep Gate C, M1, A2
  promotion, and protocol-v4 exchange work explicitly pending.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `pytest -q test/test_workspace_owner.py test/test_release_artifacts.py test/test_local_workspace_provider.py test/artifacts/test_strict_bm25_publication.py --tb=short`: 135 passed in 4.21s
- Rebuilt native workspace-owner coverage: 44 tests passed
- Independent descriptor stress: 500 successful captures plus 500 poisoned
  cleanup cycles; process descriptor count remained 4 before and after
- clang-format 18 dry-run/Werror; pinned Black 24.8.0, isort 5.13.2, and
  flake8 7.1.1 with bugbear
- Python compilation, YAML parsing, and `git diff --check`
- `mkdocs build --strict` and `scripts/check_public_docs.py`
- Full unit marker: 6928 passed, 71 skipped, 190 deselected; the two warnings
  were expected read-only pytest-cache warnings from the isolated rerun

The x86-64/AArch64 wheel lifecycle and Python 3.10–3.14 ABI3 matrix remain PR
Release-workflow merge gates. This capture-only preparation does not run or
ratify A2 measurements and does not promote a default storage route.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
