### PR TITLE
feat(storage): add atomic workspace replacement primitive

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -112,18 +112,289 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
             auditwheel repair --plat manylinux_2_28_${{ matrix.arch }}
             -w {dest_dir} {wheel}
-          CIBW_TEST_COMMAND: >-
-            python -c "import platform;
-            import codenib._workspace_owner_impl as implementation;
-            from codenib import _workspace_owner;
-            assert platform.machine() == '${{ matrix.arch }}';
-            assert implementation.workspace_owner_protocol_version == 3;
-            assert all(callable(getattr(implementation, name, None)) for name in
-            ('capture_owner_destination_exact',
-            'verify_owner_destination_binding_exact',
-            'borrow_owner_destination_descriptor_exact'));
-            assert implementation.require_support() is None;
-            _workspace_owner.require_support()"
+          CIBW_TEST_COMMAND: |
+            python - <<'PY'
+            import hashlib
+            import os
+            import platform
+            import secrets
+            import stat
+            import time
+            from pathlib import Path
+            from tempfile import TemporaryDirectory
+
+            import codenib._workspace_owner_impl as implementation
+            from codenib import _workspace_owner
+
+            assert platform.machine() == '${{ matrix.arch }}'
+            assert implementation.workspace_owner_protocol_version == 4
+            protocol_v4_symbols = (
+                "capture_owner_destination_exact",
+                "verify_owner_destination_binding_exact",
+                "borrow_owner_destination_descriptor_exact",
+                "claim_owner_replacement_permit_exact",
+                "provision_owner_replacement_exact",
+                "verify_owner_replacement_binding_exact",
+                "exchange_owner_replacement_exact",
+            )
+            assert all(
+                callable(getattr(implementation, name, None))
+                for name in protocol_v4_symbols
+            )
+            facade_v4_symbols = (
+                "capture_owner_destination",
+                "verify_owner_destination_binding",
+                "borrow_owner_destination_descriptor",
+                "claim_owner_replacement_permit",
+                "provision_owner_replacement",
+                "verify_owner_replacement_binding",
+                "exchange_owner_replacement",
+                "_bind_owner_replacement_permit",
+            )
+            assert all(
+                callable(getattr(_workspace_owner, name, None))
+                for name in facade_v4_symbols
+            )
+            assert implementation.require_support() is None
+            assert _workspace_owner.require_support() is None
+
+            plan_digest = hashlib.sha256(b"cibuildwheel-protocol-v4").hexdigest()
+            plan_digest_bytes = plan_digest.encode("ascii")
+            directories = ((b"data", 0o700),)
+            incumbent_payload = b"incumbent"
+            candidate_payload = b"candidate"
+
+            def deadline():
+                return time.monotonic_ns() + 10_000_000_000
+
+            def identity(path):
+                metadata = path.stat()
+                return metadata.st_dev, metadata.st_ino
+
+            def prepare_replacement(authority, slot_name):
+                destination = authority / "published"
+                destination.mkdir(mode=0o700)
+                destination.joinpath("incumbent.txt").write_bytes(
+                    incumbent_payload
+                )
+                incumbent_identity = identity(destination)
+                owner = _workspace_owner.create_owner()
+                try:
+                    _workspace_owner.capture_owner_destination(
+                        owner,
+                        os.fsencode(authority),
+                        b"published",
+                        deadline(),
+                    )
+                    assert _workspace_owner.owner_state(owner) == (
+                        "destination-captured"
+                    )
+                    assert (
+                        _workspace_owner.verify_owner_destination_binding(owner)
+                        is None
+                    )
+                    incumbent_descriptor = (
+                        _workspace_owner.borrow_owner_destination_descriptor(
+                            owner
+                        )
+                    )
+                    assert not os.get_inheritable(incumbent_descriptor)
+                    replacement_permit = (
+                        _workspace_owner.claim_owner_replacement_permit(owner)
+                    )
+                    _workspace_owner.provision_owner_replacement(
+                        owner,
+                        slot_name,
+                        plan_digest_bytes,
+                        0o700,
+                        directories,
+                        deadline(),
+                    )
+                    assert _workspace_owner.owner_state(owner) == (
+                        "replacement-provisioned"
+                    )
+                    _workspace_owner.verify_owner_adoption_binding(
+                        owner,
+                        os.fsencode(destination),
+                        slot_name,
+                        plan_digest_bytes,
+                    )
+                    candidate_descriptor = (
+                        _workspace_owner.borrow_owner_root_descriptor(owner)
+                    )
+                    candidate_metadata = os.fstat(candidate_descriptor)
+                    candidate_identity = (
+                        candidate_metadata.st_dev,
+                        candidate_metadata.st_ino,
+                    )
+                    assert stat.S_ISDIR(candidate_metadata.st_mode)
+                    assert candidate_identity != incumbent_identity
+                    assert not os.get_inheritable(candidate_descriptor)
+                    _workspace_owner.mark_owner_adopted(owner)
+                    _workspace_owner.begin_owner_file(
+                        owner,
+                        b"data",
+                        b"result.json",
+                        0o600,
+                    )
+                    _workspace_owner.write_owner_file(owner, candidate_payload)
+                    record = _workspace_owner.finish_owner_file(owner, 0o600)
+                    assert len(record) == 8
+                    _workspace_owner.seal_owner_directories(owner)
+                    assert _workspace_owner.owner_state(owner) == (
+                        "replacement-adopted"
+                    )
+                    assert (
+                        _workspace_owner.verify_owner_replacement_binding(owner)
+                        is None
+                    )
+                    return (
+                        owner,
+                        replacement_permit,
+                        incumbent_descriptor,
+                        candidate_descriptor,
+                        incumbent_identity,
+                        candidate_identity,
+                        destination,
+                        authority / os.fsdecode(slot_name),
+                    )
+                except BaseException:
+                    if not _workspace_owner.owner_closed(owner):
+                        _workspace_owner.abort_owner(owner)
+                    raise
+
+            with TemporaryDirectory() as temporary:
+                root = Path(temporary)
+
+                success_root = root / "success"
+                success_root.mkdir(mode=0o700)
+                success_slot_name = (
+                    f".replacement-success-{secrets.token_hex(16)}".encode(
+                        "ascii"
+                    )
+                )
+                (
+                    success_owner,
+                    success_permit,
+                    success_incumbent_descriptor,
+                    success_candidate_descriptor,
+                    success_incumbent_identity,
+                    success_candidate_identity,
+                    success_destination,
+                    success_slot,
+                ) = prepare_replacement(success_root, success_slot_name)
+                success_committed = False
+                try:
+                    success_receipt = (
+                        _workspace_owner.exchange_owner_replacement(
+                            success_permit,
+                            success_slot_name,
+                            b"published",
+                            deadline(),
+                        )
+                    )
+                    assert _workspace_owner.owner_state(success_owner) == (
+                        "replacement-exchanged-unreceipted"
+                    )
+                    assert identity(success_destination) == (
+                        success_candidate_identity
+                    )
+                    assert identity(success_slot) == success_incumbent_identity
+                    assert (
+                        success_destination / "data/result.json"
+                    ).read_bytes() == candidate_payload
+                    assert (
+                        success_slot / "incumbent.txt"
+                    ).read_bytes() == incumbent_payload
+                    assert (
+                        os.fstat(success_incumbent_descriptor).st_dev,
+                        os.fstat(success_incumbent_descriptor).st_ino,
+                    ) == success_incumbent_identity
+                    assert (
+                        os.fstat(success_candidate_descriptor).st_dev,
+                        os.fstat(success_candidate_descriptor).st_ino,
+                    ) == success_candidate_identity
+                    _workspace_owner.commit_owner_receipt(success_receipt)
+                    _workspace_owner.commit_owner_receipt(success_receipt)
+                    success_committed = True
+                    assert _workspace_owner.owner_state(success_owner) == (
+                        "replacement-receipted"
+                    )
+                    assert (
+                        os.fstat(success_incumbent_descriptor).st_dev,
+                        os.fstat(success_incumbent_descriptor).st_ino,
+                    ) == success_incumbent_identity
+                    assert (
+                        os.fstat(success_candidate_descriptor).st_dev,
+                        os.fstat(success_candidate_descriptor).st_ino,
+                    ) == success_candidate_identity
+                finally:
+                    if not _workspace_owner.owner_closed(success_owner):
+                        if success_committed:
+                            _workspace_owner.close_owner_exact(success_owner)
+                        else:
+                            _workspace_owner.abort_owner(success_owner)
+                assert _workspace_owner.owner_closed(success_owner)
+                assert _workspace_owner.owner_state(success_owner) == "closed"
+                assert identity(success_destination) == success_candidate_identity
+                assert identity(success_slot) == success_incumbent_identity
+
+                rollback_root = root / "rollback"
+                rollback_root.mkdir(mode=0o700)
+                rollback_slot_name = (
+                    f".replacement-rollback-{secrets.token_hex(16)}".encode(
+                        "ascii"
+                    )
+                )
+                (
+                    rollback_owner,
+                    rollback_permit,
+                    rollback_incumbent_descriptor,
+                    rollback_candidate_descriptor,
+                    rollback_incumbent_identity,
+                    rollback_candidate_identity,
+                    rollback_destination,
+                    rollback_slot,
+                ) = prepare_replacement(rollback_root, rollback_slot_name)
+                try:
+                    _workspace_owner.exchange_owner_replacement(
+                        rollback_permit,
+                        rollback_slot_name,
+                        b"published",
+                        deadline(),
+                    )
+                    assert _workspace_owner.owner_state(rollback_owner) == (
+                        "replacement-exchanged-unreceipted"
+                    )
+                    assert identity(rollback_destination) == (
+                        rollback_candidate_identity
+                    )
+                    assert identity(rollback_slot) == rollback_incumbent_identity
+                    assert (
+                        os.fstat(rollback_incumbent_descriptor).st_dev,
+                        os.fstat(rollback_incumbent_descriptor).st_ino,
+                    ) == rollback_incumbent_identity
+                    assert (
+                        os.fstat(rollback_candidate_descriptor).st_dev,
+                        os.fstat(rollback_candidate_descriptor).st_ino,
+                    ) == rollback_candidate_identity
+                    _workspace_owner.abort_owner(rollback_owner)
+                finally:
+                    if not _workspace_owner.owner_closed(rollback_owner):
+                        _workspace_owner.abort_owner(rollback_owner)
+                assert _workspace_owner.owner_closed(rollback_owner)
+                assert _workspace_owner.owner_state(rollback_owner) == "closed"
+                assert identity(rollback_destination) == (
+                    rollback_incumbent_identity
+                )
+                assert identity(rollback_slot) == rollback_candidate_identity
+                assert (
+                    rollback_destination / "incumbent.txt"
+                ).read_bytes() == incumbent_payload
+                assert (
+                    rollback_slot / "data/result.json"
+                ).read_bytes() == candidate_payload
+            PY
 
       - name: Upload wheel
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -369,21 +640,36 @@ jobs:
           )
 
           assert Path(implementation.__file__).name == "_workspace_owner_impl.abi3.so"
-          assert implementation.workspace_owner_protocol_version == 3
-          capture_symbols = (
+          assert implementation.workspace_owner_protocol_version == 4
+          protocol_v4_symbols = (
               "capture_owner_destination_exact",
               "verify_owner_destination_binding_exact",
               "borrow_owner_destination_descriptor_exact",
+              "claim_owner_replacement_permit_exact",
+              "provision_owner_replacement_exact",
+              "verify_owner_replacement_binding_exact",
+              "exchange_owner_replacement_exact",
           )
           assert all(
               callable(getattr(implementation, name, None))
-              for name in capture_symbols
+              for name in protocol_v4_symbols
           )
           assert implementation.require_support() is None
           assert _workspace_owner.require_support() is None
-          assert callable(_workspace_owner.capture_owner_destination)
-          assert callable(_workspace_owner.verify_owner_destination_binding)
-          assert callable(_workspace_owner.borrow_owner_destination_descriptor)
+          facade_v4_symbols = (
+              "capture_owner_destination",
+              "verify_owner_destination_binding",
+              "borrow_owner_destination_descriptor",
+              "claim_owner_replacement_permit",
+              "provision_owner_replacement",
+              "verify_owner_replacement_binding",
+              "exchange_owner_replacement",
+              "_bind_owner_replacement_permit",
+          )
+          assert all(
+              callable(getattr(_workspace_owner, name, None))
+              for name in facade_v4_symbols
+          )
 
           payload = b'{"release-smoke":"ok"}'
           with TemporaryDirectory() as temporary:
@@ -436,8 +722,15 @@ jobs:
               receipt_owner.close()
 
               assert receipt_owner.closed
-              destination_identity = (destination.stat().st_dev, destination.stat().st_ino)
-              destination_names = tuple(path.name for path in root.iterdir())
+              incumbent_identity = (
+                  destination.stat().st_dev,
+                  destination.stat().st_ino,
+              )
+              replacement_name = (
+                  f".replacement-{os.getpid()}-{time.monotonic_ns()}".encode("ascii")
+              )
+              replacement = root / os.fsdecode(replacement_name)
+              replacement_payload = b'{"release-smoke":"replacement"}'
               captured_owner = _workspace_owner.create_owner()
               try:
                   _workspace_owner.capture_owner_destination(
@@ -465,17 +758,143 @@ jobs:
                   assert (
                       descriptor_metadata.st_dev,
                       descriptor_metadata.st_ino,
-                  ) == destination_identity
+                  ) == incumbent_identity
                   assert not os.get_inheritable(destination_descriptor)
+
+                  replacement_permit = (
+                      _workspace_owner.claim_owner_replacement_permit(
+                          captured_owner
+                      )
+                  )
+                  assert _workspace_owner.owner_state(captured_owner) == (
+                      "destination-captured"
+                  )
+                  _workspace_owner.provision_owner_replacement(
+                      captured_owner,
+                      replacement_name,
+                      plan.digest.encode("ascii"),
+                      plan.root_mode,
+                      tuple(
+                          (os.fsencode(item.path.as_posix()), item.mode)
+                          for item in plan.directories
+                      ),
+                      time.monotonic_ns() + 10_000_000_000,
+                  )
+                  assert _workspace_owner.owner_state(captured_owner) == (
+                      "replacement-provisioned"
+                  )
+                  _workspace_owner.verify_owner_adoption_binding(
+                      captured_owner,
+                      os.fsencode(destination),
+                      replacement_name,
+                      plan.digest.encode("ascii"),
+                  )
+                  _workspace_owner.verify_owner_replacement_binding(
+                      captured_owner
+                  )
+                  replacement_descriptor = (
+                      _workspace_owner.borrow_owner_root_descriptor(
+                          captured_owner
+                      )
+                  )
+                  replacement_metadata = os.fstat(replacement_descriptor)
+                  replacement_identity = (
+                      replacement_metadata.st_dev,
+                      replacement_metadata.st_ino,
+                  )
+                  assert stat.S_ISDIR(replacement_metadata.st_mode)
+                  assert replacement_identity != incumbent_identity
+                  assert not os.get_inheritable(replacement_descriptor)
+
+                  _workspace_owner.mark_owner_adopted(captured_owner)
+                  assert _workspace_owner.owner_state(captured_owner) == (
+                      "replacement-adopted"
+                  )
+                  _workspace_owner.begin_owner_file(
+                      captured_owner,
+                      b"data",
+                      b"result.json",
+                      0o600,
+                  )
+                  _workspace_owner.write_owner_file(
+                      captured_owner,
+                      replacement_payload,
+                  )
+                  replacement_record = _workspace_owner.finish_owner_file(
+                      captured_owner,
+                      0o600,
+                  )
+                  assert len(replacement_record) == 8
+                  _workspace_owner.seal_owner_directories(captured_owner)
+                  _workspace_owner.verify_owner_replacement_binding(
+                      captured_owner
+                  )
+                  assert replacement.joinpath("data/result.json").read_bytes() == (
+                      replacement_payload
+                  )
+
+                  replacement_receipt = (
+                      _workspace_owner.exchange_owner_replacement(
+                          replacement_permit,
+                          replacement_name,
+                          b"published",
+                          time.monotonic_ns() + 10_000_000_000,
+                      )
+                  )
+                  assert _workspace_owner.owner_state(captured_owner) == (
+                      "replacement-exchanged-unreceipted"
+                  )
+                  assert (
+                      destination.stat().st_dev,
+                      destination.stat().st_ino,
+                  ) == replacement_identity
+                  assert (
+                      replacement.stat().st_dev,
+                      replacement.stat().st_ino,
+                  ) == incumbent_identity
+                  assert output.read_bytes() == replacement_payload
+                  assert replacement.joinpath("data/result.json").read_bytes() == (
+                      payload
+                  )
+                  assert (
+                      os.fstat(destination_descriptor).st_dev,
+                      os.fstat(destination_descriptor).st_ino,
+                  ) == incumbent_identity
+                  assert (
+                      os.fstat(replacement_descriptor).st_dev,
+                      os.fstat(replacement_descriptor).st_ino,
+                  ) == replacement_identity
+
+                  _workspace_owner.commit_owner_receipt(replacement_receipt)
+                  _workspace_owner.commit_owner_receipt(replacement_receipt)
+                  assert _workspace_owner.owner_state(captured_owner) == (
+                      "replacement-receipted"
+                  )
+                  assert (
+                      os.fstat(destination_descriptor).st_dev,
+                      os.fstat(destination_descriptor).st_ino,
+                  ) == incumbent_identity
+                  assert (
+                      os.fstat(replacement_descriptor).st_dev,
+                      os.fstat(replacement_descriptor).st_ino,
+                  ) == replacement_identity
               finally:
                   _workspace_owner.close_owner_exact(captured_owner)
 
               assert _workspace_owner.owner_closed(captured_owner)
-              assert tuple(path.name for path in root.iterdir()) == destination_names
+              assert _workspace_owner.owner_state(captured_owner) == "closed"
+              assert {path.name for path in root.iterdir()} == {
+                  "published",
+                  os.fsdecode(replacement_name),
+              }
               assert (destination.stat().st_dev, destination.stat().st_ino) == (
-                  destination_identity
+                  replacement_identity
               )
-              assert output.read_bytes() == payload
+              assert (replacement.stat().st_dev, replacement.stat().st_ino) == (
+                  incumbent_identity
+              )
+              assert output.read_bytes() == replacement_payload
+              assert replacement.joinpath("data/result.json").read_bytes() == payload
           PY
 
   install-smoke:

--- a/codenib/_workspace_owner.py
+++ b/codenib/_workspace_owner.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-_EXPECTED_WORKSPACE_OWNER_PROTOCOL_VERSION = 3
+_EXPECTED_WORKSPACE_OWNER_PROTOCOL_VERSION = 4
 _IMPORT_ERROR: BaseException | None = None
 
 try:
@@ -36,11 +36,17 @@ _create_owner_exact = _implementation_attribute("create_owner_exact")
 _claim_owner_publish_permit_exact = _implementation_attribute(
     "claim_owner_publish_permit_exact"
 )
+_claim_owner_replacement_permit_exact = _implementation_attribute(
+    "claim_owner_replacement_permit_exact"
+)
 _require_owner_exact = _implementation_attribute("require_owner_exact")
 _close_owner_exact = _implementation_attribute("close_owner_exact")
 _provision_owner_exact = _implementation_attribute("provision_owner_exact")
 _capture_owner_destination_exact = _implementation_attribute(
     "capture_owner_destination_exact"
+)
+_provision_owner_replacement_exact = _implementation_attribute(
+    "provision_owner_replacement_exact"
 )
 _verify_owner_authority_exact = _implementation_attribute(
     "verify_owner_authority_exact"
@@ -50,6 +56,9 @@ _verify_owner_adoption_binding_exact = _implementation_attribute(
 )
 _verify_owner_destination_binding_exact = _implementation_attribute(
     "verify_owner_destination_binding_exact"
+)
+_verify_owner_replacement_binding_exact = _implementation_attribute(
+    "verify_owner_replacement_binding_exact"
 )
 _borrow_owner_parent_descriptor_exact = _implementation_attribute(
     "borrow_owner_parent_descriptor_exact"
@@ -75,6 +84,9 @@ _mark_owner_adopted_exact = _implementation_attribute("mark_owner_adopted_exact"
 _rename_owner_child_noreplace_exact = _implementation_attribute(
     "rename_owner_child_noreplace_exact"
 )
+_exchange_owner_replacement_exact = _implementation_attribute(
+    "exchange_owner_replacement_exact"
+)
 _commit_owner_receipt_exact = _implementation_attribute("commit_owner_receipt_exact")
 _abort_owner_exact = _implementation_attribute("abort_owner_exact")
 _quarantine_owner_exact = _implementation_attribute("quarantine_owner_exact")
@@ -90,13 +102,16 @@ _workspace_owner_protocol_available = (
             _require_support_exact,
             _create_owner_exact,
             _claim_owner_publish_permit_exact,
+            _claim_owner_replacement_permit_exact,
             _require_owner_exact,
             _close_owner_exact,
             _provision_owner_exact,
             _capture_owner_destination_exact,
+            _provision_owner_replacement_exact,
             _verify_owner_authority_exact,
             _verify_owner_adoption_binding_exact,
             _verify_owner_destination_binding_exact,
+            _verify_owner_replacement_binding_exact,
             _borrow_owner_parent_descriptor_exact,
             _borrow_owner_root_descriptor_exact,
             _borrow_owner_destination_descriptor_exact,
@@ -109,6 +124,7 @@ _workspace_owner_protocol_available = (
             _sync_owner_parent_exact,
             _mark_owner_adopted_exact,
             _rename_owner_child_noreplace_exact,
+            _exchange_owner_replacement_exact,
             _commit_owner_receipt_exact,
             _abort_owner_exact,
             _quarantine_owner_exact,
@@ -122,13 +138,16 @@ if not _workspace_owner_protocol_available:
     _require_support_exact = None
     _create_owner_exact = None
     _claim_owner_publish_permit_exact = None
+    _claim_owner_replacement_permit_exact = None
     _require_owner_exact = None
     _close_owner_exact = None
     _provision_owner_exact = None
     _capture_owner_destination_exact = None
+    _provision_owner_replacement_exact = None
     _verify_owner_authority_exact = None
     _verify_owner_adoption_binding_exact = None
     _verify_owner_destination_binding_exact = None
+    _verify_owner_replacement_binding_exact = None
     _borrow_owner_parent_descriptor_exact = None
     _borrow_owner_root_descriptor_exact = None
     _borrow_owner_destination_descriptor_exact = None
@@ -141,6 +160,7 @@ if not _workspace_owner_protocol_available:
     _sync_owner_parent_exact = None
     _mark_owner_adopted_exact = None
     _rename_owner_child_noreplace_exact = None
+    _exchange_owner_replacement_exact = None
     _commit_owner_receipt_exact = None
     _abort_owner_exact = None
     _quarantine_owner_exact = None
@@ -183,6 +203,14 @@ def claim_owner_publish_permit(owner: object) -> object:
     return _claim_owner_publish_permit_exact(owner)
 
 
+def claim_owner_replacement_permit(owner: object) -> object:
+    """Claim the owner's private, one-shot replacement capability."""
+
+    _require_protocol()
+    assert _claim_owner_replacement_permit_exact is not None
+    return _claim_owner_replacement_permit_exact(owner)
+
+
 def _bind_owner_publish_permit(
     publication_permit: object,
 ) -> Callable[[bytes, bytes], object | None]:
@@ -196,6 +224,30 @@ def _bind_owner_publish_permit(
         return exact_rename(publication_permit, source, destination)
 
     return rename
+
+
+def _bind_owner_replacement_permit(
+    replacement_permit: object,
+) -> Callable[[bytes, bytes, int], object]:
+    """Bind one replacement permit before user callbacks run."""
+
+    _require_protocol()
+    exact_exchange = _exchange_owner_replacement_exact
+    assert exact_exchange is not None
+
+    def exchange(
+        replacement_slot: bytes,
+        destination_name: bytes,
+        deadline_ns: int,
+    ) -> object:
+        return exact_exchange(
+            replacement_permit,
+            replacement_slot,
+            destination_name,
+            deadline_ns,
+        )
+
+    return exchange
 
 
 def require_exact_owner(candidate: object) -> Any:
@@ -274,6 +326,31 @@ def capture_owner_destination(
     )
 
 
+def provision_owner_replacement(
+    owner: object,
+    replacement_slot: bytes,
+    plan_digest: bytes,
+    root_mode: int,
+    directories: tuple[tuple[bytes, int], ...],
+    deadline_ns: int,
+) -> None:
+    """Provision one candidate beside an exact captured destination."""
+
+    _require_protocol()
+    assert _provision_owner_replacement_exact is not None
+    _require_none_result(
+        _provision_owner_replacement_exact(
+            owner,
+            replacement_slot,
+            plan_digest,
+            root_mode,
+            directories,
+            deadline_ns,
+        ),
+        "replacement-provision",
+    )
+
+
 def verify_owner_authority(owner: object) -> None:
     _require_protocol()
     assert _verify_owner_authority_exact is not None
@@ -286,6 +363,15 @@ def verify_owner_destination_binding(owner: object) -> None:
     _require_none_result(
         _verify_owner_destination_binding_exact(owner),
         "destination-binding verification",
+    )
+
+
+def verify_owner_replacement_binding(owner: object) -> None:
+    _require_protocol()
+    assert _verify_owner_replacement_binding_exact is not None
+    _require_none_result(
+        _verify_owner_replacement_binding_exact(owner),
+        "replacement-binding verification",
     )
 
 
@@ -419,6 +505,22 @@ def rename_owner_child_noreplace(
     return _rename_owner_child_noreplace_exact(owner, source, destination)
 
 
+def exchange_owner_replacement(
+    replacement_permit: object,
+    replacement_slot: bytes,
+    destination_name: bytes,
+    deadline_ns: int,
+) -> object:
+    _require_protocol()
+    assert _exchange_owner_replacement_exact is not None
+    return _exchange_owner_replacement_exact(
+        replacement_permit,
+        replacement_slot,
+        destination_name,
+        deadline_ns,
+    )
+
+
 def commit_owner_receipt(receipt_token: object) -> None:
     _require_protocol()
     assert _commit_owner_receipt_exact is not None
@@ -470,15 +572,18 @@ __all__ = [
     "borrow_owner_parent_descriptor",
     "borrow_owner_root_descriptor",
     "claim_owner_publish_permit",
+    "claim_owner_replacement_permit",
     "capture_owner_destination",
     "close_owner_exact",
     "commit_owner_receipt",
     "create_owner",
+    "exchange_owner_replacement",
     "finish_owner_file",
     "mark_owner_adopted",
     "owner_closed",
     "owner_state",
     "provision_owner",
+    "provision_owner_replacement",
     "quarantine_owner",
     "rename_owner_child_noreplace",
     "require_exact_owner",
@@ -488,5 +593,6 @@ __all__ = [
     "verify_owner_adoption_binding",
     "verify_owner_authority",
     "verify_owner_destination_binding",
+    "verify_owner_replacement_binding",
     "write_owner_file",
 ]

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -22,22 +22,19 @@ import-cache` recaptures an already existing selected cache, `codenib artifact
 materialize` publishes a retained catalog ref or immutable snapshot to a
 missing portable-artifact directory, and retained `codenib mcp` cold-start
 materializes and holds one such generation for a single stdio server lifetime.
-Protocol v3 also adds an internal, capture-only authority primitive for an
-existing destination directory. It moves an otherwise empty native owner into
-the distinct `destination-captured` state, where callers may verify the
-captured root plus destination name/device/inode binding, borrow its
-authenticated directory descriptor, and close or abort the owner. The internal
-native/facade primitive performs no namespace mutation, exposes neither the
-destination-parent nor staged-workspace-root descriptor, and performs no
-publication, rename, exchange, or replacement. The borrowed destination
-descriptor remains owner-owned and valid only for the owner's lifetime;
-trusted internal callers must not close it and could still use it as a
-capability, so capture is an authority boundary rather than a Python sandbox.
+Protocol v4 also exposes an internal existing-destination replacement
+primitive. It captures the incumbent, provisions and authenticates one hidden
+same-parent candidate, exchanges the two exact directory bindings with Linux
+`renameat2(RENAME_EXCHANGE)`, and returns an opaque receipt token. The native
+aggregate owns the incumbent and candidate descriptors throughout; every
+descriptor borrowed by trusted internal code remains owner-owned and must
+never be closed by the borrower.
 
-`LocalWorkspaceProvider` remains missing-only and still rejects the strict
-BM25 producer's `provider-bound-exact` destination mode. Completing that Gate C
-provider requires an atomic exchange/replacement protocol v4, or a separately
-advertised capability; protocol v3 preparation does not close the gate.
+This primitive does not change `LocalWorkspaceProvider`: the provider remains
+missing-only and still rejects the strict BM25 producer's
+`provider-bound-exact` destination mode. Provider integration is a separate
+Gate C change, so Gate C and M1 remain open even though the protocol-v4
+primitive is available.
 
 ## Publish a normal index build
 
@@ -362,10 +359,10 @@ These retained-read routes and the explicit BM25/vector ingress above do not
 complete the hybrid-storage M1 milestone. Benchmark-backed promotion of the
 opt-in compiler and runtime routes is still missing, as is a production
 provider for the strict BM25 replacement producer's `provider-bound-exact`
-destination contract. The capture-only protocol-v3 root authority does not
-change that provider rejection and cannot exchange or replace the captured
-directory. Graph and Zoekt ingress remain M2 or later work; fenced jobs and
-runtime hot switching remain separate milestones.
+destination contract. Protocol v4 supplies the lower-level exact exchange
+primitive, but no production provider selects it and the local provider still
+rejects replacement requests. Graph and Zoekt ingress remain M2 or later work;
+fenced jobs and runtime hot switching remain separate milestones.
 
 ## Measure the retained storage gate
 
@@ -506,10 +503,10 @@ capability policy, and required view coverage. A future source-bound BM25
 default requires its own A2 decision and does not satisfy that full
 compatibility gate. The independent gate C
 `provider-bound-exact` native provider is still required before M1 closes.
-Protocol v3 supplies only its non-mutating capture preparation; the later
-exchange/replacement operation must use protocol v4 or an explicit independent
-capability. This harness does not add M2 generic generation publication or
-fenced jobs, M3 hot switching or request pins, or M5 retention and garbage
+Protocol v4 supplies a primitive-only exact exchange; it does not wire that
+primitive into `LocalWorkspaceProvider` or authorize the strict BM25 route to
+use it. This harness does not add M2 generic generation publication or fenced
+jobs, M3 hot switching or request pins, or M5 retention and garbage
 collection.
 
 ## Lifecycle
@@ -561,7 +558,7 @@ The provider deliberately has a narrow first release:
 - One absolute authority root owned by the current effective UID, with exact
   mode `0700`. The root must be a private, quiescent namespace rather than a
   directory another same-UID process actively mutates.
-- A complete protocol-v3 native extension and a successful Linux ownership
+- A complete protocol-v4 native extension and a successful Linux ownership
   support probe before the first namespace mutation.
 - A plan small enough for the process descriptor limit. The format permits up
   to 100,000 directories, but the native `RLIMIT_NOFILE` preflight may reject a
@@ -585,7 +582,7 @@ policy permits cleanup; discarding it forfeits recoverability.
 
 ## Publication guarantees
 
-The protocol-v3 native aggregate preserves the protocol-v2 missing-destination
+The protocol-v4 native aggregate preserves the protocol-v2 missing-destination
 publication contract. In that publication mode it owns the namespace and file
 descriptors for the whole operation, creates and writes files without returning
 raw file descriptors to Python, pins the root and planned directory identities,
@@ -593,8 +590,8 @@ and performs one no-replace forward rename under a one-shot permit. The
 caller's receipt-slot store is the authority linearization point:
 
 - before the store, failure quarantines the exact candidate;
-- after the store, recovery commits the same native receipt token
-  idempotently;
+- after the store, while the exact native authority remains active and before
+  its close, recovery commits the same native receipt token idempotently;
 - a fork child only authenticates and closes its inherited descriptor pairs and
   cannot rename, quarantine, or commit the parent generation.
 
@@ -602,17 +599,94 @@ Staged and published validators run inside that transaction. The returned
 receipt therefore names one exact, durably published generation rather than a
 path checked after the fact.
 
-Protocol v3's additive capture mode instead binds the private allowed root,
-destination-parent chain, existing destination directory, and exact
-name/device/inode without mutating any of them. A `destination-captured` owner
-permits only destination verification, an owner-owned borrowed destination
-descriptor, and owner close or abort; legacy destination-parent,
-staged-workspace-root, and planned-directory borrows plus file, publication,
-quarantine, and rename operations fail closed. The borrowed descriptor is valid
-only for the owner lifetime and callers must not close it. The native capture
-operation itself makes no namespace change. Trusted internal code could still
-use the destination descriptor with `*at` syscalls, so this is an authority
-boundary rather than a Python sandbox. It is root-authority evidence for future
-Gate C work, not full `_TreeOwnership` and not a `provider-bound-exact`
-provider. Atomic exchange or replacement remains a protocol-v4 or separately
-advertised capability.
+Protocol v4 extends capture with a primitive-only replacement transaction. Its
+success path has these native owner states:
+
+```text
+destination-captured
+  -> replacement-provisioning
+  -> replacement-provisioned
+  -> replacement-adopted
+  -> replacement-exchanged-unreceipted
+  -> replacement-receipted
+  -> closed
+```
+
+The native ABI adds
+`claim_owner_replacement_permit_exact`,
+`provision_owner_replacement_exact`,
+`verify_owner_replacement_binding_exact`, and
+`exchange_owner_replacement_exact`. The fail-closed facade exposes the same
+operations without `_exact`. Claim returns a distinct opaque
+`WorkspaceReplacementPermit`; exchange consumes that permit and returns an
+opaque `WorkspaceReceiptToken` for the existing `commit_owner_receipt`
+operation. Permits and receipt tokens do not expose a separate public state
+API; `owner_state` reports the aggregate state above.
+
+`replacement-provisioning` is the in-call construction state; a successful
+provision call returns in `replacement-provisioned`. Claiming the distinct
+one-shot replacement permit does not change `destination-captured`. After the
+candidate is adopted, written, sealed, and rebound to the aggregate, exchange
+returns an opaque receipt token. While the exact owner authority remains active
+and before close, committing that token is idempotent, releases the cooperative
+flock lease while retaining the authenticated parent descriptor and guard until
+owner/receipt close, and enters `replacement-receipted`. Closing a receipted
+owner only closes its handles and does not mutate either path; after close, the
+token is no longer a retry capability and commit fails closed.
+The forward parent `fsync` occurs inside exchange before a token is returned.
+If it fails, the caller has no token: the aggregate enters
+`replacement-recovery-required`, retains its lease and descriptors, and must be
+settled through owner recovery/abort. In a reachable receipt-commit path, a
+dual-binding validation or `LOCK_UN` failure also enters recovery-required but
+leaves the already-returned token unconsumed. That same exact token may retry
+`commit_owner_receipt` only while the owner remains active and after native
+reclassification proves the exchanged mapping. `abort_owner` is the alternative
+settlement authority; it reclassifies the mapping and reverses the exchange
+when required. Every lease-active
+recovery, including an operator-restored mapping or receipt retry, completes a
+parent `fsync` before eventual unlock. Other interrupted paths may enter
+`replacement-recovery-required`, `quarantined`, or `closed`.
+
+The exchange contract is deliberately narrow. It is Linux-only, requires the
+incumbent and hidden candidate to be distinct directories under the same
+captured parent and on the same device, and uses exactly
+`renameat2(RENAME_EXCHANGE)`. There is no portable or multi-rename fallback.
+The parent-directory open-file-description (OFD) guard is acquired nonblocking
+with `flock(LOCK_EX | LOCK_NB)` and is held across the live exchange until
+either the receipt is committed or an authenticated reverse exchange plus
+parent-directory `fsync` completes. This serializes only the
+exchange-to-receipt-or-reverse settlement window; it does
+not refresh an earlier capture or lock the complete writer lifecycle. A future
+provider or other cooperative caller replacing the same incumbent must supply
+outer single-writer, quiescent serialization for the entire
+capture-to-receipt-or-abort lifetime. If two owners capture the same incumbent,
+the first commits, and the second later attempts exchange, the second classifies
+the mapping as unknown, stays `replacement-recovery-required`, and retains its
+lease and descriptors. The primitive does not auto-adopt or quarantine that
+stale capture. The containing `0700` root must remain private and quiescent; a
+hostile same-UID process that ignores the guard is outside the contract.
+
+Before receipt settlement, same-process abort verifies the swapped incumbent
+and candidate mappings, reverses the exchange, flushes the parent, restores the
+incumbent at the destination, and retains the candidate at its pre-existing
+caller-supplied, authenticated hidden replacement slot for quarantine. The
+primitive validates the hidden basename but does not generate or prove
+randomness. A committed exchange leaves the new candidate at the destination
+and the old incumbent at that slot; the primitive does not reclaim it. Readers
+observing the live namespace see one complete binding or the other at the
+single exchange point, but this is live
+atomicity, not crash recovery. There is no journal and no promise to roll back
+after `SIGKILL`, host failure, or power loss. A caller that observes
+`replacement-recovery-required` must retain the owner and explicitly retry
+recovery, plus the same receipt token when a reachable receipt-commit attempt
+failed. If all references are abandoned while the mapping is unknown, native
+deallocation deliberately retains the raw descriptors and cooperative flock
+until process exit rather than silently releasing the only exclusion and
+authority; restarting is the final recovery boundary.
+
+All borrowed incumbent, candidate-root, parent, and planned-directory
+descriptors remain owned by the aggregate and are valid only for its lifetime;
+borrowers must never close them. The primitive remains an authority boundary
+for trusted internal code, not a Python sandbox or full `_TreeOwnership`.
+`LocalWorkspaceProvider` does not yet integrate it, continues to reject
+`provider-bound-exact`, and therefore does not close Gate C or M1.

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -282,24 +282,60 @@ authenticated reader pinned through synchronous consumption. The contract
 remains provider-neutral, and a concrete `LocalWorkspaceProvider` now supplies
 it on Linux for missing destinations below one private, quiescent root owned by
 the current effective UID with exact mode `0700`. Native workspace-owner
-protocol v3 preserves the v2 publication contract: it pins the namespace and
+protocol v4 preserves the v2 publication contract: it pins the namespace and
 owns every file descriptor, acquires and writes files without exposing raw file
 descriptors to Python, and gates the only forward rename with a one-shot publish
 permit. The caller-owned receipt slot is the publication-authority
 linearization point: unreceipted same-process failures quarantine the exact
 candidate, while a fork child authenticates and closes only its inherited
-descriptor pairs. V3 also adds a non-mutating capture-only mode for an existing
-destination. It enters the distinct `destination-captured` state, authenticates
-the private root and exact destination name/device/inode binding, and permits
-only verification, an owner-owned borrowed destination descriptor, and owner
-close or abort. Legacy destination-parent, staged-workspace-root, and
-planned-directory borrows reject this state, so capture creates no accidental
-parent or staged-workspace-root capability. The borrowed descriptor is valid
-only for the owner lifetime and callers must not close it. The native primitive
-performs no namespace mutation and cannot publish, exchange, or replace the
-directory. Trusted internal code could still use the descriptor with `*at`
-syscalls, so capture is not full `_TreeOwnership`. The provider remains an
-authority boundary for trusted callbacks, not an in-process Python sandbox.
+descriptor pairs. The v3-compatible capture state authenticates the private
+root and exact destination name/device/inode binding without mutation. V4 adds
+a distinct one-shot replacement permit and one aggregate for that incumbent
+plus a hidden, same-parent candidate. Its success states are
+`destination-captured` -> `replacement-provisioning` ->
+`replacement-provisioned` -> `replacement-adopted` ->
+`replacement-exchanged-unreceipted` -> `replacement-receipted`, followed by
+`closed`; interrupted paths may instead enter
+`replacement-recovery-required` or `quarantined`. The only exchange is Linux
+`renameat2(RENAME_EXCHANGE)` for two same-device directories under the captured
+parent, with no portable or multi-rename fallback. A nonblocking owner-held
+parent-directory open-file-description (OFD)
+`flock(LOCK_EX | LOCK_NB)` guards the cooperative commit window through receipt
+commit or an authenticated reverse exchange and parent `fsync`. That flock
+serializes only exchange-to-settlement, not the earlier capture or complete
+writer lifecycle. A future provider/caller must keep replacements of the same
+incumbent single-writer and quiescent from capture through receipt or abort. A
+second stale owner that captured before another owner committed classifies the
+later mapping as unknown, stays `replacement-recovery-required`, and retains
+its lease and descriptors; the primitive neither auto-adopts nor quarantines
+that capture. This assumes a private `0700` namespace whose CodeNib writers
+honor the outer serialization and guard; it is not a claim against hostile
+same-UID mutation. Before receipt settlement,
+same-process recovery can restore the incumbent and retain the candidate at its
+pre-existing, caller-supplied authenticated hidden slot. The primitive validates
+the hidden basename but does not generate or prove randomness. A committed
+exchange leaves the candidate live and the incumbent at that slot. This is live
+atomicity without a crash journal: `SIGKILL`, host failure, and power loss have
+no promised rollback. If the mapping becomes unknown, callers must retain and
+explicitly retry the recovery owner. Forward parent `fsync` runs inside exchange
+before a token is returned; its failure leaves the caller with no token and
+requires owner recovery/abort. A reachable receipt-commit dual-binding or
+`LOCK_UN` failure instead leaves the already-returned same exact receipt token
+unconsumed. While the exact owner remains active and before close, it may retry
+commit only after native reclassification proves the exchanged mapping; after
+close, the token is no longer a retry capability and commit fails closed. Owner
+abort remains the alternative reclassifying/reversing settlement. Every
+lease-active recovery, including an operator-restored mapping or receipt retry,
+performs parent `fsync` before
+eventual unlock. Abandoning recovery authority deliberately retains the raw
+descriptors and cooperative flock until process
+exit rather than silently discarding the only authority. Every borrowed
+incumbent, candidate, parent, or planned-directory descriptor remains
+owner-owned and callers must not close it. Trusted internal code could still
+use those descriptors with `*at` syscalls, so the primitive is not full
+`_TreeOwnership`.
+The provider remains an authority boundary for trusted callbacks, not an
+in-process Python sandbox.
 The explicit retained workflows construct it for operator-requested publication
 and cold start; no compiler or runtime route constructs it by default yet.
 
@@ -387,11 +423,10 @@ materialization APIs are now available as injectable library producers. The
 Linux local provider deliberately accepts only missing destinations, so
 whole-context retained materialization can use it explicitly, while strict BM25
 replacement requests `provider-bound-exact` and still lacks a concrete
-production provider. Protocol v3 now supplies its capture-only,
-root-authority-preparation half, but `LocalWorkspaceProvider` still rejects the
-request and no exchange/replacement operation exists. That mutation boundary
-must be protocol v4 or a separately advertised capability. The explicit
-retained workflows can now construct the whole-context producer for one
+production provider. Protocol v4 now supplies the lower-level exact exchange
+primitive, but `LocalWorkspaceProvider` still rejects the request and does not
+select that primitive. Provider integration remains separate Gate C work. The
+explicit retained workflows can now construct the whole-context producer for one
 existing catalog selection, publish normal compiler output, and load one
 selected generation at MCP cold start, but no default compiler/runtime route
 constructs them. M1 remains in progress and the M2 BM25 profile adapter is still
@@ -743,10 +778,9 @@ advance refs, or make retained storage the default. Benchmark-backed promotion
 of the explicit compiler and runtime routes remains outstanding M1 work; graph
 and Zoekt cache ingress and fenced job publication remain M2 or later work.
 Strict BM25 replacement also still lacks the `provider-bound-exact` production
-provider. Protocol-v3 destination capture is non-mutating preparation only;
-`LocalWorkspaceProvider` continues to reject that expectation, and atomic
-exchange/replacement remains a protocol-v4 or separately advertised
-capability.
+provider. Protocol v4 implements the primitive-only exact exchange, but
+`LocalWorkspaceProvider` continues to reject that expectation and no strict
+producer is wired to the new operation. Provider integration remains separate.
 
 #### Retained storage promotion protocol
 
@@ -763,7 +797,7 @@ that collecting a fast result cannot silently approve a production route:
 | B1 | Promote BM25 compiler publication to a configured default. | Pending A2 compiler. |
 | B2 | Promote query-only BM25 retained cold start to a configured default. | Pending A2 query-only runtime; this does not replace source-bound manifest MCP. |
 | B2 source-bound | Promote a specifically scoped source-bound BM25 retained cold start. | Pending A2 source-bound BM25 runtime; it cannot satisfy the full manifest-compatibility gate. |
-| C | Supply the `provider-bound-exact` strict BM25 native provider. | Capture-only protocol-v3 root authority is implemented as non-mutating preparation, but `LocalWorkspaceProvider` still rejects this expectation. Exchange/replacement requires protocol v4 or a separately advertised capability, so Gate C remains pending and required before M1 closes. |
+| C | Supply the `provider-bound-exact` strict BM25 native provider. | Protocol v4 implements a Linux-only, same-parent `RENAME_EXCHANGE` primitive with receipt settlement and bounded same-process rollback, but `LocalWorkspaceProvider` still rejects this expectation and no strict producer selects the primitive. Gate C remains pending and required before M1 closes. |
 
 The A1 harness fixes the BM25 `fast` compiler/runtime comparison rather than
 accepting arbitrary route substitutions. For compiler cold start, arm A runs

--- a/native/workspace_owner.c
+++ b/native/workspace_owner.c
@@ -15,6 +15,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/file.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -47,6 +48,9 @@
 #ifndef RENAME_NOREPLACE
 #define RENAME_NOREPLACE (1U << 0)
 #endif
+#ifndef RENAME_EXCHANGE
+#define RENAME_EXCHANGE (1U << 1)
+#endif
 #ifndef KCMP_FILE
 #define KCMP_FILE 0
 #endif
@@ -70,6 +74,23 @@ enum workspace_namespace_state {
   WORKSPACE_RECEIPTED = 5,
   WORKSPACE_QUARANTINED = 6,
   WORKSPACE_DESTINATION_CAPTURED = 7,
+  WORKSPACE_REPLACEMENT_PROVISIONING = 8,
+  WORKSPACE_REPLACEMENT_PROVISIONED = 9,
+  WORKSPACE_REPLACEMENT_ADOPTED = 10,
+  WORKSPACE_REPLACEMENT_EXCHANGED_UNRECEIPTED = 11,
+  WORKSPACE_REPLACEMENT_RECEIPTED = 12,
+  WORKSPACE_REPLACEMENT_RECOVERY_REQUIRED = 13,
+};
+
+enum workspace_receipt_kind {
+  WORKSPACE_RECEIPT_PUBLISH = 1,
+  WORKSPACE_RECEIPT_REPLACEMENT = 2,
+};
+
+enum workspace_replacement_mapping {
+  WORKSPACE_REPLACEMENT_MAPPING_UNKNOWN = 0,
+  WORKSPACE_REPLACEMENT_MAPPING_PREEXCHANGE = 1,
+  WORKSPACE_REPLACEMENT_MAPPING_EXCHANGED = 2,
 };
 
 typedef struct {
@@ -120,6 +141,7 @@ typedef struct WorkspaceOwner {
   char *destination_path;
   char *initial_stage_name;
   char *stage_name;
+  char *replacement_slot_name;
   char *plan_digest;
   char *orphan_name;
   WorkspaceDirectoryRecord *directories;
@@ -141,6 +163,9 @@ typedef struct WorkspaceOwner {
   off_t file_offset;
   int publish_permit_claimed;
   int publish_permit_active;
+  int replacement_permit_claimed;
+  int replacement_permit_active;
+  int replacement_lock_active;
   uint64_t receipt_generation;
 } WorkspaceOwner;
 
@@ -153,15 +178,26 @@ typedef struct {
 typedef struct {
   PyObject_HEAD WorkspaceOwner *owner;
   pid_t owner_pid;
+  int consumed;
+} WorkspaceReplacementPermit;
+
+typedef struct {
+  PyObject_HEAD WorkspaceOwner *owner;
+  pid_t owner_pid;
   uint64_t generation;
+  enum workspace_receipt_kind kind;
   int consumed;
 } WorkspaceReceiptToken;
 
 static PyObject *WorkspacePublishPermitTypeObject = NULL;
+static PyObject *WorkspaceReplacementPermitTypeObject = NULL;
 static PyObject *WorkspaceReceiptTokenTypeObject = NULL;
 
 static PyObject *new_workspace_publish_permit(WorkspaceOwner *owner);
-static PyObject *new_workspace_receipt_token(WorkspaceOwner *owner);
+static PyObject *new_workspace_replacement_permit(WorkspaceOwner *owner);
+static PyObject *new_workspace_receipt_token(WorkspaceOwner *owner,
+                                             uint64_t generation,
+                                             enum workspace_receipt_kind kind);
 
 static int set_errno_error(int error) {
   errno = error;
@@ -208,11 +244,15 @@ static int check_deadline(long long deadline_ns) {
 }
 
 static int verify_parent_binding(WorkspaceOwner *self);
+static int verify_captured_destination_binding(WorkspaceOwner *self);
 static int verify_owner_authority(WorkspaceOwner *self);
+static int verify_replacement_binding(WorkspaceOwner *self);
 static int verify_descriptor(int descriptor, int guard, dev_t device,
                              ino_t inode);
 static int verify_hidden_directory(int descriptor, dev_t device, ino_t inode);
 static int quarantine_namespace_internal(WorkspaceOwner *self);
+static int settle_replacement_namespace_internal(WorkspaceOwner *self);
+static int workspace_state_is_replacement(WorkspaceOwner *self);
 
 static int native_fsync_retry(int descriptor) {
   int attempts;
@@ -226,6 +266,49 @@ static int native_fsync_retry(int descriptor) {
   }
   errno = EINTR;
   return -1;
+}
+
+static int native_flock_retry(int descriptor, int operation) {
+#if defined(__linux__)
+  int attempts;
+  for (attempts = 0; attempts < 64; ++attempts) {
+    if (flock(descriptor, operation) == 0) {
+      return 0;
+    }
+    if (errno != EINTR) {
+      return -1;
+    }
+  }
+  errno = EINTR;
+  return -1;
+#else
+  (void)descriptor;
+  (void)operation;
+  errno = ENOSYS;
+  return -1;
+#endif
+}
+
+static void enter_replacement_recovery(WorkspaceOwner *self) {
+  self->namespace_state = WORKSPACE_REPLACEMENT_RECOVERY_REQUIRED;
+  if (self->replacement_lock_active) {
+    self->namespace_sync_pending = 1;
+  }
+}
+
+static int release_replacement_lock(WorkspaceOwner *self) {
+  if (!self->replacement_lock_active) {
+    return 0;
+  }
+  if (getpid() != self->owner_pid) {
+    errno = EPERM;
+    return -1;
+  }
+  if (native_flock_retry(self->parent_guard_fd, LOCK_UN) < 0) {
+    return -1;
+  }
+  self->replacement_lock_active = 0;
+  return 0;
 }
 
 static int native_fchmod_retry(int descriptor, mode_t mode) {
@@ -904,12 +987,30 @@ static void free_configuration(WorkspaceOwner *self) {
   self->initial_stage_name = NULL;
   free(self->stage_name);
   self->stage_name = NULL;
+  free(self->replacement_slot_name);
+  self->replacement_slot_name = NULL;
   free(self->plan_digest);
   self->plan_digest = NULL;
   free(self->orphan_name);
   self->orphan_name = NULL;
   free(self->file_name);
   self->file_name = NULL;
+}
+
+static void free_unprovisioned_replacement_configuration(WorkspaceOwner *self) {
+  Py_ssize_t index;
+
+  for (index = 0; index < self->directory_count; ++index) {
+    free(self->directories[index].path);
+    self->directories[index].path = NULL;
+  }
+  free(self->directories);
+  self->directories = NULL;
+  self->directory_count = 0;
+  free(self->replacement_slot_name);
+  self->replacement_slot_name = NULL;
+  free(self->plan_digest);
+  self->plan_digest = NULL;
 }
 
 static char *copy_exact_bytes(PyObject *value, const char *label,
@@ -1261,14 +1362,21 @@ static int same_identity_at(int parent, const char *name, dev_t device,
   return 0;
 }
 
+static const char *candidate_namespace_name(WorkspaceOwner *self) {
+  if (self->replacement_slot_name != NULL) {
+    return self->replacement_slot_name;
+  }
+  return self->stage_name;
+}
+
 static int identify_created_root(WorkspaceOwner *self) {
   struct stat metadata;
-  if (!self->namespace_created || self->parent_guard_fd < 0 ||
-      self->stage_name == NULL) {
+  const char *name = candidate_namespace_name(self);
+  if (!self->namespace_created || self->parent_guard_fd < 0 || name == NULL) {
     errno = EINVAL;
     return -1;
   }
-  if (native_fstatat_retry(self->parent_guard_fd, self->stage_name, &metadata,
+  if (native_fstatat_retry(self->parent_guard_fd, name, &metadata,
                            AT_SYMLINK_NOFOLLOW) < 0) {
     return -1;
   }
@@ -1559,6 +1667,35 @@ static int preflight_descriptor_budget(WorkspaceOwner *self,
   return 0;
 }
 
+static int preflight_additional_descriptor_budget(size_t owner_pairs) {
+  struct rlimit limit;
+  size_t required;
+  uintmax_t open_descriptors;
+
+  if (owner_pairs > (SIZE_MAX - 2 - CODENIB_FD_SAFETY_MARGIN) / (size_t)2) {
+    PyErr_SetString(PyExc_OverflowError,
+                    "workspace descriptor budget overflowed");
+    return -1;
+  }
+  required = (owner_pairs * 2) + 2 + CODENIB_FD_SAFETY_MARGIN;
+  if (getrlimit(RLIMIT_NOFILE, &limit) < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    return -1;
+  }
+  if (count_open_descriptors(&open_descriptors) < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    return -1;
+  }
+  if (limit.rlim_cur != RLIM_INFINITY &&
+      (open_descriptors > (uintmax_t)limit.rlim_cur ||
+       (uintmax_t)required > (uintmax_t)limit.rlim_cur - open_descriptors)) {
+    errno = EMFILE;
+    PyErr_SetFromErrno(PyExc_OSError);
+    return -1;
+  }
+  return 0;
+}
+
 static int verify_allowed_root_policy(WorkspaceOwner *self) {
   struct stat metadata;
   int flags;
@@ -1632,6 +1769,7 @@ static PyObject *WorkspaceOwner_new(PyTypeObject *type, PyObject *args,
   self->destination_path = NULL;
   self->initial_stage_name = NULL;
   self->stage_name = NULL;
+  self->replacement_slot_name = NULL;
   self->plan_digest = NULL;
   self->orphan_name = NULL;
   self->directories = NULL;
@@ -1650,6 +1788,9 @@ static PyObject *WorkspaceOwner_new(PyTypeObject *type, PyObject *args,
   self->file_offset = 0;
   self->publish_permit_claimed = 0;
   self->publish_permit_active = 0;
+  self->replacement_permit_claimed = 0;
+  self->replacement_permit_active = 0;
+  self->replacement_lock_active = 0;
   self->receipt_generation = 0;
   for (Py_ssize_t index = 0; index < CODENIB_MAX_SCRATCH_FDS; ++index) {
     self->scratch[index].path = NULL;
@@ -1663,16 +1804,37 @@ static PyObject *WorkspaceOwner_new(PyTypeObject *type, PyObject *args,
 
 static void WorkspaceOwner_dealloc(WorkspaceOwner *self) {
   freefunc release;
-  if (!self->closed && getpid() == self->owner_pid && self->namespace_created &&
-      self->namespace_state != WORKSPACE_RECEIPTED) {
+  PyObject *error_type;
+  PyObject *error_value;
+  PyObject *error_traceback;
+  int settlement_failed = 0;
+
+  PyErr_Fetch(&error_type, &error_value, &error_traceback);
+  if (!self->closed && getpid() == self->owner_pid &&
+      workspace_state_is_replacement(self)) {
+    if (settle_replacement_namespace_internal(self) < 0 &&
+        (self->replacement_lock_active ||
+         self->namespace_state == WORKSPACE_REPLACEMENT_RECOVERY_REQUIRED)) {
+      /* Lease-held or recovery-required replacement ownership must not release
+         its cooperative lease or close its pinned descriptors.  A pre-exchange
+         contention failure acquired no lease and changed no namespace, so its
+         descriptors can be closed without settling the sibling-owned names. */
+      settlement_failed = 1;
+    }
+  } else if (!self->closed && getpid() == self->owner_pid &&
+             self->namespace_created &&
+             self->namespace_state != WORKSPACE_RECEIPTED) {
     (void)quarantine_namespace_internal(self);
   }
-  close_all(self);
+  if (!settlement_failed) {
+    close_all(self);
+  }
   free_configuration(self);
   release = (freefunc)PyType_GetSlot(Py_TYPE(self), Py_tp_free);
   if (release != NULL) {
     release((PyObject *)self);
   }
+  PyErr_Restore(error_type, error_value, error_traceback);
 }
 
 static PyObject *
@@ -1685,6 +1847,7 @@ WorkspaceOwner_claim_publish_permit(WorkspaceOwner *self,
   }
   if (self->closed || self->publish_permit_claimed || self->provision_started ||
       self->namespace_state != WORKSPACE_EMPTY || self->namespace_created ||
+      self->replacement_permit_claimed || self->replacement_permit_active ||
       self->anchor_fd >= 0) {
     PyErr_SetString(PyExc_RuntimeError,
                     "native workspace publish permit is not claimable");
@@ -1696,6 +1859,33 @@ WorkspaceOwner_claim_publish_permit(WorkspaceOwner *self,
   }
   self->publish_permit_claimed = 1;
   self->publish_permit_active = 1;
+  return permit;
+}
+
+static PyObject *
+WorkspaceOwner_claim_replacement_permit(WorkspaceOwner *self,
+                                        PyObject *Py_UNUSED(ignored)) {
+  PyObject *permit;
+
+  if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (self->closed || self->namespace_state != WORKSPACE_DESTINATION_CAPTURED ||
+      self->replacement_permit_claimed || self->replacement_permit_active ||
+      self->publish_permit_claimed || self->publish_permit_active ||
+      self->namespace_created || self->root_fd >= 0 ||
+      self->root_guard_fd >= 0 ||
+      verify_captured_destination_binding(self) < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace replacement permit is not claimable");
+    return NULL;
+  }
+  permit = new_workspace_replacement_permit(self);
+  if (permit == NULL) {
+    return NULL;
+  }
+  self->replacement_permit_claimed = 1;
+  self->replacement_permit_active = 1;
   return permit;
 }
 
@@ -1749,7 +1939,8 @@ static PyObject *WorkspaceOwner_provision(WorkspaceOwner *self,
     return NULL;
   }
   if (self->namespace_state != WORKSPACE_EMPTY || self->closed ||
-      self->provision_started || self->anchor_fd >= 0) {
+      self->provision_started || self->replacement_permit_claimed ||
+      self->replacement_permit_active || self->anchor_fd >= 0) {
     PyErr_SetString(PyExc_RuntimeError, "native workspace owner is not empty");
     return NULL;
   }
@@ -2139,21 +2330,23 @@ static PyObject *WorkspaceOwner_capture_destination(WorkspaceOwner *self,
       self->namespace_sync_pending ||
       self->namespace_state != WORKSPACE_EMPTY ||
       self->publish_permit_claimed || self->publish_permit_active ||
-      self->anchor_fd >= 0 || self->anchor_guard_fd >= 0 ||
-      self->parent_fd >= 0 || self->parent_guard_fd >= 0 ||
-      self->root_fd >= 0 || self->root_guard_fd >= 0 ||
-      self->captured_destination_fd >= 0 ||
+      self->replacement_permit_claimed || self->replacement_permit_active ||
+      self->replacement_lock_active || self->anchor_fd >= 0 ||
+      self->anchor_guard_fd >= 0 || self->parent_fd >= 0 ||
+      self->parent_guard_fd >= 0 || self->root_fd >= 0 ||
+      self->root_guard_fd >= 0 || self->captured_destination_fd >= 0 ||
       self->captured_destination_guard_fd >= 0 || self->directories != NULL ||
       self->directory_count != 0 || self->scratch_count != 0 ||
       self->absolute_chain_count != 0 || self->relative_chain_count != 0 ||
       self->destination_name != NULL || self->destination_path != NULL ||
       self->initial_stage_name != NULL || self->stage_name != NULL ||
-      self->plan_digest != NULL || self->orphan_name != NULL ||
-      self->file_fd >= 0 || self->file_guard_fd >= 0 ||
-      self->file_name != NULL || self->file_active || self->file_failed ||
-      self->receipt_generation != 0 || self->allowed_root_policy_known ||
-      self->anchor_identity_known || self->parent_identity_known ||
-      self->root_identity_known || self->captured_destination_identity_known) {
+      self->replacement_slot_name != NULL || self->plan_digest != NULL ||
+      self->orphan_name != NULL || self->file_fd >= 0 ||
+      self->file_guard_fd >= 0 || self->file_name != NULL ||
+      self->file_active || self->file_failed || self->receipt_generation != 0 ||
+      self->allowed_root_policy_known || self->anchor_identity_known ||
+      self->parent_identity_known || self->root_identity_known ||
+      self->captured_destination_identity_known) {
     PyErr_SetString(PyExc_RuntimeError,
                     "native workspace owner is not empty for destination "
                     "capture");
@@ -2355,6 +2548,306 @@ error:
   return NULL;
 }
 
+static int verify_incumbent_at_destination(WorkspaceOwner *self) {
+  if (verify_parent_binding(self) < 0 ||
+      verify_descriptor(self->captured_destination_fd,
+                        self->captured_destination_guard_fd,
+                        self->captured_destination_device,
+                        self->captured_destination_inode) < 0 ||
+      self->captured_destination_device != self->parent_device ||
+      same_identity_at(self->parent_guard_fd, self->destination_name,
+                       self->captured_destination_device,
+                       self->captured_destination_inode) < 0) {
+    return -1;
+  }
+  return 0;
+}
+
+static PyObject *WorkspaceOwner_provision_replacement(WorkspaceOwner *self,
+                                                      PyObject *args) {
+  PyObject *slot_object;
+  PyObject *digest_object;
+  PyObject *root_mode_object;
+  PyObject *directories_object;
+  PyObject *deadline_object;
+  char *slot_name = NULL;
+  char *plan_digest = NULL;
+  long root_mode;
+  long long deadline_ns;
+  struct stat metadata;
+  dev_t opened_device;
+  ino_t opened_inode;
+  Py_ssize_t index;
+  int parent;
+  int mutation_attempted = 0;
+  const char *name;
+
+  if (require_linux() < 0 || require_owner_pid(self) < 0) {
+    return NULL;
+  }
+#if !defined(SYS_renameat2) || !defined(SYS_fstat) ||                          \
+    !defined(SYS_newfstatat) || !defined(SYS_kcmp) || !defined(SYS_close)
+  PyErr_SetString(PyExc_RuntimeError,
+                  "native strict workspace replacement requires Linux "
+                  "descriptor, flock, and renameat2 syscalls");
+  return NULL;
+#endif
+  if (self->closed || self->namespace_state != WORKSPACE_DESTINATION_CAPTURED ||
+      !self->replacement_permit_claimed || !self->replacement_permit_active ||
+      self->namespace_created || self->root_fd >= 0 ||
+      self->root_guard_fd >= 0 || self->replacement_slot_name != NULL ||
+      self->directories != NULL ||
+      verify_captured_destination_binding(self) < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace owner is not replacement-ready");
+    return NULL;
+  }
+  if (!PyArg_UnpackTuple(args, "provision_replacement", 5, 5, &slot_object,
+                         &digest_object, &root_mode_object, &directories_object,
+                         &deadline_object)) {
+    return NULL;
+  }
+  if (!PyLong_CheckExact(deadline_object)) {
+    PyErr_SetString(PyExc_TypeError,
+                    "workspace replacement deadline must be an exact integer");
+    return NULL;
+  }
+  deadline_ns = PyLong_AsLongLong(deadline_object);
+  if (deadline_ns == -1 && PyErr_Occurred()) {
+    return NULL;
+  }
+  if (deadline_ns <= 0) {
+    PyErr_SetString(PyExc_ValueError,
+                    "workspace replacement deadline is invalid");
+    return NULL;
+  }
+  if (check_deadline(deadline_ns) < 0) {
+    return NULL;
+  }
+  slot_name = copy_exact_bytes(slot_object, "workspace replacement slot",
+                               CODENIB_MAX_COMPONENT_BYTES);
+  plan_digest = copy_exact_bytes(digest_object, "workspace plan digest", 128);
+  if (slot_name == NULL || plan_digest == NULL) {
+    goto error;
+  }
+  if (!valid_component(slot_name) || slot_name[0] != '.' ||
+      strcmp(slot_name, self->destination_name) == 0 ||
+      strlen(plan_digest) != 64) {
+    PyErr_SetString(PyExc_ValueError,
+                    "native workspace replacement arguments are invalid");
+    goto error;
+  }
+  for (index = 0; index < 64; ++index) {
+    if (!((plan_digest[index] >= '0' && plan_digest[index] <= '9') ||
+          (plan_digest[index] >= 'a' && plan_digest[index] <= 'f'))) {
+      PyErr_SetString(PyExc_ValueError,
+                      "workspace plan digest must be lowercase hexadecimal");
+      goto error;
+    }
+  }
+  if (!PyLong_CheckExact(root_mode_object)) {
+    PyErr_SetString(PyExc_TypeError,
+                    "workspace root mode must be an exact integer");
+    goto error;
+  }
+  root_mode = PyLong_AsLong(root_mode_object);
+  if (root_mode == -1 && PyErr_Occurred()) {
+    goto error;
+  }
+  if (root_mode < 0 || root_mode > 0777) {
+    PyErr_SetString(PyExc_ValueError, "workspace root mode is invalid");
+    goto error;
+  }
+  if (parse_directories(self, directories_object, deadline_ns) < 0 ||
+      validate_directory_plan(self, deadline_ns) < 0 ||
+      preflight_additional_descriptor_budget((size_t)self->directory_count +
+                                             1) < 0) {
+    goto error;
+  }
+  self->replacement_slot_name = slot_name;
+  slot_name = NULL;
+  self->plan_digest = plan_digest;
+  plan_digest = NULL;
+  if (check_deadline(deadline_ns) < 0 ||
+      verify_incumbent_at_destination(self) < 0) {
+    if (!PyErr_Occurred()) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "workspace incumbent binding changed before provision");
+    }
+    goto error;
+  }
+  if (native_fstatat_retry(self->parent_guard_fd, self->replacement_slot_name,
+                           &metadata, AT_SYMLINK_NOFOLLOW) == 0) {
+    PyErr_SetString(PyExc_FileExistsError,
+                    "workspace replacement slot already exists");
+    goto error;
+  }
+  if (errno != ENOENT || check_deadline(deadline_ns) < 0) {
+    if (!PyErr_Occurred()) {
+      PyErr_SetFromErrno(PyExc_OSError);
+    }
+    goto error;
+  }
+  if (verify_incumbent_at_destination(self) < 0 ||
+      verify_allowed_root_policy(self) < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "workspace replacement binding changed before mutation");
+    goto error;
+  }
+  self->namespace_state = WORKSPACE_REPLACEMENT_PROVISIONING;
+  mutation_attempted = 1;
+  if (mkdirat(self->parent_guard_fd, self->replacement_slot_name, 0700) < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  self->namespace_created = 1;
+  self->namespace_sync_pending = 1;
+  if (identify_created_root(self) < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  self->root_identity_known = 1;
+  self->root_fd =
+      open_directory_at(self->parent_guard_fd, self->replacement_slot_name);
+  if (self->root_fd < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  self->root_guard_fd = duplicate_cloexec(self->root_fd);
+  if (self->root_guard_fd < 0) {
+    int error_number = errno;
+    discard_uncommitted_pair(&self->root_fd, &self->root_guard_fd,
+                             error_number);
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  if (record_identity(self->root_fd, &opened_device, &opened_inode, S_IFDIR) <
+      0) {
+    int error_number = errno;
+    discard_uncommitted_pair(&self->root_fd, &self->root_guard_fd,
+                             error_number);
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  if (opened_device != self->root_device || opened_inode != self->root_inode) {
+    errno = ESTALE;
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  if (native_fchmod_retry(self->root_guard_fd, (mode_t)root_mode) < 0 ||
+      same_identity_at(self->parent_guard_fd, self->replacement_slot_name,
+                       self->root_device, self->root_inode) < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  if (self->root_device != self->parent_device ||
+      self->root_device != self->captured_destination_device) {
+    PyErr_SetString(PyExc_ValueError,
+                    "workspace replacement roots cross the parent device");
+    goto error;
+  }
+  for (index = 0; index < self->directory_count; ++index) {
+    if (check_deadline(deadline_ns) < 0 ||
+        verify_incumbent_at_destination(self) < 0) {
+      if (!PyErr_Occurred()) {
+        PyErr_SetString(
+            PyExc_RuntimeError,
+            "workspace replacement binding changed during provision");
+      }
+      goto error;
+    }
+    parent = find_parent_descriptor(self, self->directories[index].path);
+    if (parent < 0) {
+      PyErr_SetString(PyExc_ValueError,
+                      "workspace directory parent is absent from its plan");
+      goto error;
+    }
+    name = path_basename(self->directories[index].path);
+    if (verify_allowed_root_policy(self) < 0 ||
+        mkdirat(parent, name, 0700) < 0 ||
+        native_fstatat_retry(parent, name, &metadata, AT_SYMLINK_NOFOLLOW) <
+            0) {
+      PyErr_SetFromErrno(PyExc_OSError);
+      goto error;
+    }
+    if (!S_ISDIR(metadata.st_mode) || metadata.st_dev == 0 ||
+        metadata.st_ino == 0) {
+      errno = EINVAL;
+      PyErr_SetFromErrno(PyExc_OSError);
+      goto error;
+    }
+    self->directories[index].device = metadata.st_dev;
+    self->directories[index].inode = metadata.st_ino;
+    self->directories[index].identity_known = 1;
+    self->directories[index].fd = open_directory_at(parent, name);
+    if (self->directories[index].fd < 0) {
+      PyErr_SetFromErrno(PyExc_OSError);
+      goto error;
+    }
+    self->directories[index].guard_fd =
+        duplicate_cloexec(self->directories[index].fd);
+    if (self->directories[index].guard_fd < 0) {
+      int error_number = errno;
+      discard_uncommitted_pair(&self->directories[index].fd,
+                               &self->directories[index].guard_fd,
+                               error_number);
+      PyErr_SetFromErrno(PyExc_OSError);
+      goto error;
+    }
+    if (record_identity(self->directories[index].fd, &opened_device,
+                        &opened_inode, S_IFDIR) < 0) {
+      int error_number = errno;
+      discard_uncommitted_pair(&self->directories[index].fd,
+                               &self->directories[index].guard_fd,
+                               error_number);
+      PyErr_SetFromErrno(PyExc_OSError);
+      goto error;
+    }
+    if (opened_device != self->directories[index].device ||
+        opened_inode != self->directories[index].inode) {
+      errno = ESTALE;
+      PyErr_SetFromErrno(PyExc_OSError);
+      goto error;
+    }
+    if (native_fchmod_retry(self->directories[index].guard_fd,
+                            self->directories[index].mode) < 0 ||
+        same_identity_at(parent, name, self->directories[index].device,
+                         self->directories[index].inode) < 0) {
+      PyErr_SetFromErrno(PyExc_OSError);
+      goto error;
+    }
+    if (self->directories[index].device != self->root_device) {
+      PyErr_SetString(
+          PyExc_ValueError,
+          "workspace directory crosses the replacement root device");
+      goto error;
+    }
+  }
+  if (native_fsync_retry(self->root_guard_fd) < 0 ||
+      native_fsync_retry(self->parent_guard_fd) < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  self->namespace_sync_pending = 0;
+  if (verify_replacement_binding(self) < 0 ||
+      verify_allowed_root_policy(self) < 0) {
+    PyErr_SetString(
+        PyExc_RuntimeError,
+        "workspace replacement binding changed before provision commit");
+    goto error;
+  }
+  self->namespace_state = WORKSPACE_REPLACEMENT_PROVISIONED;
+  Py_RETURN_NONE;
+
+error:
+  if (!mutation_attempted) {
+    free_unprovisioned_replacement_configuration(self);
+  }
+  free(slot_name);
+  free(plan_digest);
+  return NULL;
+}
+
 static int verify_descriptor(int descriptor, int guard, dev_t device,
                              ino_t inode) {
   struct stat metadata;
@@ -2497,12 +2990,125 @@ static int verify_parent_binding(WorkspaceOwner *self) {
   return 0;
 }
 
+static int metadata_matches_directory(const struct stat *metadata, dev_t device,
+                                      ino_t inode) {
+  return S_ISDIR(metadata->st_mode) && metadata->st_dev == device &&
+         metadata->st_ino == inode;
+}
+
+static enum workspace_replacement_mapping
+classify_replacement_mapping(WorkspaceOwner *self) {
+  struct stat destination_metadata;
+  struct stat slot_metadata;
+  int destination_result;
+  int slot_result;
+
+  if (self->parent_guard_fd < 0 || self->destination_name == NULL ||
+      self->replacement_slot_name == NULL || !self->root_identity_known ||
+      !self->captured_destination_identity_known) {
+    return WORKSPACE_REPLACEMENT_MAPPING_UNKNOWN;
+  }
+  destination_result =
+      native_fstatat_retry(self->parent_guard_fd, self->destination_name,
+                           &destination_metadata, AT_SYMLINK_NOFOLLOW);
+  slot_result =
+      native_fstatat_retry(self->parent_guard_fd, self->replacement_slot_name,
+                           &slot_metadata, AT_SYMLINK_NOFOLLOW);
+  if (destination_result < 0 || slot_result < 0) {
+    return WORKSPACE_REPLACEMENT_MAPPING_UNKNOWN;
+  }
+  if (metadata_matches_directory(&destination_metadata,
+                                 self->captured_destination_device,
+                                 self->captured_destination_inode) &&
+      metadata_matches_directory(&slot_metadata, self->root_device,
+                                 self->root_inode)) {
+    return WORKSPACE_REPLACEMENT_MAPPING_PREEXCHANGE;
+  }
+  if (metadata_matches_directory(&destination_metadata, self->root_device,
+                                 self->root_inode) &&
+      metadata_matches_directory(&slot_metadata,
+                                 self->captured_destination_device,
+                                 self->captured_destination_inode)) {
+    return WORKSPACE_REPLACEMENT_MAPPING_EXCHANGED;
+  }
+  return WORKSPACE_REPLACEMENT_MAPPING_UNKNOWN;
+}
+
+static int replacement_state_expects_preexchange(WorkspaceOwner *self) {
+  return self->namespace_state == WORKSPACE_REPLACEMENT_PROVISIONING ||
+         self->namespace_state == WORKSPACE_REPLACEMENT_PROVISIONED ||
+         self->namespace_state == WORKSPACE_REPLACEMENT_ADOPTED;
+}
+
+static int replacement_state_expects_exchange(WorkspaceOwner *self) {
+  return self->namespace_state == WORKSPACE_REPLACEMENT_EXCHANGED_UNRECEIPTED ||
+         self->namespace_state == WORKSPACE_REPLACEMENT_RECEIPTED;
+}
+
+static int verify_replacement_binding(WorkspaceOwner *self) {
+  enum workspace_replacement_mapping mapping;
+  Py_ssize_t index;
+
+  if (self->closed || !self->destination_capture_started ||
+      !self->namespace_created || !self->replacement_permit_claimed ||
+      self->publish_permit_claimed || self->publish_permit_active ||
+      self->destination_name == NULL || self->destination_path == NULL ||
+      self->replacement_slot_name == NULL || self->plan_digest == NULL ||
+      !self->root_identity_known ||
+      !self->captured_destination_identity_known || self->root_device == 0 ||
+      self->root_inode == 0 || self->captured_destination_device == 0 ||
+      self->captured_destination_inode == 0 ||
+      self->root_device != self->parent_device ||
+      self->captured_destination_device != self->parent_device ||
+      verify_parent_binding(self) < 0 ||
+      verify_descriptor(self->root_fd, self->root_guard_fd, self->root_device,
+                        self->root_inode) < 0 ||
+      verify_descriptor(self->captured_destination_fd,
+                        self->captured_destination_guard_fd,
+                        self->captured_destination_device,
+                        self->captured_destination_inode) < 0) {
+    errno = ESTALE;
+    return -1;
+  }
+  mapping = classify_replacement_mapping(self);
+  if ((replacement_state_expects_preexchange(self) &&
+       mapping != WORKSPACE_REPLACEMENT_MAPPING_PREEXCHANGE) ||
+      (replacement_state_expects_exchange(self) &&
+       mapping != WORKSPACE_REPLACEMENT_MAPPING_EXCHANGED) ||
+      (!replacement_state_expects_preexchange(self) &&
+       !replacement_state_expects_exchange(self))) {
+    errno = ESTALE;
+    return -1;
+  }
+  for (index = 0; index < self->directory_count; ++index) {
+    int parent;
+    const char *name;
+    if (!self->directories[index].identity_known ||
+        verify_descriptor(self->directories[index].fd,
+                          self->directories[index].guard_fd,
+                          self->directories[index].device,
+                          self->directories[index].inode) < 0) {
+      return -1;
+    }
+    parent = find_parent_descriptor(self, self->directories[index].path);
+    name = path_basename(self->directories[index].path);
+    if (parent < 0 ||
+        same_identity_at(parent, name, self->directories[index].device,
+                         self->directories[index].inode) < 0) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
 static int verify_captured_destination_binding(WorkspaceOwner *self) {
   if (self->namespace_state != WORKSPACE_DESTINATION_CAPTURED || self->closed ||
       !self->provision_started || !self->destination_capture_started ||
       self->namespace_created || self->namespace_sync_pending ||
       self->publish_permit_claimed || self->publish_permit_active ||
-      self->destination_name == NULL || self->destination_path == NULL ||
+      self->replacement_permit_active > self->replacement_permit_claimed ||
+      self->replacement_lock_active || self->destination_name == NULL ||
+      self->destination_path == NULL ||
       !self->captured_destination_identity_known ||
       self->captured_destination_device == 0 ||
       self->captured_destination_inode == 0 || self->root_fd >= 0 ||
@@ -2511,8 +3117,8 @@ static int verify_captured_destination_binding(WorkspaceOwner *self) {
       self->file_fd >= 0 || self->file_guard_fd >= 0 || self->file_active ||
       self->file_failed || self->file_name != NULL ||
       self->initial_stage_name != NULL || self->stage_name != NULL ||
-      self->plan_digest != NULL || self->orphan_name != NULL ||
-      self->receipt_generation != 0 ||
+      self->replacement_slot_name != NULL || self->plan_digest != NULL ||
+      self->orphan_name != NULL || self->receipt_generation != 0 ||
       self->parent_device != self->anchor_device ||
       self->captured_destination_device != self->parent_device ||
       verify_parent_binding(self) < 0 ||
@@ -2531,6 +3137,9 @@ static int verify_captured_destination_binding(WorkspaceOwner *self) {
 
 static int verify_owner_authority(WorkspaceOwner *self) {
   Py_ssize_t index;
+  if (self->replacement_slot_name != NULL) {
+    return verify_replacement_binding(self);
+  }
   if (self->destination_capture_started) {
     return verify_captured_destination_binding(self);
   }
@@ -2577,13 +3186,33 @@ WorkspaceOwner_verify_destination_binding(WorkspaceOwner *self,
   Py_RETURN_NONE;
 }
 
+static PyObject *
+WorkspaceOwner_verify_replacement_binding(WorkspaceOwner *self,
+                                          PyObject *Py_UNUSED(ignored)) {
+  if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if ((self->namespace_state != WORKSPACE_REPLACEMENT_PROVISIONED &&
+       self->namespace_state != WORKSPACE_REPLACEMENT_ADOPTED &&
+       self->namespace_state != WORKSPACE_REPLACEMENT_EXCHANGED_UNRECEIPTED &&
+       self->namespace_state != WORKSPACE_REPLACEMENT_RECEIPTED) ||
+      verify_replacement_binding(self) < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace replacement binding changed");
+    return NULL;
+  }
+  Py_RETURN_NONE;
+}
+
 static PyObject *WorkspaceOwner_verify(WorkspaceOwner *self,
                                        PyObject *Py_UNUSED(ignored)) {
   Py_ssize_t index;
   if (require_owner_pid(self) < 0) {
     return NULL;
   }
-  if (self->closed || verify_owner_authority(self) < 0) {
+  if (self->closed ||
+      self->namespace_state == WORKSPACE_REPLACEMENT_PROVISIONING ||
+      verify_owner_authority(self) < 0) {
     PyErr_SetString(PyExc_RuntimeError,
                     "native workspace descriptor authority changed");
     return NULL;
@@ -2613,18 +3242,42 @@ static PyObject *WorkspaceOwner_verify(WorkspaceOwner *self,
   Py_RETURN_NONE;
 }
 
+static int workspace_state_is_provisioned(WorkspaceOwner *self) {
+  return self->namespace_state == WORKSPACE_PROVISIONED ||
+         self->namespace_state == WORKSPACE_REPLACEMENT_PROVISIONED;
+}
+
+static int workspace_state_is_adopted(WorkspaceOwner *self) {
+  return self->namespace_state == WORKSPACE_ADOPTED ||
+         self->namespace_state == WORKSPACE_REPLACEMENT_ADOPTED;
+}
+
+static int workspace_state_is_replacement(WorkspaceOwner *self) {
+  return self->replacement_permit_claimed ||
+         self->replacement_slot_name != NULL || self->replacement_lock_active ||
+         self->namespace_state == WORKSPACE_REPLACEMENT_PROVISIONING ||
+         self->namespace_state == WORKSPACE_REPLACEMENT_PROVISIONED ||
+         self->namespace_state == WORKSPACE_REPLACEMENT_ADOPTED ||
+         self->namespace_state == WORKSPACE_REPLACEMENT_EXCHANGED_UNRECEIPTED ||
+         self->namespace_state == WORKSPACE_REPLACEMENT_RECEIPTED ||
+         self->namespace_state == WORKSPACE_REPLACEMENT_RECOVERY_REQUIRED;
+}
+
 static PyObject *WorkspaceOwner_mark_adopted(WorkspaceOwner *self,
                                              PyObject *Py_UNUSED(ignored)) {
   if (require_owner_pid(self) < 0) {
     return NULL;
   }
-  if (self->closed || self->namespace_state != WORKSPACE_PROVISIONED ||
+  if (self->closed || !workspace_state_is_provisioned(self) ||
       verify_owner_authority(self) < 0) {
     PyErr_SetString(PyExc_RuntimeError,
                     "native workspace owner is not provisioned");
     return NULL;
   }
-  self->namespace_state = WORKSPACE_ADOPTED;
+  self->namespace_state =
+      self->namespace_state == WORKSPACE_REPLACEMENT_PROVISIONED
+          ? WORKSPACE_REPLACEMENT_ADOPTED
+          : WORKSPACE_ADOPTED;
   Py_RETURN_NONE;
 }
 
@@ -2657,6 +3310,7 @@ static PyObject *WorkspaceOwner_verify_adoption_binding(WorkspaceOwner *self,
   PyObject *destination;
   PyObject *stage;
   PyObject *plan_digest;
+  const char *candidate_name;
 
   if (require_owner_pid(self) < 0) {
     return NULL;
@@ -2665,8 +3319,9 @@ static PyObject *WorkspaceOwner_verify_adoption_binding(WorkspaceOwner *self,
                          &stage, &plan_digest)) {
     return NULL;
   }
-  if (self->closed || self->namespace_state != WORKSPACE_PROVISIONED ||
-      self->destination_path == NULL || self->stage_name == NULL ||
+  candidate_name = candidate_namespace_name(self);
+  if (self->closed || !workspace_state_is_provisioned(self) ||
+      self->destination_path == NULL || candidate_name == NULL ||
       self->plan_digest == NULL) {
     PyErr_SetString(PyExc_RuntimeError,
                     "native workspace owner is not provisioned");
@@ -2674,7 +3329,7 @@ static PyObject *WorkspaceOwner_verify_adoption_binding(WorkspaceOwner *self,
   }
   if (exact_bytes_equal(destination, self->destination_path,
                         "workspace adoption destination") < 0 ||
-      exact_bytes_equal(stage, self->stage_name, "workspace adoption stage") <
+      exact_bytes_equal(stage, candidate_name, "workspace adoption stage") <
           0 ||
       exact_bytes_equal(plan_digest, self->plan_digest,
                         "workspace adoption plan digest") < 0) {
@@ -2849,9 +3504,8 @@ static PyObject *WorkspaceOwner_begin_file(WorkspaceOwner *self,
                          &mode_object)) {
     return NULL;
   }
-  if (self->closed || self->namespace_state != WORKSPACE_ADOPTED ||
-      self->file_active || self->file_failed ||
-      verify_owner_authority(self) < 0) {
+  if (self->closed || !workspace_state_is_adopted(self) || self->file_active ||
+      self->file_failed || verify_owner_authority(self) < 0) {
     PyErr_SetString(PyExc_RuntimeError,
                     "native workspace owner cannot begin a file");
     return NULL;
@@ -2921,7 +3575,7 @@ static PyObject *WorkspaceOwner_write_file(WorkspaceOwner *self,
   if (require_owner_pid(self) < 0) {
     return NULL;
   }
-  if (self->destination_capture_started) {
+  if (self->destination_capture_started && !workspace_state_is_adopted(self)) {
     PyErr_SetString(PyExc_RuntimeError,
                     "captured destination owner cannot write a file");
     return NULL;
@@ -2945,7 +3599,7 @@ static PyObject *WorkspaceOwner_write_file(WorkspaceOwner *self,
                     "workspace file payload exceeds the native chunk budget");
     return NULL;
   }
-  if (self->closed || self->namespace_state != WORKSPACE_ADOPTED ||
+  if (self->closed || !workspace_state_is_adopted(self) ||
       verify_inflight_file(self, &metadata) < 0) {
     self->file_failed = 1;
     PyErr_SetString(PyExc_RuntimeError,
@@ -2997,7 +3651,7 @@ static PyObject *WorkspaceOwner_finish_file(WorkspaceOwner *self,
   if (require_owner_pid(self) < 0) {
     return NULL;
   }
-  if (self->destination_capture_started) {
+  if (self->destination_capture_started && !workspace_state_is_adopted(self)) {
     PyErr_SetString(PyExc_RuntimeError,
                     "captured destination owner cannot finish a file");
     return NULL;
@@ -3009,7 +3663,7 @@ static PyObject *WorkspaceOwner_finish_file(WorkspaceOwner *self,
     }
     return NULL;
   }
-  if (self->closed || self->namespace_state != WORKSPACE_ADOPTED) {
+  if (self->closed || !workspace_state_is_adopted(self)) {
     self->file_failed = 1;
     PyErr_SetString(PyExc_RuntimeError,
                     "native workspace file is not finishable");
@@ -3085,7 +3739,7 @@ static PyObject *WorkspaceOwner_abort_file(WorkspaceOwner *self,
   if (require_owner_pid(self) < 0) {
     return NULL;
   }
-  if (self->destination_capture_started) {
+  if (self->destination_capture_started && !workspace_state_is_adopted(self)) {
     PyErr_SetString(PyExc_RuntimeError,
                     "captured destination owner cannot abort a file");
     return NULL;
@@ -3109,9 +3763,8 @@ static PyObject *WorkspaceOwner_seal_directories(WorkspaceOwner *self,
   if (require_owner_pid(self) < 0) {
     return NULL;
   }
-  if (self->closed || self->namespace_state != WORKSPACE_ADOPTED ||
-      self->file_active || self->file_failed ||
-      verify_owner_authority(self) < 0) {
+  if (self->closed || !workspace_state_is_adopted(self) || self->file_active ||
+      self->file_failed || verify_owner_authority(self) < 0) {
     PyErr_SetString(PyExc_RuntimeError,
                     "native workspace directories are not seal-ready");
     return NULL;
@@ -3140,12 +3793,17 @@ WorkspaceOwner_sync_parent_method(WorkspaceOwner *self,
   if (require_owner_pid(self) < 0) {
     return NULL;
   }
-  if (self->destination_capture_started) {
+  if (self->destination_capture_started &&
+      self->namespace_state != WORKSPACE_REPLACEMENT_PROVISIONED &&
+      self->namespace_state != WORKSPACE_REPLACEMENT_ADOPTED) {
     PyErr_SetString(PyExc_RuntimeError,
                     "captured destination owner cannot sync its parent");
     return NULL;
   }
-  if (self->closed || verify_parent_binding(self) < 0 ||
+  if (self->closed ||
+      (workspace_state_is_replacement(self)
+           ? verify_owner_authority(self)
+           : verify_parent_binding(self)) < 0 ||
       sync_parent(self) < 0) {
     if (errno == ESTALE) {
       PyErr_SetString(PyExc_RuntimeError,
@@ -3168,6 +3826,19 @@ static int rename_noreplace(int parent, const char *source,
   (void)parent;
   (void)source;
   (void)destination;
+  errno = ENOSYS;
+  return -1;
+#endif
+}
+
+static int rename_exchange(int parent, const char *left, const char *right) {
+#if defined(__linux__) && defined(SYS_renameat2)
+  return (int)syscall(SYS_renameat2, parent, left, parent, right,
+                      RENAME_EXCHANGE);
+#else
+  (void)parent;
+  (void)left;
+  (void)right;
   errno = ENOSYS;
   return -1;
 #endif
@@ -3297,7 +3968,8 @@ WorkspacePublishPermit_rename_child_noreplace(WorkspacePublishPermit *permit,
   self->namespace_sync_pending = 0;
   if (publishes_receipt) {
     ++self->receipt_generation;
-    receipt_token = new_workspace_receipt_token(self);
+    receipt_token = new_workspace_receipt_token(self, self->receipt_generation,
+                                                WORKSPACE_RECEIPT_PUBLISH);
     if (receipt_token == NULL) {
       goto error;
     }
@@ -3315,20 +3987,258 @@ error:
   return NULL;
 }
 
+static PyObject *
+WorkspaceReplacementPermit_exchange(WorkspaceReplacementPermit *permit,
+                                    PyObject *args) {
+  WorkspaceOwner *self = permit->owner;
+  PyObject *slot_object;
+  PyObject *destination_object;
+  PyObject *deadline_object;
+  char *slot = NULL;
+  char *destination = NULL;
+  long long deadline_ns;
+  uint64_t generation;
+  PyObject *receipt_token = NULL;
+  int exchange_result;
+  int exchange_error;
+  int deadline_expired;
+  enum workspace_replacement_mapping mapping;
+
+  if (self == NULL || permit->consumed || !self->replacement_permit_claimed ||
+      !self->replacement_permit_active) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace replacement permit is unavailable");
+    return NULL;
+  }
+  if (getpid() != permit->owner_pid) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace owner cannot cross a PID boundary");
+    return NULL;
+  }
+  if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (!PyArg_UnpackTuple(args, "exchange_replacement", 3, 3, &slot_object,
+                         &destination_object, &deadline_object)) {
+    return NULL;
+  }
+  slot = copy_exact_bytes(slot_object, "workspace replacement slot",
+                          CODENIB_MAX_COMPONENT_BYTES);
+  destination =
+      copy_exact_bytes(destination_object, "workspace replacement destination",
+                       CODENIB_MAX_COMPONENT_BYTES);
+  if (slot == NULL || destination == NULL) {
+    goto error;
+  }
+  if (!valid_component(slot) || !valid_component(destination) ||
+      self->replacement_slot_name == NULL || self->destination_name == NULL ||
+      strcmp(slot, self->replacement_slot_name) != 0 ||
+      strcmp(destination, self->destination_name) != 0 ||
+      strcmp(slot, destination) == 0) {
+    PyErr_SetString(PyExc_ValueError,
+                    "native workspace replacement names differ");
+    goto error;
+  }
+  if (!PyLong_CheckExact(deadline_object)) {
+    PyErr_SetString(PyExc_TypeError,
+                    "workspace exchange deadline must be an exact integer");
+    goto error;
+  }
+  deadline_ns = PyLong_AsLongLong(deadline_object);
+  if (deadline_ns == -1 && PyErr_Occurred()) {
+    goto error;
+  }
+  if (deadline_ns <= 0) {
+    PyErr_SetString(PyExc_ValueError, "workspace exchange deadline is invalid");
+    goto error;
+  }
+  if (self->closed || self->namespace_state != WORKSPACE_REPLACEMENT_ADOPTED ||
+      self->file_active || self->file_failed || self->replacement_lock_active ||
+      verify_replacement_binding(self) < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace replacement is not exchange-ready");
+    goto error;
+  }
+  if (check_deadline(deadline_ns) < 0) {
+    goto error;
+  }
+  if (self->receipt_generation == UINT64_MAX) {
+    PyErr_SetString(PyExc_OverflowError,
+                    "native workspace receipt generation exhausted");
+    goto error;
+  }
+  generation = self->receipt_generation + 1;
+  receipt_token = new_workspace_receipt_token(self, generation,
+                                              WORKSPACE_RECEIPT_REPLACEMENT);
+  if (receipt_token == NULL) {
+    goto error;
+  }
+
+  permit->consumed = 1;
+  self->replacement_permit_active = 0;
+  if (native_flock_retry(self->parent_guard_fd, LOCK_EX | LOCK_NB) < 0) {
+    if (errno == EWOULDBLOCK || errno == EAGAIN) {
+      PyErr_SetFromErrno(PyExc_BlockingIOError);
+    } else {
+      PyErr_SetFromErrno(PyExc_OSError);
+    }
+    goto error;
+  }
+  self->replacement_lock_active = 1;
+  deadline_expired = check_deadline(deadline_ns) < 0;
+  if (verify_replacement_binding(self) < 0) {
+    enter_replacement_recovery(self);
+    if (!deadline_expired) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "native workspace replacement binding changed under "
+                      "its commit lease");
+    }
+    goto error;
+  }
+  if (deadline_expired) {
+    if (release_replacement_lock(self) < 0) {
+      enter_replacement_recovery(self);
+    }
+    goto error;
+  }
+  if (check_deadline(deadline_ns) < 0) {
+    if (release_replacement_lock(self) < 0) {
+      enter_replacement_recovery(self);
+    }
+    goto error;
+  }
+
+  exchange_result =
+      rename_exchange(self->parent_guard_fd, self->replacement_slot_name,
+                      self->destination_name);
+  exchange_error = exchange_result < 0 ? (errno == 0 ? EIO : errno) : 0;
+  mapping = classify_replacement_mapping(self);
+  if (mapping == WORKSPACE_REPLACEMENT_MAPPING_EXCHANGED) {
+    self->namespace_state = WORKSPACE_REPLACEMENT_EXCHANGED_UNRECEIPTED;
+    self->namespace_sync_pending = 1;
+    self->receipt_generation = generation;
+    if (native_fsync_retry(self->parent_guard_fd) < 0) {
+      enter_replacement_recovery(self);
+      PyErr_SetFromErrno(PyExc_OSError);
+      goto error;
+    }
+    self->namespace_sync_pending = 0;
+    free(slot);
+    free(destination);
+    return receipt_token;
+  }
+  if (mapping == WORKSPACE_REPLACEMENT_MAPPING_PREEXCHANGE) {
+    if (exchange_result == 0) {
+      self->namespace_sync_pending = 1;
+      if (native_fsync_retry(self->parent_guard_fd) < 0) {
+        enter_replacement_recovery(self);
+        PyErr_SetFromErrno(PyExc_OSError);
+        goto error;
+      }
+      self->namespace_sync_pending = 0;
+    }
+    if (verify_replacement_binding(self) < 0) {
+      enter_replacement_recovery(self);
+      PyErr_SetString(PyExc_RuntimeError,
+                      "native workspace replacement binding changed after "
+                      "its exchange attempt");
+      goto error;
+    }
+    if (release_replacement_lock(self) < 0) {
+      enter_replacement_recovery(self);
+      if (exchange_result < 0) {
+        errno = exchange_error;
+        PyErr_SetFromErrno(PyExc_OSError);
+      } else {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "native workspace exchange reported success without "
+                        "swapping its exact roots");
+      }
+      goto error;
+    }
+    if (exchange_result < 0) {
+      errno = exchange_error;
+      PyErr_SetFromErrno(PyExc_OSError);
+    } else {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "native workspace exchange reported success without "
+                      "swapping its exact roots");
+    }
+    goto error;
+  }
+  enter_replacement_recovery(self);
+  PyErr_SetString(PyExc_RuntimeError,
+                  "native workspace exchange outcome is unknown");
+
+error:
+  free(slot);
+  free(destination);
+  Py_XDECREF(receipt_token);
+  return NULL;
+}
+
 static PyObject *WorkspaceReceiptToken_commit(WorkspaceReceiptToken *token) {
   WorkspaceOwner *self = token->owner;
 
-  if (self == NULL || getpid() != token->owner_pid ||
-      require_owner_pid(self) < 0) {
-    if (!PyErr_Occurred()) {
-      PyErr_SetString(PyExc_RuntimeError,
-                      "native workspace receipt token is unavailable");
-    }
+  if (self == NULL) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace receipt token is unavailable");
+    return NULL;
+  }
+  if (getpid() != token->owner_pid) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace owner cannot cross a PID boundary");
+    return NULL;
+  }
+  if (require_owner_pid(self) < 0) {
     return NULL;
   }
   if (self->closed) {
     PyErr_SetString(PyExc_RuntimeError,
                     "closed native workspace owner cannot commit a receipt");
+    return NULL;
+  }
+  if (token->kind == WORKSPACE_RECEIPT_REPLACEMENT) {
+    if (token->consumed &&
+        self->namespace_state == WORKSPACE_REPLACEMENT_RECEIPTED &&
+        token->generation == self->receipt_generation) {
+      Py_RETURN_NONE;
+    }
+    if (token->consumed || token->generation != self->receipt_generation ||
+        (self->namespace_state != WORKSPACE_REPLACEMENT_EXCHANGED_UNRECEIPTED &&
+         self->namespace_state != WORKSPACE_REPLACEMENT_RECOVERY_REQUIRED) ||
+        self->file_active || self->file_failed ||
+        !self->replacement_lock_active) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "native workspace replacement is not receipt-ready");
+      return NULL;
+    }
+    if (self->namespace_sync_pending &&
+        native_fsync_retry(self->parent_guard_fd) < 0) {
+      enter_replacement_recovery(self);
+      return PyErr_SetFromErrno(PyExc_OSError);
+    }
+    self->namespace_sync_pending = 0;
+    if (self->namespace_state == WORKSPACE_REPLACEMENT_RECOVERY_REQUIRED) {
+      self->namespace_state = WORKSPACE_REPLACEMENT_EXCHANGED_UNRECEIPTED;
+    }
+    if (verify_replacement_binding(self) < 0) {
+      enter_replacement_recovery(self);
+      PyErr_SetString(PyExc_RuntimeError,
+                      "native workspace replacement binding changed");
+      return NULL;
+    }
+    if (release_replacement_lock(self) < 0) {
+      enter_replacement_recovery(self);
+      return PyErr_SetFromErrno(PyExc_OSError);
+    }
+    self->namespace_state = WORKSPACE_REPLACEMENT_RECEIPTED;
+    token->consumed = 1;
+    Py_RETURN_NONE;
+  }
+  if (token->kind != WORKSPACE_RECEIPT_PUBLISH) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace receipt kind is invalid");
     return NULL;
   }
   if (token->consumed && self->namespace_state == WORKSPACE_RECEIPTED &&
@@ -3384,6 +4294,145 @@ static int random_bytes(unsigned char *buffer, size_t size) {
   errno = ENOSYS;
   return -1;
 #endif
+}
+
+static int ensure_replacement_candidate_authority(WorkspaceOwner *self) {
+  enum workspace_replacement_mapping mapping;
+  const char *candidate_name;
+  dev_t opened_device;
+  ino_t opened_inode;
+
+  if (!self->namespace_created || self->replacement_slot_name == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (!self->root_identity_known) {
+    /* Once mkdirat has returned, only the identity captured immediately in
+       that provisioning frame may authorize cleanup.  Adopting the current
+       slot after a later failure could bless a foreign same-name directory. */
+    errno = ESTALE;
+    return -1;
+  }
+  if (self->root_fd < 0 && self->root_guard_fd < 0) {
+    mapping = classify_replacement_mapping(self);
+    if (mapping == WORKSPACE_REPLACEMENT_MAPPING_PREEXCHANGE) {
+      candidate_name = self->replacement_slot_name;
+    } else if (mapping == WORKSPACE_REPLACEMENT_MAPPING_EXCHANGED) {
+      candidate_name = self->destination_name;
+    } else {
+      errno = ESTALE;
+      return -1;
+    }
+    self->root_fd = open_directory_at(self->parent_guard_fd, candidate_name);
+    if (self->root_fd < 0) {
+      return -1;
+    }
+    self->root_guard_fd = duplicate_cloexec(self->root_fd);
+    if (self->root_guard_fd < 0) {
+      int error_number = errno;
+      discard_uncommitted_pair(&self->root_fd, &self->root_guard_fd,
+                               error_number);
+      return -1;
+    }
+  }
+  if (record_identity(self->root_fd, &opened_device, &opened_inode, S_IFDIR) <
+          0 ||
+      opened_device != self->root_device || opened_inode != self->root_inode ||
+      opened_device != self->parent_device ||
+      verify_descriptor(self->root_fd, self->root_guard_fd, self->root_device,
+                        self->root_inode) < 0) {
+    errno = ESTALE;
+    return -1;
+  }
+  return 0;
+}
+
+static int settle_replacement_namespace_internal(WorkspaceOwner *self) {
+  enum workspace_replacement_mapping mapping;
+  int reverse_result;
+  int reverse_error;
+
+  if (!workspace_state_is_replacement(self)) {
+    return 0;
+  }
+  if (getpid() != self->owner_pid) {
+    errno = EPERM;
+    return -1;
+  }
+  if (self->namespace_state == WORKSPACE_REPLACEMENT_RECEIPTED) {
+    if (self->replacement_lock_active) {
+      errno = ESTALE;
+      return -1;
+    }
+    return 0;
+  }
+  if (self->namespace_created) {
+    if (!self->replacement_lock_active) {
+      if (native_flock_retry(self->parent_guard_fd, LOCK_EX | LOCK_NB) < 0) {
+        return -1;
+      }
+      self->replacement_lock_active = 1;
+    }
+    if (verify_parent_binding(self) < 0 ||
+        ensure_replacement_candidate_authority(self) < 0 ||
+        verify_descriptor(self->captured_destination_fd,
+                          self->captured_destination_guard_fd,
+                          self->captured_destination_device,
+                          self->captured_destination_inode) < 0) {
+      enter_replacement_recovery(self);
+      errno = ESTALE;
+      return -1;
+    }
+    mapping = classify_replacement_mapping(self);
+    if (mapping == WORKSPACE_REPLACEMENT_MAPPING_EXCHANGED) {
+      reverse_result =
+          rename_exchange(self->parent_guard_fd, self->replacement_slot_name,
+                          self->destination_name);
+      reverse_error = reverse_result < 0 ? (errno == 0 ? EIO : errno) : 0;
+      self->namespace_sync_pending = 1;
+      mapping = classify_replacement_mapping(self);
+      if (mapping != WORKSPACE_REPLACEMENT_MAPPING_PREEXCHANGE) {
+        enter_replacement_recovery(self);
+        errno = mapping == WORKSPACE_REPLACEMENT_MAPPING_EXCHANGED &&
+                        reverse_error != 0
+                    ? reverse_error
+                    : ESTALE;
+        return -1;
+      }
+    } else if (mapping != WORKSPACE_REPLACEMENT_MAPPING_PREEXCHANGE) {
+      enter_replacement_recovery(self);
+      errno = ESTALE;
+      return -1;
+    }
+  }
+  if (self->namespace_sync_pending) {
+    if (native_fsync_retry(self->parent_guard_fd) < 0) {
+      enter_replacement_recovery(self);
+      return -1;
+    }
+    self->namespace_sync_pending = 0;
+  }
+  if (self->namespace_created &&
+      (verify_parent_binding(self) < 0 ||
+       ensure_replacement_candidate_authority(self) < 0 ||
+       verify_descriptor(self->captured_destination_fd,
+                         self->captured_destination_guard_fd,
+                         self->captured_destination_device,
+                         self->captured_destination_inode) < 0 ||
+       classify_replacement_mapping(self) !=
+           WORKSPACE_REPLACEMENT_MAPPING_PREEXCHANGE)) {
+    enter_replacement_recovery(self);
+    errno = ESTALE;
+    return -1;
+  }
+  if (self->replacement_lock_active && release_replacement_lock(self) < 0) {
+    enter_replacement_recovery(self);
+    return -1;
+  }
+  if (self->namespace_created) {
+    self->namespace_state = WORKSPACE_QUARANTINED;
+  }
+  return 0;
 }
 
 static int quarantine_namespace_internal(WorkspaceOwner *self) {
@@ -3496,8 +4545,12 @@ static PyObject *WorkspaceOwner_close(WorkspaceOwner *self,
     }
     Py_RETURN_NONE;
   }
-  if (!owner_changed && self->namespace_created &&
-      self->namespace_state != WORKSPACE_RECEIPTED) {
+  if (!owner_changed && workspace_state_is_replacement(self)) {
+    if (settle_replacement_namespace_internal(self) < 0) {
+      return PyErr_SetFromErrno(PyExc_OSError);
+    }
+  } else if (!owner_changed && self->namespace_created &&
+             self->namespace_state != WORKSPACE_RECEIPTED) {
     if (quarantine_namespace_internal(self) < 0) {
       if (errno == ENOMEM) {
         PyErr_NoMemory();
@@ -3530,7 +4583,12 @@ static PyObject *WorkspaceOwner_abort(WorkspaceOwner *self,
   if (self->closed) {
     Py_RETURN_NONE;
   }
-  if (self->namespace_created && self->namespace_state != WORKSPACE_RECEIPTED) {
+  if (workspace_state_is_replacement(self)) {
+    if (settle_replacement_namespace_internal(self) < 0) {
+      return PyErr_SetFromErrno(PyExc_OSError);
+    }
+  } else if (self->namespace_created &&
+             self->namespace_state != WORKSPACE_RECEIPTED) {
     if (quarantine_namespace_internal(self) < 0) {
       if (errno == ENOMEM) {
         PyErr_NoMemory();
@@ -3555,7 +4613,10 @@ static PyObject *WorkspaceOwner_directory_descriptor(WorkspaceOwner *self,
   Py_ssize_t index;
 
   if (require_owner_pid(self) < 0 || self->closed ||
-      self->destination_capture_started || verify_owner_authority(self) < 0) {
+      (self->destination_capture_started &&
+       !workspace_state_is_provisioned(self) &&
+       !workspace_state_is_adopted(self)) ||
+      verify_owner_authority(self) < 0) {
     if (!PyErr_Occurred()) {
       PyErr_SetString(PyExc_RuntimeError, "native workspace owner is closed");
     }
@@ -3588,8 +4649,13 @@ static PyObject *WorkspaceOwner_get_parent_descriptor(WorkspaceOwner *self,
                                                       void *closure) {
   (void)closure;
   if (require_owner_pid(self) < 0 || self->closed ||
-      self->destination_capture_started || self->parent_fd < 0 ||
-      verify_parent_binding(self) < 0) {
+      (self->destination_capture_started &&
+       !workspace_state_is_provisioned(self) &&
+       !workspace_state_is_adopted(self)) ||
+      self->parent_fd < 0 ||
+      (workspace_state_is_replacement(self)
+           ? verify_owner_authority(self)
+           : verify_parent_binding(self)) < 0) {
     if (!PyErr_Occurred()) {
       PyErr_SetString(PyExc_RuntimeError,
                       "native workspace parent descriptor is unavailable");
@@ -3603,8 +4669,11 @@ static PyObject *WorkspaceOwner_get_parent_descriptor(WorkspaceOwner *self,
 static PyObject *WorkspaceOwner_get_root_descriptor(WorkspaceOwner *self,
                                                     void *closure) {
   (void)closure;
-  if (require_owner_pid(self) < 0 || self->closed || self->root_fd < 0 ||
-      verify_owner_authority(self) < 0) {
+  if (require_owner_pid(self) < 0 || self->closed ||
+      (workspace_state_is_replacement(self) &&
+       !workspace_state_is_provisioned(self) &&
+       !workspace_state_is_adopted(self)) ||
+      self->root_fd < 0 || verify_owner_authority(self) < 0) {
     if (!PyErr_Occurred()) {
       PyErr_SetString(PyExc_RuntimeError,
                       "native workspace root descriptor is unavailable");
@@ -3666,6 +4735,24 @@ static PyObject *WorkspaceOwner_get_state(WorkspaceOwner *self, void *closure) {
       break;
     case WORKSPACE_DESTINATION_CAPTURED:
       state = "destination-captured";
+      break;
+    case WORKSPACE_REPLACEMENT_PROVISIONING:
+      state = "replacement-provisioning";
+      break;
+    case WORKSPACE_REPLACEMENT_PROVISIONED:
+      state = "replacement-provisioned";
+      break;
+    case WORKSPACE_REPLACEMENT_ADOPTED:
+      state = "replacement-adopted";
+      break;
+    case WORKSPACE_REPLACEMENT_EXCHANGED_UNRECEIPTED:
+      state = "replacement-exchanged-unreceipted";
+      break;
+    case WORKSPACE_REPLACEMENT_RECEIPTED:
+      state = "replacement-receipted";
+      break;
+    case WORKSPACE_REPLACEMENT_RECOVERY_REQUIRED:
+      state = "replacement-recovery-required";
       break;
     default:
       state = "invalid";
@@ -3769,6 +4856,90 @@ require_workspace_publish_permit_exact(PyObject *candidate) {
   return (WorkspacePublishPermit *)candidate;
 }
 
+static PyObject *WorkspaceReplacementPermit_new(PyTypeObject *type,
+                                                PyObject *args,
+                                                PyObject *keywords) {
+  (void)type;
+  (void)args;
+  (void)keywords;
+  PyErr_SetString(PyExc_TypeError,
+                  "native workspace replacement permits cannot be constructed");
+  return NULL;
+}
+
+static void
+WorkspaceReplacementPermit_dealloc(WorkspaceReplacementPermit *self) {
+  freefunc release;
+  WorkspaceOwner *owner = self->owner;
+
+  self->owner = NULL;
+  if (owner != NULL) {
+    if (!self->consumed && getpid() == self->owner_pid) {
+      owner->replacement_permit_active = 0;
+    }
+    Py_DECREF((PyObject *)owner);
+  }
+  release = (freefunc)PyType_GetSlot(Py_TYPE(self), Py_tp_free);
+  if (release != NULL) {
+    release((PyObject *)self);
+  }
+}
+
+static PyType_Slot WorkspaceReplacementPermit_slots[] = {
+    {Py_tp_new, WorkspaceReplacementPermit_new},
+    {Py_tp_dealloc, WorkspaceReplacementPermit_dealloc},
+    {Py_tp_doc,
+     "Private one-shot capability for one native workspace replacement."},
+    {0, NULL},
+};
+
+static PyType_Spec WorkspaceReplacementPermit_spec = {
+    "codenib._workspace_owner_impl._WorkspaceReplacementPermit",
+    sizeof(WorkspaceReplacementPermit),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE,
+    WorkspaceReplacementPermit_slots,
+};
+
+static PyObject *new_workspace_replacement_permit(WorkspaceOwner *owner) {
+  allocfunc allocate;
+  WorkspaceReplacementPermit *permit;
+
+  if (WorkspaceReplacementPermitTypeObject == NULL) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace replacement permit type is unavailable");
+    return NULL;
+  }
+  allocate = (allocfunc)PyType_GetSlot(
+      (PyTypeObject *)WorkspaceReplacementPermitTypeObject, Py_tp_alloc);
+  if (allocate == NULL) {
+    return NULL;
+  }
+  permit = (WorkspaceReplacementPermit *)allocate(
+      (PyTypeObject *)WorkspaceReplacementPermitTypeObject, 0);
+  if (permit == NULL) {
+    return NULL;
+  }
+  Py_INCREF((PyObject *)owner);
+  permit->owner = owner;
+  permit->owner_pid = owner->owner_pid;
+  permit->consumed = 0;
+  return (PyObject *)permit;
+}
+
+static WorkspaceReplacementPermit *
+require_workspace_replacement_permit_exact(PyObject *candidate) {
+  if (WorkspaceReplacementPermitTypeObject == NULL ||
+      Py_TYPE(candidate) !=
+          (PyTypeObject *)WorkspaceReplacementPermitTypeObject) {
+    PyErr_SetString(
+        PyExc_TypeError,
+        "workspace replacement capability has an invalid native type");
+    return NULL;
+  }
+  return (WorkspaceReplacementPermit *)candidate;
+}
+
 static PyObject *WorkspaceReceiptToken_new(PyTypeObject *type, PyObject *args,
                                            PyObject *keywords) {
   (void)type;
@@ -3809,7 +4980,9 @@ static PyType_Spec WorkspaceReceiptToken_spec = {
     WorkspaceReceiptToken_slots,
 };
 
-static PyObject *new_workspace_receipt_token(WorkspaceOwner *owner) {
+static PyObject *new_workspace_receipt_token(WorkspaceOwner *owner,
+                                             uint64_t generation,
+                                             enum workspace_receipt_kind kind) {
   allocfunc allocate;
   WorkspaceReceiptToken *token;
 
@@ -3831,7 +5004,8 @@ static PyObject *new_workspace_receipt_token(WorkspaceOwner *owner) {
   Py_INCREF((PyObject *)owner);
   token->owner = owner;
   token->owner_pid = owner->owner_pid;
-  token->generation = owner->receipt_generation;
+  token->generation = generation;
+  token->kind = kind;
   token->consumed = 0;
   return (PyObject *)token;
 }
@@ -3929,11 +5103,26 @@ static PyObject *module_capture_owner_destination_exact(PyObject *module,
                                       WorkspaceOwner_capture_destination);
 }
 
+static PyObject *module_provision_owner_replacement_exact(PyObject *module,
+                                                          PyObject *args) {
+  (void)module;
+  return dispatch_owner_varargs_exact(args, 6,
+                                      "provision_owner_replacement_exact",
+                                      WorkspaceOwner_provision_replacement);
+}
+
 static PyObject *module_claim_owner_publish_permit_exact(PyObject *module,
                                                          PyObject *owner) {
   (void)module;
   return dispatch_owner_noargs_exact(owner,
                                      WorkspaceOwner_claim_publish_permit);
+}
+
+static PyObject *module_claim_owner_replacement_permit_exact(PyObject *module,
+                                                             PyObject *owner) {
+  (void)module;
+  return dispatch_owner_noargs_exact(owner,
+                                     WorkspaceOwner_claim_replacement_permit);
 }
 
 static PyObject *module_verify_owner_authority_exact(PyObject *module,
@@ -3948,6 +5137,14 @@ module_verify_owner_destination_binding_exact(PyObject *module,
   (void)module;
   return dispatch_owner_noargs_exact(owner,
                                      WorkspaceOwner_verify_destination_binding);
+}
+
+static PyObject *
+module_verify_owner_replacement_binding_exact(PyObject *module,
+                                              PyObject *owner) {
+  (void)module;
+  return dispatch_owner_noargs_exact(owner,
+                                     WorkspaceOwner_verify_replacement_binding);
 }
 
 static PyObject *module_verify_owner_adoption_binding_exact(PyObject *module,
@@ -4071,6 +5268,31 @@ static PyObject *module_rename_owner_child_noreplace_exact(PyObject *module,
   return result;
 }
 
+static PyObject *module_exchange_owner_replacement_exact(PyObject *module,
+                                                         PyObject *args) {
+  WorkspaceReplacementPermit *permit;
+  PyObject *tail;
+  PyObject *result;
+  (void)module;
+  if (!PyTuple_CheckExact(args) || PyTuple_Size(args) != 4) {
+    PyErr_SetString(
+        PyExc_TypeError,
+        "exchange_owner_replacement_exact requires exactly 4 arguments");
+    return NULL;
+  }
+  permit = require_workspace_replacement_permit_exact(PyTuple_GetItem(args, 0));
+  if (permit == NULL) {
+    return NULL;
+  }
+  tail = PyTuple_GetSlice(args, 1, 4);
+  if (tail == NULL) {
+    return NULL;
+  }
+  result = WorkspaceReplacementPermit_exchange(permit, tail);
+  Py_DECREF(tail);
+  return result;
+}
+
 static PyObject *module_commit_owner_receipt_exact(PyObject *module,
                                                    PyObject *candidate) {
   WorkspaceReceiptToken *token;
@@ -4128,6 +5350,7 @@ static PyObject *module_create_owner_exact(PyObject *module,
   (void)module;
   if (WorkspaceOwnerTypeObject == NULL ||
       WorkspacePublishPermitTypeObject == NULL ||
+      WorkspaceReplacementPermitTypeObject == NULL ||
       WorkspaceReceiptTokenTypeObject == NULL) {
     PyErr_SetString(PyExc_RuntimeError,
                     "native workspace owner type is unavailable");
@@ -4145,13 +5368,14 @@ static PyObject *module_require_owner_exact(PyObject *module, PyObject *owner) {
   return owner;
 }
 
-#define CODENIB_WORKSPACE_OWNER_PROTOCOL_VERSION 3
+#define CODENIB_WORKSPACE_OWNER_PROTOCOL_VERSION 4
 
 static PyObject *module_require_support(PyObject *module,
                                         PyObject *Py_UNUSED(ignored)) {
   (void)module;
   if (WorkspaceOwnerTypeObject == NULL ||
       WorkspacePublishPermitTypeObject == NULL ||
+      WorkspaceReplacementPermitTypeObject == NULL ||
       WorkspaceReceiptTokenTypeObject == NULL) {
     PyErr_SetString(PyExc_RuntimeError,
                     "native workspace owner ABI is incomplete");
@@ -4190,15 +5414,24 @@ static PyMethodDef workspace_module_methods[] = {
     {"capture_owner_destination_exact",
      (PyCFunction)module_capture_owner_destination_exact, METH_VARARGS,
      "Capture one existing destination through exact native-owner dispatch."},
+    {"provision_owner_replacement_exact",
+     (PyCFunction)module_provision_owner_replacement_exact, METH_VARARGS,
+     "Provision one candidate beside an exact captured destination."},
     {"claim_owner_publish_permit_exact",
      (PyCFunction)module_claim_owner_publish_permit_exact, METH_O,
      "Claim the exact owner's private one-shot publication capability."},
+    {"claim_owner_replacement_permit_exact",
+     (PyCFunction)module_claim_owner_replacement_permit_exact, METH_O,
+     "Claim the exact owner's private one-shot replacement capability."},
     {"verify_owner_authority_exact",
      (PyCFunction)module_verify_owner_authority_exact, METH_O,
      "Verify authority through exact native-owner dispatch."},
     {"verify_owner_destination_binding_exact",
      (PyCFunction)module_verify_owner_destination_binding_exact, METH_O,
      "Verify one exact captured destination binding."},
+    {"verify_owner_replacement_binding_exact",
+     (PyCFunction)module_verify_owner_replacement_binding_exact, METH_O,
+     "Verify one exact incumbent and candidate replacement binding."},
     {"verify_owner_adoption_binding_exact",
      (PyCFunction)module_verify_owner_adoption_binding_exact, METH_VARARGS,
      "Verify adoption binding through exact native-owner dispatch."},
@@ -4232,6 +5465,9 @@ static PyMethodDef workspace_module_methods[] = {
     {"rename_owner_child_noreplace_exact",
      (PyCFunction)module_rename_owner_child_noreplace_exact, METH_VARARGS,
      "Publish through one exact native publication capability."},
+    {"exchange_owner_replacement_exact",
+     (PyCFunction)module_exchange_owner_replacement_exact, METH_VARARGS,
+     "Exchange exact incumbent and candidate roots under one commit lease."},
     {"commit_owner_receipt_exact",
      (PyCFunction)module_commit_owner_receipt_exact, METH_O,
      "Commit one exact native receipt capability."},
@@ -4264,6 +5500,7 @@ PyMODINIT_FUNC PyInit__workspace_owner_impl(void) {
   PyObject *module;
   PyObject *owner_type;
   PyObject *publish_permit_type;
+  PyObject *replacement_permit_type;
   PyObject *receipt_token_type;
 
   module = PyModule_Create(&workspace_owner_module);
@@ -4286,8 +5523,16 @@ PyMODINIT_FUNC PyInit__workspace_owner_impl(void) {
     Py_DECREF(module);
     return NULL;
   }
+  replacement_permit_type = PyType_FromSpec(&WorkspaceReplacementPermit_spec);
+  if (replacement_permit_type == NULL) {
+    Py_DECREF(publish_permit_type);
+    Py_DECREF(owner_type);
+    Py_DECREF(module);
+    return NULL;
+  }
   receipt_token_type = PyType_FromSpec(&WorkspaceReceiptToken_spec);
   if (receipt_token_type == NULL) {
+    Py_DECREF(replacement_permit_type);
     Py_DECREF(publish_permit_type);
     Py_DECREF(owner_type);
     Py_DECREF(module);
@@ -4297,6 +5542,7 @@ PyMODINIT_FUNC PyInit__workspace_owner_impl(void) {
      module-level wrapper, never through mutable attribute dispatch. */
   WorkspaceOwnerTypeObject = owner_type;
   WorkspacePublishPermitTypeObject = publish_permit_type;
+  WorkspaceReplacementPermitTypeObject = replacement_permit_type;
   WorkspaceReceiptTokenTypeObject = receipt_token_type;
   return module;
 }

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -631,11 +631,23 @@ def test_registry_publishers_use_separate_workflows() -> None:
         in wheel_env["CIBW_REPAIR_WHEEL_COMMAND_LINUX"]
     )
     wheel_smoke = wheel_env["CIBW_TEST_COMMAND"]
-    assert "workspace_owner_protocol_version == 3" in wheel_smoke
+    assert "workspace_owner_protocol_version == 4" in wheel_smoke
     for symbol in (
         "capture_owner_destination_exact",
         "verify_owner_destination_binding_exact",
         "borrow_owner_destination_descriptor_exact",
+        "claim_owner_replacement_permit_exact",
+        "provision_owner_replacement_exact",
+        "verify_owner_replacement_binding_exact",
+        "exchange_owner_replacement_exact",
+    ):
+        assert symbol in wheel_smoke
+    for symbol in (
+        "claim_owner_replacement_permit",
+        "provision_owner_replacement",
+        "verify_owner_replacement_binding",
+        "exchange_owner_replacement",
+        "_bind_owner_replacement_permit",
     ):
         assert symbol in wheel_smoke
     assert "implementation.require_support() is None" in wheel_smoke
@@ -706,11 +718,15 @@ def test_registry_publishers_use_separate_workflows() -> None:
         "run"
     ]
     assert 'name == "_workspace_owner_impl.abi3.so"' in abi3_exercise
-    assert "workspace_owner_protocol_version == 3" in abi3_exercise
+    assert "workspace_owner_protocol_version == 4" in abi3_exercise
     for symbol in (
         "capture_owner_destination_exact",
         "verify_owner_destination_binding_exact",
         "borrow_owner_destination_descriptor_exact",
+        "claim_owner_replacement_permit_exact",
+        "provision_owner_replacement_exact",
+        "verify_owner_replacement_binding_exact",
+        "exchange_owner_replacement_exact",
     ):
         assert symbol in abi3_exercise
     assert "implementation.require_support() is None" in abi3_exercise
@@ -729,13 +745,30 @@ def test_registry_publishers_use_separate_workflows() -> None:
     assert "_workspace_owner.borrow_owner_destination_descriptor(" in abi3_exercise
     assert "stat.S_ISDIR(descriptor_metadata.st_mode)" in abi3_exercise
     assert "not os.get_inheritable(destination_descriptor)" in abi3_exercise
+    assert "_workspace_owner.claim_owner_replacement_permit(" in abi3_exercise
+    assert "_workspace_owner.provision_owner_replacement(" in abi3_exercise
+    assert "replacement-provisioned" in abi3_exercise
+    assert "_workspace_owner.verify_owner_adoption_binding(" in abi3_exercise
+    assert "_workspace_owner.verify_owner_replacement_binding(" in abi3_exercise
+    assert "_workspace_owner.borrow_owner_root_descriptor(" in abi3_exercise
+    assert "not os.get_inheritable(replacement_descriptor)" in abi3_exercise
+    assert "_workspace_owner.mark_owner_adopted(" in abi3_exercise
+    assert "replacement-adopted" in abi3_exercise
+    assert "_workspace_owner.begin_owner_file(" in abi3_exercise
+    assert "_workspace_owner.write_owner_file(" in abi3_exercise
+    assert "_workspace_owner.finish_owner_file(" in abi3_exercise
+    assert "_workspace_owner.seal_owner_directories(" in abi3_exercise
+    assert "_workspace_owner.exchange_owner_replacement(" in abi3_exercise
+    assert "replacement-exchanged-unreceipted" in abi3_exercise
+    assert abi3_exercise.count("_workspace_owner.commit_owner_receipt(") == 2
+    assert "replacement-receipted" in abi3_exercise
     assert "os.close(destination_descriptor)" not in abi3_exercise
+    assert "os.close(replacement_descriptor)" not in abi3_exercise
     assert "_workspace_owner.close_owner_exact(captured_owner)" in abi3_exercise
     assert "_workspace_owner.owner_closed(captured_owner)" in abi3_exercise
-    assert "tuple(path.name for path in root.iterdir()) == destination_names" in (
-        abi3_exercise
-    )
-    assert abi3_exercise.count("assert output.read_bytes() == payload") == 2
+    assert 'owner_state(captured_owner) == "closed"' in abi3_exercise
+    assert "assert output.read_bytes() == replacement_payload" in abi3_exercise
+    assert "replacement.joinpath" in abi3_exercise
 
     compatible_install_steps = {
         "abi3-smoke": "Install the compatible ABI3 wheel",
@@ -767,3 +800,107 @@ def test_registry_publishers_use_separate_workflows() -> None:
                 revision = action.rpartition("@")[2]
                 assert len(revision) == 40
                 assert all(character in "0123456789abcdef" for character in revision)
+
+
+def test_both_release_wheel_architectures_run_protocol_v4_exchange_smoke() -> None:
+    root = Path(__file__).resolve().parents[1]
+    with (root / ".github/workflows/release-verify.yml").open(
+        encoding="utf-8"
+    ) as handle:
+        verification = yaml.load(handle, Loader=yaml.BaseLoader)
+
+    wheel_job = verification["jobs"]["build-wheel"]
+    architectures = wheel_job["strategy"]["matrix"]["arch"]
+    wheel_step = next(
+        step
+        for step in wheel_job["steps"]
+        if step["name"] == "Build and smoke-test wheel"
+    )
+    smoke_template = wheel_step["env"]["CIBW_TEST_COMMAND"]
+    expanded_smokes = {
+        architecture: smoke_template.replace("${{ matrix.arch }}", architecture)
+        for architecture in architectures
+    }
+
+    assert set(expanded_smokes) == {"x86_64", "aarch64"}
+    for architecture, smoke in expanded_smokes.items():
+        assert f"platform.machine() == {architecture!r}" in smoke
+        for operation in (
+            "capture_owner_destination(",
+            "verify_owner_destination_binding(",
+            "claim_owner_replacement_permit(",
+            "provision_owner_replacement(",
+            "verify_owner_adoption_binding(",
+            "borrow_owner_root_descriptor(",
+            "mark_owner_adopted(",
+            "begin_owner_file(",
+            "write_owner_file(",
+            "finish_owner_file(",
+            "seal_owner_directories(",
+            "verify_owner_replacement_binding(",
+        ):
+            assert f"_workspace_owner.{operation}" in smoke
+        assert smoke.count("_workspace_owner.exchange_owner_replacement(") == 2
+        assert smoke.count("_workspace_owner.commit_owner_receipt(") == 2
+        assert "success_committed = True" in smoke
+        assert "replacement-exchanged-unreceipted" in smoke
+        assert "replacement-receipted" in smoke
+        assert smoke.count('owner_state(success_owner) == "closed"') == 1
+        assert smoke.count('owner_state(rollback_owner) == "closed"') == 1
+        assert "_workspace_owner.abort_owner(rollback_owner)" in smoke
+        assert "rollback_incumbent_identity" in smoke
+        assert "rollback_candidate_identity" in smoke
+        assert 'rollback_destination / "incumbent.txt"' in smoke
+        assert 'rollback_slot / "data/result.json"' in smoke
+        assert "os.close(" not in smoke
+
+
+def test_protocol_v4_workspace_replacement_limits_are_documented() -> None:
+    root = Path(__file__).resolve().parents[1]
+    provider = (root / "docs/development/local-workspace-provider.md").read_text(
+        encoding="utf-8"
+    )
+    roadmap = (root / "docs/storage_backend_roadmap.md").read_text(encoding="utf-8")
+    provider_prose = " ".join(provider.split())
+
+    for text in (provider, roadmap):
+        prose = " ".join(text.split())
+        assert "protocol v4" in text.lower()
+        assert "renameat2(RENAME_EXCHANGE)" in text
+        assert "flock(LOCK_EX | LOCK_NB)" in text
+        assert "open-file-description (OFD)" in text
+        assert "replacement-exchanged-unreceipted" in text
+        assert "replacement-receipted" in text
+        assert "replacement-recovery-required" in text
+        assert "SIGKILL" in text
+        assert "process exit" in prose
+        assert "same exact" in prose
+        assert "unconsumed" in prose
+        assert "reclassification" in prose
+        assert "before a token is returned" in prose
+        assert "no token" in prose
+        assert "operator-restored" in prose
+        assert "before eventual unlock" in prose
+        assert "after close" in prose
+        assert "no longer a retry capability" in prose
+        assert "single-writer" in prose
+        assert "stale" in prose
+        assert "auto-adopt" in prose
+        assert "does not generate" in prose
+        assert "randomness" in prose
+
+    assert "There is no portable or multi-rename fallback" in provider
+    assert "this is live atomicity, not crash recovery" in provider_prose
+    assert "borrowers must never close them" in provider_prose
+    for symbol in (
+        "claim_owner_replacement_permit_exact",
+        "provision_owner_replacement_exact",
+        "verify_owner_replacement_binding_exact",
+        "exchange_owner_replacement_exact",
+        "WorkspaceReplacementPermit",
+        "WorkspaceReceiptToken",
+    ):
+        assert symbol in provider
+    assert "the provider remains missing-only" in provider_prose
+    assert "Gate C and M1 remain open" in provider_prose
+    assert "Gate C remains pending and required before M1 closes" in roadmap

--- a/test/test_workspace_owner.py
+++ b/test/test_workspace_owner.py
@@ -110,6 +110,60 @@ def _capture_existing_destination(root: Path, destination: bytes) -> object:
     return owner
 
 
+def _provision_replacement(
+    root: Path,
+    *,
+    destination: bytes = b"published",
+    slot: bytes = b".replacement",
+    plan: WorkspacePlan | None = None,
+) -> tuple[object, WorkspacePlan, object, int]:
+    selected_plan = _file_plan() if plan is None else plan
+    owner = _capture_existing_destination(root, destination)
+    incumbent_descriptor = workspace_owner.borrow_owner_destination_descriptor(owner)
+    replacement_permit = workspace_owner.claim_owner_replacement_permit(owner)
+    workspace_owner.provision_owner_replacement(
+        owner,
+        slot,
+        selected_plan.digest.encode("ascii"),
+        selected_plan.root_mode,
+        tuple(
+            (os.fsencode(item.path.as_posix()), item.mode)
+            for item in selected_plan.directories
+        ),
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    return owner, selected_plan, replacement_permit, incumbent_descriptor
+
+
+def _adopt_and_fill_replacement(
+    root: Path,
+    owner: object,
+    plan: WorkspacePlan,
+    *,
+    destination: bytes = b"published",
+    slot: bytes = b".replacement",
+    payload: bytes = b"replacement",
+) -> None:
+    workspace_owner.verify_owner_adoption_binding(
+        owner,
+        os.fsencode(root / os.fsdecode(destination)),
+        slot,
+        plan.digest.encode("ascii"),
+    )
+    workspace_owner.mark_owner_adopted(owner)
+    if plan.files:
+        file_spec = plan.files[0]
+        workspace_owner.begin_owner_file(
+            owner,
+            os.fsencode(file_spec.path.parent.as_posix()),
+            os.fsencode(file_spec.path.name),
+            file_spec.mode,
+        )
+        workspace_owner.write_owner_file(owner, payload)
+        workspace_owner.finish_owner_file(owner, file_spec.mode)
+    workspace_owner.seal_owner_directories(owner)
+
+
 def _tree_fingerprint(root: Path) -> tuple[tuple[object, ...], ...]:
     entries: list[tuple[object, ...]] = []
     for path in (root, *sorted(root.rglob("*"))):
@@ -134,6 +188,290 @@ def _tree_fingerprint(root: Path) -> tuple[tuple[object, ...], ...]:
             )
         )
     return tuple(entries)
+
+
+def _compile_exchange_fault_shim(tmp_path: Path) -> Path:
+    compiler = shutil.which("cc")
+    if compiler is None:
+        pytest.skip("a C compiler is required for the exchange fault shim")
+    source = tmp_path / "exchange_faults.c"
+    library = tmp_path / "exchange_faults.so"
+    source.write_text(
+        textwrap.dedent(
+            r"""
+            #define _GNU_SOURCE
+            #include <dlfcn.h>
+            #include <errno.h>
+            #include <fcntl.h>
+            #include <stdarg.h>
+            #include <stdlib.h>
+            #include <string.h>
+            #include <sys/file.h>
+            #include <sys/syscall.h>
+            #include <unistd.h>
+
+            #ifndef RENAME_EXCHANGE
+            #define RENAME_EXCHANGE (1U << 1)
+            #endif
+
+            typedef long (*syscall_function)(long, ...);
+            typedef int (*fsync_function)(int);
+            typedef int (*flock_function)(int, int);
+
+            static syscall_function real_syscall;
+            static fsync_function real_fsync;
+            static flock_function real_flock;
+            static int exchange_calls;
+            static int exchange_live;
+            static int fsync_failed;
+            static int unlock_failed;
+            static int slot_stats;
+            static int post_exchange_fsyncs;
+            static int lock_rebind_injected;
+            static int lock_delay_injected;
+
+            static const char *fault_mode(void) {
+              const char *mode = getenv("CODENIB_EXCHANGE_FAULT");
+              return mode == NULL ? "" : mode;
+            }
+
+            static void resolve_symbols(void) {
+              if (real_syscall == NULL) {
+                real_syscall = (syscall_function)dlsym(RTLD_NEXT, "syscall");
+              }
+              if (real_fsync == NULL) {
+                real_fsync = (fsync_function)dlsym(RTLD_NEXT, "fsync");
+              }
+              if (real_flock == NULL) {
+                real_flock = (flock_function)dlsym(RTLD_NEXT, "flock");
+              }
+            }
+
+            long syscall(long number, ...) {
+              va_list arguments;
+              long first;
+              long second;
+              long third;
+              long fourth;
+              long fifth;
+              long sixth;
+              long result;
+              const char *mode;
+
+              resolve_symbols();
+              if (real_syscall == NULL) {
+                errno = ENOSYS;
+                return -1;
+              }
+              mode = fault_mode();
+              va_start(arguments, number);
+              first = va_arg(arguments, long);
+              if (number == SYS_close) {
+                va_end(arguments);
+                return real_syscall(number, first);
+              }
+              second = va_arg(arguments, long);
+              if (number == SYS_fstat) {
+                va_end(arguments);
+                return real_syscall(number, first, second);
+              }
+              third = va_arg(arguments, long);
+              fourth = va_arg(arguments, long);
+              if (number == SYS_newfstatat) {
+                va_end(arguments);
+                if (strcmp(mode, "provision-identity-fail") == 0 &&
+                    second != 0 &&
+                    strcmp((const char *)second, ".replacement") == 0 &&
+                    ++slot_stats == 2) {
+                  errno = EIO;
+                  return -1;
+                }
+                return real_syscall(number, first, second, third, fourth);
+              }
+              fifth = va_arg(arguments, long);
+              if (number == SYS_kcmp) {
+                va_end(arguments);
+                return real_syscall(number, first, second, third, fourth, fifth);
+              }
+              if (number == SYS_renameat2) {
+                va_end(arguments);
+                if ((unsigned int)fifth != RENAME_EXCHANGE) {
+                  return real_syscall(number, first, second, third, fourth, fifth);
+                }
+                ++exchange_calls;
+                if (strcmp(mode, "unsupported") == 0) {
+                  errno = EOPNOTSUPP;
+                  return -1;
+                }
+                if (strcmp(mode, "success-without-swap") == 0) {
+                  return 0;
+                }
+                if (strcmp(mode, "reverse-error-once") == 0 &&
+                    exchange_calls == 2) {
+                  errno = EIO;
+                  return -1;
+                }
+                if (strcmp(mode, "reverse-success-without-restore") == 0 &&
+                    exchange_calls == 2) {
+                  return 0;
+                }
+                result = real_syscall(number, first, second, third, fourth, fifth);
+                if (result == 0) {
+                  exchange_live = !exchange_live;
+                }
+                if (strcmp(mode, "error-after-swap") == 0 &&
+                    exchange_calls == 1 && result == 0) {
+                  errno = EIO;
+                  return -1;
+                }
+                if (strcmp(mode, "reverse-error-after-restore") == 0 &&
+                    exchange_calls == 2 && result == 0) {
+                  errno = EIO;
+                  return -1;
+                }
+                return result;
+              }
+              sixth = va_arg(arguments, long);
+              va_end(arguments);
+              return real_syscall(
+                  number, first, second, third, fourth, fifth, sixth
+              );
+            }
+
+            int fsync(int descriptor) {
+              const char *mode;
+              resolve_symbols();
+              if (real_fsync == NULL) {
+                errno = ENOSYS;
+                return -1;
+              }
+              mode = fault_mode();
+              if (exchange_calls > 0) {
+                ++post_exchange_fsyncs;
+              }
+              if (!fsync_failed && exchange_live &&
+                  strcmp(mode, "forward-fsync-once") == 0) {
+                fsync_failed = 1;
+                errno = EIO;
+                return -1;
+              }
+              if (!fsync_failed && !exchange_live && exchange_calls >= 2 &&
+                  strcmp(mode, "reverse-fsync-once") == 0) {
+                fsync_failed = 1;
+                errno = EIO;
+                return -1;
+              }
+              return real_fsync(descriptor);
+            }
+
+            int flock(int descriptor, int operation) {
+              int result;
+              resolve_symbols();
+              if (real_flock == NULL) {
+                errno = ENOSYS;
+                return -1;
+              }
+              if (!unlock_failed && exchange_live && operation == LOCK_UN &&
+                  strcmp(fault_mode(), "unlock-fail-once") == 0) {
+                unlock_failed = 1;
+                errno = EIO;
+                return -1;
+              }
+              if (!unlock_failed && operation == LOCK_UN &&
+                  strcmp(fault_mode(),
+                         "deadline-after-lock-unlock-fail") == 0) {
+                unlock_failed = 1;
+                errno = EIO;
+                return -1;
+              }
+              result = real_flock(descriptor, operation);
+              if (result == 0 && !lock_delay_injected &&
+                  operation == (LOCK_EX | LOCK_NB) &&
+                  strcmp(fault_mode(),
+                         "deadline-after-lock-unlock-fail") == 0) {
+                lock_delay_injected = 1;
+                usleep(100000);
+              }
+              if (result == 0 && !lock_rebind_injected &&
+                  operation == (LOCK_EX | LOCK_NB) &&
+                  strcmp(fault_mode(), "slot-rebind-after-lock") == 0) {
+                if (real_syscall(SYS_renameat2, descriptor, ".replacement",
+                                 descriptor, ".foreign", RENAME_EXCHANGE) != 0) {
+                  int exchange_error = errno;
+                  real_flock(descriptor, LOCK_UN);
+                  errno = exchange_error;
+                  return -1;
+                }
+                lock_rebind_injected = 1;
+              }
+              return result;
+            }
+
+            int codenib_exchange_fault_exchange_calls(void) {
+              return exchange_calls;
+            }
+
+            int codenib_exchange_fault_fsync_failed(void) {
+              return fsync_failed;
+            }
+
+            int codenib_exchange_fault_unlock_failed(void) {
+              return unlock_failed;
+            }
+
+            int codenib_exchange_fault_slot_stats(void) {
+              return slot_stats;
+            }
+
+            int codenib_exchange_fault_post_exchange_fsyncs(void) {
+              return post_exchange_fsyncs;
+            }
+
+            int codenib_exchange_fault_lock_rebind_injected(void) {
+              return lock_rebind_injected;
+            }
+
+            int codenib_exchange_fault_lock_delay_injected(void) {
+              return lock_delay_injected;
+            }
+            """
+        ),
+        encoding="utf-8",
+    )
+    subprocess.run(
+        [compiler, "-shared", "-fPIC", "-O2", "-Wall", "-o", library, source, "-ldl"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return library
+
+
+def _run_exchange_fault_script(
+    root: Path,
+    library: Path,
+    mode: str,
+    script: str,
+) -> None:
+    repository_root = Path(__file__).resolve().parents[1]
+    environment = dict(os.environ)
+    existing_preload = environment.get("LD_PRELOAD")
+    environment["LD_PRELOAD"] = os.pathsep.join(
+        value for value in (os.fspath(library), existing_preload) if value
+    )
+    environment["CODENIB_EXCHANGE_FAULT"] = mode
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (str(repository_root), environment.get("PYTHONPATH", ""))
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script, os.fspath(root), os.fspath(library)],
+        cwd=repository_root,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
 
 
 def test_workspace_owner_facade_rejects_an_incomplete_abi(
@@ -215,18 +553,21 @@ def test_workspace_owner_facade_rejects_symbol_complete_protocol_v2() -> None:
     )
 
 
-def test_workspace_owner_facade_rejects_each_incomplete_protocol_v3_abi() -> None:
+def test_workspace_owner_facade_rejects_symbol_complete_protocol_v3() -> None:
     required_symbols = (
         "require_support",
         "create_owner_exact",
         "claim_owner_publish_permit_exact",
+        "claim_owner_replacement_permit_exact",
         "require_owner_exact",
         "close_owner_exact",
         "provision_owner_exact",
         "capture_owner_destination_exact",
+        "provision_owner_replacement_exact",
         "verify_owner_authority_exact",
         "verify_owner_adoption_binding_exact",
         "verify_owner_destination_binding_exact",
+        "verify_owner_replacement_binding_exact",
         "borrow_owner_parent_descriptor_exact",
         "borrow_owner_root_descriptor_exact",
         "borrow_owner_destination_descriptor_exact",
@@ -239,6 +580,79 @@ def test_workspace_owner_facade_rejects_each_incomplete_protocol_v3_abi() -> Non
         "sync_owner_parent_exact",
         "mark_owner_adopted_exact",
         "rename_owner_child_noreplace_exact",
+        "exchange_owner_replacement_exact",
+        "commit_owner_receipt_exact",
+        "abort_owner_exact",
+        "quarantine_owner_exact",
+        "owner_state_exact",
+        "owner_closed_exact",
+    )
+    script = textwrap.dedent(
+        f"""
+        import sys
+        import types
+
+        implementation = types.ModuleType("codenib._workspace_owner_impl")
+        implementation.workspace_owner_protocol_version = 3
+        for name in {required_symbols!r}:
+            setattr(implementation, name, lambda *args, **kwargs: None)
+        sys.modules[implementation.__name__] = implementation
+
+        import codenib._workspace_owner as facade
+
+        assert not facade._workspace_owner_protocol_available
+        try:
+            facade.require_support()
+        except RuntimeError as error:
+            assert "workspace-owner extension" in str(error)
+        else:
+            raise AssertionError("protocol-v3 implementation was accepted")
+        """
+    )
+    repository_root = Path(__file__).resolve().parents[1]
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (str(repository_root), environment.get("PYTHONPATH", ""))
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repository_root,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_workspace_owner_facade_rejects_each_incomplete_protocol_v4_abi() -> None:
+    required_symbols = (
+        "require_support",
+        "create_owner_exact",
+        "claim_owner_publish_permit_exact",
+        "claim_owner_replacement_permit_exact",
+        "require_owner_exact",
+        "close_owner_exact",
+        "provision_owner_exact",
+        "capture_owner_destination_exact",
+        "provision_owner_replacement_exact",
+        "verify_owner_authority_exact",
+        "verify_owner_adoption_binding_exact",
+        "verify_owner_destination_binding_exact",
+        "verify_owner_replacement_binding_exact",
+        "borrow_owner_parent_descriptor_exact",
+        "borrow_owner_root_descriptor_exact",
+        "borrow_owner_destination_descriptor_exact",
+        "borrow_owner_directory_descriptor_exact",
+        "begin_owner_file_exact",
+        "write_owner_file_exact",
+        "finish_owner_file_exact",
+        "abort_owner_file_exact",
+        "seal_owner_directories_exact",
+        "sync_owner_parent_exact",
+        "mark_owner_adopted_exact",
+        "rename_owner_child_noreplace_exact",
+        "exchange_owner_replacement_exact",
         "commit_owner_receipt_exact",
         "abort_owner_exact",
         "quarantine_owner_exact",
@@ -260,7 +674,7 @@ def test_workspace_owner_facade_rejects_each_incomplete_protocol_v3_abi() -> Non
         )
         for missing in required:
             implementation = types.ModuleType("codenib._workspace_owner_impl")
-            implementation.workspace_owner_protocol_version = 3
+            implementation.workspace_owner_protocol_version = 4
             for name in required:
                 if name != missing:
                     setattr(implementation, name, lambda *args, **kwargs: None)
@@ -279,7 +693,7 @@ def test_workspace_owner_facade_rejects_each_incomplete_protocol_v3_abi() -> Non
             except RuntimeError as error:
                 assert "workspace-owner extension" in str(error)
             else:
-                raise AssertionError(f"incomplete protocol-v3 ABI accepted: {{missing}}")
+                raise AssertionError(f"incomplete protocol-v4 ABI accepted: {{missing}}")
         """
     )
     repository_root = Path(__file__).resolve().parents[1]
@@ -576,6 +990,106 @@ def test_native_low_available_fd_failure_is_cleanup_atomic(tmp_path: Path) -> No
     )
     if completed.returncode == 77:
         pytest.skip("RLIMIT_NOFILE is too low for the probe")
+    assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="requires Linux")
+def test_native_replacement_additional_fd_budget_fails_before_mkdir(
+    tmp_path: Path,
+) -> None:
+    probe_owner = _require_native_owner()
+    workspace_owner.close_owner_exact(probe_owner)
+    root = tmp_path / "replacement-low-fd"
+    (root / "published").mkdir(parents=True)
+    root.chmod(0o700)
+    script = textwrap.dedent(
+        """
+        import errno
+        import gc
+        import os
+        import resource
+        import sys
+        import time
+
+        import codenib._workspace_owner as workspace_owner
+
+        root = os.fsencode(sys.argv[1])
+        owner = workspace_owner.create_owner()
+        workspace_owner.capture_owner_destination(
+            owner,
+            root,
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        permit = workspace_owner.claim_owner_replacement_permit(owner)
+        soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+        selected_limit = (
+            128 if hard_limit == resource.RLIM_INFINITY else min(hard_limit, 128)
+        )
+        if selected_limit < 96:
+            raise SystemExit(77)
+        resource.setrlimit(resource.RLIMIT_NOFILE, (selected_limit, hard_limit))
+        pressure = []
+        try:
+            while True:
+                pressure.append(
+                    os.open("/dev/null", os.O_RDONLY | getattr(os, "O_CLOEXEC", 0))
+                )
+        except OSError as error:
+            assert error.errno == errno.EMFILE
+        for descriptor in pressure[-11:]:
+            os.close(descriptor)
+        del pressure[-11:]
+
+        try:
+            workspace_owner.provision_owner_replacement(
+                owner,
+                b".replacement",
+                b"0" * 64,
+                0o700,
+                (),
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        except OSError as error:
+            assert error.errno == errno.EMFILE
+        else:
+            raise AssertionError("replacement descriptor preflight succeeded")
+        assert workspace_owner.owner_state(owner) == "destination-captured"
+        assert not os.path.exists(os.path.join(os.fsdecode(root), ".replacement"))
+
+        workspace_owner.abort_owner(owner)
+        assert workspace_owner.owner_closed(owner)
+        del permit
+        del owner
+        gc.collect()
+        targets = []
+        for name in os.listdir("/proc/self/fd"):
+            try:
+                target = os.readlink(f"/proc/self/fd/{name}")
+            except OSError:
+                continue
+            if os.fsdecode(root) in target:
+                targets.append(target)
+        assert targets == []
+        for descriptor in pressure:
+            os.close(descriptor)
+        """
+    )
+    repository_root = Path(__file__).resolve().parents[1]
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (str(repository_root), environment.get("PYTHONPATH", ""))
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script, os.fspath(root)],
+        cwd=repository_root,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode == 77:
+        pytest.skip("RLIMIT_NOFILE is too low for the replacement probe")
     assert completed.returncode == 0, completed.stderr
 
 
@@ -1860,3 +2374,1635 @@ def test_native_captured_destination_child_revokes_inherited_fds_without_mutatio
     workspace_owner.abort_owner(owner)
     assert workspace_owner.owner_closed(owner)
     assert _tree_fingerprint(root) == before
+
+
+def test_native_owner_atomically_exchanges_exact_replacement_and_commits_receipt(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "incumbent.txt").write_bytes(b"incumbent")
+    incumbent_identity = destination.stat().st_dev, destination.stat().st_ino
+    owner, plan, permit, incumbent_descriptor = _provision_replacement(root)
+
+    assert workspace_owner.owner_state(owner) == "replacement-provisioned"
+    candidate_descriptor = workspace_owner.borrow_owner_root_descriptor(owner)
+    parent_descriptor = workspace_owner.borrow_owner_parent_descriptor(owner)
+    assert os.fstat(incumbent_descriptor).st_ino == incumbent_identity[1]
+    _adopt_and_fill_replacement(root, owner, plan)
+    assert workspace_owner.owner_state(owner) == "replacement-adopted"
+    assert workspace_owner.verify_owner_replacement_binding(owner) is None
+
+    receipt_token = workspace_owner.exchange_owner_replacement(
+        permit,
+        b".replacement",
+        b"published",
+        time.monotonic_ns() + 10_000_000_000,
+    )
+
+    assert workspace_owner.owner_state(owner) == ("replacement-exchanged-unreceipted")
+    assert workspace_owner.verify_owner_replacement_binding(owner) is None
+    assert (destination / "views/bm25/documents.json").read_bytes() == b"replacement"
+    assert (root / ".replacement" / "incumbent.txt").read_bytes() == b"incumbent"
+    assert (
+        os.fstat(candidate_descriptor).st_dev,
+        os.fstat(candidate_descriptor).st_ino,
+    ) == (
+        destination.stat().st_dev,
+        destination.stat().st_ino,
+    )
+    assert (
+        os.fstat(incumbent_descriptor).st_dev,
+        os.fstat(incumbent_descriptor).st_ino,
+    ) == (
+        (root / ".replacement").stat().st_dev,
+        (root / ".replacement").stat().st_ino,
+    )
+
+    independent_parent = os.open(
+        root,
+        os.O_RDONLY
+        | os.O_DIRECTORY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_CLOEXEC", 0),
+    )
+    try:
+        with pytest.raises(BlockingIOError):
+            fcntl.flock(independent_parent, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        workspace_owner.commit_owner_receipt(receipt_token)
+        workspace_owner.commit_owner_receipt(receipt_token)
+        assert workspace_owner.owner_state(owner) == "replacement-receipted"
+        fcntl.flock(independent_parent, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(independent_parent, fcntl.LOCK_UN)
+    finally:
+        os.close(independent_parent)
+
+    assert os.fstat(parent_descriptor).st_ino == root.stat().st_ino
+    workspace_owner.close_owner_exact(owner)
+    assert workspace_owner.owner_closed(owner)
+    assert (destination / "views/bm25/documents.json").read_bytes() == b"replacement"
+    assert (root / ".replacement" / "incumbent.txt").read_bytes() == b"incumbent"
+
+
+def test_native_owner_rolls_back_unreceipted_replacement_and_quarantines_candidate(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "incumbent.txt").write_bytes(b"incumbent")
+    owner, plan, permit, _incumbent_descriptor = _provision_replacement(root)
+    _adopt_and_fill_replacement(root, owner, plan, payload=b"candidate")
+    workspace_owner.exchange_owner_replacement(
+        permit,
+        b".replacement",
+        b"published",
+        time.monotonic_ns() + 10_000_000_000,
+    )
+
+    assert workspace_owner.abort_owner(owner) is None
+
+    assert workspace_owner.owner_closed(owner)
+    assert (destination / "incumbent.txt").read_bytes() == b"incumbent"
+    assert (root / ".replacement" / "views/bm25/documents.json").read_bytes() == (
+        b"candidate"
+    )
+
+
+def test_native_owner_baseexception_after_exchange_return_rolls_back_exactly(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "incumbent.txt").write_bytes(b"incumbent")
+    owner, plan, permit, _incumbent_descriptor = _provision_replacement(root)
+    _adopt_and_fill_replacement(root, owner, plan, payload=b"candidate")
+    error = KeyboardInterrupt("after native exchange return")
+
+    with pytest.raises(KeyboardInterrupt) as raised:
+        try:
+            workspace_owner.exchange_owner_replacement(
+                permit,
+                b".replacement",
+                b"published",
+                time.monotonic_ns() + 10_000_000_000,
+            )
+            raise error
+        finally:
+            workspace_owner.abort_owner(owner)
+
+    assert raised.value is error
+    assert workspace_owner.owner_closed(owner)
+    assert (destination / "incumbent.txt").read_bytes() == b"incumbent"
+    assert (root / ".replacement" / "views/bm25/documents.json").read_bytes() == (
+        b"candidate"
+    )
+
+
+def test_native_replacement_commit_is_idempotent_after_return_interruption(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "incumbent.txt").write_bytes(b"incumbent")
+    owner, plan, permit, _incumbent_descriptor = _provision_replacement(root)
+    _adopt_and_fill_replacement(root, owner, plan, payload=b"candidate")
+    receipt_token = workspace_owner.exchange_owner_replacement(
+        permit,
+        b".replacement",
+        b"published",
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    exact_commit = workspace_owner._commit_owner_receipt_exact
+    assert exact_commit is not None
+    interruption = KeyboardInterrupt("after replacement commit return")
+
+    def commit_then_interrupt(token: object) -> None:
+        assert exact_commit(token) is None
+        raise interruption
+
+    monkeypatch.setattr(
+        workspace_owner,
+        "_commit_owner_receipt_exact",
+        commit_then_interrupt,
+    )
+    with pytest.raises(KeyboardInterrupt) as raised:
+        workspace_owner.commit_owner_receipt(receipt_token)
+    assert raised.value is interruption
+    assert workspace_owner.owner_state(owner) == "replacement-receipted"
+
+    monkeypatch.setattr(
+        workspace_owner,
+        "_commit_owner_receipt_exact",
+        exact_commit,
+    )
+    workspace_owner.commit_owner_receipt(receipt_token)
+    workspace_owner.close_owner_exact(owner)
+    assert (destination / "views/bm25/documents.json").read_bytes() == b"candidate"
+    assert (root / ".replacement" / "incumbent.txt").read_bytes() == b"incumbent"
+
+
+def test_native_replacement_requires_exact_bounded_arguments(tmp_path: Path) -> None:
+    class BytesSubclass(bytes):
+        pass
+
+    root = tmp_path / "authority"
+    (root / "published").mkdir(parents=True)
+    root.chmod(0o700)
+    digest = _plan().digest.encode("ascii")
+    deadline = time.monotonic_ns() + 10_000_000_000
+    invalid_arguments = (
+        (".replacement", digest, 0o700, (), deadline, TypeError),
+        (BytesSubclass(b".replacement"), digest, 0o700, (), deadline, TypeError),
+        (b"", digest, 0o700, (), deadline, ValueError),
+        (b"replacement", digest, 0o700, (), deadline, ValueError),
+        (b"nested/slot", digest, 0o700, (), deadline, ValueError),
+        (b"published", digest, 0o700, (), deadline, ValueError),
+        (b".replacement", digest.decode(), 0o700, (), deadline, TypeError),
+        (b".replacement", BytesSubclass(digest), 0o700, (), deadline, TypeError),
+        (b".replacement", b"0" * 63, 0o700, (), deadline, ValueError),
+        (b".replacement", b"A" * 64, 0o700, (), deadline, ValueError),
+        (b".replacement", digest, True, (), deadline, TypeError),
+        (b".replacement", digest, -1, (), deadline, ValueError),
+        (b".replacement", digest, 0o1000, (), deadline, ValueError),
+        (b".replacement", digest, 0o700, [], deadline, TypeError),
+        (b".replacement", digest, 0o700, (("views", 0o700),), deadline, TypeError),
+        (b".replacement", digest, 0o700, ((b"views", True),), deadline, TypeError),
+        (b".replacement", digest, 0o700, (), True, TypeError),
+        (b".replacement", digest, 0o700, (), 0, ValueError),
+        (
+            b".replacement",
+            digest,
+            0o700,
+            (),
+            time.monotonic_ns() - 1,
+            TimeoutError,
+        ),
+    )
+
+    for (
+        slot,
+        plan_digest,
+        mode,
+        directories,
+        provision_deadline,
+        error_type,
+    ) in invalid_arguments:
+        owner = _capture_existing_destination(root, b"published")
+        replacement_permit = workspace_owner.claim_owner_replacement_permit(owner)
+        with pytest.raises(error_type):
+            workspace_owner.provision_owner_replacement(
+                owner,
+                slot,  # type: ignore[arg-type]
+                plan_digest,  # type: ignore[arg-type]
+                mode,
+                directories,  # type: ignore[arg-type]
+                provision_deadline,
+            )
+        assert workspace_owner.owner_state(owner) == "destination-captured"
+        assert not (root / ".replacement").exists()
+        del replacement_permit
+        workspace_owner.abort_owner(owner)
+        assert workspace_owner.owner_closed(owner)
+
+
+def test_native_replacement_permit_is_exact_owner_bound_and_one_shot(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    owner, plan, permit, _incumbent_descriptor = _provision_replacement(root)
+    _adopt_and_fill_replacement(root, owner, plan)
+
+    with pytest.raises(TypeError, match="cannot be constructed"):
+        type(permit)()
+    with pytest.raises(TypeError, match="invalid native type"):
+        workspace_owner.exchange_owner_replacement(
+            owner,
+            b".replacement",
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+    with pytest.raises(TypeError, match="invalid native type"):
+        workspace_owner.claim_owner_replacement_permit(object())
+    with pytest.raises(TypeError, match="invalid native type"):
+        workspace_owner.provision_owner_replacement(
+            object(),
+            b".replacement",
+            b"0" * 64,
+            0o700,
+            (),
+            time.monotonic_ns() + 10_000_000_000,
+        )
+    with pytest.raises(TypeError, match="invalid native type"):
+        workspace_owner.verify_owner_replacement_binding(object())
+    for slot, destination_name, deadline, error_type in (
+        (".replacement", b"published", time.monotonic_ns() + 10_000_000_000, TypeError),
+        (b".replacement", "published", time.monotonic_ns() + 10_000_000_000, TypeError),
+        (b"wrong", b"published", time.monotonic_ns() + 10_000_000_000, ValueError),
+        (b".replacement", b"wrong", time.monotonic_ns() + 10_000_000_000, ValueError),
+        (b".replacement", b"published", True, TypeError),
+        (b".replacement", b"published", 0, ValueError),
+    ):
+        with pytest.raises(error_type):
+            workspace_owner.exchange_owner_replacement(
+                permit,
+                slot,  # type: ignore[arg-type]
+                destination_name,  # type: ignore[arg-type]
+                deadline,
+            )
+        assert workspace_owner.owner_state(owner) == "replacement-adopted"
+
+    receipt_token = workspace_owner.exchange_owner_replacement(
+        permit,
+        b".replacement",
+        b"published",
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    with pytest.raises(RuntimeError, match="unavailable"):
+        workspace_owner.exchange_owner_replacement(
+            permit,
+            b".replacement",
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+    workspace_owner.commit_owner_receipt(receipt_token)
+    workspace_owner.close_owner_exact(owner)
+
+
+def test_native_replacement_permit_drop_and_cross_owner_use_fail_closed(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    (root / "first").mkdir(parents=True)
+    (root / "second").mkdir()
+    root.chmod(0o700)
+    first_owner = _capture_existing_destination(root, b"first")
+    second_owner = _capture_existing_destination(root, b"second")
+    first_permit = workspace_owner.claim_owner_replacement_permit(first_owner)
+    second_permit = workspace_owner.claim_owner_replacement_permit(second_owner)
+    workspace_owner.provision_owner_replacement(
+        second_owner,
+        b".second-replacement",
+        b"0" * 64,
+        0o700,
+        (),
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    workspace_owner.verify_owner_adoption_binding(
+        second_owner,
+        os.fsencode(root / "second"),
+        b".second-replacement",
+        b"0" * 64,
+    )
+    workspace_owner.mark_owner_adopted(second_owner)
+    workspace_owner.seal_owner_directories(second_owner)
+
+    with pytest.raises(ValueError, match="names differ"):
+        workspace_owner.exchange_owner_replacement(
+            first_permit,
+            b".second-replacement",
+            b"second",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+    assert workspace_owner.owner_state(second_owner) == "replacement-adopted"
+
+    del first_permit
+    gc.collect()
+    with pytest.raises(RuntimeError, match="not replacement-ready"):
+        workspace_owner.provision_owner_replacement(
+            first_owner,
+            b".replacement",
+            b"0" * 64,
+            0o700,
+            (),
+            time.monotonic_ns() + 10_000_000_000,
+        )
+    assert workspace_owner.owner_state(first_owner) == "destination-captured"
+    assert not (root / ".replacement").exists()
+    workspace_owner.abort_owner(first_owner)
+    workspace_owner.abort_owner(second_owner)
+    del second_permit
+
+
+def test_native_exchanged_replacement_rejects_every_legacy_owner_operation(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    owner, plan, permit, _incumbent_descriptor = _provision_replacement(root)
+    _adopt_and_fill_replacement(root, owner, plan)
+    receipt_token = workspace_owner.exchange_owner_replacement(
+        permit,
+        b".replacement",
+        b"published",
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    before = _tree_fingerprint(root)
+
+    rejected = (
+        lambda: workspace_owner.claim_owner_publish_permit(owner),
+        lambda: workspace_owner.claim_owner_replacement_permit(owner),
+        lambda: workspace_owner.capture_owner_destination(
+            owner,
+            os.fsencode(root),
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        ),
+        lambda: workspace_owner.provision_owner(
+            owner,
+            os.fsencode(root),
+            b"other",
+            b".stage",
+            b"0" * 64,
+            0o700,
+            (),
+            time.monotonic_ns() + 10_000_000_000,
+        ),
+        lambda: workspace_owner.borrow_owner_destination_descriptor(owner),
+        lambda: workspace_owner.borrow_owner_parent_descriptor(owner),
+        lambda: workspace_owner.borrow_owner_root_descriptor(owner),
+        lambda: workspace_owner.borrow_owner_directory_descriptor(owner, b"views"),
+        lambda: workspace_owner.begin_owner_file(owner, b"", b"late", 0o600),
+        lambda: workspace_owner.write_owner_file(owner, b"late"),
+        lambda: workspace_owner.finish_owner_file(owner, 0o600),
+        lambda: workspace_owner.abort_owner_file(owner),
+        lambda: workspace_owner.seal_owner_directories(owner),
+        lambda: workspace_owner.sync_owner_parent(owner),
+        lambda: workspace_owner.mark_owner_adopted(owner),
+        lambda: workspace_owner.quarantine_owner(owner),
+    )
+    for operation in rejected:
+        with pytest.raises((RuntimeError, TypeError)):
+            operation()
+        assert workspace_owner.owner_state(owner) == (
+            "replacement-exchanged-unreceipted"
+        )
+        assert _tree_fingerprint(root) == before
+
+    workspace_owner.commit_owner_receipt(receipt_token)
+    workspace_owner.close_owner_exact(owner)
+
+
+@pytest.mark.parametrize("rebind", ("destination", "replacement-slot"))
+@pytest.mark.parametrize("phase", ("provisioned", "adopted"))
+def test_native_replacement_sync_rejects_every_rebound_root(
+    tmp_path: Path,
+    rebind: str,
+    phase: str,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "incumbent.txt").write_bytes(b"incumbent")
+    owner, plan, _permit, _incumbent_descriptor = _provision_replacement(root)
+    if phase == "adopted":
+        _adopt_and_fill_replacement(root, owner, plan, payload=b"candidate")
+    assert workspace_owner.owner_state(owner) == f"replacement-{phase}"
+    slot = root / ".replacement"
+    rebound = destination if rebind == "destination" else slot
+    retained = root / f".retained-sync-{phase}-{rebind}"
+    foreign = root / f".foreign-sync-{phase}-{rebind}"
+    rebound.rename(retained)
+    rebound.mkdir()
+    (rebound / "foreign.txt").write_bytes(b"foreign")
+    before = _tree_fingerprint(root)
+
+    with pytest.raises(RuntimeError, match="binding changed"):
+        workspace_owner.sync_owner_parent(owner)
+    assert workspace_owner.owner_state(owner) == f"replacement-{phase}"
+    assert _tree_fingerprint(root) == before
+
+    rebound.rename(foreign)
+    retained.rename(rebound)
+    workspace_owner.abort_owner(owner)
+    assert workspace_owner.owner_closed(owner)
+    assert (foreign / "foreign.txt").read_bytes() == b"foreign"
+
+
+@pytest.mark.parametrize("rebind", ("destination", "replacement-slot"))
+def test_native_preexchange_settlement_retains_lease_until_rebind_is_restored(
+    tmp_path: Path,
+    rebind: str,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "incumbent.txt").write_bytes(b"incumbent")
+    owner, plan, permit, _incumbent_descriptor = _provision_replacement(root)
+    _adopt_and_fill_replacement(root, owner, plan, payload=b"candidate")
+    slot = root / ".replacement"
+    rebound = destination if rebind == "destination" else slot
+    retained = root / f".retained-{rebind}"
+    foreign = root / f".foreign-{rebind}"
+    rebound.rename(retained)
+    rebound.mkdir()
+    (rebound / "foreign.txt").write_bytes(b"foreign")
+
+    with pytest.raises(RuntimeError, match="changed"):
+        workspace_owner.verify_owner_replacement_binding(owner)
+    with pytest.raises(RuntimeError, match="unavailable"):
+        workspace_owner.borrow_owner_parent_descriptor(owner)
+    with pytest.raises(RuntimeError, match="not exchange-ready"):
+        workspace_owner.exchange_owner_replacement(
+            permit,
+            b".replacement",
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+    with pytest.raises(OSError):
+        workspace_owner.abort_owner(owner)
+    assert workspace_owner.owner_state(owner) == "replacement-recovery-required"
+    with pytest.raises(OSError):
+        workspace_owner.close_owner_exact(owner)
+
+    independent_parent = os.open(
+        root,
+        os.O_RDONLY
+        | os.O_DIRECTORY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_CLOEXEC", 0),
+    )
+    try:
+        with pytest.raises(BlockingIOError):
+            fcntl.flock(independent_parent, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    finally:
+        os.close(independent_parent)
+
+    rebound.rename(foreign)
+    retained.rename(rebound)
+    workspace_owner.abort_owner(owner)
+    assert workspace_owner.owner_closed(owner)
+    assert (foreign / "foreign.txt").read_bytes() == b"foreign"
+    assert (destination / "incumbent.txt").read_bytes() == b"incumbent"
+    assert (slot / "views/bm25/documents.json").read_bytes() == b"candidate"
+
+
+@pytest.mark.parametrize("rebind", ("destination", "replacement-slot"))
+def test_native_postexchange_rebind_never_blindly_rolls_back_foreign_name(
+    tmp_path: Path,
+    rebind: str,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "incumbent.txt").write_bytes(b"incumbent")
+    owner, plan, permit, _incumbent_descriptor = _provision_replacement(root)
+    _adopt_and_fill_replacement(root, owner, plan, payload=b"candidate")
+    workspace_owner.exchange_owner_replacement(
+        permit,
+        b".replacement",
+        b"published",
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    slot = root / ".replacement"
+    rebound = destination if rebind == "destination" else slot
+    retained = root / f".retained-post-{rebind}"
+    foreign = root / f".foreign-post-{rebind}"
+    rebound.rename(retained)
+    rebound.mkdir()
+    (rebound / "foreign.txt").write_bytes(b"foreign")
+
+    with pytest.raises(OSError):
+        workspace_owner.abort_owner(owner)
+    assert workspace_owner.owner_state(owner) == "replacement-recovery-required"
+    assert (rebound / "foreign.txt").read_bytes() == b"foreign"
+
+    rebound.rename(foreign)
+    retained.rename(rebound)
+    workspace_owner.abort_owner(owner)
+    assert workspace_owner.owner_closed(owner)
+    assert (foreign / "foreign.txt").read_bytes() == b"foreign"
+    assert (destination / "incumbent.txt").read_bytes() == b"incumbent"
+    assert (slot / "views/bm25/documents.json").read_bytes() == b"candidate"
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="requires Linux")
+def test_native_abort_reverses_an_exact_exchange_observed_in_preexchange_state(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "incumbent.txt").write_bytes(b"incumbent")
+    owner, plan, _permit, _incumbent_descriptor = _provision_replacement(root)
+    _adopt_and_fill_replacement(root, owner, plan, payload=b"candidate")
+    libc = ctypes.CDLL(None, use_errno=True)
+    renameat2 = getattr(libc, "renameat2", None)
+    if renameat2 is None:
+        workspace_owner.abort_owner(owner)
+        pytest.skip("libc does not expose renameat2")
+    renameat2.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    ]
+    renameat2.restype = ctypes.c_int
+    result = renameat2(
+        -100,
+        os.fsencode(root / ".replacement"),
+        -100,
+        os.fsencode(destination),
+        1 << 1,
+    )
+    if result != 0:
+        error_number = ctypes.get_errno()
+        workspace_owner.abort_owner(owner)
+        pytest.skip(f"RENAME_EXCHANGE unavailable: errno {error_number}")
+
+    assert (destination / "views/bm25/documents.json").read_bytes() == b"candidate"
+    workspace_owner.abort_owner(owner)
+
+    assert workspace_owner.owner_closed(owner)
+    assert (destination / "incumbent.txt").read_bytes() == b"incumbent"
+    assert (root / ".replacement" / "views/bm25/documents.json").read_bytes() == (
+        b"candidate"
+    )
+
+
+def test_native_parent_commit_lease_serializes_cooperative_sibling_replacements(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    first_destination = root / "first"
+    second_destination = root / "second"
+    first_destination.mkdir(parents=True)
+    second_destination.mkdir()
+    root.chmod(0o700)
+    (first_destination / "old.txt").write_bytes(b"first")
+    (second_destination / "old.txt").write_bytes(b"second")
+    first_owner, first_plan, first_permit, _ = _provision_replacement(
+        root,
+        destination=b"first",
+        slot=b".first-replacement",
+    )
+    second_owner, second_plan, second_permit, _ = _provision_replacement(
+        root,
+        destination=b"second",
+        slot=b".second-replacement",
+    )
+    _adopt_and_fill_replacement(
+        root,
+        first_owner,
+        first_plan,
+        destination=b"first",
+        slot=b".first-replacement",
+        payload=b"first-new",
+    )
+    _adopt_and_fill_replacement(
+        root,
+        second_owner,
+        second_plan,
+        destination=b"second",
+        slot=b".second-replacement",
+        payload=b"second-new",
+    )
+    first_token = workspace_owner.exchange_owner_replacement(
+        first_permit,
+        b".first-replacement",
+        b"first",
+        time.monotonic_ns() + 10_000_000_000,
+    )
+
+    with pytest.raises(BlockingIOError):
+        workspace_owner.exchange_owner_replacement(
+            second_permit,
+            b".second-replacement",
+            b"second",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+    assert workspace_owner.owner_state(second_owner) == "replacement-adopted"
+    with pytest.raises(BlockingIOError):
+        workspace_owner.abort_owner(second_owner)
+
+    workspace_owner.commit_owner_receipt(first_token)
+    workspace_owner.close_owner_exact(first_owner)
+    workspace_owner.abort_owner(second_owner)
+    assert workspace_owner.owner_closed(second_owner)
+    assert (first_destination / "views/bm25/documents.json").read_bytes() == (
+        b"first-new"
+    )
+    assert (second_destination / "old.txt").read_bytes() == b"second"
+
+
+def test_native_preexchange_contention_dealloc_closes_only_the_losing_owner(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    first_destination = root / "first"
+    second_destination = root / "second"
+    first_destination.mkdir(parents=True)
+    second_destination.mkdir()
+    root.chmod(0o700)
+    (first_destination / "old.txt").write_bytes(b"first")
+    (second_destination / "old.txt").write_bytes(b"second")
+    first_owner, first_plan, first_permit, _ = _provision_replacement(
+        root,
+        destination=b"first",
+        slot=b".first-replacement",
+    )
+    _adopt_and_fill_replacement(
+        root,
+        first_owner,
+        first_plan,
+        destination=b"first",
+        slot=b".first-replacement",
+        payload=b"first-new",
+    )
+    first_token = workspace_owner.exchange_owner_replacement(
+        first_permit,
+        b".first-replacement",
+        b"first",
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    gc.collect()
+    baseline_fd_count = len(os.listdir("/proc/self/fd"))
+
+    second_owner, second_plan, second_permit, _ = _provision_replacement(
+        root,
+        destination=b"second",
+        slot=b".second-replacement",
+    )
+    _adopt_and_fill_replacement(
+        root,
+        second_owner,
+        second_plan,
+        destination=b"second",
+        slot=b".second-replacement",
+        payload=b"second-new",
+    )
+    before_cleanup = _tree_fingerprint(root)
+    with pytest.raises(BlockingIOError):
+        workspace_owner.exchange_owner_replacement(
+            second_permit,
+            b".second-replacement",
+            b"second",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+    with pytest.raises(BlockingIOError):
+        workspace_owner.abort_owner(second_owner)
+    with pytest.raises(BlockingIOError):
+        workspace_owner.close_owner_exact(second_owner)
+    assert not workspace_owner.owner_closed(second_owner)
+    assert workspace_owner.owner_state(second_owner) == "replacement-adopted"
+    assert _tree_fingerprint(root) == before_cleanup
+
+    sentinel = KeyboardInterrupt("sentinel")
+    try:
+        raise sentinel
+    except BaseException:  # noqa: B036 - assert dealloc preserves the exception
+        del second_permit
+        del second_owner
+        gc.collect()
+        assert sys.exc_info()[1] is sentinel
+
+    assert len(os.listdir("/proc/self/fd")) == baseline_fd_count
+    assert _tree_fingerprint(root) == before_cleanup
+    independent_parent = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        with pytest.raises(BlockingIOError):
+            fcntl.flock(independent_parent, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    finally:
+        os.close(independent_parent)
+
+    workspace_owner.commit_owner_receipt(first_token)
+    workspace_owner.close_owner_exact(first_owner)
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="requires Linux")
+def test_native_overlapping_same_destination_capture_fails_closed_after_commit(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "incumbent.txt").write_bytes(b"incumbent")
+    first_owner, first_plan, first_permit, _ = _provision_replacement(
+        root,
+        slot=b".first-replacement",
+    )
+    second_owner, second_plan, second_permit, _ = _provision_replacement(
+        root,
+        slot=b".second-replacement",
+    )
+    _adopt_and_fill_replacement(
+        root,
+        first_owner,
+        first_plan,
+        slot=b".first-replacement",
+        payload=b"first-candidate",
+    )
+    _adopt_and_fill_replacement(
+        root,
+        second_owner,
+        second_plan,
+        slot=b".second-replacement",
+        payload=b"second-candidate",
+    )
+    first_token = workspace_owner.exchange_owner_replacement(
+        first_permit,
+        b".first-replacement",
+        b"published",
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    workspace_owner.commit_owner_receipt(first_token)
+
+    with pytest.raises(RuntimeError, match="not exchange-ready"):
+        workspace_owner.exchange_owner_replacement(
+            second_permit,
+            b".second-replacement",
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+    assert workspace_owner.owner_state(second_owner) == "replacement-adopted"
+    with pytest.raises(OSError):
+        workspace_owner.abort_owner(second_owner)
+    assert workspace_owner.owner_state(second_owner) == (
+        "replacement-recovery-required"
+    )
+    assert (destination / "views/bm25/documents.json").read_bytes() == (
+        b"first-candidate"
+    )
+    assert (
+        root / ".second-replacement" / "views/bm25/documents.json"
+    ).read_bytes() == b"second-candidate"
+    independent_parent = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        with pytest.raises(BlockingIOError):
+            fcntl.flock(independent_parent, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    finally:
+        os.close(independent_parent)
+
+    temporary = root / ".restore-first-candidate"
+    destination.rename(temporary)
+    (root / ".first-replacement").rename(destination)
+    temporary.rename(root / ".first-replacement")
+    workspace_owner.abort_owner(second_owner)
+    workspace_owner.close_owner_exact(first_owner)
+
+
+def test_native_replacement_fd_reuse_and_dealloc_preserve_primary_baseexception(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    script = textwrap.dedent(
+        """
+        import fcntl
+        import gc
+        import os
+        import sys
+        import time
+        from pathlib import Path
+
+        import codenib._workspace_owner as workspace_owner
+
+        root = Path(sys.argv[1])
+        owner = workspace_owner.create_owner()
+        workspace_owner.capture_owner_destination(
+            owner,
+            os.fsencode(root),
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        workspace_owner.borrow_owner_destination_descriptor(owner)
+        permit = workspace_owner.claim_owner_replacement_permit(owner)
+        workspace_owner.provision_owner_replacement(
+            owner,
+            b".replacement",
+            b"0" * 64,
+            0o700,
+            (),
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        descriptor = workspace_owner.borrow_owner_root_descriptor(owner)
+        os.close(descriptor)
+        independent = os.open(
+            root / ".replacement",
+            os.O_RDONLY
+            | os.O_DIRECTORY
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0),
+        )
+        if independent != descriptor:
+            os.dup2(independent, descriptor, inheritable=False)
+        try:
+            try:
+                workspace_owner.verify_owner_replacement_binding(owner)
+            except RuntimeError:
+                pass
+            else:
+                raise AssertionError("independent same-inode OFD was accepted")
+            try:
+                workspace_owner.abort_owner(owner)
+            except OSError:
+                pass
+            else:
+                raise AssertionError("reused candidate FD cleanup succeeded")
+            assert workspace_owner.owner_state(owner) == (
+                "replacement-recovery-required"
+            )
+            replacement = os.fstat(descriptor)
+            expected = (root / ".replacement").stat()
+            assert (replacement.st_dev, replacement.st_ino) == (
+                expected.st_dev,
+                expected.st_ino,
+            )
+            parent = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                try:
+                    fcntl.flock(parent, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    pass
+                else:
+                    raise AssertionError("recovery owner released its lease")
+            finally:
+                os.close(parent)
+
+            sentinel = KeyboardInterrupt("sentinel")
+            retained_fd_count = len(os.listdir("/proc/self/fd"))
+            try:
+                raise sentinel
+            except BaseException:
+                del permit
+                del owner
+                gc.collect()
+                assert sys.exc_info()[1] is sentinel
+            assert len(os.listdir("/proc/self/fd")) == retained_fd_count
+            retained_parent = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                try:
+                    fcntl.flock(retained_parent, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    pass
+                else:
+                    raise AssertionError("deallocated recovery owner released its lease")
+            finally:
+                os.close(retained_parent)
+        finally:
+            os.close(descriptor)
+            if independent != descriptor:
+                os.close(independent)
+        """
+    )
+    repository_root = Path(__file__).resolve().parents[1]
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (str(repository_root), environment.get("PYTHONPATH", ""))
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script, os.fspath(root)],
+        cwd=repository_root,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
+def test_native_replacement_permit_cannot_cross_a_pid_boundary(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "incumbent.txt").write_bytes(b"incumbent")
+    owner, plan, permit, _incumbent_descriptor = _provision_replacement(root)
+    _adopt_and_fill_replacement(root, owner, plan, payload=b"candidate")
+    read_descriptor, write_descriptor = os.pipe()
+    child_pid = os.fork()
+    if child_pid == 0:
+        os.close(read_descriptor)
+        try:
+            workspace_owner.exchange_owner_replacement(
+                permit,
+                b".replacement",
+                b"published",
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        except RuntimeError as error:
+            report = b"ok" if "PID boundary" in str(error) else repr(error).encode()
+        else:
+            report = b"cross-PID replacement permit succeeded"
+        os.write(write_descriptor, report)
+        os.close(write_descriptor)
+        os._exit(0)
+
+    os.close(write_descriptor)
+    report = os.read(read_descriptor, 4096)
+    os.close(read_descriptor)
+    waited_pid, status = os.waitpid(child_pid, 0)
+    assert waited_pid == child_pid
+    assert os.waitstatus_to_exitcode(status) == 0
+    assert report == b"ok"
+
+    receipt_token = workspace_owner.exchange_owner_replacement(
+        permit,
+        b".replacement",
+        b"published",
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    workspace_owner.commit_owner_receipt(receipt_token)
+    workspace_owner.close_owner_exact(owner)
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
+def test_native_replacement_child_closes_fds_without_unlocking_or_mutating(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "incumbent.txt").write_bytes(b"incumbent")
+    owner, plan, permit, incumbent_descriptor = _provision_replacement(root)
+    candidate_descriptor = workspace_owner.borrow_owner_root_descriptor(owner)
+    _adopt_and_fill_replacement(root, owner, plan, payload=b"candidate")
+    receipt_token = workspace_owner.exchange_owner_replacement(
+        permit,
+        b".replacement",
+        b"published",
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    before = _tree_fingerprint(root)
+    read_descriptor, write_descriptor = os.pipe()
+    child_pid = os.fork()
+    if child_pid == 0:
+        os.close(read_descriptor)
+        try:
+            for operation in (
+                lambda: workspace_owner.verify_owner_replacement_binding(owner),
+                lambda: workspace_owner.commit_owner_receipt(receipt_token),
+                lambda: workspace_owner.abort_owner(owner),
+            ):
+                try:
+                    operation()
+                except RuntimeError as error:
+                    assert "PID boundary" in str(error)
+                else:
+                    raise AssertionError("cross-PID replacement operation succeeded")
+            try:
+                workspace_owner.close_owner_exact(owner)
+            except RuntimeError as error:
+                assert "PID boundary" in str(error)
+            else:
+                raise AssertionError("cross-PID close did not report its boundary")
+            for descriptor in (incumbent_descriptor, candidate_descriptor):
+                try:
+                    os.fstat(descriptor)
+                except OSError:
+                    pass
+                else:
+                    raise AssertionError("child retained an inherited owner FD")
+            os.write(write_descriptor, b"ok")
+        except BaseException as error:  # noqa: B036 - report child failure
+            os.write(write_descriptor, repr(error).encode("utf-8"))
+        finally:
+            os.close(write_descriptor)
+            os._exit(0)
+
+    os.close(write_descriptor)
+    report = os.read(read_descriptor, 4096)
+    os.close(read_descriptor)
+    waited_pid, status = os.waitpid(child_pid, 0)
+    assert waited_pid == child_pid
+    assert os.waitstatus_to_exitcode(status) == 0
+    assert report == b"ok"
+    assert _tree_fingerprint(root) == before
+
+    independent_parent = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        with pytest.raises(BlockingIOError):
+            fcntl.flock(independent_parent, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    finally:
+        os.close(independent_parent)
+    workspace_owner.commit_owner_receipt(receipt_token)
+    workspace_owner.close_owner_exact(owner)
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="requires Linux")
+@pytest.mark.parametrize(
+    "fault_mode",
+    (
+        "deadline-after-lock-unlock-fail",
+        "success-without-swap",
+        "error-after-swap",
+        "forward-fsync-once",
+        "reverse-error-after-restore",
+        "reverse-error-once",
+        "reverse-fsync-once",
+        "reverse-success-without-restore",
+        "slot-rebind-after-lock",
+        "unlock-fail-once",
+    ),
+)
+def test_native_exchange_faults_are_classified_and_settled_exactly(
+    tmp_path: Path,
+    fault_mode: str,
+) -> None:
+    library = _compile_exchange_fault_shim(tmp_path)
+    root = tmp_path / "authority"
+    script = textwrap.dedent(
+        """
+        import ctypes
+        import errno
+        import fcntl
+        import os
+        import sys
+        import time
+        from pathlib import Path
+
+        import codenib._workspace_owner as workspace_owner
+
+        root = Path(sys.argv[1])
+        faults = ctypes.CDLL(sys.argv[2])
+        mode = os.environ["CODENIB_EXCHANGE_FAULT"]
+        for counter_name in (
+            "codenib_exchange_fault_exchange_calls",
+            "codenib_exchange_fault_fsync_failed",
+            "codenib_exchange_fault_unlock_failed",
+            "codenib_exchange_fault_post_exchange_fsyncs",
+            "codenib_exchange_fault_lock_rebind_injected",
+            "codenib_exchange_fault_lock_delay_injected",
+        ):
+            getattr(faults, counter_name).restype = ctypes.c_int
+
+        def counter(name):
+            return getattr(faults, name)()
+
+        def parent_lease_is_held():
+            descriptor = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                try:
+                    fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    return True
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+                return False
+            finally:
+                os.close(descriptor)
+
+        destination = root / "published"
+        destination.mkdir(parents=True)
+        root.chmod(0o700)
+        (destination / "incumbent.txt").write_bytes(b"incumbent")
+        digest = b"0" * 64
+        owner = workspace_owner.create_owner()
+        workspace_owner.capture_owner_destination(
+            owner,
+            os.fsencode(root),
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        permit = workspace_owner.claim_owner_replacement_permit(owner)
+        workspace_owner.provision_owner_replacement(
+            owner,
+            b".replacement",
+            digest,
+            0o700,
+            ((b"views", 0o700), (b"views/bm25", 0o700)),
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        workspace_owner.verify_owner_adoption_binding(
+            owner,
+            os.fsencode(destination),
+            b".replacement",
+            digest,
+        )
+        workspace_owner.mark_owner_adopted(owner)
+        workspace_owner.begin_owner_file(
+            owner, b"views/bm25", b"documents.json", 0o600
+        )
+        workspace_owner.write_owner_file(owner, b"candidate")
+        workspace_owner.finish_owner_file(owner, 0o600)
+        workspace_owner.seal_owner_directories(owner)
+        if mode == "slot-rebind-after-lock":
+            foreign = root / ".foreign"
+            foreign.mkdir()
+            (foreign / "foreign.txt").write_bytes(b"foreign")
+        if mode == "deadline-after-lock-unlock-fail":
+            deadline = time.monotonic_ns() + 20_000_000
+        else:
+            deadline = time.monotonic_ns() + 10_000_000_000
+
+        if mode == "deadline-after-lock-unlock-fail":
+            try:
+                workspace_owner.exchange_owner_replacement(
+                    permit, b".replacement", b"published", deadline
+                )
+            except TimeoutError:
+                pass
+            else:
+                raise AssertionError("post-lock deadline expiry was hidden")
+            assert counter("codenib_exchange_fault_lock_delay_injected") == 1
+            assert counter("codenib_exchange_fault_unlock_failed") == 1
+            assert counter("codenib_exchange_fault_exchange_calls") == 0
+            assert workspace_owner.owner_state(owner) == (
+                "replacement-recovery-required"
+            )
+            assert parent_lease_is_held()
+            workspace_owner.abort_owner(owner)
+        elif mode == "success-without-swap":
+            try:
+                workspace_owner.exchange_owner_replacement(
+                    permit, b".replacement", b"published", deadline
+                )
+            except RuntimeError as error:
+                assert "success without swapping" in str(error)
+            else:
+                raise AssertionError("false exchange success was accepted")
+            assert counter("codenib_exchange_fault_exchange_calls") == 1
+            assert counter("codenib_exchange_fault_post_exchange_fsyncs") >= 1
+            assert workspace_owner.owner_state(owner) == "replacement-adopted"
+            assert not parent_lease_is_held()
+            workspace_owner.abort_owner(owner)
+        elif mode == "error-after-swap":
+            token = workspace_owner.exchange_owner_replacement(
+                permit, b".replacement", b"published", deadline
+            )
+            assert counter("codenib_exchange_fault_exchange_calls") == 1
+            assert workspace_owner.owner_state(owner) == (
+                "replacement-exchanged-unreceipted"
+            )
+            workspace_owner.commit_owner_receipt(token)
+            workspace_owner.close_owner_exact(owner)
+        elif mode == "forward-fsync-once":
+            try:
+                workspace_owner.exchange_owner_replacement(
+                    permit, b".replacement", b"published", deadline
+                )
+            except OSError as error:
+                assert error.errno == errno.EIO
+            else:
+                raise AssertionError("forward fsync failure was hidden")
+            assert counter("codenib_exchange_fault_exchange_calls") == 1
+            assert counter("codenib_exchange_fault_fsync_failed") == 1
+            assert workspace_owner.owner_state(owner) == (
+                "replacement-recovery-required"
+            )
+            assert parent_lease_is_held()
+            try:
+                workspace_owner.verify_owner_replacement_binding(owner)
+            except RuntimeError:
+                pass
+            else:
+                raise AssertionError("recovery owner exposed ordinary verification")
+            workspace_owner.abort_owner(owner)
+        elif mode == "reverse-error-once":
+            workspace_owner.exchange_owner_replacement(
+                permit, b".replacement", b"published", deadline
+            )
+            try:
+                workspace_owner.abort_owner(owner)
+            except OSError as error:
+                assert error.errno == errno.EIO
+            else:
+                raise AssertionError("reverse exchange error was hidden")
+            assert counter("codenib_exchange_fault_exchange_calls") == 2
+            assert workspace_owner.owner_state(owner) == (
+                "replacement-recovery-required"
+            )
+            assert parent_lease_is_held()
+            workspace_owner.abort_owner(owner)
+            assert counter("codenib_exchange_fault_exchange_calls") == 3
+        elif mode == "reverse-error-after-restore":
+            workspace_owner.exchange_owner_replacement(
+                permit, b".replacement", b"published", deadline
+            )
+            workspace_owner.abort_owner(owner)
+            assert counter("codenib_exchange_fault_exchange_calls") == 2
+            assert counter("codenib_exchange_fault_post_exchange_fsyncs") >= 2
+        elif mode == "reverse-fsync-once":
+            workspace_owner.exchange_owner_replacement(
+                permit, b".replacement", b"published", deadline
+            )
+            try:
+                workspace_owner.abort_owner(owner)
+            except OSError as error:
+                assert error.errno == errno.EIO
+            else:
+                raise AssertionError("reverse fsync error was hidden")
+            assert counter("codenib_exchange_fault_exchange_calls") == 2
+            assert counter("codenib_exchange_fault_fsync_failed") == 1
+            assert workspace_owner.owner_state(owner) == (
+                "replacement-recovery-required"
+            )
+            assert parent_lease_is_held()
+            workspace_owner.abort_owner(owner)
+            assert counter("codenib_exchange_fault_exchange_calls") == 2
+        elif mode == "reverse-success-without-restore":
+            workspace_owner.exchange_owner_replacement(
+                permit, b".replacement", b"published", deadline
+            )
+            try:
+                workspace_owner.abort_owner(owner)
+            except OSError:
+                pass
+            else:
+                raise AssertionError("false reverse success was accepted")
+            assert counter("codenib_exchange_fault_exchange_calls") == 2
+            assert workspace_owner.owner_state(owner) == (
+                "replacement-recovery-required"
+            )
+            assert parent_lease_is_held()
+            syncs_before_retry = counter(
+                "codenib_exchange_fault_post_exchange_fsyncs"
+            )
+            temporary = root / ".restore-candidate"
+            (root / "published").rename(temporary)
+            (root / ".replacement").rename(root / "published")
+            temporary.rename(root / ".replacement")
+            workspace_owner.abort_owner(owner)
+            assert counter("codenib_exchange_fault_exchange_calls") == 2
+            assert (
+                counter("codenib_exchange_fault_post_exchange_fsyncs")
+                > syncs_before_retry
+            )
+        elif mode == "slot-rebind-after-lock":
+            try:
+                workspace_owner.exchange_owner_replacement(
+                    permit, b".replacement", b"published", deadline
+                )
+            except RuntimeError as error:
+                assert "binding changed under" in str(error)
+            else:
+                raise AssertionError("under-lease slot rebind was accepted")
+            assert counter("codenib_exchange_fault_lock_rebind_injected") == 1
+            assert counter("codenib_exchange_fault_exchange_calls") == 0
+            assert workspace_owner.owner_state(owner) == (
+                "replacement-recovery-required"
+            )
+            assert parent_lease_is_held()
+            retained_foreign = root / ".retained-foreign"
+            (root / ".replacement").rename(retained_foreign)
+            (root / ".foreign").rename(root / ".replacement")
+            retained_foreign.rename(root / ".foreign")
+            workspace_owner.abort_owner(owner)
+            assert (root / ".foreign" / "foreign.txt").read_bytes() == b"foreign"
+        elif mode == "unlock-fail-once":
+            token = workspace_owner.exchange_owner_replacement(
+                permit, b".replacement", b"published", deadline
+            )
+            try:
+                workspace_owner.commit_owner_receipt(token)
+            except OSError as error:
+                assert error.errno == errno.EIO
+            else:
+                raise AssertionError("receipt unlock failure was hidden")
+            assert counter("codenib_exchange_fault_unlock_failed") == 1
+            assert workspace_owner.owner_state(owner) == (
+                "replacement-recovery-required"
+            )
+            assert parent_lease_is_held()
+            syncs_before_retry = counter(
+                "codenib_exchange_fault_post_exchange_fsyncs"
+            )
+            workspace_owner.commit_owner_receipt(token)
+            assert counter("codenib_exchange_fault_unlock_failed") == 1
+            assert (
+                counter("codenib_exchange_fault_post_exchange_fsyncs")
+                > syncs_before_retry
+            )
+            assert workspace_owner.owner_state(owner) == "replacement-receipted"
+            assert not parent_lease_is_held()
+            workspace_owner.close_owner_exact(owner)
+        else:
+            raise AssertionError(f"unexpected fault mode: {mode}")
+
+        assert workspace_owner.owner_closed(owner)
+        if mode in ("error-after-swap", "unlock-fail-once"):
+            assert not (destination / "incumbent.txt").exists()
+            assert (
+                destination / "views/bm25/documents.json"
+            ).read_bytes() == b"candidate"
+            assert (
+                root / ".replacement" / "incumbent.txt"
+            ).read_bytes() == b"incumbent"
+        else:
+            assert (destination / "incumbent.txt").read_bytes() == b"incumbent"
+            assert (
+                root / ".replacement" / "views/bm25/documents.json"
+            ).read_bytes() == b"candidate"
+        """
+    )
+    _run_exchange_fault_script(root, library, fault_mode, script)
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="requires Linux")
+def test_native_unsupported_exchange_preserves_error_during_last_owner_dealloc(
+    tmp_path: Path,
+) -> None:
+    library = _compile_exchange_fault_shim(tmp_path)
+    root = tmp_path / "authority"
+    script = textwrap.dedent(
+        """
+        import ctypes
+        import errno
+        import os
+        import sys
+        import time
+        from pathlib import Path
+
+        import codenib._workspace_owner as workspace_owner
+
+        root = Path(sys.argv[1])
+        faults = ctypes.CDLL(sys.argv[2])
+        faults.codenib_exchange_fault_exchange_calls.restype = ctypes.c_int
+        destination = root / "published"
+        destination.mkdir(parents=True)
+        root.chmod(0o700)
+        (destination / "incumbent.txt").write_bytes(b"incumbent")
+        owner = workspace_owner.create_owner()
+        workspace_owner.capture_owner_destination(
+            owner,
+            os.fsencode(root),
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        permit = workspace_owner.claim_owner_replacement_permit(owner)
+        workspace_owner.provision_owner_replacement(
+            owner,
+            b".replacement",
+            b"0" * 64,
+            0o700,
+            (),
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        workspace_owner.verify_owner_adoption_binding(
+            owner,
+            os.fsencode(destination),
+            b".replacement",
+            b"0" * 64,
+        )
+        workspace_owner.mark_owner_adopted(owner)
+        workspace_owner.seal_owner_directories(owner)
+        holder = [permit]
+        del permit
+        del owner
+        exact_exchange = workspace_owner._exchange_owner_replacement_exact
+        assert exact_exchange is not None
+
+        try:
+            exact_exchange(
+                holder.pop(),
+                b".replacement",
+                b"published",
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        except OSError as error:
+            assert error.errno == errno.EOPNOTSUPP
+        else:
+            raise AssertionError("unsupported exchange did not raise OSError")
+
+        assert faults.codenib_exchange_fault_exchange_calls() == 1
+        assert not holder
+        assert (destination / "incumbent.txt").read_bytes() == b"incumbent"
+        assert (root / ".replacement").is_dir()
+        """
+    )
+    _run_exchange_fault_script(root, library, "unsupported", script)
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="requires Linux")
+def test_native_partial_replacement_identity_failure_never_adopts_rebound_slot(
+    tmp_path: Path,
+) -> None:
+    library = _compile_exchange_fault_shim(tmp_path)
+    root = tmp_path / "authority"
+    script = textwrap.dedent(
+        """
+        import ctypes
+        import fcntl
+        import gc
+        import os
+        import sys
+        import time
+        from pathlib import Path
+
+        import codenib._workspace_owner as workspace_owner
+
+        root = Path(sys.argv[1])
+        faults = ctypes.CDLL(sys.argv[2])
+        faults.codenib_exchange_fault_slot_stats.restype = ctypes.c_int
+        destination = root / "published"
+        destination.mkdir(parents=True)
+        root.chmod(0o700)
+        (destination / "incumbent.txt").write_bytes(b"incumbent")
+        owner = workspace_owner.create_owner()
+        workspace_owner.capture_owner_destination(
+            owner,
+            os.fsencode(root),
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        permit = workspace_owner.claim_owner_replacement_permit(owner)
+        try:
+            workspace_owner.provision_owner_replacement(
+                owner,
+                b".replacement",
+                b"0" * 64,
+                0o700,
+                (),
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        except OSError:
+            pass
+        else:
+            raise AssertionError("candidate identity fault was hidden")
+        assert faults.codenib_exchange_fault_slot_stats() == 2
+        assert workspace_owner.owner_state(owner) == "replacement-provisioning"
+
+        for operation in (
+            lambda: workspace_owner.verify_owner_authority(owner),
+            lambda: workspace_owner.verify_owner_replacement_binding(owner),
+            lambda: workspace_owner.borrow_owner_parent_descriptor(owner),
+            lambda: workspace_owner.borrow_owner_root_descriptor(owner),
+            lambda: workspace_owner.borrow_owner_destination_descriptor(owner),
+            lambda: workspace_owner.borrow_owner_directory_descriptor(
+                owner, b"views"
+            ),
+            lambda: workspace_owner.begin_owner_file(
+                owner, b"", b"unexpected", 0o600
+            ),
+            lambda: workspace_owner.abort_owner_file(owner),
+            lambda: workspace_owner.seal_owner_directories(owner),
+            lambda: workspace_owner.sync_owner_parent(owner),
+            lambda: workspace_owner.mark_owner_adopted(owner),
+            lambda: workspace_owner.quarantine_owner(owner),
+        ):
+            try:
+                operation()
+            except (RuntimeError, KeyError):
+                pass
+            else:
+                raise AssertionError("partial replacement exposed an operation")
+            assert workspace_owner.owner_state(owner) == (
+                "replacement-provisioning"
+            )
+
+        slot = root / ".replacement"
+        retained = root / ".retained-candidate"
+        slot.rename(retained)
+        slot.mkdir()
+        (slot / "foreign.txt").write_bytes(b"foreign")
+        for operation in (
+            lambda: workspace_owner.abort_owner(owner),
+            lambda: workspace_owner.close_owner_exact(owner),
+        ):
+            try:
+                operation()
+            except OSError:
+                pass
+            else:
+                raise AssertionError("unknown candidate identity was settled")
+            assert workspace_owner.owner_state(owner) == (
+                "replacement-recovery-required"
+            )
+            assert (slot / "foreign.txt").read_bytes() == b"foreign"
+            assert retained.is_dir()
+
+        independent = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            try:
+                fcntl.flock(independent, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                pass
+            else:
+                raise AssertionError("unknown candidate released its lease")
+        finally:
+            os.close(independent)
+
+        holder = [permit]
+        del permit
+        del owner
+        gc.collect()
+        try:
+            workspace_owner._exchange_owner_replacement_exact(
+                holder.pop(),
+                b".replacement",
+                b"published",
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("recovery permit unexpectedly exchanged")
+        assert not holder
+        assert (slot / "foreign.txt").read_bytes() == b"foreign"
+        assert retained.is_dir()
+        """
+    )
+    _run_exchange_fault_script(root, library, "provision-identity-fail", script)
+    assert (root / ".replacement" / "foreign.txt").read_bytes() == b"foreign"
+    assert (root / ".retained-candidate").is_dir()
+    assert (root / "published" / "incumbent.txt").read_bytes() == b"incumbent"
+
+
+@pytest.mark.parametrize("rebind", ("destination", "replacement-slot"))
+def test_native_replacement_receipt_recovery_retries_only_exact_exchanged_mapping(
+    tmp_path: Path,
+    rebind: str,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "incumbent.txt").write_bytes(b"incumbent")
+    owner, plan, permit, _incumbent_descriptor = _provision_replacement(root)
+    _adopt_and_fill_replacement(root, owner, plan, payload=b"candidate")
+    receipt_token = workspace_owner.exchange_owner_replacement(
+        permit,
+        b".replacement",
+        b"published",
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    slot = root / ".replacement"
+    rebound = destination if rebind == "destination" else slot
+    retained = root / f".retained-receipt-{rebind}"
+    foreign = root / f".foreign-receipt-{rebind}"
+    rebound.rename(retained)
+    rebound.mkdir()
+    (rebound / "foreign.txt").write_bytes(b"foreign")
+
+    with pytest.raises(RuntimeError, match="binding changed"):
+        workspace_owner.commit_owner_receipt(receipt_token)
+    assert workspace_owner.owner_state(owner) == "replacement-recovery-required"
+    independent_parent = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        with pytest.raises(BlockingIOError):
+            fcntl.flock(independent_parent, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    finally:
+        os.close(independent_parent)
+
+    rebound.rename(foreign)
+    retained.rename(rebound)
+    workspace_owner.commit_owner_receipt(receipt_token)
+    assert workspace_owner.owner_state(owner) == "replacement-receipted"
+    workspace_owner.close_owner_exact(owner)
+    assert (foreign / "foreign.txt").read_bytes() == b"foreign"
+    assert (destination / "views/bm25/documents.json").read_bytes() == b"candidate"
+    assert (slot / "incumbent.txt").read_bytes() == b"incumbent"


### PR DESCRIPTION
## Summary

Add a Linux-only protocol-v4 primitive that atomically exchanges one captured workspace destination with one authenticated same-parent candidate using `renameat2(RENAME_EXCHANGE)`.

This is primitive-only preparation for the strict BM25 `provider-bound-exact` provider. `LocalWorkspaceProvider` remains missing-only, and Gate C and M1 remain open.

Related to #199; this PR does not close it.

## Changes

- Extend the native workspace-owner ABI and fail-closed Python facade with a distinct one-shot replacement permit, candidate provisioning, exact binding verification, atomic exchange, and receipt settlement.
- Retain the incumbent and candidate in one aggregate owner, serialize cooperative settlement with a parent OFD `flock`, and fail closed when the exact namespace mapping cannot be proven.
- Add recovery and contention-cleanup coverage for deadline, syscall-outcome, parent `fsync`, unlock, descriptor-reuse, fork, cancellation, `BaseException`, and namespace-rebinding failures.
- Make the release workflow run committed and reverse-abort replacement lifecycles for both x86_64 and AArch64 wheel builds and the installed ABI3 Python 3.10–3.14 matrix.
- Document the protocol-v4 state machine, Linux/private-root/same-parent/same-device requirements, cooperative single-writer boundary, live-atomicity limit, lack of a crash journal or fallback, and remaining provider-integration work.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Combined targeted suite: `176 passed`
- Native workspace-owner suite: `83 passed`
- Release-artifact suite: `30 passed`
- Security stress: 500 committed exchanges plus 500 reverse-abort exchanges, with file descriptors stable at 4 to 4
- Independent integrity stress: 100 committed exchanges plus 100 rollback exchanges, with file descriptors stable at 4 to 4
- Contention cleanup stress: 100 losing-owner deallocations, with file descriptors stable at 4 to 4 while the winning owner retained its lease
- Full exact unit marker in a fresh read-only bwrap environment: `6969 passed, 71 skipped, 190 deselected`; the two warnings were expected read-only pytest-cache warnings
- A direct host run reached `3655 passed, 49 skipped` before stopping on the host-only absence of `/usr/bin/docker`; rerunning the complete unit tier with the Docker command namespace supplied produced the passing result above
- Black, isort, flake8, clang-format, Python compilation, and strict/public documentation checks passed
- The release workflow contains statically asserted semantic exchange coverage for both wheel architectures and the ABI3 matrix; execution on GitHub-hosted x86_64/AArch64 builders remains required PR CI

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
