### PR TITLE
feat(wiki): add multimodal repository knowledge contracts

### DIFF
--- a/codenib/wiki/__init__.py
+++ b/codenib/wiki/__init__.py
@@ -11,5 +11,30 @@ to a real symbol span pulled from the indexes (no fabricated lines).
 """
 
 from .builder import WikiBuilder
+from .media_artifacts import discover_media_manifest
+from .media_evidence import build_media_evidence_pack
+from .media_facts import build_visual_facts_manifest, deterministic_visual_facts
+from .media_grounding import (
+    discover_source_symbol_candidates,
+    ground_visual_facts_to_sources,
+)
+from .media_knowledge import (
+    build_multimodal_knowledge_view,
+    find_visual_code_links,
+    get_visual_evidence,
+    search_visual_context,
+)
 
-__all__ = ["WikiBuilder"]
+__all__ = [
+    "WikiBuilder",
+    "build_media_evidence_pack",
+    "build_multimodal_knowledge_view",
+    "build_visual_facts_manifest",
+    "deterministic_visual_facts",
+    "discover_media_manifest",
+    "discover_source_symbol_candidates",
+    "find_visual_code_links",
+    "get_visual_evidence",
+    "ground_visual_facts_to_sources",
+    "search_visual_context",
+]

--- a/codenib/wiki/_safe_file_reads.py
+++ b/codenib/wiki/_safe_file_reads.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small descriptor-authenticated reads for repository discovery helpers."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+
+def read_regular_bytes(path: Path, *, max_bytes: int) -> bytes | None:
+    """Read one stable regular file without following a replaceable symlink."""
+
+    try:
+        before = path.lstat()
+    except OSError:
+        return None
+    if not stat.S_ISREG(before.st_mode) or before.st_size > max_bytes:
+        return None
+
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        return None
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_size > max_bytes
+            or (opened.st_dev, opened.st_ino) != (before.st_dev, before.st_ino)
+        ):
+            return None
+
+        chunks: list[bytes] = []
+        remaining = max_bytes + 1
+        while remaining:
+            chunk = os.read(descriptor, min(64 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+
+        finished = os.fstat(descriptor)
+        if (
+            finished.st_size,
+            finished.st_mtime_ns,
+            finished.st_ctime_ns,
+        ) != (opened.st_size, opened.st_mtime_ns, opened.st_ctime_ns):
+            return None
+        payload = b"".join(chunks)
+        return payload if len(payload) <= max_bytes else None
+    finally:
+        os.close(descriptor)
+
+
+__all__ = ["read_regular_bytes"]

--- a/codenib/wiki/media_artifacts.py
+++ b/codenib/wiki/media_artifacts.py
@@ -151,12 +151,16 @@ def discover_media_manifest(
         relative = path.relative_to(root).as_posix()
         artifact_references = tuple(references.get(relative, ()))
         caption = _caption(artifact_references)
+        try:
+            digest = _sha256_file(path, max_bytes=_MAX_MEDIA_BYTES)
+        except (OSError, ValueError):
+            continue
         artifacts.append(
             MediaArtifact(
                 path=relative,
                 media_type=_media_type(path),
                 mime_type=_mime_type(path),
-                sha256=_sha256_file(path),
+                sha256=digest,
                 size_bytes=size,
                 role_hint=_role_hint(relative, artifact_references),
                 references=artifact_references,
@@ -309,10 +313,14 @@ def _role_hint(path: str, references: tuple[MediaReference, ...]) -> str:
     return "repository_image"
 
 
-def _sha256_file(path: Path) -> str:
+def _sha256_file(path: Path, *, max_bytes: int) -> str:
     digest = hashlib.sha256()
+    consumed = 0
     with path.open("rb") as handle:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            consumed += len(chunk)
+            if consumed > max_bytes:
+                raise ValueError("media artifact exceeds the byte limit")
             digest.update(chunk)
     return digest.hexdigest()
 

--- a/codenib/wiki/media_artifacts.py
+++ b/codenib/wiki/media_artifacts.py
@@ -1,0 +1,362 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Discovery manifest for repository-native multimodal artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import mimetypes
+import os
+import re
+import subprocess
+from dataclasses import asdict, dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Mapping
+from urllib.parse import unquote, urlsplit
+
+from ..repository_filters import walk_repository_files
+from ..repository_source_selection import (
+    DEFAULT_REPOSITORY_SOURCE_SELECTION,
+    RepositorySourceSelection,
+)
+
+MEDIA_MANIFEST_SCHEMA = "codenib.media-manifest.v1"
+MEDIA_MANIFEST_VERSION = 1
+SUPPORTED_MEDIA_EXTENSIONS = frozenset({".jpg", ".jpeg", ".png", ".svg", ".webp"})
+
+_MARKDOWN_EXTENSIONS = frozenset({".md", ".mdx"})
+_MAX_MEDIA_ARTIFACTS = 4096
+_MAX_MEDIA_BYTES = 32 * 1024 * 1024
+_MAX_MARKDOWN_BYTES = 2 * 1024 * 1024
+_MAX_TEXT_BYTES = 4096
+_MARKDOWN_IMAGE_RE = re.compile(
+    r"!\[(?P<alt>[^\]]{0,2048})\]\((?P<target>[^)\s]{1,4096})(?:\s+\"(?P<title>[^\"]{0,2048})\")?\)"
+)
+_HTML_IMAGE_RE = re.compile(
+    r"<img\b[^>]*\bsrc=[\"'](?P<target>[^\"']{1,4096})[\"'][^>]*>",
+    flags=re.IGNORECASE,
+)
+_HTML_ALT_RE = re.compile(
+    r"\balt=[\"'](?P<alt>[^\"']{0,2048})[\"']",
+    flags=re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class MediaReference:
+    """One markdown/html reference that points to a repository media artifact."""
+
+    markdown_path: str
+    line: int
+    alt_text: str = ""
+    title: str = ""
+    surrounding_text: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class MediaArtifact:
+    """A repository-native visual asset prepared for later VLM extraction."""
+
+    path: str
+    media_type: str
+    mime_type: str
+    sha256: str
+    size_bytes: int
+    role_hint: str = "repository_image"
+    references: tuple[MediaReference, ...] = ()
+    caption: str = ""
+    surrounding_text: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["references"] = [reference.to_dict() for reference in self.references]
+        return data
+
+
+@dataclass(frozen=True)
+class MediaManifest:
+    """Stable manifest for media artifacts discovered inside one repository."""
+
+    schema: str
+    version: int
+    commit: str
+    source_selection_digest: str
+    artifacts: tuple[MediaArtifact, ...] = ()
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "version": self.version,
+            "commit": self.commit,
+            "source_selection_digest": self.source_selection_digest,
+            "artifact_count": len(self.artifacts),
+            "artifacts": [artifact.to_dict() for artifact in self.artifacts],
+            "metadata": dict(self.metadata),
+            "manifest_sha256": self.manifest_sha256,
+        }
+
+    @property
+    def manifest_sha256(self) -> str:
+        payload = {
+            "schema": self.schema,
+            "version": self.version,
+            "commit": self.commit,
+            "source_selection_digest": self.source_selection_digest,
+            "artifacts": [artifact.to_dict() for artifact in self.artifacts],
+            "metadata": dict(self.metadata),
+        }
+        return _sha256_json(payload)
+
+
+def discover_media_manifest(
+    repo_path: str | Path,
+    *,
+    commit: str | None = None,
+    exclude_roots: Iterable[str | Path] = (),
+    selection: RepositorySourceSelection = DEFAULT_REPOSITORY_SOURCE_SELECTION,
+    max_artifacts: int = _MAX_MEDIA_ARTIFACTS,
+) -> dict[str, Any]:
+    """Discover repository-native visual artifacts and return a stable manifest."""
+
+    root = Path(repo_path).expanduser().resolve()
+    selected = RepositorySourceSelection(selection.exclude_subtrees)
+    references = _discover_markdown_references(
+        root,
+        exclude_roots=exclude_roots,
+        selection=selected,
+    )
+    artifacts: list[MediaArtifact] = []
+    for path in walk_repository_files(
+        root,
+        exclude_roots=exclude_roots,
+        selection=selected,
+    ):
+        if len(artifacts) >= max(0, max_artifacts):
+            break
+        if path.is_symlink() or path.suffix.lower() not in SUPPORTED_MEDIA_EXTENSIONS:
+            continue
+        try:
+            size = path.stat().st_size
+        except OSError:
+            continue
+        if size < 0 or size > _MAX_MEDIA_BYTES:
+            continue
+        relative = path.relative_to(root).as_posix()
+        artifact_references = tuple(references.get(relative, ()))
+        caption = _caption(artifact_references)
+        artifacts.append(
+            MediaArtifact(
+                path=relative,
+                media_type=_media_type(path),
+                mime_type=_mime_type(path),
+                sha256=_sha256_file(path),
+                size_bytes=size,
+                role_hint=_role_hint(relative, artifact_references),
+                references=artifact_references,
+                caption=caption,
+                surrounding_text=_surrounding_text(artifact_references),
+            )
+        )
+
+    manifest = MediaManifest(
+        schema=MEDIA_MANIFEST_SCHEMA,
+        version=MEDIA_MANIFEST_VERSION,
+        commit=commit if commit is not None else _git_commit(root),
+        source_selection_digest=selected.digest,
+        artifacts=tuple(sorted(artifacts, key=lambda artifact: artifact.path)),
+        metadata={
+            "supported_extensions": sorted(SUPPORTED_MEDIA_EXTENSIONS),
+            "max_media_bytes": _MAX_MEDIA_BYTES,
+        },
+    )
+    return manifest.to_dict()
+
+
+def _discover_markdown_references(
+    root: Path,
+    *,
+    exclude_roots: Iterable[str | Path],
+    selection: RepositorySourceSelection,
+) -> dict[str, list[MediaReference]]:
+    references: dict[str, list[MediaReference]] = {}
+    for path in walk_repository_files(
+        root,
+        exclude_roots=exclude_roots,
+        selection=selection,
+    ):
+        if path.is_symlink() or path.suffix.lower() not in _MARKDOWN_EXTENSIONS:
+            continue
+        try:
+            if path.stat().st_size > _MAX_MARKDOWN_BYTES:
+                continue
+            markdown = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        lines = markdown.splitlines()
+        relative_markdown = path.relative_to(root).as_posix()
+        for line_number, line in enumerate(lines, start=1):
+            for target, alt, title in _line_image_links(line):
+                target_path = _resolve_media_target(
+                    target,
+                    markdown_path=Path(relative_markdown),
+                )
+                if target_path is None:
+                    continue
+                references.setdefault(target_path, []).append(
+                    MediaReference(
+                        markdown_path=relative_markdown,
+                        line=line_number,
+                        alt_text=_safe_text(alt),
+                        title=_safe_text(title),
+                        surrounding_text=_safe_text(
+                            _markdown_window(lines, line_number)
+                        ),
+                    )
+                )
+    return {
+        key: sorted(value, key=lambda ref: (ref.markdown_path, ref.line))
+        for key, value in references.items()
+    }
+
+
+def _line_image_links(line: str) -> list[tuple[str, str, str]]:
+    links = [
+        (
+            match.group("target"),
+            match.group("alt") or "",
+            match.group("title") or "",
+        )
+        for match in _MARKDOWN_IMAGE_RE.finditer(line)
+    ]
+    for match in _HTML_IMAGE_RE.finditer(line):
+        tag = match.group(0)
+        alt_match = _HTML_ALT_RE.search(tag)
+        links.append(
+            (match.group("target"), alt_match.group("alt") if alt_match else "", "")
+        )
+    return links
+
+
+def _resolve_media_target(target: str, *, markdown_path: Path) -> str | None:
+    value = unquote(str(target or "").strip()).split("#", 1)[0].split("?", 1)[0]
+    if not value:
+        return None
+    parsed = urlsplit(value)
+    if parsed.scheme or parsed.netloc or value.startswith("//"):
+        return None
+    candidate = PurePosixPath(value)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        return None
+    resolved = (markdown_path.parent / candidate).as_posix()
+    normalized = PurePosixPath(resolved).as_posix()
+    if normalized == "." or normalized.startswith("../"):
+        return None
+    if PurePosixPath(normalized).suffix.lower() not in SUPPORTED_MEDIA_EXTENSIONS:
+        return None
+    return normalized
+
+
+def _markdown_window(lines: list[str], line_number: int) -> str:
+    start = max(0, line_number - 2)
+    end = min(len(lines), line_number + 1)
+    return "\n".join(line.strip() for line in lines[start:end] if line.strip())
+
+
+def _caption(references: tuple[MediaReference, ...]) -> str:
+    for reference in references:
+        caption = reference.alt_text or reference.title
+        if caption:
+            return caption
+    return ""
+
+
+def _surrounding_text(references: tuple[MediaReference, ...]) -> str:
+    for reference in references:
+        if reference.surrounding_text:
+            return reference.surrounding_text
+    return ""
+
+
+def _media_type(path: Path) -> str:
+    return "svg" if path.suffix.lower() == ".svg" else "image"
+
+
+def _mime_type(path: Path) -> str:
+    if path.suffix.lower() == ".svg":
+        return "image/svg+xml"
+    return mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+
+
+def _role_hint(path: str, references: tuple[MediaReference, ...]) -> str:
+    text = " ".join(
+        [
+            path,
+            *(reference.alt_text for reference in references),
+            *(reference.surrounding_text for reference in references),
+        ]
+    ).lower()
+    if any(token in text for token in ("architecture", "diagram", "sequence", "flow")):
+        return "architecture_diagram"
+    if any(token in text for token in ("screenshot", "screen shot", "ui", "dashboard")):
+        return "ui_screenshot"
+    return "repository_image"
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _sha256_json(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        payload,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _git_commit(root: Path) -> str:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", os.fspath(root), "rev-parse", "HEAD"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return completed.stdout.strip() if completed.returncode == 0 else ""
+
+
+def _safe_text(value: Any, *, max_bytes: int = _MAX_TEXT_BYTES) -> str:
+    text = str(value or "").strip()
+    if len(text.encode("utf-8")) <= max_bytes:
+        return text
+    encoded = text.encode("utf-8")[: max(0, max_bytes - 1)]
+    return encoded.decode("utf-8", errors="ignore").rstrip() + "…"
+
+
+__all__ = [
+    "MEDIA_MANIFEST_SCHEMA",
+    "MEDIA_MANIFEST_VERSION",
+    "SUPPORTED_MEDIA_EXTENSIONS",
+    "MediaArtifact",
+    "MediaManifest",
+    "MediaReference",
+    "discover_media_manifest",
+]

--- a/codenib/wiki/media_artifacts.py
+++ b/codenib/wiki/media_artifacts.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import mimetypes
 import os
+import posixpath
 import re
 import subprocess
 from dataclasses import asdict, dataclass, field
@@ -22,6 +23,7 @@ from ..repository_source_selection import (
     DEFAULT_REPOSITORY_SOURCE_SELECTION,
     RepositorySourceSelection,
 )
+from ._safe_file_reads import read_regular_bytes
 
 MEDIA_MANIFEST_SCHEMA = "codenib.media-manifest.v1"
 MEDIA_MANIFEST_VERSION = 1
@@ -31,6 +33,8 @@ _MARKDOWN_EXTENSIONS = frozenset({".md", ".mdx"})
 _MAX_MEDIA_ARTIFACTS = 4096
 _MAX_MEDIA_BYTES = 32 * 1024 * 1024
 _MAX_MARKDOWN_BYTES = 2 * 1024 * 1024
+_MAX_MARKDOWN_FILES = 8192
+_MAX_REFERENCES_PER_ARTIFACT = 64
 _MAX_TEXT_BYTES = 4096
 _MARKDOWN_IMAGE_RE = re.compile(
     r"!\[(?P<alt>[^\]]{0,2048})\]\((?P<target>[^)\s]{1,4096})(?:\s+\"(?P<title>[^\"]{0,2048})\")?\)"
@@ -127,34 +131,40 @@ def discover_media_manifest(
 
     root = Path(repo_path).expanduser().resolve()
     selected = RepositorySourceSelection(selection.exclude_subtrees)
-    references = _discover_markdown_references(
-        root,
-        exclude_roots=exclude_roots,
-        selection=selected,
+    artifact_limit = _validated_limit(
+        max_artifacts,
+        name="max_artifacts",
+        maximum=_MAX_MEDIA_ARTIFACTS,
     )
-    artifacts: list[MediaArtifact] = []
+    excluded = tuple(exclude_roots)
+    discovered: list[tuple[Path, str, str, int]] = []
     for path in walk_repository_files(
         root,
-        exclude_roots=exclude_roots,
+        exclude_roots=excluded,
         selection=selected,
     ):
-        if len(artifacts) >= max(0, max_artifacts):
+        if len(discovered) >= artifact_limit:
             break
         if path.is_symlink() or path.suffix.lower() not in SUPPORTED_MEDIA_EXTENSIONS:
             continue
-        try:
-            size = path.stat().st_size
-        except OSError:
-            continue
-        if size < 0 or size > _MAX_MEDIA_BYTES:
+        payload = read_regular_bytes(path, max_bytes=_MAX_MEDIA_BYTES)
+        if payload is None:
             continue
         relative = path.relative_to(root).as_posix()
+        discovered.append(
+            (path, relative, hashlib.sha256(payload).hexdigest(), len(payload))
+        )
+
+    references = _discover_markdown_references(
+        root,
+        artifact_paths=frozenset(relative for _, relative, _, _ in discovered),
+        exclude_roots=excluded,
+        selection=selected,
+    )
+    artifacts: list[MediaArtifact] = []
+    for path, relative, digest, size in discovered:
         artifact_references = tuple(references.get(relative, ()))
         caption = _caption(artifact_references)
-        try:
-            digest = _sha256_file(path, max_bytes=_MAX_MEDIA_BYTES)
-        except (OSError, ValueError):
-            continue
         artifacts.append(
             MediaArtifact(
                 path=relative,
@@ -186,10 +196,14 @@ def discover_media_manifest(
 def _discover_markdown_references(
     root: Path,
     *,
+    artifact_paths: frozenset[str],
     exclude_roots: Iterable[str | Path],
     selection: RepositorySourceSelection,
 ) -> dict[str, list[MediaReference]]:
+    if not artifact_paths:
+        return {}
     references: dict[str, list[MediaReference]] = {}
+    markdown_files = 0
     for path in walk_repository_files(
         root,
         exclude_roots=exclude_roots,
@@ -197,11 +211,15 @@ def _discover_markdown_references(
     ):
         if path.is_symlink() or path.suffix.lower() not in _MARKDOWN_EXTENSIONS:
             continue
+        if markdown_files >= _MAX_MARKDOWN_FILES:
+            break
+        markdown_files += 1
+        payload = read_regular_bytes(path, max_bytes=_MAX_MARKDOWN_BYTES)
+        if payload is None:
+            continue
         try:
-            if path.stat().st_size > _MAX_MARKDOWN_BYTES:
-                continue
-            markdown = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+            markdown = payload.decode("utf-8")
+        except UnicodeDecodeError:
             continue
         lines = markdown.splitlines()
         relative_markdown = path.relative_to(root).as_posix()
@@ -211,9 +229,12 @@ def _discover_markdown_references(
                     target,
                     markdown_path=Path(relative_markdown),
                 )
-                if target_path is None:
+                if target_path is None or target_path not in artifact_paths:
                     continue
-                references.setdefault(target_path, []).append(
+                target_references = references.setdefault(target_path, [])
+                if len(target_references) >= _MAX_REFERENCES_PER_ARTIFACT:
+                    continue
+                target_references.append(
                     MediaReference(
                         markdown_path=relative_markdown,
                         line=line_number,
@@ -252,16 +273,24 @@ def _resolve_media_target(target: str, *, markdown_path: Path) -> str | None:
     value = unquote(str(target or "").strip()).split("#", 1)[0].split("?", 1)[0]
     if not value:
         return None
-    parsed = urlsplit(value)
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return None
     if parsed.scheme or parsed.netloc or value.startswith("//"):
         return None
     candidate = PurePosixPath(value)
-    if candidate.is_absolute() or ".." in candidate.parts:
+    if candidate.is_absolute():
         return None
-    resolved = (markdown_path.parent / candidate).as_posix()
-    normalized = PurePosixPath(resolved).as_posix()
-    if normalized == "." or normalized.startswith("../"):
+    resolved = posixpath.normpath((markdown_path.parent / candidate).as_posix())
+    normalized_path = PurePosixPath(resolved)
+    if (
+        resolved == "."
+        or normalized_path.is_absolute()
+        or (normalized_path.parts and normalized_path.parts[0] == "..")
+    ):
         return None
+    normalized = normalized_path.as_posix()
     if PurePosixPath(normalized).suffix.lower() not in SUPPORTED_MEDIA_EXTENSIONS:
         return None
     return normalized
@@ -313,18 +342,6 @@ def _role_hint(path: str, references: tuple[MediaReference, ...]) -> str:
     return "repository_image"
 
 
-def _sha256_file(path: Path, *, max_bytes: int) -> str:
-    digest = hashlib.sha256()
-    consumed = 0
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            consumed += len(chunk)
-            if consumed > max_bytes:
-                raise ValueError("media artifact exceeds the byte limit")
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
 def _sha256_json(payload: Mapping[str, Any]) -> str:
     encoded = json.dumps(
         payload,
@@ -357,6 +374,16 @@ def _safe_text(value: Any, *, max_bytes: int = _MAX_TEXT_BYTES) -> str:
         return text
     encoded = text.encode("utf-8")[: max(0, max_bytes - 1)]
     return encoded.decode("utf-8", errors="ignore").rstrip() + "…"
+
+
+def _validated_limit(value: Any, *, name: str, maximum: int) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value <= maximum
+    ):
+        raise ValueError(f"{name} must be an integer between 0 and {maximum}")
+    return value
 
 
 __all__ = [

--- a/codenib/wiki/media_facts.py
+++ b/codenib/wiki/media_facts.py
@@ -1,0 +1,461 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Structured visual facts extracted from repository media artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable, Iterable, Mapping
+
+MEDIA_FACTS_SCHEMA = "codenib.media-facts.v1"
+MEDIA_FACTS_VERSION = 1
+
+_MAX_PROMPT_BYTES = 32 * 1024
+_MAX_TEXT_BYTES = 4096
+_MAX_FACTS_PER_ARTIFACT = 32
+_WORD_RE = re.compile(r"[A-Za-z][A-Za-z0-9_]{2,}")
+_STOPWORDS = frozenset(
+    {
+        "and",
+        "are",
+        "asset",
+        "below",
+        "code",
+        "diagram",
+        "docs",
+        "image",
+        "maps",
+        "media",
+        "overview",
+        "png",
+        "repository",
+        "screenshot",
+        "service",
+        "shown",
+        "svg",
+        "the",
+        "this",
+        "webp",
+        "wiki",
+    }
+)
+
+VisualFactExtractor = Callable[[Mapping[str, Any]], Mapping[str, Any]]
+
+
+@dataclass(frozen=True)
+class VisualEntity:
+    """One entity mentioned or depicted by a repository media artifact."""
+
+    name: str
+    type: str
+    evidence: str = ""
+    confidence: float = 0.0
+    grounding_candidates: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["grounding_candidates"] = list(self.grounding_candidates)
+        return data
+
+
+@dataclass(frozen=True)
+class VisualRelation:
+    """One relation between extracted visual entities."""
+
+    source: str
+    relation: str
+    target: str
+    evidence: str = ""
+    confidence: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class VisualClaim:
+    """One source-grounded claim inferred from a media artifact."""
+
+    text: str
+    evidence: str
+    confidence: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class VisualFactPack:
+    """Structured facts for one repository media artifact."""
+
+    artifact_path: str
+    artifact_sha256: str
+    role_hint: str
+    extractor: str
+    entities: tuple[VisualEntity, ...] = ()
+    relations: tuple[VisualRelation, ...] = ()
+    claims: tuple[VisualClaim, ...] = ()
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "artifact_path": self.artifact_path,
+            "artifact_sha256": self.artifact_sha256,
+            "role_hint": self.role_hint,
+            "extractor": self.extractor,
+            "entities": [entity.to_dict() for entity in self.entities],
+            "relations": [relation.to_dict() for relation in self.relations],
+            "claims": [claim.to_dict() for claim in self.claims],
+            "metadata": dict(self.metadata),
+            "fact_pack_sha256": self.fact_pack_sha256,
+        }
+
+    @property
+    def fact_pack_sha256(self) -> str:
+        payload = {
+            "artifact_path": self.artifact_path,
+            "artifact_sha256": self.artifact_sha256,
+            "role_hint": self.role_hint,
+            "extractor": self.extractor,
+            "entities": [entity.to_dict() for entity in self.entities],
+            "relations": [relation.to_dict() for relation in self.relations],
+            "claims": [claim.to_dict() for claim in self.claims],
+            "metadata": dict(self.metadata),
+        }
+        return _sha256_json(payload)
+
+
+@dataclass(frozen=True)
+class VisualFactsManifest:
+    """A stable collection of visual fact packs for one media manifest."""
+
+    schema: str
+    version: int
+    media_manifest_sha256: str
+    facts: tuple[VisualFactPack, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "version": self.version,
+            "media_manifest_sha256": self.media_manifest_sha256,
+            "fact_count": len(self.facts),
+            "facts": [fact.to_dict() for fact in self.facts],
+            "manifest_sha256": self.manifest_sha256,
+        }
+
+    @property
+    def manifest_sha256(self) -> str:
+        payload = {
+            "schema": self.schema,
+            "version": self.version,
+            "media_manifest_sha256": self.media_manifest_sha256,
+            "facts": [fact.to_dict() for fact in self.facts],
+        }
+        return _sha256_json(payload)
+
+
+def build_visual_fact_extraction_prompt(artifact: Mapping[str, Any]) -> str:
+    """Build a bounded VLM prompt that asks for structured visual facts."""
+
+    payload = {
+        "task": "extract_repository_visual_facts",
+        "artifact": _artifact_prompt_payload(artifact),
+        "output_schema": {
+            "entities": [
+                {
+                    "name": "string",
+                    "type": "component|ui_element|data_store|process|unknown",
+                    "evidence": "string",
+                    "confidence": "number between 0 and 1",
+                    "grounding_candidates": ["symbol_or_file_name"],
+                }
+            ],
+            "relations": [
+                {
+                    "source": "entity name",
+                    "relation": "calls|depends_on|renders|routes_to|contains|unknown",
+                    "target": "entity name",
+                    "evidence": "string",
+                    "confidence": "number between 0 and 1",
+                }
+            ],
+            "claims": [
+                {
+                    "text": "source-grounded visual claim",
+                    "evidence": "caption, surrounding markdown, visual region, or label",
+                    "confidence": "number between 0 and 1",
+                }
+            ],
+        },
+        "requirements": [
+            "Return JSON only.",
+            "Do not invent repository symbols that are not visually or textually supported.",
+            "Prefer entities that can later be grounded to files, symbols, routes, or dependencies.",
+            "Use the artifact caption and surrounding markdown as supporting context, not as proof of unseen code.",
+        ],
+    }
+    prompt = (
+        "Extract structured repository knowledge from this visual artifact.\n\n"
+        + json.dumps(payload, ensure_ascii=True, sort_keys=True, indent=2)
+    )
+    if len(prompt.encode("utf-8")) > _MAX_PROMPT_BYTES:
+        raise ValueError("visual fact extraction prompt exceeds the byte limit")
+    return prompt
+
+
+def deterministic_visual_facts(artifact: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a conservative local fact pack from artifact metadata only."""
+
+    path = _safe_text(artifact.get("path"))
+    sha256 = _safe_text(artifact.get("sha256"))
+    role = _safe_text(artifact.get("role_hint") or "repository_image")
+    caption = _safe_text(artifact.get("caption"))
+    surrounding = _safe_text(artifact.get("surrounding_text"))
+    references = artifact.get("references") or ()
+    entities = _metadata_entities(path, role, caption, surrounding)
+    claims = _metadata_claims(path, role, caption, surrounding, references)
+    pack = VisualFactPack(
+        artifact_path=path,
+        artifact_sha256=sha256,
+        role_hint=role,
+        extractor="local/metadata",
+        entities=tuple(entities[:_MAX_FACTS_PER_ARTIFACT]),
+        claims=tuple(claims[:_MAX_FACTS_PER_ARTIFACT]),
+        metadata={"source": "artifact-path-caption-surrounding-markdown"},
+    )
+    return pack.to_dict()
+
+
+def build_visual_facts_manifest(
+    media_manifest: Mapping[str, Any],
+    *,
+    extractor: VisualFactExtractor = deterministic_visual_facts,
+) -> dict[str, Any]:
+    """Extract visual fact packs for every artifact in a media manifest."""
+
+    facts = []
+    for artifact in media_manifest.get("artifacts") or ():
+        if not isinstance(artifact, Mapping):
+            continue
+        pack = extractor(artifact)
+        facts.append(_fact_pack_from_mapping(pack))
+    manifest = VisualFactsManifest(
+        schema=MEDIA_FACTS_SCHEMA,
+        version=MEDIA_FACTS_VERSION,
+        media_manifest_sha256=_safe_text(media_manifest.get("manifest_sha256")),
+        facts=tuple(sorted(facts, key=lambda fact: fact.artifact_path)),
+    )
+    return manifest.to_dict()
+
+
+def _artifact_prompt_payload(artifact: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "path": _safe_text(artifact.get("path")),
+        "mime_type": _safe_text(artifact.get("mime_type")),
+        "role_hint": _safe_text(artifact.get("role_hint")),
+        "caption": _safe_text(artifact.get("caption")),
+        "surrounding_text": _safe_text(artifact.get("surrounding_text")),
+        "references": [
+            {
+                "markdown_path": _safe_text(reference.get("markdown_path")),
+                "line": reference.get("line")
+                if type(reference.get("line")) is int
+                else 0,
+                "alt_text": _safe_text(reference.get("alt_text")),
+                "title": _safe_text(reference.get("title")),
+            }
+            for reference in _mapping_items(artifact.get("references"))
+        ][:8],
+    }
+
+
+def _metadata_entities(
+    path: str,
+    role: str,
+    caption: str,
+    surrounding: str,
+) -> list[VisualEntity]:
+    names = _entity_names(" ".join([path, caption, surrounding]))
+    entity_type = {
+        "architecture_diagram": "component",
+        "ui_screenshot": "ui_element",
+    }.get(role, "unknown")
+    entities = [
+        VisualEntity(
+            name=name,
+            type=entity_type,
+            evidence=caption or path,
+            confidence=0.35,
+            grounding_candidates=(name,),
+        )
+        for name in names
+    ]
+    if role and not entities:
+        entities.append(
+            VisualEntity(
+                name=role.replace("_", " "),
+                type=entity_type,
+                evidence=path,
+                confidence=0.25,
+            )
+        )
+    return entities
+
+
+def _metadata_claims(
+    path: str,
+    role: str,
+    caption: str,
+    surrounding: str,
+    references: Any,
+) -> list[VisualClaim]:
+    claims = [
+        VisualClaim(
+            text=f"{path} is a repository visual artifact with role hint {role}.",
+            evidence=path,
+            confidence=0.5,
+        )
+    ]
+    if caption:
+        claims.append(
+            VisualClaim(
+                text=f"{path} is described as: {caption}",
+                evidence=caption,
+                confidence=0.45,
+            )
+        )
+    if surrounding:
+        claims.append(
+            VisualClaim(
+                text=f"{path} is referenced from nearby documentation context.",
+                evidence=surrounding,
+                confidence=0.4,
+            )
+        )
+    reference_count = len(list(_mapping_items(references)))
+    if reference_count:
+        claims.append(
+            VisualClaim(
+                text=f"{path} has {reference_count} repository documentation reference(s).",
+                evidence="markdown references",
+                confidence=0.5,
+            )
+        )
+    return claims
+
+
+def _fact_pack_from_mapping(value: Mapping[str, Any]) -> VisualFactPack:
+    return VisualFactPack(
+        artifact_path=_safe_text(value.get("artifact_path")),
+        artifact_sha256=_safe_text(value.get("artifact_sha256")),
+        role_hint=_safe_text(value.get("role_hint")),
+        extractor=_safe_text(value.get("extractor")),
+        entities=tuple(
+            VisualEntity(
+                name=_safe_text(entity.get("name")),
+                type=_safe_text(entity.get("type") or "unknown"),
+                evidence=_safe_text(entity.get("evidence")),
+                confidence=_confidence(entity.get("confidence")),
+                grounding_candidates=tuple(
+                    _safe_text(candidate)
+                    for candidate in entity.get("grounding_candidates") or ()
+                    if _safe_text(candidate)
+                ),
+            )
+            for entity in _mapping_items(value.get("entities"))
+        ),
+        relations=tuple(
+            VisualRelation(
+                source=_safe_text(relation.get("source")),
+                relation=_safe_text(relation.get("relation") or "unknown"),
+                target=_safe_text(relation.get("target")),
+                evidence=_safe_text(relation.get("evidence")),
+                confidence=_confidence(relation.get("confidence")),
+            )
+            for relation in _mapping_items(value.get("relations"))
+        ),
+        claims=tuple(
+            VisualClaim(
+                text=_safe_text(claim.get("text")),
+                evidence=_safe_text(claim.get("evidence")),
+                confidence=_confidence(claim.get("confidence")),
+            )
+            for claim in _mapping_items(value.get("claims"))
+        ),
+        metadata=dict(value.get("metadata"))
+        if isinstance(value.get("metadata"), Mapping)
+        else {},
+    )
+
+
+def _entity_names(text: str) -> list[str]:
+    seen = set()
+    names = []
+    for match in _WORD_RE.finditer(text):
+        value = match.group(0)
+        normalized = value.lower()
+        if normalized in _STOPWORDS or normalized in seen:
+            continue
+        seen.add(normalized)
+        names.append(value)
+        if len(names) >= 12:
+            break
+    return names
+
+
+def _mapping_items(value: Any) -> Iterable[Mapping[str, Any]]:
+    if isinstance(value, (str, bytes, bytearray)):
+        return ()
+    if not isinstance(value, Iterable):
+        return ()
+    return (item for item in value if isinstance(item, Mapping))
+
+
+def _confidence(value: Any) -> float:
+    if isinstance(value, bool):
+        return 0.0
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return min(1.0, max(0.0, confidence))
+
+
+def _sha256_json(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        payload,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _safe_text(value: Any, *, max_bytes: int = _MAX_TEXT_BYTES) -> str:
+    text = str(value or "").strip()
+    if len(text.encode("utf-8")) <= max_bytes:
+        return text
+    encoded = text.encode("utf-8")[: max(0, max_bytes - 1)]
+    return encoded.decode("utf-8", errors="ignore").rstrip() + "…"
+
+
+__all__ = [
+    "MEDIA_FACTS_SCHEMA",
+    "MEDIA_FACTS_VERSION",
+    "VisualClaim",
+    "VisualEntity",
+    "VisualFactPack",
+    "VisualFactsManifest",
+    "VisualRelation",
+    "build_visual_fact_extraction_prompt",
+    "build_visual_facts_manifest",
+    "deterministic_visual_facts",
+]

--- a/codenib/wiki/media_facts.py
+++ b/codenib/wiki/media_facts.py
@@ -10,6 +10,8 @@ import hashlib
 import json
 import re
 from dataclasses import asdict, dataclass, field
+from itertools import islice
+from pathlib import PurePosixPath
 from typing import Any, Callable, Iterable, Mapping
 
 MEDIA_FACTS_SCHEMA = "codenib.media-facts.v1"
@@ -17,7 +19,13 @@ MEDIA_FACTS_VERSION = 1
 
 _MAX_PROMPT_BYTES = 32 * 1024
 _MAX_TEXT_BYTES = 4096
+_MAX_ARTIFACTS = 4096
 _MAX_FACTS_PER_ARTIFACT = 32
+_MAX_FACT_PACK_BYTES = 64 * 1024
+_MAX_GROUNDING_CANDIDATES = 32
+_MAX_METADATA_BYTES = 8 * 1024
+_MAX_METADATA_ITEMS = 32
+_MAX_REFERENCES_PER_ARTIFACT = 64
 _WORD_RE = re.compile(r"[A-Za-z][A-Za-z0-9_]{2,}")
 _STOPWORDS = frozenset(
     {
@@ -213,7 +221,7 @@ def build_visual_fact_extraction_prompt(artifact: Mapping[str, Any]) -> str:
 def deterministic_visual_facts(artifact: Mapping[str, Any]) -> dict[str, Any]:
     """Return a conservative local fact pack from artifact metadata only."""
 
-    path = _safe_text(artifact.get("path"))
+    path = _safe_relative_path(artifact.get("path"))
     sha256 = _safe_text(artifact.get("sha256"))
     role = _safe_text(artifact.get("role_hint") or "repository_image")
     caption = _safe_text(artifact.get("caption"))
@@ -241,11 +249,25 @@ def build_visual_facts_manifest(
     """Extract visual fact packs for every artifact in a media manifest."""
 
     facts = []
-    for artifact in media_manifest.get("artifacts") or ():
-        if not isinstance(artifact, Mapping):
+    for artifact in _mapping_items(
+        media_manifest.get("artifacts"),
+        limit=_MAX_ARTIFACTS,
+    ):
+        artifact_path = _safe_relative_path(artifact.get("path"))
+        if not artifact_path:
             continue
         pack = extractor(artifact)
-        facts.append(_fact_pack_from_mapping(pack))
+        if not isinstance(pack, Mapping):
+            raise ValueError("visual fact extractor must return a mapping")
+        normalized = _fact_pack_from_mapping(
+            pack,
+            artifact_path=artifact_path,
+            artifact_sha256=_safe_text(artifact.get("sha256")),
+            role_hint=_safe_text(artifact.get("role_hint") or "repository_image"),
+        )
+        if _json_size(normalized.to_dict()) > _MAX_FACT_PACK_BYTES:
+            raise ValueError("visual fact pack exceeds the byte limit")
+        facts.append(normalized)
     manifest = VisualFactsManifest(
         schema=MEDIA_FACTS_SCHEMA,
         version=MEDIA_FACTS_VERSION,
@@ -271,8 +293,8 @@ def _artifact_prompt_payload(artifact: Mapping[str, Any]) -> dict[str, Any]:
                 "alt_text": _safe_text(reference.get("alt_text")),
                 "title": _safe_text(reference.get("title")),
             }
-            for reference in _mapping_items(artifact.get("references"))
-        ][:8],
+            for reference in _mapping_items(artifact.get("references"), limit=8)
+        ],
     }
 
 
@@ -339,7 +361,13 @@ def _metadata_claims(
                 confidence=0.4,
             )
         )
-    reference_count = len(list(_mapping_items(references)))
+    reference_count = sum(
+        1
+        for _ in _mapping_items(
+            references,
+            limit=_MAX_REFERENCES_PER_ARTIFACT,
+        )
+    )
     if reference_count:
         claims.append(
             VisualClaim(
@@ -351,11 +379,17 @@ def _metadata_claims(
     return claims
 
 
-def _fact_pack_from_mapping(value: Mapping[str, Any]) -> VisualFactPack:
+def _fact_pack_from_mapping(
+    value: Mapping[str, Any],
+    *,
+    artifact_path: str,
+    artifact_sha256: str,
+    role_hint: str,
+) -> VisualFactPack:
     return VisualFactPack(
-        artifact_path=_safe_text(value.get("artifact_path")),
-        artifact_sha256=_safe_text(value.get("artifact_sha256")),
-        role_hint=_safe_text(value.get("role_hint")),
+        artifact_path=artifact_path,
+        artifact_sha256=artifact_sha256,
+        role_hint=role_hint,
         extractor=_safe_text(value.get("extractor")),
         entities=tuple(
             VisualEntity(
@@ -365,11 +399,17 @@ def _fact_pack_from_mapping(value: Mapping[str, Any]) -> VisualFactPack:
                 confidence=_confidence(entity.get("confidence")),
                 grounding_candidates=tuple(
                     _safe_text(candidate)
-                    for candidate in entity.get("grounding_candidates") or ()
+                    for candidate in islice(
+                        _non_string_iterable(entity.get("grounding_candidates")),
+                        _MAX_GROUNDING_CANDIDATES,
+                    )
                     if _safe_text(candidate)
                 ),
             )
-            for entity in _mapping_items(value.get("entities"))
+            for entity in _mapping_items(
+                value.get("entities"),
+                limit=_MAX_FACTS_PER_ARTIFACT,
+            )
         ),
         relations=tuple(
             VisualRelation(
@@ -379,7 +419,10 @@ def _fact_pack_from_mapping(value: Mapping[str, Any]) -> VisualFactPack:
                 evidence=_safe_text(relation.get("evidence")),
                 confidence=_confidence(relation.get("confidence")),
             )
-            for relation in _mapping_items(value.get("relations"))
+            for relation in _mapping_items(
+                value.get("relations"),
+                limit=_MAX_FACTS_PER_ARTIFACT,
+            )
         ),
         claims=tuple(
             VisualClaim(
@@ -387,11 +430,12 @@ def _fact_pack_from_mapping(value: Mapping[str, Any]) -> VisualFactPack:
                 evidence=_safe_text(claim.get("evidence")),
                 confidence=_confidence(claim.get("confidence")),
             )
-            for claim in _mapping_items(value.get("claims"))
+            for claim in _mapping_items(
+                value.get("claims"),
+                limit=_MAX_FACTS_PER_ARTIFACT,
+            )
         ),
-        metadata=dict(value.get("metadata"))
-        if isinstance(value.get("metadata"), Mapping)
-        else {},
+        metadata=_bounded_metadata(value.get("metadata")),
     )
 
 
@@ -410,12 +454,27 @@ def _entity_names(text: str) -> list[str]:
     return names
 
 
-def _mapping_items(value: Any) -> Iterable[Mapping[str, Any]]:
-    if isinstance(value, (str, bytes, bytearray)):
+def _mapping_items(
+    value: Any,
+    *,
+    limit: int,
+) -> Iterable[Mapping[str, Any]]:
+    if isinstance(value, (str, bytes, bytearray, Mapping)):
         return ()
-    if not isinstance(value, Iterable):
+    try:
+        values = iter(value or ())
+    except TypeError:
         return ()
-    return (item for item in value if isinstance(item, Mapping))
+    return (item for item in islice(values, limit) if isinstance(item, Mapping))
+
+
+def _non_string_iterable(value: Any) -> Iterable[Any]:
+    if isinstance(value, (str, bytes, bytearray, Mapping)):
+        return ()
+    try:
+        return iter(value or ())
+    except TypeError:
+        return ()
 
 
 def _confidence(value: Any) -> float:
@@ -426,6 +485,35 @@ def _confidence(value: Any) -> float:
     except (TypeError, ValueError):
         return 0.0
     return min(1.0, max(0.0, confidence))
+
+
+def _bounded_metadata(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    metadata = {
+        key: item
+        for raw_key, item in islice(value.items(), _MAX_METADATA_ITEMS)
+        if (key := _safe_text(raw_key, max_bytes=256))
+    }
+    try:
+        size = _json_size(metadata)
+    except (RecursionError, TypeError, ValueError) as exc:
+        raise ValueError("visual fact metadata must contain bounded JSON") from exc
+    if size > _MAX_METADATA_BYTES:
+        raise ValueError("visual fact metadata exceeds the byte limit")
+    return metadata
+
+
+def _json_size(payload: Mapping[str, Any]) -> int:
+    return len(
+        json.dumps(
+            payload,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    )
 
 
 def _sha256_json(payload: Mapping[str, Any]) -> str:
@@ -445,6 +533,16 @@ def _safe_text(value: Any, *, max_bytes: int = _MAX_TEXT_BYTES) -> str:
         return text
     encoded = text.encode("utf-8")[: max(0, max_bytes - 1)]
     return encoded.decode("utf-8", errors="ignore").rstrip() + "…"
+
+
+def _safe_relative_path(value: Any) -> str:
+    text = _safe_text(value)
+    if not text or "\\" in text:
+        return ""
+    path = PurePosixPath(text)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        return ""
+    return path.as_posix()
 
 
 __all__ = [

--- a/codenib/wiki/media_grounding.py
+++ b/codenib/wiki/media_grounding.py
@@ -1,0 +1,350 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Ground structured visual facts to repository files and symbols."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from ..repository_filters import walk_repository_files
+from ..repository_source_selection import (
+    DEFAULT_REPOSITORY_SOURCE_SELECTION,
+    RepositorySourceSelection,
+)
+
+MEDIA_GROUNDING_SCHEMA = "codenib.media-grounding.v1"
+MEDIA_GROUNDING_VERSION = 1
+
+_SOURCE_EXTENSIONS = frozenset(
+    {
+        ".go",
+        ".java",
+        ".js",
+        ".jsx",
+        ".kt",
+        ".py",
+        ".rs",
+        ".scala",
+        ".swift",
+        ".ts",
+        ".tsx",
+    }
+)
+_MAX_SOURCE_BYTES = 1024 * 1024
+_MAX_CANDIDATES = 8192
+_MAX_BINDINGS_PER_ENTITY = 5
+_SYMBOL_RE = re.compile(
+    r"\b(?:class|def|function|const|let|var|interface|type|struct|enum)\s+([A-Za-z_][A-Za-z0-9_]*)"
+)
+_CAMEL_RE = re.compile(r"\b[A-Z][A-Za-z0-9_]{2,}\b")
+
+
+@dataclass(frozen=True)
+class SourceSymbolCandidate:
+    """One repository source target that a visual entity can bind to."""
+
+    path: str
+    symbol: str = ""
+    kind: str = "source"
+    line: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class VisualCodeBinding:
+    """A candidate grounding from a visual entity to source evidence."""
+
+    artifact_path: str
+    entity_name: str
+    source_path: str
+    symbol: str = ""
+    kind: str = "source"
+    line: int = 0
+    score: float = 0.0
+    evidence: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class VisualGroundingManifest:
+    """Stable visual-code binding manifest for one visual facts manifest."""
+
+    schema: str
+    version: int
+    visual_facts_manifest_sha256: str
+    bindings: tuple[VisualCodeBinding, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "version": self.version,
+            "visual_facts_manifest_sha256": self.visual_facts_manifest_sha256,
+            "binding_count": len(self.bindings),
+            "bindings": [binding.to_dict() for binding in self.bindings],
+            "manifest_sha256": self.manifest_sha256,
+        }
+
+    @property
+    def manifest_sha256(self) -> str:
+        payload = {
+            "schema": self.schema,
+            "version": self.version,
+            "visual_facts_manifest_sha256": self.visual_facts_manifest_sha256,
+            "bindings": [binding.to_dict() for binding in self.bindings],
+        }
+        return _sha256_json(payload)
+
+
+def discover_source_symbol_candidates(
+    repo_path: str | Path,
+    *,
+    exclude_roots: Iterable[str | Path] = (),
+    selection: RepositorySourceSelection = DEFAULT_REPOSITORY_SOURCE_SELECTION,
+    max_candidates: int = _MAX_CANDIDATES,
+) -> list[dict[str, Any]]:
+    """Return a bounded, deterministic source-symbol inventory for grounding."""
+
+    root = Path(repo_path).expanduser().resolve()
+    selected = RepositorySourceSelection(selection.exclude_subtrees)
+    candidates: list[SourceSymbolCandidate] = []
+    seen: set[tuple[str, str, int]] = set()
+    for path in walk_repository_files(
+        root,
+        exclude_roots=exclude_roots,
+        selection=selected,
+    ):
+        if len(candidates) >= max(0, max_candidates):
+            break
+        if path.is_symlink() or path.suffix.lower() not in _SOURCE_EXTENSIONS:
+            continue
+        try:
+            if path.stat().st_size > _MAX_SOURCE_BYTES:
+                continue
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        relative = path.relative_to(root).as_posix()
+        candidates.append(SourceSymbolCandidate(path=relative))
+        for symbol, line in _symbols(text):
+            key = (relative, symbol, line)
+            if key in seen:
+                continue
+            seen.add(key)
+            candidates.append(
+                SourceSymbolCandidate(
+                    path=relative,
+                    symbol=symbol,
+                    kind="symbol",
+                    line=line,
+                )
+            )
+            if len(candidates) >= max(0, max_candidates):
+                break
+    return [candidate.to_dict() for candidate in candidates[: max(0, max_candidates)]]
+
+
+def ground_visual_facts_to_sources(
+    visual_facts_manifest: Mapping[str, Any],
+    source_candidates: Iterable[Mapping[str, Any]],
+    *,
+    max_bindings_per_entity: int = _MAX_BINDINGS_PER_ENTITY,
+) -> dict[str, Any]:
+    """Ground visual entities to a source inventory using deterministic scoring."""
+
+    candidates = [
+        _candidate_from_mapping(candidate)
+        for candidate in source_candidates
+        if isinstance(candidate, Mapping)
+    ]
+    bindings: list[VisualCodeBinding] = []
+    for fact_pack in visual_facts_manifest.get("facts") or ():
+        if not isinstance(fact_pack, Mapping):
+            continue
+        artifact_path = _safe_text(fact_pack.get("artifact_path"))
+        for entity in fact_pack.get("entities") or ():
+            if not isinstance(entity, Mapping):
+                continue
+            entity_name = _safe_text(entity.get("name"))
+            if not entity_name:
+                continue
+            hints = [
+                entity_name,
+                *[
+                    _safe_text(candidate)
+                    for candidate in entity.get("grounding_candidates") or ()
+                ],
+            ]
+            scored = [
+                binding
+                for binding in (
+                    _score_candidate(
+                        artifact_path=artifact_path,
+                        entity_name=entity_name,
+                        hints=hints,
+                        candidate=candidate,
+                    )
+                    for candidate in candidates
+                )
+                if binding is not None
+            ]
+            scored.sort(
+                key=lambda binding: (
+                    -binding.score,
+                    binding.source_path,
+                    binding.symbol,
+                    binding.line,
+                )
+            )
+            bindings.extend(scored[: max(0, max_bindings_per_entity)])
+    manifest = VisualGroundingManifest(
+        schema=MEDIA_GROUNDING_SCHEMA,
+        version=MEDIA_GROUNDING_VERSION,
+        visual_facts_manifest_sha256=_safe_text(
+            visual_facts_manifest.get("manifest_sha256")
+        ),
+        bindings=tuple(
+            sorted(
+                _dedupe_bindings(bindings),
+                key=lambda binding: (
+                    binding.artifact_path,
+                    binding.entity_name,
+                    -binding.score,
+                    binding.source_path,
+                    binding.symbol,
+                ),
+            )
+        ),
+    )
+    return manifest.to_dict()
+
+
+def _score_candidate(
+    *,
+    artifact_path: str,
+    entity_name: str,
+    hints: Iterable[str],
+    candidate: SourceSymbolCandidate,
+) -> VisualCodeBinding | None:
+    normalized_hints = [_normalize(hint) for hint in hints if _normalize(hint)]
+    candidate_symbol = _normalize(candidate.symbol)
+    candidate_path = _normalize(Path(candidate.path).stem)
+    candidate_full_path = _normalize(candidate.path)
+    score = 0.0
+    evidence = ""
+    for hint in normalized_hints:
+        if candidate_symbol and hint == candidate_symbol:
+            score = max(score, 1.0)
+            evidence = "exact symbol match"
+        elif candidate_symbol and (
+            hint in candidate_symbol or candidate_symbol in hint
+        ):
+            score = max(score, 0.75)
+            evidence = "partial symbol match"
+        elif hint == candidate_path:
+            score = max(score, 0.6)
+            evidence = "file stem match"
+        elif hint in candidate_full_path:
+            score = max(score, 0.45)
+            evidence = "path match"
+    if score <= 0:
+        return None
+    return VisualCodeBinding(
+        artifact_path=artifact_path,
+        entity_name=entity_name,
+        source_path=candidate.path,
+        symbol=candidate.symbol,
+        kind=candidate.kind,
+        line=candidate.line,
+        score=round(score, 4),
+        evidence=evidence,
+    )
+
+
+def _symbols(text: str) -> Iterable[tuple[str, int]]:
+    seen = set()
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        for regex in (_SYMBOL_RE, _CAMEL_RE):
+            for match in regex.finditer(line):
+                symbol = match.group(1) if regex is _SYMBOL_RE else match.group(0)
+                if symbol in seen:
+                    continue
+                seen.add(symbol)
+                yield symbol, line_number
+
+
+def _candidate_from_mapping(value: Mapping[str, Any]) -> SourceSymbolCandidate:
+    return SourceSymbolCandidate(
+        path=_safe_text(value.get("path")),
+        symbol=_safe_text(value.get("symbol")),
+        kind=_safe_text(value.get("kind") or "source"),
+        line=_positive_int(value.get("line")),
+    )
+
+
+def _dedupe_bindings(
+    bindings: Iterable[VisualCodeBinding],
+) -> tuple[VisualCodeBinding, ...]:
+    best: dict[tuple[str, str, str, str, int], VisualCodeBinding] = {}
+    for binding in bindings:
+        key = (
+            binding.artifact_path,
+            binding.entity_name,
+            binding.source_path,
+            binding.symbol,
+            binding.line,
+        )
+        previous = best.get(key)
+        if previous is None or binding.score > previous.score:
+            best[key] = binding
+    return tuple(best.values())
+
+
+def _normalize(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", str(value or "").lower())
+
+
+def _positive_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, number)
+
+
+def _sha256_json(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        payload,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _safe_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+__all__ = [
+    "MEDIA_GROUNDING_SCHEMA",
+    "MEDIA_GROUNDING_VERSION",
+    "SourceSymbolCandidate",
+    "VisualCodeBinding",
+    "VisualGroundingManifest",
+    "discover_source_symbol_candidates",
+    "ground_visual_facts_to_sources",
+]

--- a/codenib/wiki/media_grounding.py
+++ b/codenib/wiki/media_grounding.py
@@ -10,7 +10,7 @@ import hashlib
 import json
 import re
 from dataclasses import asdict, dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Iterable, Mapping
 
 from ..repository_filters import walk_repository_files
@@ -40,6 +40,8 @@ _SOURCE_EXTENSIONS = frozenset(
 _MAX_SOURCE_BYTES = 1024 * 1024
 _MAX_CANDIDATES = 8192
 _MAX_BINDINGS_PER_ENTITY = 5
+_MAX_TEXT_BYTES = 4096
+_MAX_PATH_BYTES = 4096
 _SYMBOL_RE = re.compile(
     r"\b(?:class|def|function|const|let|var|interface|type|struct|enum)\s+([A-Za-z_][A-Za-z0-9_]*)"
 )
@@ -163,15 +165,21 @@ def ground_visual_facts_to_sources(
     """Ground visual entities to a source inventory using deterministic scoring."""
 
     candidates = [
-        _candidate_from_mapping(candidate)
-        for candidate in source_candidates
-        if isinstance(candidate, Mapping)
+        candidate
+        for candidate in (
+            _candidate_from_mapping(candidate)
+            for candidate in source_candidates
+            if isinstance(candidate, Mapping)
+        )
+        if candidate.path
     ]
     bindings: list[VisualCodeBinding] = []
     for fact_pack in visual_facts_manifest.get("facts") or ():
         if not isinstance(fact_pack, Mapping):
             continue
-        artifact_path = _safe_text(fact_pack.get("artifact_path"))
+        artifact_path = _safe_relative_path(fact_pack.get("artifact_path"))
+        if not artifact_path:
+            continue
         for entity in fact_pack.get("entities") or ():
             if not isinstance(entity, Mapping):
                 continue
@@ -229,6 +237,15 @@ def ground_visual_facts_to_sources(
     return manifest.to_dict()
 
 
+def _candidate_from_mapping(value: Mapping[str, Any]) -> SourceSymbolCandidate:
+    return SourceSymbolCandidate(
+        path=_safe_relative_path(value.get("path")),
+        symbol=_safe_text(value.get("symbol")),
+        kind=_safe_text(value.get("kind") or "source"),
+        line=_positive_int(value.get("line")),
+    )
+
+
 def _score_candidate(
     *,
     artifact_path: str,
@@ -283,15 +300,6 @@ def _symbols(text: str) -> Iterable[tuple[str, int]]:
                 yield symbol, line_number
 
 
-def _candidate_from_mapping(value: Mapping[str, Any]) -> SourceSymbolCandidate:
-    return SourceSymbolCandidate(
-        path=_safe_text(value.get("path")),
-        symbol=_safe_text(value.get("symbol")),
-        kind=_safe_text(value.get("kind") or "source"),
-        line=_positive_int(value.get("line")),
-    )
-
-
 def _dedupe_bindings(
     bindings: Iterable[VisualCodeBinding],
 ) -> tuple[VisualCodeBinding, ...]:
@@ -335,8 +343,29 @@ def _sha256_json(payload: Mapping[str, Any]) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _safe_text(value: Any) -> str:
-    return str(value or "").strip()
+def _safe_relative_path(value: Any) -> str:
+    text = _safe_text(value, max_bytes=_MAX_PATH_BYTES)
+    if not text or "\\" in text:
+        return ""
+    path = PurePosixPath(text)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        return ""
+    return path.as_posix()
+
+
+def _safe_text(value: Any, *, max_bytes: int = _MAX_TEXT_BYTES) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    text = "".join(
+        character
+        for character in text
+        if ord(character) >= 0x20 and ord(character) != 0x7F
+    )
+    raw = text.encode("utf-8")
+    if len(raw) <= max_bytes:
+        return text
+    return raw[:max_bytes].decode("utf-8", errors="ignore").rstrip()
 
 
 __all__ = [

--- a/codenib/wiki/media_grounding.py
+++ b/codenib/wiki/media_grounding.py
@@ -10,35 +10,28 @@ import hashlib
 import json
 import re
 from dataclasses import asdict, dataclass
+from itertools import islice
 from pathlib import Path, PurePosixPath
 from typing import Any, Iterable, Mapping
 
+from ..languages import extension_to_language_map
 from ..repository_filters import walk_repository_files
 from ..repository_source_selection import (
     DEFAULT_REPOSITORY_SOURCE_SELECTION,
     RepositorySourceSelection,
 )
+from ._safe_file_reads import read_regular_bytes
 
 MEDIA_GROUNDING_SCHEMA = "codenib.media-grounding.v1"
 MEDIA_GROUNDING_VERSION = 1
 
-_SOURCE_EXTENSIONS = frozenset(
-    {
-        ".go",
-        ".java",
-        ".js",
-        ".jsx",
-        ".kt",
-        ".py",
-        ".rs",
-        ".scala",
-        ".swift",
-        ".ts",
-        ".tsx",
-    }
-)
+_SOURCE_EXTENSIONS = frozenset(extension_to_language_map("chunker"))
 _MAX_SOURCE_BYTES = 1024 * 1024
 _MAX_CANDIDATES = 8192
+_MAX_FACT_PACKS = 4096
+_MAX_ENTITIES_PER_ARTIFACT = 32
+_MAX_TOTAL_ENTITIES = 4096
+_MAX_GROUNDING_HINTS = 32
 _MAX_BINDINGS_PER_ENTITY = 5
 _MAX_TEXT_BYTES = 4096
 _MAX_PATH_BYTES = 4096
@@ -119,6 +112,11 @@ def discover_source_symbol_candidates(
 
     root = Path(repo_path).expanduser().resolve()
     selected = RepositorySourceSelection(selection.exclude_subtrees)
+    candidate_limit = _validated_limit(
+        max_candidates,
+        name="max_candidates",
+        maximum=_MAX_CANDIDATES,
+    )
     candidates: list[SourceSymbolCandidate] = []
     seen: set[tuple[str, str, int]] = set()
     for path in walk_repository_files(
@@ -126,18 +124,21 @@ def discover_source_symbol_candidates(
         exclude_roots=exclude_roots,
         selection=selected,
     ):
-        if len(candidates) >= max(0, max_candidates):
+        if len(candidates) >= candidate_limit:
             break
         if path.is_symlink() or path.suffix.lower() not in _SOURCE_EXTENSIONS:
             continue
+        payload = read_regular_bytes(path, max_bytes=_MAX_SOURCE_BYTES)
+        if payload is None:
+            continue
         try:
-            if path.stat().st_size > _MAX_SOURCE_BYTES:
-                continue
-            text = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+            text = payload.decode("utf-8")
+        except UnicodeDecodeError:
             continue
         relative = path.relative_to(root).as_posix()
         candidates.append(SourceSymbolCandidate(path=relative))
+        if len(candidates) >= candidate_limit:
+            break
         for symbol, line in _symbols(text):
             key = (relative, symbol, line)
             if key in seen:
@@ -151,9 +152,9 @@ def discover_source_symbol_candidates(
                     line=line,
                 )
             )
-            if len(candidates) >= max(0, max_candidates):
+            if len(candidates) >= candidate_limit:
                 break
-    return [candidate.to_dict() for candidate in candidates[: max(0, max_candidates)]]
+    return [candidate.to_dict() for candidate in candidates[:candidate_limit]]
 
 
 def ground_visual_facts_to_sources(
@@ -164,25 +165,37 @@ def ground_visual_facts_to_sources(
 ) -> dict[str, Any]:
     """Ground visual entities to a source inventory using deterministic scoring."""
 
-    candidates = [
-        candidate
-        for candidate in (
-            _candidate_from_mapping(candidate)
-            for candidate in source_candidates
-            if isinstance(candidate, Mapping)
-        )
-        if candidate.path
-    ]
-    bindings: list[VisualCodeBinding] = []
-    for fact_pack in visual_facts_manifest.get("facts") or ():
-        if not isinstance(fact_pack, Mapping):
+    binding_limit = _validated_limit(
+        max_bindings_per_entity,
+        name="max_bindings_per_entity",
+        maximum=_MAX_BINDINGS_PER_ENTITY,
+    )
+    candidates_by_key: dict[tuple[str, str, str, int], SourceSymbolCandidate] = {}
+    for value in _mapping_items(source_candidates, limit=_MAX_CANDIDATES):
+        candidate = _candidate_from_mapping(value)
+        if not candidate.path:
             continue
+        key = (candidate.path, candidate.symbol, candidate.kind, candidate.line)
+        candidates_by_key.setdefault(key, candidate)
+    candidates = list(candidates_by_key.values())
+    bindings: list[VisualCodeBinding] = []
+    entity_count = 0
+    for fact_pack in _mapping_items(
+        visual_facts_manifest.get("facts"),
+        limit=_MAX_FACT_PACKS,
+    ):
+        if entity_count >= _MAX_TOTAL_ENTITIES:
+            break
         artifact_path = _safe_relative_path(fact_pack.get("artifact_path"))
         if not artifact_path:
             continue
-        for entity in fact_pack.get("entities") or ():
-            if not isinstance(entity, Mapping):
-                continue
+        for entity in _mapping_items(
+            fact_pack.get("entities"),
+            limit=_MAX_ENTITIES_PER_ARTIFACT,
+        ):
+            if entity_count >= _MAX_TOTAL_ENTITIES:
+                break
+            entity_count += 1
             entity_name = _safe_text(entity.get("name"))
             if not entity_name:
                 continue
@@ -190,7 +203,10 @@ def ground_visual_facts_to_sources(
                 entity_name,
                 *[
                     _safe_text(candidate)
-                    for candidate in entity.get("grounding_candidates") or ()
+                    for candidate in islice(
+                        _non_string_iterable(entity.get("grounding_candidates")),
+                        _MAX_GROUNDING_HINTS,
+                    )
                 ],
             ]
             scored = [
@@ -214,7 +230,7 @@ def ground_visual_facts_to_sources(
                     binding.line,
                 )
             )
-            bindings.extend(scored[: max(0, max_bindings_per_entity)])
+            bindings.extend(scored[:binding_limit])
     manifest = VisualGroundingManifest(
         schema=MEDIA_GROUNDING_SCHEMA,
         version=MEDIA_GROUNDING_VERSION,
@@ -330,6 +346,39 @@ def _positive_int(value: Any) -> int:
     except (TypeError, ValueError):
         return 0
     return max(0, number)
+
+
+def _mapping_items(
+    value: Any,
+    *,
+    limit: int,
+) -> Iterable[Mapping[str, Any]]:
+    if isinstance(value, (str, bytes, bytearray, Mapping)):
+        return ()
+    try:
+        values = iter(value or ())
+    except TypeError:
+        return ()
+    return (item for item in islice(values, limit) if isinstance(item, Mapping))
+
+
+def _non_string_iterable(value: Any) -> Iterable[Any]:
+    if isinstance(value, (str, bytes, bytearray, Mapping)):
+        return ()
+    try:
+        return iter(value or ())
+    except TypeError:
+        return ()
+
+
+def _validated_limit(value: Any, *, name: str, maximum: int) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value <= maximum
+    ):
+        raise ValueError(f"{name} must be an integer between 0 and {maximum}")
+    return value
 
 
 def _sha256_json(payload: Mapping[str, Any]) -> str:

--- a/codenib/wiki/media_knowledge.py
+++ b/codenib/wiki/media_knowledge.py
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Queryable multimodal repository knowledge view for wiki media."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+MULTIMODAL_KNOWLEDGE_SCHEMA = "codenib.multimodal-knowledge-view.v1"
+MULTIMODAL_KNOWLEDGE_VERSION = 1
+
+
+@dataclass(frozen=True)
+class MultimodalKnowledgeView:
+    """A compact, persistent view joining media artifacts, facts, and grounding."""
+
+    payload: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return dict(self.payload)
+
+    def search_visual_context(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]:
+        return search_visual_context(self.payload, query, limit=limit)
+
+    def get_visual_evidence(self, artifact_path: str) -> dict[str, Any] | None:
+        return get_visual_evidence(self.payload, artifact_path)
+
+    def find_visual_code_links(
+        self,
+        source_path: str,
+        *,
+        symbol: str = "",
+    ) -> list[dict[str, Any]]:
+        return find_visual_code_links(self.payload, source_path, symbol=symbol)
+
+
+def build_multimodal_knowledge_view(
+    media_manifest: Mapping[str, Any],
+    visual_facts_manifest: Mapping[str, Any],
+    grounding_manifest: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Join media artifacts, visual facts, and source bindings into one view."""
+
+    artifacts = {
+        str(artifact.get("path") or ""): dict(artifact)
+        for artifact in media_manifest.get("artifacts") or ()
+        if isinstance(artifact, Mapping) and artifact.get("path")
+    }
+    facts = {
+        str(fact.get("artifact_path") or ""): dict(fact)
+        for fact in visual_facts_manifest.get("facts") or ()
+        if isinstance(fact, Mapping) and fact.get("artifact_path")
+    }
+    bindings_by_artifact: dict[str, list[dict[str, Any]]] = {}
+    for binding in grounding_manifest.get("bindings") or ():
+        if not isinstance(binding, Mapping):
+            continue
+        artifact_path = str(binding.get("artifact_path") or "")
+        if artifact_path:
+            bindings_by_artifact.setdefault(artifact_path, []).append(dict(binding))
+
+    entries = []
+    for path in sorted(set(artifacts) | set(facts) | set(bindings_by_artifact)):
+        artifact = artifacts.get(path, {})
+        fact = facts.get(path, {})
+        bindings = sorted(
+            bindings_by_artifact.get(path, []),
+            key=lambda item: (
+                str(item.get("source_path") or ""),
+                str(item.get("symbol") or ""),
+                str(item.get("entity_name") or ""),
+            ),
+        )
+        entries.append(
+            {
+                "artifact": artifact,
+                "facts": fact,
+                "bindings": bindings,
+                "search_text": _entry_search_text(artifact, fact, bindings),
+            }
+        )
+    payload = {
+        "schema": MULTIMODAL_KNOWLEDGE_SCHEMA,
+        "version": MULTIMODAL_KNOWLEDGE_VERSION,
+        "media_manifest_sha256": str(media_manifest.get("manifest_sha256") or ""),
+        "visual_facts_manifest_sha256": str(
+            visual_facts_manifest.get("manifest_sha256") or ""
+        ),
+        "grounding_manifest_sha256": str(
+            grounding_manifest.get("manifest_sha256") or ""
+        ),
+        "entry_count": len(entries),
+        "entries": entries,
+    }
+    payload["view_sha256"] = _sha256_json(
+        {key: value for key, value in payload.items() if key != "view_sha256"}
+    )
+    return payload
+
+
+def search_visual_context(
+    view: Mapping[str, Any],
+    query: str,
+    *,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Search multimodal entries using a deterministic lexical scorer."""
+
+    tokens = _tokens(query)
+    if not tokens:
+        return []
+    results = []
+    for entry in view.get("entries") or ():
+        if not isinstance(entry, Mapping):
+            continue
+        haystack = str(entry.get("search_text") or "").lower()
+        score = sum(1 for token in tokens if token in haystack)
+        if score:
+            results.append(
+                {
+                    "artifact_path": ((entry.get("artifact") or {}).get("path") or ""),
+                    "score": score,
+                    "artifact": dict(entry.get("artifact") or {}),
+                    "facts": dict(entry.get("facts") or {}),
+                    "bindings": list(entry.get("bindings") or ()),
+                }
+            )
+    results.sort(key=lambda item: (-item["score"], item["artifact_path"]))
+    return results[: max(0, limit)]
+
+
+def get_visual_evidence(
+    view: Mapping[str, Any],
+    artifact_path: str,
+) -> dict[str, Any] | None:
+    """Return one visual knowledge entry by artifact path."""
+
+    for entry in view.get("entries") or ():
+        if not isinstance(entry, Mapping):
+            continue
+        artifact = entry.get("artifact") or {}
+        if isinstance(artifact, Mapping) and artifact.get("path") == artifact_path:
+            return {
+                "artifact": dict(artifact),
+                "facts": dict(entry.get("facts") or {}),
+                "bindings": list(entry.get("bindings") or ()),
+            }
+    return None
+
+
+def find_visual_code_links(
+    view: Mapping[str, Any],
+    source_path: str,
+    *,
+    symbol: str = "",
+) -> list[dict[str, Any]]:
+    """Return visual entries that ground to a file, optionally a symbol."""
+
+    links = []
+    for entry in view.get("entries") or ():
+        if not isinstance(entry, Mapping):
+            continue
+        for binding in entry.get("bindings") or ():
+            if not isinstance(binding, Mapping):
+                continue
+            if binding.get("source_path") != source_path:
+                continue
+            if symbol and binding.get("symbol") != symbol:
+                continue
+            links.append(
+                {
+                    "artifact_path": ((entry.get("artifact") or {}).get("path") or ""),
+                    "binding": dict(binding),
+                    "artifact": dict(entry.get("artifact") or {}),
+                    "facts": dict(entry.get("facts") or {}),
+                }
+            )
+    links.sort(
+        key=lambda item: (
+            str(item["artifact_path"]),
+            str(item["binding"].get("entity_name") or ""),
+            str(item["binding"].get("symbol") or ""),
+        )
+    )
+    return links
+
+
+def _entry_search_text(
+    artifact: Mapping[str, Any],
+    fact: Mapping[str, Any],
+    bindings: list[Mapping[str, Any]],
+) -> str:
+    parts = [
+        artifact.get("path"),
+        artifact.get("role_hint"),
+        artifact.get("caption"),
+        artifact.get("surrounding_text"),
+    ]
+    for entity in fact.get("entities") or ():
+        if isinstance(entity, Mapping):
+            parts.extend(
+                [entity.get("name"), entity.get("type"), entity.get("evidence")]
+            )
+    for claim in fact.get("claims") or ():
+        if isinstance(claim, Mapping):
+            parts.extend([claim.get("text"), claim.get("evidence")])
+    for binding in bindings:
+        parts.extend(
+            [
+                binding.get("entity_name"),
+                binding.get("source_path"),
+                binding.get("symbol"),
+                binding.get("evidence"),
+            ]
+        )
+    return " ".join(str(part or "") for part in parts)
+
+
+def _tokens(value: str) -> list[str]:
+    return [
+        token
+        for token in re.split(r"[^a-z0-9_]+", str(value or "").lower())
+        if len(token) >= 2
+    ]
+
+
+def _sha256_json(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        payload,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+__all__ = [
+    "MULTIMODAL_KNOWLEDGE_SCHEMA",
+    "MULTIMODAL_KNOWLEDGE_VERSION",
+    "MultimodalKnowledgeView",
+    "build_multimodal_knowledge_view",
+    "find_visual_code_links",
+    "get_visual_evidence",
+    "search_visual_context",
+]

--- a/docs/experiments/multimodal_repository_knowledge.md
+++ b/docs/experiments/multimodal_repository_knowledge.md
@@ -32,8 +32,11 @@ supported visual artifacts:
 - `.webp`
 
 It respects the shared repository traversal and source-selection policy, skips
-symlinks, hashes media content, and records markdown references, alt text,
-captions, and surrounding documentation context.
+symlinks, reads bounded stable regular files, hashes media content, and records
+bounded markdown references, alt text, captions, and surrounding documentation
+context. Repository-contained parent references such as
+`../assets/architecture.svg` are normalized while paths that escape the
+repository are ignored.
 
 ### VisualFactPack
 
@@ -52,9 +55,9 @@ while keeping the same schema.
 
 `codenib.wiki.media_grounding` grounds extracted visual entities to repository
 files and symbols. The first implementation uses deterministic lexical scoring
-against a bounded source-symbol inventory. Later versions can replace the
-scorer with BM25, embeddings, CodeGraph, LSP facts, or `FactQueryIndex` /
-`FactBatch`.
+against a bounded source-symbol inventory derived from the shared language
+registry. Later versions can replace the scorer with BM25, embeddings,
+CodeGraph, LSP facts, or `FactQueryIndex` / `FactBatch`.
 
 ### MultimodalKnowledgeView
 

--- a/docs/experiments/multimodal_repository_knowledge.md
+++ b/docs/experiments/multimodal_repository_knowledge.md
@@ -1,0 +1,98 @@
+# Source-grounded multimodal repository knowledge
+
+This experiment extends the wiki media slot work into a first-class multimodal
+repository knowledge pipeline.
+
+The goal is not to make wiki pages more decorative. The goal is to make
+repository-native images, diagrams, and screenshots reusable as source-grounded
+context for wiki pages and coding agents.
+
+## Pipeline
+
+```text
+repository images / svg / screenshots
+  -> MediaManifest
+  -> VisualFactPack
+  -> VisualGroundingManifest
+  -> MultimodalKnowledgeView
+  -> Wiki / future MCP query APIs
+```
+
+## Components
+
+### MediaManifest
+
+`codenib.wiki.media_artifacts.discover_media_manifest()` scans a repository for
+supported visual artifacts:
+
+- `.png`
+- `.jpg`
+- `.jpeg`
+- `.svg`
+- `.webp`
+
+It respects the shared repository traversal and source-selection policy, skips
+symlinks, hashes media content, and records markdown references, alt text,
+captions, and surrounding documentation context.
+
+### VisualFactPack
+
+`codenib.wiki.media_facts` defines the structured output expected from a VLM:
+
+- visual entities
+- visual relations
+- source-grounded claims
+- grounding candidates
+
+The local `deterministic_visual_facts()` fallback extracts conservative facts
+from artifact metadata only. Future VLM backends can replace that extractor
+while keeping the same schema.
+
+### VisualGroundingManifest
+
+`codenib.wiki.media_grounding` grounds extracted visual entities to repository
+files and symbols. The first implementation uses deterministic lexical scoring
+against a bounded source-symbol inventory. Later versions can replace the
+scorer with BM25, embeddings, CodeGraph, LSP facts, or `FactQueryIndex` /
+`FactBatch`.
+
+### MultimodalKnowledgeView
+
+`codenib.wiki.media_knowledge` joins artifacts, facts, and source bindings into
+a queryable view. It exposes three functions that future MCP tools can wrap:
+
+- `search_visual_context`
+- `get_visual_evidence`
+- `find_visual_code_links`
+
+## Why evidence stays server-side
+
+Media generation may use bounded source snippets inside provider prompts. Those
+prompts should not be returned to the browser. Public asset payloads expose
+safe provenance such as source citations and evidence-pack hashes, while the
+full evidence pack remains a transient server-side input.
+
+## Minimal local example
+
+```python
+from codenib.wiki.media_artifacts import discover_media_manifest
+from codenib.wiki.media_facts import build_visual_facts_manifest
+from codenib.wiki.media_grounding import (
+    discover_source_symbol_candidates,
+    ground_visual_facts_to_sources,
+)
+from codenib.wiki.media_knowledge import build_multimodal_knowledge_view
+
+repo = "/path/to/repository"
+
+media = discover_media_manifest(repo)
+facts = build_visual_facts_manifest(media)
+sources = discover_source_symbol_candidates(repo)
+grounding = ground_visual_facts_to_sources(facts, sources)
+view = build_multimodal_knowledge_view(media, facts, grounding)
+
+print(view["entry_count"])
+```
+
+This creates a deterministic local view. A VLM extractor can be added later by
+passing a custom extractor into `build_visual_facts_manifest()`.

--- a/test/wiki/test_media_artifacts.py
+++ b/test/wiki/test_media_artifacts.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import hashlib
 
 from codenib.repository_source_selection import RepositorySourceSelection
+import codenib.wiki.media_artifacts as media_artifacts
 from codenib.wiki.media_artifacts import discover_media_manifest
 
 
@@ -108,3 +109,15 @@ def test_discover_media_manifest_skips_symlinks_and_large_media(tmp_path):
     manifest = discover_media_manifest(tmp_path, commit="abc123")
 
     assert [artifact["path"] for artifact in manifest["artifacts"]] == ["diagram.png"]
+
+
+def test_discover_media_manifest_skips_files_that_exceed_hash_limit(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(media_artifacts, "_MAX_MEDIA_BYTES", 2)
+    (tmp_path / "diagram.png").write_bytes(b"png")
+
+    manifest = discover_media_manifest(tmp_path, commit="abc123")
+
+    assert manifest["artifacts"] == []

--- a/test/wiki/test_media_artifacts.py
+++ b/test/wiki/test_media_artifacts.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+
+from codenib.repository_source_selection import RepositorySourceSelection
+from codenib.wiki.media_artifacts import discover_media_manifest
+
+
+def test_discover_media_manifest_collects_markdown_context(tmp_path):
+    repo = tmp_path
+    docs = repo / "docs"
+    assets = docs / "assets"
+    assets.mkdir(parents=True)
+    image = assets / "architecture.svg"
+    image.write_text("<svg>architecture</svg>", encoding="utf-8")
+    (repo / "README.md").write_text(
+        "\n".join(
+            [
+                "# Demo",
+                "",
+                "The service architecture is shown below.",
+                "![Architecture overview](docs/assets/architecture.svg)",
+                "It maps API requests to the wiki runtime.",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    manifest = discover_media_manifest(repo, commit="abc123")
+
+    assert manifest["schema"] == "codenib.media-manifest.v1"
+    assert manifest["commit"] == "abc123"
+    assert manifest["artifact_count"] == 1
+    artifact = manifest["artifacts"][0]
+    assert artifact["path"] == "docs/assets/architecture.svg"
+    assert artifact["media_type"] == "svg"
+    assert artifact["mime_type"] == "image/svg+xml"
+    assert artifact["sha256"] == hashlib.sha256(b"<svg>architecture</svg>").hexdigest()
+    assert artifact["role_hint"] == "architecture_diagram"
+    assert artifact["caption"] == "Architecture overview"
+    assert "service architecture" in artifact["surrounding_text"]
+    assert artifact["references"] == [
+        {
+            "markdown_path": "README.md",
+            "line": 4,
+            "alt_text": "Architecture overview",
+            "title": "",
+            "surrounding_text": (
+                "The service architecture is shown below.\n"
+                "![Architecture overview](docs/assets/architecture.svg)\n"
+                "It maps API requests to the wiki runtime."
+            ),
+        }
+    ]
+    assert manifest["manifest_sha256"]
+
+
+def test_discover_media_manifest_respects_source_selection(tmp_path):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "screenshot.png").write_bytes(b"png")
+    (tmp_path / "hidden").mkdir()
+    (tmp_path / "hidden" / "architecture.png").write_bytes(b"hidden")
+
+    manifest = discover_media_manifest(
+        tmp_path,
+        commit="abc123",
+        selection=RepositorySourceSelection(["hidden"]),
+    )
+
+    assert [artifact["path"] for artifact in manifest["artifacts"]] == [
+        "docs/screenshot.png"
+    ]
+
+
+def test_discover_media_manifest_ignores_external_and_parent_markdown_links(tmp_path):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "local.webp").write_bytes(b"webp")
+    (tmp_path / "docs" / "README.md").write_text(
+        "\n".join(
+            [
+                "![Remote](https://example.com/asset.png)",
+                "![Parent](../secret.png)",
+                '<img src="local.webp" alt="Dashboard screenshot">',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    manifest = discover_media_manifest(tmp_path, commit="abc123")
+
+    assert manifest["artifact_count"] == 1
+    artifact = manifest["artifacts"][0]
+    assert artifact["path"] == "docs/local.webp"
+    assert artifact["role_hint"] == "ui_screenshot"
+    assert artifact["caption"] == "Dashboard screenshot"
+
+
+def test_discover_media_manifest_skips_symlinks_and_large_media(tmp_path):
+    small = tmp_path / "diagram.png"
+    small.write_bytes(b"png")
+    linked = tmp_path / "linked.png"
+    linked.symlink_to(small)
+
+    manifest = discover_media_manifest(tmp_path, commit="abc123")
+
+    assert [artifact["path"] for artifact in manifest["artifacts"]] == ["diagram.png"]

--- a/test/wiki/test_media_artifacts.py
+++ b/test/wiki/test_media_artifacts.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 
 import hashlib
 
-from codenib.repository_source_selection import RepositorySourceSelection
+import pytest
+
 import codenib.wiki.media_artifacts as media_artifacts
+from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.wiki.media_artifacts import discover_media_manifest
 
 
@@ -77,14 +79,14 @@ def test_discover_media_manifest_respects_source_selection(tmp_path):
     ]
 
 
-def test_discover_media_manifest_ignores_external_and_parent_markdown_links(tmp_path):
+def test_discover_media_manifest_ignores_external_and_escaping_markdown_links(tmp_path):
     (tmp_path / "docs").mkdir()
     (tmp_path / "docs" / "local.webp").write_bytes(b"webp")
     (tmp_path / "docs" / "README.md").write_text(
         "\n".join(
             [
                 "![Remote](https://example.com/asset.png)",
-                "![Parent](../secret.png)",
+                "![Escape](../../secret.png)",
                 '<img src="local.webp" alt="Dashboard screenshot">',
             ]
         ),
@@ -98,6 +100,24 @@ def test_discover_media_manifest_ignores_external_and_parent_markdown_links(tmp_
     assert artifact["path"] == "docs/local.webp"
     assert artifact["role_hint"] == "ui_screenshot"
     assert artifact["caption"] == "Dashboard screenshot"
+
+
+def test_discover_media_manifest_resolves_safe_parent_markdown_links(tmp_path):
+    (tmp_path / "docs" / "guide").mkdir(parents=True)
+    (tmp_path / "docs" / "assets").mkdir()
+    (tmp_path / "docs" / "assets" / "architecture.svg").write_text(
+        "<svg/>", encoding="utf-8"
+    )
+    (tmp_path / "docs" / "guide" / "README.md").write_text(
+        "![Architecture](../assets/architecture.svg)",
+        encoding="utf-8",
+    )
+
+    manifest = discover_media_manifest(tmp_path, commit="abc123")
+
+    artifact = manifest["artifacts"][0]
+    assert artifact["caption"] == "Architecture"
+    assert artifact["references"][0]["markdown_path"] == "docs/guide/README.md"
 
 
 def test_discover_media_manifest_skips_symlinks_and_large_media(tmp_path):
@@ -121,3 +141,25 @@ def test_discover_media_manifest_skips_files_that_exceed_hash_limit(
     manifest = discover_media_manifest(tmp_path, commit="abc123")
 
     assert manifest["artifacts"] == []
+
+
+def test_discover_media_manifest_reuses_generator_exclusions_for_both_scans(tmp_path):
+    (tmp_path / "visible").mkdir()
+    (tmp_path / "visible" / "diagram.png").write_bytes(b"visible")
+    (tmp_path / "excluded").mkdir()
+    (tmp_path / "excluded" / "secret.png").write_bytes(b"secret")
+
+    manifest = discover_media_manifest(
+        tmp_path,
+        commit="abc123",
+        exclude_roots=(path for path in [tmp_path / "excluded"]),
+    )
+
+    assert [artifact["path"] for artifact in manifest["artifacts"]] == [
+        "visible/diagram.png"
+    ]
+
+
+def test_discover_media_manifest_rejects_unbounded_artifact_limits(tmp_path):
+    with pytest.raises(ValueError, match="max_artifacts"):
+        discover_media_manifest(tmp_path, max_artifacts=4097)

--- a/test/wiki/test_media_facts.py
+++ b/test/wiki/test_media_facts.py
@@ -133,6 +133,78 @@ def test_build_visual_facts_manifest_accepts_custom_vlm_extractor():
     ]
 
 
+def test_build_visual_facts_manifest_anchors_untrusted_extractor_provenance():
+    media_manifest = {
+        "manifest_sha256": "media-manifest-hash",
+        "artifacts": [_artifact()],
+    }
+
+    def untrusted_extractor(_artifact_value):
+        return {
+            "artifact_path": "../../outside.png",
+            "artifact_sha256": "forged",
+            "role_hint": "forged",
+            "extractor": "vlm/test",
+        }
+
+    manifest = build_visual_facts_manifest(
+        media_manifest,
+        extractor=untrusted_extractor,
+    )
+
+    fact = manifest["facts"][0]
+    assert fact["artifact_path"] == _artifact()["path"]
+    assert fact["artifact_sha256"] == _artifact()["sha256"]
+    assert fact["role_hint"] == _artifact()["role_hint"]
+
+
+def test_build_visual_facts_manifest_bounds_untrusted_fact_lists():
+    media_manifest = {
+        "manifest_sha256": "media-manifest-hash",
+        "artifacts": [_artifact()],
+    }
+
+    def noisy_extractor(_artifact_value):
+        return {
+            "extractor": "vlm/test",
+            "entities": (
+                {
+                    "name": f"Entity{index}",
+                    "grounding_candidates": (
+                        f"Candidate{candidate}" for candidate in range(100)
+                    ),
+                }
+                for index in range(100)
+            ),
+            "relations": ({"source": "a", "target": "b"} for _ in range(100)),
+            "claims": (
+                {"text": f"claim {index}", "evidence": "test"} for index in range(100)
+            ),
+        }
+
+    manifest = build_visual_facts_manifest(
+        media_manifest,
+        extractor=noisy_extractor,
+    )
+    fact = manifest["facts"][0]
+
+    assert len(fact["entities"]) == 32
+    assert len(fact["entities"][0]["grounding_candidates"]) == 32
+    assert len(fact["relations"]) == 32
+    assert len(fact["claims"]) == 32
+
+
+def test_build_visual_facts_manifest_rejects_non_json_metadata():
+    def invalid_extractor(_artifact_value):
+        return {"extractor": "vlm/test", "metadata": {"value": object()}}
+
+    with pytest.raises(ValueError, match="metadata must contain bounded JSON"):
+        build_visual_facts_manifest(
+            {"artifacts": [_artifact()]},
+            extractor=invalid_extractor,
+        )
+
+
 def test_build_visual_fact_extraction_prompt_bounds_oversized_context():
     artifact = _artifact()
     artifact["surrounding_text"] = "x" * (40 * 1024)

--- a/test/wiki/test_media_facts.py
+++ b/test/wiki/test_media_facts.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from codenib.wiki.media_facts import (
+    build_visual_fact_extraction_prompt,
+    build_visual_facts_manifest,
+    deterministic_visual_facts,
+)
+
+
+def _artifact():
+    return {
+        "path": "docs/assets/architecture.svg",
+        "mime_type": "image/svg+xml",
+        "sha256": "abc123",
+        "role_hint": "architecture_diagram",
+        "caption": "IndexCompiler to VectorStore architecture",
+        "surrounding_text": "The diagram shows how IndexCompiler writes to VectorStore.",
+        "references": [
+            {
+                "markdown_path": "README.md",
+                "line": 7,
+                "alt_text": "IndexCompiler to VectorStore architecture",
+                "title": "",
+            }
+        ],
+    }
+
+
+def test_build_visual_fact_extraction_prompt_requests_structured_json():
+    prompt = build_visual_fact_extraction_prompt(_artifact())
+
+    assert "extract_repository_visual_facts" in prompt
+    assert "entities" in prompt
+    assert "relations" in prompt
+    assert "grounding_candidates" in prompt
+    assert "IndexCompiler" in prompt
+    assert "Return JSON only" in prompt
+
+
+def test_deterministic_visual_facts_extracts_metadata_entities_and_claims():
+    facts = deterministic_visual_facts(_artifact())
+
+    assert facts["artifact_path"] == "docs/assets/architecture.svg"
+    assert facts["artifact_sha256"] == "abc123"
+    assert facts["role_hint"] == "architecture_diagram"
+    assert facts["extractor"] == "local/metadata"
+    entity_names = {entity["name"] for entity in facts["entities"]}
+    assert "IndexCompiler" in entity_names
+    assert "VectorStore" in entity_names
+    assert facts["claims"]
+    assert facts["fact_pack_sha256"]
+
+
+def test_build_visual_facts_manifest_is_stable_and_links_media_manifest():
+    media_manifest = {
+        "manifest_sha256": "media-manifest-hash",
+        "artifacts": [_artifact()],
+    }
+
+    first = build_visual_facts_manifest(media_manifest)
+    second = build_visual_facts_manifest(media_manifest)
+
+    assert first == second
+    assert first["schema"] == "codenib.media-facts.v1"
+    assert first["media_manifest_sha256"] == "media-manifest-hash"
+    assert first["fact_count"] == 1
+    assert first["manifest_sha256"]
+
+
+def test_build_visual_facts_manifest_accepts_custom_vlm_extractor():
+    media_manifest = {
+        "manifest_sha256": "media-manifest-hash",
+        "artifacts": [_artifact()],
+    }
+
+    def fake_vlm_extractor(artifact):
+        return {
+            "artifact_path": artifact["path"],
+            "artifact_sha256": artifact["sha256"],
+            "role_hint": artifact["role_hint"],
+            "extractor": "vlm/test",
+            "entities": [
+                {
+                    "name": "IndexCompiler",
+                    "type": "component",
+                    "evidence": "visual label",
+                    "confidence": 0.9,
+                    "grounding_candidates": ["IndexCompiler"],
+                }
+            ],
+            "relations": [
+                {
+                    "source": "IndexCompiler",
+                    "relation": "writes_to",
+                    "target": "VectorStore",
+                    "evidence": "arrow",
+                    "confidence": 0.8,
+                }
+            ],
+            "claims": [
+                {
+                    "text": "IndexCompiler writes to VectorStore.",
+                    "evidence": "arrow label",
+                    "confidence": 0.8,
+                }
+            ],
+            "metadata": {"provider": "fake"},
+        }
+
+    manifest = build_visual_facts_manifest(
+        media_manifest,
+        extractor=fake_vlm_extractor,
+    )
+
+    fact = manifest["facts"][0]
+    assert fact["extractor"] == "vlm/test"
+    assert fact["relations"] == [
+        {
+            "source": "IndexCompiler",
+            "relation": "writes_to",
+            "target": "VectorStore",
+            "evidence": "arrow",
+            "confidence": 0.8,
+        }
+    ]
+
+
+def test_build_visual_fact_extraction_prompt_bounds_oversized_context():
+    artifact = _artifact()
+    artifact["surrounding_text"] = "x" * (40 * 1024)
+
+    prompt = build_visual_fact_extraction_prompt(artifact)
+
+    assert len(prompt.encode("utf-8")) < 32 * 1024
+    assert "\\u2026" in prompt
+
+
+def test_fact_manifest_output_is_json_serializable():
+    payload = build_visual_facts_manifest(
+        {"manifest_sha256": "media-manifest-hash", "artifacts": [_artifact()]}
+    )
+
+    json.dumps(payload, allow_nan=False)

--- a/test/wiki/test_media_grounding.py
+++ b/test/wiki/test_media_grounding.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.wiki.media_grounding import (
     discover_source_symbol_candidates,
@@ -58,6 +60,28 @@ def test_discover_source_symbol_candidates_respects_source_selection(tmp_path):
 
     assert all(not candidate["path"].startswith("hidden/") for candidate in candidates)
     assert any(candidate["symbol"] == "Visible" for candidate in candidates)
+
+
+@pytest.mark.parametrize(
+    ("filename", "source", "symbol"),
+    [
+        ("service.cpp", "class NativeService {};", "NativeService"),
+        ("service.cs", "class ManagedService {}", "ManagedService"),
+        ("service.rb", "class RubyService\nend", "RubyService"),
+        ("service.php", "class PhpService {}", "PhpService"),
+    ],
+)
+def test_source_symbol_inventory_uses_registered_language_extensions(
+    tmp_path,
+    filename,
+    source,
+    symbol,
+):
+    (tmp_path / filename).write_text(source, encoding="utf-8")
+
+    candidates = discover_source_symbol_candidates(tmp_path)
+
+    assert any(candidate["symbol"] == symbol for candidate in candidates)
 
 
 def test_ground_visual_facts_to_sources_binds_entities_to_symbols():
@@ -172,6 +196,41 @@ def test_ground_visual_facts_to_sources_deduplicates_bindings():
     assert len(manifest["bindings"]) == 1
 
 
+def test_grounding_deduplicates_candidates_before_applying_result_limit():
+    visual_facts = {
+        "manifest_sha256": "visual-facts-hash",
+        "facts": [
+            {
+                "artifact_path": "docs/architecture.svg",
+                "entities": [{"name": "WikiService"}],
+            }
+        ],
+    }
+    exact = {
+        "path": "src/wiki.py",
+        "symbol": "WikiService",
+        "kind": "symbol",
+        "line": 3,
+    }
+    partial = {
+        "path": "src/wiki_service.py",
+        "symbol": "WikiServiceAdapter",
+        "kind": "symbol",
+        "line": 7,
+    }
+
+    manifest = ground_visual_facts_to_sources(
+        visual_facts,
+        [exact, exact, partial],
+        max_bindings_per_entity=2,
+    )
+
+    assert [binding["symbol"] for binding in manifest["bindings"]] == [
+        "WikiService",
+        "WikiServiceAdapter",
+    ]
+
+
 def test_ground_visual_facts_to_sources_drops_unsafe_external_paths():
     visual_facts = {
         "manifest_sha256": "visual-facts-hash",
@@ -218,3 +277,10 @@ def test_ground_visual_facts_to_sources_drops_unsafe_external_paths():
     assert manifest["bindings"][0]["artifact_path"] == "docs/architecture.svg"
     assert manifest["bindings"][0]["source_path"] == "src/wiki.py"
     assert manifest["bindings"][0]["entity_name"] == "WikiServicewith control"
+
+
+def test_grounding_rejects_limits_above_contract_maximum(tmp_path):
+    with pytest.raises(ValueError, match="max_candidates"):
+        discover_source_symbol_candidates(tmp_path, max_candidates=8193)
+    with pytest.raises(ValueError, match="max_bindings_per_entity"):
+        ground_visual_facts_to_sources({}, (), max_bindings_per_entity=6)

--- a/test/wiki/test_media_grounding.py
+++ b/test/wiki/test_media_grounding.py
@@ -170,3 +170,51 @@ def test_ground_visual_facts_to_sources_deduplicates_bindings():
     manifest = ground_visual_facts_to_sources(visual_facts, [source, source])
 
     assert len(manifest["bindings"]) == 1
+
+
+def test_ground_visual_facts_to_sources_drops_unsafe_external_paths():
+    visual_facts = {
+        "manifest_sha256": "visual-facts-hash",
+        "facts": [
+            {
+                "artifact_path": "/tmp/leak.svg",
+                "entities": [{"name": "Unsafe"}],
+            },
+            {
+                "artifact_path": "docs/architecture.svg",
+                "entities": [
+                    {
+                        "name": "WikiService\nwith control",
+                        "grounding_candidates": ["WikiService"],
+                    }
+                ],
+            },
+        ],
+    }
+    source_candidates = [
+        {
+            "path": "/tmp/leak.py",
+            "symbol": "WikiService",
+            "kind": "symbol",
+            "line": 1,
+        },
+        {
+            "path": "../secret.py",
+            "symbol": "WikiService",
+            "kind": "symbol",
+            "line": 2,
+        },
+        {
+            "path": "src/wiki.py",
+            "symbol": "WikiService",
+            "kind": "symbol",
+            "line": 3,
+        },
+    ]
+
+    manifest = ground_visual_facts_to_sources(visual_facts, source_candidates)
+
+    assert manifest["binding_count"] == 1
+    assert manifest["bindings"][0]["artifact_path"] == "docs/architecture.svg"
+    assert manifest["bindings"][0]["source_path"] == "src/wiki.py"
+    assert manifest["bindings"][0]["entity_name"] == "WikiServicewith control"

--- a/test/wiki/test_media_grounding.py
+++ b/test/wiki/test_media_grounding.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from codenib.repository_source_selection import RepositorySourceSelection
+from codenib.wiki.media_grounding import (
+    discover_source_symbol_candidates,
+    ground_visual_facts_to_sources,
+)
+
+
+def test_discover_source_symbol_candidates_extracts_files_and_symbols(tmp_path):
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "compiler.py").write_text(
+        "\n".join(
+            [
+                "class IndexCompiler:",
+                "    pass",
+                "",
+                "def build_vector_store():",
+                "    VectorStore = object()",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    candidates = discover_source_symbol_candidates(tmp_path)
+
+    assert {
+        "path": "src/compiler.py",
+        "symbol": "",
+        "kind": "source",
+        "line": 0,
+    } in candidates
+    symbols = {candidate["symbol"] for candidate in candidates}
+    assert "IndexCompiler" in symbols
+    assert "build_vector_store" in symbols
+    assert "VectorStore" in symbols
+
+
+def test_discover_source_symbol_candidates_respects_source_selection(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "visible.py").write_text(
+        "class Visible: pass", encoding="utf-8"
+    )
+    (tmp_path / "hidden").mkdir()
+    (tmp_path / "hidden" / "secret.py").write_text(
+        "class Secret: pass", encoding="utf-8"
+    )
+
+    candidates = discover_source_symbol_candidates(
+        tmp_path,
+        selection=RepositorySourceSelection(["hidden"]),
+    )
+
+    assert all(not candidate["path"].startswith("hidden/") for candidate in candidates)
+    assert any(candidate["symbol"] == "Visible" for candidate in candidates)
+
+
+def test_ground_visual_facts_to_sources_binds_entities_to_symbols():
+    visual_facts = {
+        "manifest_sha256": "visual-facts-hash",
+        "facts": [
+            {
+                "artifact_path": "docs/assets/architecture.svg",
+                "entities": [
+                    {
+                        "name": "IndexCompiler",
+                        "grounding_candidates": ["IndexCompiler"],
+                    },
+                    {
+                        "name": "Vector Store",
+                        "grounding_candidates": ["VectorStore"],
+                    },
+                ],
+            }
+        ],
+    }
+    source_candidates = [
+        {
+            "path": "codenib/compiler/index_compiler.py",
+            "symbol": "IndexCompiler",
+            "kind": "symbol",
+            "line": 42,
+        },
+        {
+            "path": "codenib/index/embedding/vector_store.py",
+            "symbol": "VectorStore",
+            "kind": "symbol",
+            "line": 10,
+        },
+    ]
+
+    manifest = ground_visual_facts_to_sources(visual_facts, source_candidates)
+
+    assert manifest["schema"] == "codenib.media-grounding.v1"
+    assert manifest["visual_facts_manifest_sha256"] == "visual-facts-hash"
+    bindings = manifest["bindings"]
+    assert {
+        "artifact_path": "docs/assets/architecture.svg",
+        "entity_name": "IndexCompiler",
+        "source_path": "codenib/compiler/index_compiler.py",
+        "symbol": "IndexCompiler",
+        "kind": "symbol",
+        "line": 42,
+        "score": 1.0,
+        "evidence": "exact symbol match",
+    } in bindings
+    assert any(binding["entity_name"] == "Vector Store" for binding in bindings)
+    assert manifest["manifest_sha256"]
+
+
+def test_ground_visual_facts_to_sources_prefers_exact_symbol_match():
+    visual_facts = {
+        "manifest_sha256": "visual-facts-hash",
+        "facts": [
+            {
+                "artifact_path": "docs/architecture.svg",
+                "entities": [{"name": "WikiService"}],
+            }
+        ],
+    }
+    manifest = ground_visual_facts_to_sources(
+        visual_facts,
+        [
+            {
+                "path": "codenib/wiki/wiki_service.py",
+                "symbol": "",
+                "kind": "source",
+                "line": 0,
+            },
+            {
+                "path": "codenib/wiki/service.py",
+                "symbol": "WikiService",
+                "kind": "symbol",
+                "line": 17,
+            },
+        ],
+    )
+
+    assert manifest["bindings"][0]["symbol"] == "WikiService"
+    assert manifest["bindings"][0]["score"] == 1.0
+
+
+def test_ground_visual_facts_to_sources_deduplicates_bindings():
+    visual_facts = {
+        "manifest_sha256": "visual-facts-hash",
+        "facts": [
+            {
+                "artifact_path": "docs/architecture.svg",
+                "entities": [
+                    {
+                        "name": "WikiService",
+                        "grounding_candidates": ["WikiService", "WikiService"],
+                    }
+                ],
+            }
+        ],
+    }
+    source = {
+        "path": "codenib/wiki/service.py",
+        "symbol": "WikiService",
+        "kind": "symbol",
+        "line": 17,
+    }
+
+    manifest = ground_visual_facts_to_sources(visual_facts, [source, source])
+
+    assert len(manifest["bindings"]) == 1

--- a/test/wiki/test_media_knowledge.py
+++ b/test/wiki/test_media_knowledge.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from codenib.wiki.media_knowledge import (
+    MultimodalKnowledgeView,
+    build_multimodal_knowledge_view,
+    find_visual_code_links,
+    get_visual_evidence,
+    search_visual_context,
+)
+
+
+def _view():
+    media = {
+        "manifest_sha256": "media-hash",
+        "artifacts": [
+            {
+                "path": "docs/assets/architecture.svg",
+                "role_hint": "architecture_diagram",
+                "caption": "IndexCompiler architecture",
+                "surrounding_text": "IndexCompiler writes to VectorStore.",
+            }
+        ],
+    }
+    facts = {
+        "manifest_sha256": "facts-hash",
+        "facts": [
+            {
+                "artifact_path": "docs/assets/architecture.svg",
+                "entities": [
+                    {
+                        "name": "IndexCompiler",
+                        "type": "component",
+                        "evidence": "caption",
+                    },
+                    {
+                        "name": "VectorStore",
+                        "type": "component",
+                        "evidence": "caption",
+                    },
+                ],
+                "claims": [
+                    {
+                        "text": "IndexCompiler writes to VectorStore.",
+                        "evidence": "surrounding markdown",
+                    }
+                ],
+            }
+        ],
+    }
+    grounding = {
+        "manifest_sha256": "grounding-hash",
+        "bindings": [
+            {
+                "artifact_path": "docs/assets/architecture.svg",
+                "entity_name": "IndexCompiler",
+                "source_path": "codenib/compiler/index_compiler.py",
+                "symbol": "IndexCompiler",
+                "kind": "symbol",
+                "line": 42,
+                "score": 1.0,
+                "evidence": "exact symbol match",
+            }
+        ],
+    }
+    return build_multimodal_knowledge_view(media, facts, grounding)
+
+
+def test_build_multimodal_knowledge_view_joins_artifacts_facts_and_bindings():
+    view = _view()
+
+    assert view["schema"] == "codenib.multimodal-knowledge-view.v1"
+    assert view["media_manifest_sha256"] == "media-hash"
+    assert view["visual_facts_manifest_sha256"] == "facts-hash"
+    assert view["grounding_manifest_sha256"] == "grounding-hash"
+    assert view["entry_count"] == 1
+    assert view["entries"][0]["artifact"]["path"] == "docs/assets/architecture.svg"
+    assert view["entries"][0]["facts"]["entities"][0]["name"] == "IndexCompiler"
+    assert view["entries"][0]["bindings"][0]["symbol"] == "IndexCompiler"
+    assert view["view_sha256"]
+
+
+def test_search_visual_context_finds_visual_entries():
+    results = search_visual_context(_view(), "VectorStore architecture")
+
+    assert len(results) == 1
+    assert results[0]["artifact_path"] == "docs/assets/architecture.svg"
+    assert results[0]["score"] >= 2
+
+
+def test_get_visual_evidence_returns_one_artifact_entry():
+    evidence = get_visual_evidence(_view(), "docs/assets/architecture.svg")
+
+    assert evidence is not None
+    assert evidence["artifact"]["caption"] == "IndexCompiler architecture"
+    assert (
+        evidence["bindings"][0]["source_path"] == "codenib/compiler/index_compiler.py"
+    )
+
+
+def test_find_visual_code_links_returns_entries_for_source_symbol():
+    links = find_visual_code_links(
+        _view(),
+        "codenib/compiler/index_compiler.py",
+        symbol="IndexCompiler",
+    )
+
+    assert len(links) == 1
+    assert links[0]["artifact_path"] == "docs/assets/architecture.svg"
+    assert links[0]["binding"]["line"] == 42
+
+
+def test_multimodal_knowledge_view_wrapper_methods():
+    wrapper = MultimodalKnowledgeView(_view())
+
+    assert wrapper.search_visual_context("IndexCompiler")
+    assert wrapper.get_visual_evidence("docs/assets/architecture.svg") is not None
+    assert wrapper.find_visual_code_links("codenib/compiler/index_compiler.py")

--- a/test/wiki/test_media_pipeline.py
+++ b/test/wiki/test_media_pipeline.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from codenib.wiki import (
+    build_multimodal_knowledge_view,
+    build_visual_facts_manifest,
+    discover_media_manifest,
+    discover_source_symbol_candidates,
+    find_visual_code_links,
+    ground_visual_facts_to_sources,
+    search_visual_context,
+)
+
+
+def test_multimodal_repository_knowledge_pipeline(tmp_path):
+    (tmp_path / "docs" / "assets").mkdir(parents=True)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "docs" / "assets" / "architecture.svg").write_text(
+        "<svg>IndexCompiler VectorStore</svg>",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "\n".join(
+            [
+                "# Demo",
+                "The architecture diagram shows IndexCompiler and VectorStore.",
+                "![IndexCompiler architecture](docs/assets/architecture.svg)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "src" / "compiler.py").write_text(
+        "\n".join(
+            [
+                "class IndexCompiler:",
+                "    pass",
+                "",
+                "class VectorStore:",
+                "    pass",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    media = discover_media_manifest(tmp_path, commit="abc123")
+    facts = build_visual_facts_manifest(media)
+    sources = discover_source_symbol_candidates(tmp_path)
+    grounding = ground_visual_facts_to_sources(facts, sources)
+    view = build_multimodal_knowledge_view(media, facts, grounding)
+
+    assert media["artifact_count"] == 1
+    assert facts["fact_count"] == 1
+    assert grounding["binding_count"] >= 1
+    assert view["entry_count"] == 1
+    assert search_visual_context(view, "IndexCompiler architecture")
+    assert find_visual_code_links(view, "src/compiler.py", symbol="IndexCompiler")


### PR DESCRIPTION
"<!--\nSPDX-FileCopyrightText: 2025-2026 CodeNib Contributors\n\nSPDX-License-Identifier: Apache-2.0\n-->\n\n## Summary\nAdds the PR2 slice for #655: repository-native media discovery and the core multimodal knowledge contracts that later VLM, MCP, storage, and Wiki UI slices can build on.\n\nThis intentionally stays below the serving/runtime layer. It does not add a VLM API adapter, MCP tools, persisted bundle loading, or frontend UI changes.\n\n## Changes\n- Add a bounded repository media manifest for PNG/JPEG/WebP/SVG artifacts referenced from Markdown/HTML docs.\n- Add structured visual fact contracts for entities, relations, and claims, with deterministic local metadata extraction.\n- Add deterministic source-symbol candidate discovery and visual-to-code grounding bindings.\n- Add a compact multimodal knowledge view with search/evidence/code-link helpers.\n- Export the new wiki helpers and document the local contract pipeline.\n- Add focused tests for media discovery, visual facts, grounding, knowledge view, and the contract pipeline.\\n- Bound repository reads and untrusted extractor inputs, anchor fact provenance to manifest artifacts, normalize safe parent media references, and derive source extensions from the shared language registry.\n\n## Type of Change\n- [ ] Bug fix\n- [x] New feature\n- [ ] Breaking change\n- [x] Documentation update\n- [ ] Refactoring\n- [ ] Performance improvement\n- [x] Tests\n\n## Testing\n- [x] Tests pass locally\n- [x] Added new tests for the changes\n\nCommands run locally:\n\n```text\npython -m pytest test/wiki\npython -m py_compile codenib/wiki/media_artifacts.py codenib/wiki/media_facts.py codenib/wiki/media_grounding.py codenib/wiki/media_knowledge.py codenib/wiki/__init__.py\ngit diff --check origin/main...HEAD\n```\n\nLocal result:\n\n```text\n388 passed\n```\n\n## Checklist\n- [x] My code follows the project's style guidelines\n- [x] I have performed a self-review of my code\n- [x] I have commented my code, particularly in hard-to-understand areas\n- [x] My changes generate no new warnings\n- [x] Any dependent changes have been merged and published\n\n## Notes for reviewers\nThis is based on current upstream `main` after #656. The upstream diff is limited to the repository media manifest and core multimodal knowledge-contract slice requested in #655. Later slices should stay stacked separately."