### PR TITLE
feat(storage): lease replacements before mutation

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -127,10 +127,12 @@ jobs:
             from codenib import _workspace_owner
 
             assert platform.machine() == '${{ matrix.arch }}'
-            assert implementation.workspace_owner_protocol_version == 4
-            protocol_v4_symbols = (
+            assert implementation.workspace_owner_protocol_version == 5
+            protocol_v5_symbols = (
                 "capture_owner_destination_exact",
+                "acquire_owner_replacement_lease_exact",
                 "verify_owner_destination_binding_exact",
+                "borrow_owner_parent_descriptor_exact",
                 "borrow_owner_destination_descriptor_exact",
                 "claim_owner_replacement_permit_exact",
                 "provision_owner_replacement_exact",
@@ -139,11 +141,13 @@ jobs:
             )
             assert all(
                 callable(getattr(implementation, name, None))
-                for name in protocol_v4_symbols
+                for name in protocol_v5_symbols
             )
-            facade_v4_symbols = (
+            facade_v5_symbols = (
                 "capture_owner_destination",
+                "acquire_owner_replacement_lease",
                 "verify_owner_destination_binding",
+                "borrow_owner_parent_descriptor",
                 "borrow_owner_destination_descriptor",
                 "claim_owner_replacement_permit",
                 "provision_owner_replacement",
@@ -153,12 +157,12 @@ jobs:
             )
             assert all(
                 callable(getattr(_workspace_owner, name, None))
-                for name in facade_v4_symbols
+                for name in facade_v5_symbols
             )
             assert implementation.require_support() is None
             assert _workspace_owner.require_support() is None
 
-            plan_digest = hashlib.sha256(b"cibuildwheel-protocol-v4").hexdigest()
+            plan_digest = hashlib.sha256(b"cibuildwheel-protocol-v5").hexdigest()
             plan_digest_bytes = plan_digest.encode("ascii")
             directories = ((b"data", 0o700),)
             incumbent_payload = b"incumbent"
@@ -199,6 +203,24 @@ jobs:
                         )
                     )
                     assert not os.get_inheritable(incumbent_descriptor)
+                    _workspace_owner.acquire_owner_replacement_lease(
+                        owner,
+                        deadline(),
+                    )
+                    assert _workspace_owner.owner_state(owner) == (
+                        "destination-leased"
+                    )
+                    parent_descriptor = (
+                        _workspace_owner.borrow_owner_parent_descriptor(owner)
+                    )
+                    parent_metadata = os.fstat(parent_descriptor)
+                    parent_identity = (
+                        parent_metadata.st_dev,
+                        parent_metadata.st_ino,
+                    )
+                    assert stat.S_ISDIR(parent_metadata.st_mode)
+                    assert parent_identity == identity(authority)
+                    assert not os.get_inheritable(parent_descriptor)
                     replacement_permit = (
                         _workspace_owner.claim_owner_replacement_permit(owner)
                     )
@@ -251,6 +273,7 @@ jobs:
                     return (
                         owner,
                         replacement_permit,
+                        parent_descriptor,
                         incumbent_descriptor,
                         candidate_descriptor,
                         incumbent_identity,
@@ -276,6 +299,7 @@ jobs:
                 (
                     success_owner,
                     success_permit,
+                    success_parent_descriptor,
                     success_incumbent_descriptor,
                     success_candidate_descriptor,
                     success_incumbent_identity,
@@ -307,6 +331,10 @@ jobs:
                         success_slot / "incumbent.txt"
                     ).read_bytes() == incumbent_payload
                     assert (
+                        os.fstat(success_parent_descriptor).st_dev,
+                        os.fstat(success_parent_descriptor).st_ino,
+                    ) == identity(success_root)
+                    assert (
                         os.fstat(success_incumbent_descriptor).st_dev,
                         os.fstat(success_incumbent_descriptor).st_ino,
                     ) == success_incumbent_identity
@@ -320,6 +348,10 @@ jobs:
                     assert _workspace_owner.owner_state(success_owner) == (
                         "replacement-receipted"
                     )
+                    assert (
+                        os.fstat(success_parent_descriptor).st_dev,
+                        os.fstat(success_parent_descriptor).st_ino,
+                    ) == identity(success_root)
                     assert (
                         os.fstat(success_incumbent_descriptor).st_dev,
                         os.fstat(success_incumbent_descriptor).st_ino,
@@ -349,6 +381,7 @@ jobs:
                 (
                     rollback_owner,
                     rollback_permit,
+                    rollback_parent_descriptor,
                     rollback_incumbent_descriptor,
                     rollback_candidate_descriptor,
                     rollback_incumbent_identity,
@@ -370,6 +403,10 @@ jobs:
                         rollback_candidate_identity
                     )
                     assert identity(rollback_slot) == rollback_incumbent_identity
+                    assert (
+                        os.fstat(rollback_parent_descriptor).st_dev,
+                        os.fstat(rollback_parent_descriptor).st_ino,
+                    ) == identity(rollback_root)
                     assert (
                         os.fstat(rollback_incumbent_descriptor).st_dev,
                         os.fstat(rollback_incumbent_descriptor).st_ino,
@@ -640,10 +677,12 @@ jobs:
           )
 
           assert Path(implementation.__file__).name == "_workspace_owner_impl.abi3.so"
-          assert implementation.workspace_owner_protocol_version == 4
-          protocol_v4_symbols = (
+          assert implementation.workspace_owner_protocol_version == 5
+          protocol_v5_symbols = (
               "capture_owner_destination_exact",
+              "acquire_owner_replacement_lease_exact",
               "verify_owner_destination_binding_exact",
+              "borrow_owner_parent_descriptor_exact",
               "borrow_owner_destination_descriptor_exact",
               "claim_owner_replacement_permit_exact",
               "provision_owner_replacement_exact",
@@ -652,13 +691,15 @@ jobs:
           )
           assert all(
               callable(getattr(implementation, name, None))
-              for name in protocol_v4_symbols
+              for name in protocol_v5_symbols
           )
           assert implementation.require_support() is None
           assert _workspace_owner.require_support() is None
-          facade_v4_symbols = (
+          facade_v5_symbols = (
               "capture_owner_destination",
+              "acquire_owner_replacement_lease",
               "verify_owner_destination_binding",
+              "borrow_owner_parent_descriptor",
               "borrow_owner_destination_descriptor",
               "claim_owner_replacement_permit",
               "provision_owner_replacement",
@@ -668,7 +709,7 @@ jobs:
           )
           assert all(
               callable(getattr(_workspace_owner, name, None))
-              for name in facade_v4_symbols
+              for name in facade_v5_symbols
           )
 
           payload = b'{"release-smoke":"ok"}'
@@ -761,13 +802,33 @@ jobs:
                   ) == incumbent_identity
                   assert not os.get_inheritable(destination_descriptor)
 
+                  _workspace_owner.acquire_owner_replacement_lease(
+                      captured_owner,
+                      time.monotonic_ns() + 10_000_000_000,
+                  )
+                  assert _workspace_owner.owner_state(captured_owner) == (
+                      "destination-leased"
+                  )
+                  parent_descriptor = (
+                      _workspace_owner.borrow_owner_parent_descriptor(
+                          captured_owner
+                      )
+                  )
+                  parent_metadata = os.fstat(parent_descriptor)
+                  assert stat.S_ISDIR(parent_metadata.st_mode)
+                  assert (
+                      parent_metadata.st_dev,
+                      parent_metadata.st_ino,
+                  ) == (root.stat().st_dev, root.stat().st_ino)
+                  assert not os.get_inheritable(parent_descriptor)
+
                   replacement_permit = (
                       _workspace_owner.claim_owner_replacement_permit(
                           captured_owner
                       )
                   )
                   assert _workspace_owner.owner_state(captured_owner) == (
-                      "destination-captured"
+                      "destination-leased"
                   )
                   _workspace_owner.provision_owner_replacement(
                       captured_owner,
@@ -857,6 +918,10 @@ jobs:
                       payload
                   )
                   assert (
+                      os.fstat(parent_descriptor).st_dev,
+                      os.fstat(parent_descriptor).st_ino,
+                  ) == (root.stat().st_dev, root.stat().st_ino)
+                  assert (
                       os.fstat(destination_descriptor).st_dev,
                       os.fstat(destination_descriptor).st_ino,
                   ) == incumbent_identity
@@ -870,6 +935,10 @@ jobs:
                   assert _workspace_owner.owner_state(captured_owner) == (
                       "replacement-receipted"
                   )
+                  assert (
+                      os.fstat(parent_descriptor).st_dev,
+                      os.fstat(parent_descriptor).st_ino,
+                  ) == (root.stat().st_dev, root.stat().st_ino)
                   assert (
                       os.fstat(destination_descriptor).st_dev,
                       os.fstat(destination_descriptor).st_ino,
@@ -895,6 +964,169 @@ jobs:
               )
               assert output.read_bytes() == replacement_payload
               assert replacement.joinpath("data/result.json").read_bytes() == payload
+
+              rollback_incumbent_identity = (
+                  destination.stat().st_dev,
+                  destination.stat().st_ino,
+              )
+              rollback_name = (
+                  f".rollback-{os.getpid()}-{time.monotonic_ns()}".encode("ascii")
+              )
+              rollback = root / os.fsdecode(rollback_name)
+              rollback_payload = b'{"release-smoke":"rollback-candidate"}'
+              rollback_owner = _workspace_owner.create_owner()
+              try:
+                  _workspace_owner.capture_owner_destination(
+                      rollback_owner,
+                      os.fsencode(root),
+                      b"published",
+                      time.monotonic_ns() + 10_000_000_000,
+                  )
+                  assert _workspace_owner.owner_state(rollback_owner) == (
+                      "destination-captured"
+                  )
+                  _workspace_owner.verify_owner_destination_binding(
+                      rollback_owner
+                  )
+                  rollback_incumbent_descriptor = (
+                      _workspace_owner.borrow_owner_destination_descriptor(
+                          rollback_owner
+                      )
+                  )
+                  assert not os.get_inheritable(rollback_incumbent_descriptor)
+                  _workspace_owner.acquire_owner_replacement_lease(
+                      rollback_owner,
+                      time.monotonic_ns() + 10_000_000_000,
+                  )
+                  assert _workspace_owner.owner_state(rollback_owner) == (
+                      "destination-leased"
+                  )
+                  rollback_parent_descriptor = (
+                      _workspace_owner.borrow_owner_parent_descriptor(
+                          rollback_owner
+                      )
+                  )
+                  rollback_parent_metadata = os.fstat(
+                      rollback_parent_descriptor
+                  )
+                  assert stat.S_ISDIR(rollback_parent_metadata.st_mode)
+                  assert (
+                      rollback_parent_metadata.st_dev,
+                      rollback_parent_metadata.st_ino,
+                  ) == (root.stat().st_dev, root.stat().st_ino)
+                  assert not os.get_inheritable(rollback_parent_descriptor)
+                  rollback_permit = (
+                      _workspace_owner.claim_owner_replacement_permit(
+                          rollback_owner
+                      )
+                  )
+                  _workspace_owner.provision_owner_replacement(
+                      rollback_owner,
+                      rollback_name,
+                      plan.digest.encode("ascii"),
+                      plan.root_mode,
+                      tuple(
+                          (os.fsencode(item.path.as_posix()), item.mode)
+                          for item in plan.directories
+                      ),
+                      time.monotonic_ns() + 10_000_000_000,
+                  )
+                  assert _workspace_owner.owner_state(rollback_owner) == (
+                      "replacement-provisioned"
+                  )
+                  _workspace_owner.verify_owner_adoption_binding(
+                      rollback_owner,
+                      os.fsencode(destination),
+                      rollback_name,
+                      plan.digest.encode("ascii"),
+                  )
+                  rollback_descriptor = (
+                      _workspace_owner.borrow_owner_root_descriptor(
+                          rollback_owner
+                      )
+                  )
+                  rollback_metadata = os.fstat(rollback_descriptor)
+                  rollback_identity = (
+                      rollback_metadata.st_dev,
+                      rollback_metadata.st_ino,
+                  )
+                  assert stat.S_ISDIR(rollback_metadata.st_mode)
+                  assert rollback_identity != rollback_incumbent_identity
+                  assert not os.get_inheritable(rollback_descriptor)
+                  _workspace_owner.mark_owner_adopted(rollback_owner)
+                  _workspace_owner.begin_owner_file(
+                      rollback_owner,
+                      b"data",
+                      b"result.json",
+                      0o600,
+                  )
+                  _workspace_owner.write_owner_file(
+                      rollback_owner,
+                      rollback_payload,
+                  )
+                  rollback_record = _workspace_owner.finish_owner_file(
+                      rollback_owner,
+                      0o600,
+                  )
+                  assert len(rollback_record) == 8
+                  _workspace_owner.seal_owner_directories(rollback_owner)
+                  assert _workspace_owner.owner_state(rollback_owner) == (
+                      "replacement-adopted"
+                  )
+                  _workspace_owner.verify_owner_replacement_binding(
+                      rollback_owner
+                  )
+                  _workspace_owner.exchange_owner_replacement(
+                      rollback_permit,
+                      rollback_name,
+                      b"published",
+                      time.monotonic_ns() + 10_000_000_000,
+                  )
+                  assert _workspace_owner.owner_state(rollback_owner) == (
+                      "replacement-exchanged-unreceipted"
+                  )
+                  assert (
+                      destination.stat().st_dev,
+                      destination.stat().st_ino,
+                  ) == rollback_identity
+                  assert (
+                      rollback.stat().st_dev,
+                      rollback.stat().st_ino,
+                  ) == rollback_incumbent_identity
+                  assert output.read_bytes() == rollback_payload
+                  assert rollback.joinpath("data/result.json").read_bytes() == (
+                      replacement_payload
+                  )
+                  assert (
+                      os.fstat(rollback_parent_descriptor).st_dev,
+                      os.fstat(rollback_parent_descriptor).st_ino,
+                  ) == (root.stat().st_dev, root.stat().st_ino)
+                  assert (
+                      os.fstat(rollback_incumbent_descriptor).st_dev,
+                      os.fstat(rollback_incumbent_descriptor).st_ino,
+                  ) == rollback_incumbent_identity
+                  assert (
+                      os.fstat(rollback_descriptor).st_dev,
+                      os.fstat(rollback_descriptor).st_ino,
+                  ) == rollback_identity
+                  _workspace_owner.abort_owner(rollback_owner)
+              finally:
+                  if not _workspace_owner.owner_closed(rollback_owner):
+                      _workspace_owner.abort_owner(rollback_owner)
+
+              assert _workspace_owner.owner_closed(rollback_owner)
+              assert _workspace_owner.owner_state(rollback_owner) == "closed"
+              assert (
+                  destination.stat().st_dev,
+                  destination.stat().st_ino,
+              ) == rollback_incumbent_identity
+              assert (rollback.stat().st_dev, rollback.stat().st_ino) == (
+                  rollback_identity
+              )
+              assert output.read_bytes() == replacement_payload
+              assert rollback.joinpath("data/result.json").read_bytes() == (
+                  rollback_payload
+              )
           PY
 
   install-smoke:

--- a/codenib/_workspace_owner.py
+++ b/codenib/_workspace_owner.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-_EXPECTED_WORKSPACE_OWNER_PROTOCOL_VERSION = 4
+_EXPECTED_WORKSPACE_OWNER_PROTOCOL_VERSION = 5
 _IMPORT_ERROR: BaseException | None = None
 
 try:
@@ -44,6 +44,9 @@ _close_owner_exact = _implementation_attribute("close_owner_exact")
 _provision_owner_exact = _implementation_attribute("provision_owner_exact")
 _capture_owner_destination_exact = _implementation_attribute(
     "capture_owner_destination_exact"
+)
+_acquire_owner_replacement_lease_exact = _implementation_attribute(
+    "acquire_owner_replacement_lease_exact"
 )
 _provision_owner_replacement_exact = _implementation_attribute(
     "provision_owner_replacement_exact"
@@ -107,6 +110,7 @@ _workspace_owner_protocol_available = (
             _close_owner_exact,
             _provision_owner_exact,
             _capture_owner_destination_exact,
+            _acquire_owner_replacement_lease_exact,
             _provision_owner_replacement_exact,
             _verify_owner_authority_exact,
             _verify_owner_adoption_binding_exact,
@@ -143,6 +147,7 @@ if not _workspace_owner_protocol_available:
     _close_owner_exact = None
     _provision_owner_exact = None
     _capture_owner_destination_exact = None
+    _acquire_owner_replacement_lease_exact = None
     _provision_owner_replacement_exact = None
     _verify_owner_authority_exact = None
     _verify_owner_adoption_binding_exact = None
@@ -323,6 +328,17 @@ def capture_owner_destination(
             deadline_ns,
         ),
         "destination-capture",
+    )
+
+
+def acquire_owner_replacement_lease(owner: object, deadline_ns: int) -> None:
+    """Lease the captured parent and revalidate its destination under lock."""
+
+    _require_protocol()
+    assert _acquire_owner_replacement_lease_exact is not None
+    _require_none_result(
+        _acquire_owner_replacement_lease_exact(owner, deadline_ns),
+        "replacement-lease",
     )
 
 
@@ -564,6 +580,7 @@ def owner_closed(owner: object) -> bool:
 
 
 __all__ = [
+    "acquire_owner_replacement_lease",
     "abort_owner",
     "abort_owner_file",
     "begin_owner_file",

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -22,18 +22,20 @@ import-cache` recaptures an already existing selected cache, `codenib artifact
 materialize` publishes a retained catalog ref or immutable snapshot to a
 missing portable-artifact directory, and retained `codenib mcp` cold-start
 materializes and holds one such generation for a single stdio server lifetime.
-Protocol v4 also exposes an internal existing-destination replacement
-primitive. It captures the incumbent, provisions and authenticates one hidden
-same-parent candidate, exchanges the two exact directory bindings with Linux
-`renameat2(RENAME_EXCHANGE)`, and returns an opaque receipt token. The native
-aggregate owns the incumbent and candidate descriptors throughout; every
-descriptor borrowed by trusted internal code remains owner-owned and must
-never be closed by the borrower.
+Protocol v4 introduced an internal existing-destination replacement primitive:
+it captures the incumbent, provisions and authenticates one hidden same-parent
+candidate, exchanges the two exact directory bindings with Linux
+`renameat2(RENAME_EXCHANGE)`, and returns an opaque receipt token. Protocol v5
+keeps that exchange contract and moves a cooperative, parent-wide cross-process
+lease ahead of every candidate mutation. The native aggregate owns the parent,
+incumbent, and candidate descriptors throughout; every descriptor borrowed by
+trusted internal code remains owner-owned and must never be closed by the
+borrower.
 
 This primitive does not change `LocalWorkspaceProvider`: the provider remains
 missing-only and still rejects the strict BM25 producer's
 `provider-bound-exact` destination mode. Provider integration is a separate
-Gate C change, so Gate C and M1 remain open even though the protocol-v4
+Gate C change, so Gate C and M1 remain open even though the protocol-v5
 primitive is available.
 
 ## Publish a normal index build
@@ -558,7 +560,7 @@ The provider deliberately has a narrow first release:
 - One absolute authority root owned by the current effective UID, with exact
   mode `0700`. The root must be a private, quiescent namespace rather than a
   directory another same-UID process actively mutates.
-- A complete protocol-v4 native extension and a successful Linux ownership
+- A complete protocol-v5 native extension and a successful Linux ownership
   support probe before the first namespace mutation.
 - A plan small enough for the process descriptor limit. The format permits up
   to 100,000 directories, but the native `RLIMIT_NOFILE` preflight may reject a
@@ -582,7 +584,7 @@ policy permits cleanup; discarding it forfeits recoverability.
 
 ## Publication guarantees
 
-The protocol-v4 native aggregate preserves the protocol-v2 missing-destination
+The protocol-v5 native aggregate preserves the protocol-v2 missing-destination
 publication contract. In that publication mode it owns the namespace and file
 descriptors for the whole operation, creates and writes files without returning
 raw file descriptors to Python, pins the root and planned directory identities,
@@ -599,11 +601,13 @@ Staged and published validators run inside that transaction. The returned
 receipt therefore names one exact, durably published generation rather than a
 path checked after the fact.
 
-Protocol v4 extends capture with a primitive-only replacement transaction. Its
-success path has these native owner states:
+Protocol v4 extended capture with a primitive-only replacement transaction.
+Protocol v5 preserves that history and adds a required pre-mutation lease
+transition. Its success path has these native owner states:
 
 ```text
 destination-captured
+  -> destination-leased
   -> replacement-provisioning
   -> replacement-provisioned
   -> replacement-adopted
@@ -612,27 +616,48 @@ destination-captured
   -> closed
 ```
 
-The native ABI adds
-`claim_owner_replacement_permit_exact`,
+Protocol v4 added `claim_owner_replacement_permit_exact`,
 `provision_owner_replacement_exact`,
 `verify_owner_replacement_binding_exact`, and
-`exchange_owner_replacement_exact`. The fail-closed facade exposes the same
-operations without `_exact`. Claim returns a distinct opaque
+`exchange_owner_replacement_exact`. Protocol v5 adds
+`acquire_owner_replacement_lease_exact` and requires it after capture and before
+permit claim or provisioning. The fail-closed facade exposes the same
+operations without `_exact`, including `acquire_owner_replacement_lease`.
+Claim returns a distinct opaque
 `WorkspaceReplacementPermit`; exchange consumes that permit and returns an
 opaque `WorkspaceReceiptToken` for the existing `commit_owner_receipt`
 operation. Permits and receipt tokens do not expose a separate public state
 API; `owner_state` reports the aggregate state above.
 
+`destination-captured` is speculative and does not hold the lease. Capture
+retains one owner/guard pair for the borrowable parent authority used by
+namespace operations and `fsync`, and separately opens a never-exposed parent
+descriptor plus guard for the lease. The lease pair is authenticated as the
+same parent identity, internally the same open-file-description (OFD), and a
+different OFD from the
+borrowable parent pair. Acquisition flocks only that hidden OFD and then
+revalidates the complete captured parent chain and incumbent
+name/device/inode binding under the lock. Only success enters
+`destination-leased`. A borrower's `flock(LOCK_UN)` on the exposed parent
+therefore cannot release the replacement lease. Lease contention returns cleanly in
+`destination-captured`, and a stale capture is rejected under lock with zero
+candidate mutation before the flock is released. If an earlier owner instead
+reverses its exchange and restores the captured incumbent, a waiting owner may
+acquire normally on a later retry.
+
 `replacement-provisioning` is the in-call construction state; a successful
 provision call returns in `replacement-provisioned`. Claiming the distinct
-one-shot replacement permit does not change `destination-captured`. After the
+one-shot replacement permit does not change `destination-leased`. After the
 candidate is adopted, written, sealed, and rebound to the aggregate, exchange
 returns an opaque receipt token. While the exact owner authority remains active
 and before close, committing that token is idempotent, releases the cooperative
 flock lease while retaining the authenticated parent descriptor and guard until
-owner/receipt close, and enters `replacement-receipted`. Closing a receipted
-owner only closes its handles and does not mutate either path; after close, the
-token is no longer a retry capability and commit fails closed.
+owner/receipt close, and enters `replacement-receipted`. The receipted state is
+sealed against a path-based live-name verifier: replacement binding verification
+and new parent-descriptor borrows are unavailable there, while descriptors
+borrowed earlier remain owner-owned until close. Closing a receipted owner only
+closes its handles and does not mutate either path; after close, the token is no
+longer a retry capability and commit fails closed.
 The forward parent `fsync` occurs inside exchange before a token is returned.
 If it fails, the caller has no token: the aggregate enters
 `replacement-recovery-required`, retains its lease and descriptors, and must be
@@ -651,20 +676,23 @@ The exchange contract is deliberately narrow. It is Linux-only, requires the
 incumbent and hidden candidate to be distinct directories under the same
 captured parent and on the same device, and uses exactly
 `renameat2(RENAME_EXCHANGE)`. There is no portable or multi-rename fallback.
-The parent-directory open-file-description (OFD) guard is acquired nonblocking
-with `flock(LOCK_EX | LOCK_NB)` and is held across the live exchange until
-either the receipt is committed or an authenticated reverse exchange plus
-parent-directory `fsync` completes. This serializes only the
-exchange-to-receipt-or-reverse settlement window; it does
-not refresh an earlier capture or lock the complete writer lifecycle. A future
-provider or other cooperative caller replacing the same incumbent must supply
-outer single-writer, quiescent serialization for the entire
-capture-to-receipt-or-abort lifetime. If two owners capture the same incumbent,
-the first commits, and the second later attempts exchange, the second classifies
-the mapping as unknown, stays `replacement-recovery-required`, and retains its
-lease and descriptors. The primitive does not auto-adopt or quarantine that
-stale capture. The containing `0700` root must remain private and quiescent; a
-hostile same-UID process that ignores the guard is outside the contract.
+The separately opened, hidden parent open-file-description (OFD) is acquired
+nonblocking with `flock(LOCK_EX | LOCK_NB)` before candidate mutation and is held across
+provisioning, adoption, the live exchange, and return settlement until either
+the receipt is committed or an authenticated reverse exchange plus
+parent-directory `fsync` completes. Namespace operations and durability syncs
+continue to use the original parent authority; the hidden lease pair is never
+borrowed. Because the flock covers the parent rather than one basename, it
+provides one cooperative cross-process single-writer boundary even for
+different destination names under that parent. Capture itself remains
+speculative, but all live capture revalidation occurs under the lease before
+mutation. If two owners capture the same incumbent and the first commits, the
+second later rejects its stale capture during lease acquisition, performs zero
+candidate mutation, releases its newly acquired lease, and remains
+`destination-captured`; it does not auto-adopt or quarantine the newer mapping.
+The containing `0700` root must remain private and quiescent. This is a
+cooperative/private threat model, not protection against a hostile same-UID
+process that ignores the guard.
 
 Before receipt settlement, same-process abort verifies the swapped incumbent
 and candidate mappings, reverses the exchange, flushes the parent, restores the
@@ -675,14 +703,28 @@ randomness. A committed exchange leaves the new candidate at the destination
 and the old incumbent at that slot; the primitive does not reclaim it. Readers
 observing the live namespace see one complete binding or the other at the
 single exchange point, but this is live
-atomicity, not crash recovery. There is no journal and no promise to roll back
+atomicity, not crash recovery. There is no crash journal and no promise to roll back
 after `SIGKILL`, host failure, or power loss. A caller that observes
 `replacement-recovery-required` must retain the owner and explicitly retry
 recovery, plus the same receipt token when a reachable receipt-commit attempt
 failed. If all references are abandoned while the mapping is unknown, native
 deallocation deliberately retains the raw descriptors and cooperative flock
 until process exit rather than silently releasing the only exclusion and
-authority; restarting is the final recovery boundary.
+authority; restarting is the final recovery boundary. If acquisition or
+pre-mutation provisioning reported an error before a candidate was confirmed,
+settlement first authenticates the incumbent and hidden authorities while the
+lease remains held. It treats the attempt as no-candidate only when
+`fstatat(..., AT_SYMLINK_NOFOLLOW)` reports exact `ENOENT` for the configured
+slot, then syncs the parent before unlock. An existing or rebound slot, or any
+ambiguous stat result, enters or retains `replacement-recovery-required` with
+the lease and configuration intact for retry. Unlock or close interruption is
+handled by the same retained-authority retry rather than requiring an
+externally stale live name to be restored. An interruption after the native
+lease return but before Python observes it leaves `destination-leased`;
+repeating acquisition is idempotent and
+does not take a second flock. A fork child cannot mutate, reverse, commit, or
+unlock the parent's lease. It only authenticates and closes its inherited
+descriptor pairs, leaving the parent process's authority and lock intact.
 
 All borrowed incumbent, candidate-root, parent, and planned-directory
 descriptors remain owned by the aggregate and are valid only for its lifetime;

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -282,58 +282,86 @@ authenticated reader pinned through synchronous consumption. The contract
 remains provider-neutral, and a concrete `LocalWorkspaceProvider` now supplies
 it on Linux for missing destinations below one private, quiescent root owned by
 the current effective UID with exact mode `0700`. Native workspace-owner
-protocol v4 preserves the v2 publication contract: it pins the namespace and
+protocol v5 preserves the v2 publication contract: it pins the namespace and
 owns every file descriptor, acquires and writes files without exposing raw file
 descriptors to Python, and gates the only forward rename with a one-shot publish
 permit. The caller-owned receipt slot is the publication-authority
 linearization point: unreceipted same-process failures quarantine the exact
 candidate, while a fork child authenticates and closes only its inherited
 descriptor pairs. The v3-compatible capture state authenticates the private
-root and exact destination name/device/inode binding without mutation. V4 adds
-a distinct one-shot replacement permit and one aggregate for that incumbent
-plus a hidden, same-parent candidate. Its success states are
-`destination-captured` -> `replacement-provisioning` ->
-`replacement-provisioned` -> `replacement-adopted` ->
-`replacement-exchanged-unreceipted` -> `replacement-receipted`, followed by
-`closed`; interrupted paths may instead enter
-`replacement-recovery-required` or `quarantined`. The only exchange is Linux
-`renameat2(RENAME_EXCHANGE)` for two same-device directories under the captured
-parent, with no portable or multi-rename fallback. A nonblocking owner-held
-parent-directory open-file-description (OFD)
-`flock(LOCK_EX | LOCK_NB)` guards the cooperative commit window through receipt
-commit or an authenticated reverse exchange and parent `fsync`. That flock
-serializes only exchange-to-settlement, not the earlier capture or complete
-writer lifecycle. A future provider/caller must keep replacements of the same
-incumbent single-writer and quiescent from capture through receipt or abort. A
-second stale owner that captured before another owner committed classifies the
-later mapping as unknown, stays `replacement-recovery-required`, and retains
-its lease and descriptors; the primitive neither auto-adopts nor quarantines
-that capture. This assumes a private `0700` namespace whose CodeNib writers
-honor the outer serialization and guard; it is not a claim against hostile
-same-UID mutation. Before receipt settlement,
-same-process recovery can restore the incumbent and retain the candidate at its
-pre-existing, caller-supplied authenticated hidden slot. The primitive validates
-the hidden basename but does not generate or prove randomness. A committed
-exchange leaves the candidate live and the incumbent at that slot. This is live
-atomicity without a crash journal: `SIGKILL`, host failure, and power loss have
-no promised rollback. If the mapping becomes unknown, callers must retain and
-explicitly retry the recovery owner. Forward parent `fsync` runs inside exchange
-before a token is returned; its failure leaves the caller with no token and
-requires owner recovery/abort. A reachable receipt-commit dual-binding or
-`LOCK_UN` failure instead leaves the already-returned same exact receipt token
-unconsumed. While the exact owner remains active and before close, it may retry
-commit only after native reclassification proves the exchanged mapping; after
-close, the token is no longer a retry capability and commit fails closed. Owner
-abort remains the alternative reclassifying/reversing settlement. Every
-lease-active recovery, including an operator-restored mapping or receipt retry,
-performs parent `fsync` before
-eventual unlock. Abandoning recovery authority deliberately retains the raw
-descriptors and cooperative flock until process
-exit rather than silently discarding the only authority. Every borrowed
-incumbent, candidate, parent, or planned-directory descriptor remains
-owner-owned and callers must not close it. Trusted internal code could still
-use those descriptors with `*at` syscalls, so the primitive is not full
-`_TreeOwnership`.
+root and exact destination name/device/inode binding without mutation. Protocol
+v4 added a distinct one-shot replacement permit and one aggregate for that
+incumbent plus a hidden, same-parent candidate. Protocol v5 retains that atomic
+exchange history and inserts a required parent lease before candidate mutation.
+Its success states are `destination-captured` -> `destination-leased` ->
+`replacement-provisioning` -> `replacement-provisioned` ->
+`replacement-adopted` -> `replacement-exchanged-unreceipted` ->
+`replacement-receipted`, followed by `closed`; interrupted paths may instead
+enter `replacement-recovery-required` or `quarantined`.
+
+Capture is speculative and lock-free. It retains one owner/guard pair for the
+borrowable parent authority used by namespace operations and `fsync`, and opens
+a separate, never-exposed parent descriptor plus guard for the lease. Native
+capture authenticates the hidden pair as the same parent identity, internally
+the same open-file-description (OFD), and a different OFD from the borrowable
+parent pair. Lease
+acquisition applies nonblocking `flock(LOCK_EX | LOCK_NB)` only to that hidden
+OFD, then revalidates the complete parent chain and captured destination binding
+under the lock. A borrower's `LOCK_UN` on the exposed parent cannot release the
+lease. A stale capture is rejected under lock with zero candidate mutation and
+releases the lease, remaining `destination-captured`; it neither auto-adopts nor
+quarantines the newer mapping. Contention likewise makes no candidate. If an
+earlier owner reverses its exchange and restores the captured incumbent,
+another owner may acquire successfully on retry. The parent-wide flock provides
+one cooperative cross-process single-writer boundary, including different
+destination names under the same parent, from before provisioning through
+receipt commit or an authenticated reverse exchange and parent `fsync`.
+
+The only exchange is Linux `renameat2(RENAME_EXCHANGE)` for two same-device
+directories under the captured parent, with no portable or multi-rename
+fallback. Before receipt settlement, same-process recovery can restore the
+incumbent and retain the candidate at its pre-existing, caller-supplied
+authenticated hidden slot. The primitive validates the hidden basename but
+does not generate or prove randomness. A committed exchange leaves the
+candidate live and the incumbent at that slot. This is live atomicity without a
+crash journal: `SIGKILL`, host failure, and power loss have no promised
+rollback. This assumes a private, quiescent `0700` namespace whose cooperative
+CodeNib writers honor the guard; it is not protection against hostile same-UID
+mutation.
+
+If the mapping becomes unknown, callers must retain and explicitly retry the
+recovery owner. Forward parent `fsync` runs inside exchange before a token is
+returned; its failure leaves the caller with no token and requires owner
+recovery/abort. A reachable receipt-commit dual-binding or `LOCK_UN` failure
+instead leaves the already-returned same exact receipt token unconsumed. While
+the exact owner remains active and before close, it may retry commit only after
+native reclassification proves the exchanged mapping; after close, the token is
+no longer a retry capability and commit fails closed. Owner abort remains the
+alternative reclassifying/reversing settlement. Every lease-active recovery,
+including an operator-restored mapping or receipt retry, performs parent `fsync`
+before eventual unlock. If replacement `mkdirat` reports failure before a
+candidate identity is confirmed, settlement keeps the lease held while it
+authenticates the incumbent and hidden authorities. Only an exact
+`fstatat(..., AT_SYMLINK_NOFOLLOW)` `ENOENT` for the configured slot authorizes
+no-candidate settlement, parent `fsync`, unlock, configuration reset, and close.
+An existing or rebound slot, or any ambiguous stat result, enters or retains
+`replacement-recovery-required` with the lease and configuration intact for
+retry. A no-candidate unlock/close retry can therefore settle without requiring
+an externally stale live name to be restored. If native lease acquisition
+returns but Python return is interrupted, the owner remains
+`destination-leased` and repeated acquisition is idempotent without taking a
+second flock. A fork child cannot mutate, reverse, commit, or unlock the
+parent's lease; it only authenticates and closes its own inherited descriptor
+pairs.
+
+The receipted aggregate seals its path-based live-name verifier and new parent
+borrows, while earlier borrowed descriptors remain owner-owned until close.
+Abandoning unknown recovery authority deliberately retains the raw descriptors
+and cooperative flock until process exit rather than silently discarding the
+only authority. Every borrowed incumbent, candidate, parent, or
+planned-directory descriptor remains owner-owned and callers must not close it.
+Trusted internal code could still use those descriptors with `*at` syscalls, so
+the primitive is not full `_TreeOwnership`.
 The provider remains an authority boundary for trusted callbacks, not an
 in-process Python sandbox.
 The explicit retained workflows construct it for operator-requested publication
@@ -797,7 +825,7 @@ that collecting a fast result cannot silently approve a production route:
 | B1 | Promote BM25 compiler publication to a configured default. | Pending A2 compiler. |
 | B2 | Promote query-only BM25 retained cold start to a configured default. | Pending A2 query-only runtime; this does not replace source-bound manifest MCP. |
 | B2 source-bound | Promote a specifically scoped source-bound BM25 retained cold start. | Pending A2 source-bound BM25 runtime; it cannot satisfy the full manifest-compatibility gate. |
-| C | Supply the `provider-bound-exact` strict BM25 native provider. | Protocol v4 implements a Linux-only, same-parent `RENAME_EXCHANGE` primitive with receipt settlement and bounded same-process rollback, but `LocalWorkspaceProvider` still rejects this expectation and no strict producer selects the primitive. Gate C remains pending and required before M1 closes. |
+| C | Supply the `provider-bound-exact` strict BM25 native provider. | Protocol v4 introduced the Linux-only, same-parent `RENAME_EXCHANGE` primitive; protocol v5 moves a parent-wide cross-process flock before candidate mutation and retains receipt settlement and bounded same-process rollback. `LocalWorkspaceProvider` still rejects this expectation and no strict producer selects the primitive. Gate C remains pending and required before M1 closes. |
 
 The A1 harness fixes the BM25 `fast` compiler/runtime comparison rather than
 accepting arbitrary route substitutions. For compiler cold start, arm A runs

--- a/native/workspace_owner.c
+++ b/native/workspace_owner.c
@@ -80,6 +80,7 @@ enum workspace_namespace_state {
   WORKSPACE_REPLACEMENT_EXCHANGED_UNRECEIPTED = 11,
   WORKSPACE_REPLACEMENT_RECEIPTED = 12,
   WORKSPACE_REPLACEMENT_RECOVERY_REQUIRED = 13,
+  WORKSPACE_DESTINATION_LEASED = 14,
 };
 
 enum workspace_receipt_kind {
@@ -119,6 +120,8 @@ typedef struct WorkspaceOwner {
   int parent_fd;
   int parent_guard_fd;
   int parent_exposed;
+  int replacement_lock_fd;
+  int replacement_lock_guard_fd;
   int root_fd;
   int root_guard_fd;
   int root_exposed;
@@ -131,6 +134,9 @@ typedef struct WorkspaceOwner {
   dev_t parent_device;
   ino_t parent_inode;
   int parent_identity_known;
+  dev_t replacement_lock_device;
+  ino_t replacement_lock_inode;
+  int replacement_lock_identity_known;
   dev_t root_device;
   ino_t root_inode;
   int root_identity_known;
@@ -244,9 +250,13 @@ static int check_deadline(long long deadline_ns) {
 }
 
 static int verify_parent_binding(WorkspaceOwner *self);
+static int verify_captured_destination_hidden_authority(WorkspaceOwner *self);
+static int verify_captured_destination_local_authority(WorkspaceOwner *self);
+static int verify_captured_destination_authority(WorkspaceOwner *self);
 static int verify_captured_destination_binding(WorkspaceOwner *self);
 static int verify_owner_authority(WorkspaceOwner *self);
 static int verify_replacement_binding(WorkspaceOwner *self);
+static int verify_replacement_lock_authority(WorkspaceOwner *self);
 static int verify_descriptor(int descriptor, int guard, dev_t device,
                              ino_t inode);
 static int verify_hidden_directory(int descriptor, dev_t device, ino_t inode);
@@ -304,7 +314,8 @@ static int release_replacement_lock(WorkspaceOwner *self) {
     errno = EPERM;
     return -1;
   }
-  if (native_flock_retry(self->parent_guard_fd, LOCK_UN) < 0) {
+  if (verify_replacement_lock_authority(self) < 0 ||
+      native_flock_retry(self->replacement_lock_fd, LOCK_UN) < 0) {
     return -1;
   }
   self->replacement_lock_active = 0;
@@ -837,6 +848,13 @@ static int close_inherited_descriptors(WorkspaceOwner *self) {
   if (first_error == 0 && error != 0) {
     first_error = error;
   }
+  error = close_one(
+      self, &self->replacement_lock_fd, &self->replacement_lock_guard_fd,
+      &self->replacement_lock_device, &self->replacement_lock_inode,
+      &self->replacement_lock_identity_known, 0);
+  if (first_error == 0 && error != 0) {
+    first_error = error;
+  }
   error = close_one(self, &self->parent_fd, &self->parent_guard_fd,
                     &self->parent_device, &self->parent_inode,
                     &self->parent_identity_known, self->parent_exposed);
@@ -860,7 +878,8 @@ static int close_inherited_descriptors(WorkspaceOwner *self) {
   }
   self->closed = self->captured_destination_fd < 0 &&
                  self->captured_destination_guard_fd < 0 && self->root_fd < 0 &&
-                 self->root_guard_fd < 0 && self->parent_fd < 0 &&
+                 self->root_guard_fd < 0 && self->replacement_lock_fd < 0 &&
+                 self->replacement_lock_guard_fd < 0 && self->parent_fd < 0 &&
                  self->parent_guard_fd < 0 && self->anchor_fd < 0 &&
                  self->anchor_guard_fd < 0;
   for (index = 0; index < self->directory_count; ++index) {
@@ -925,6 +944,13 @@ static int close_all(WorkspaceOwner *self) {
   if (first_error == 0 && error != 0) {
     first_error = error;
   }
+  error = close_one(
+      self, &self->replacement_lock_fd, &self->replacement_lock_guard_fd,
+      &self->replacement_lock_device, &self->replacement_lock_inode,
+      &self->replacement_lock_identity_known, 0);
+  if (first_error == 0 && error != 0) {
+    first_error = error;
+  }
   error = close_one(self, &self->parent_fd, &self->parent_guard_fd,
                     &self->parent_device, &self->parent_inode,
                     &self->parent_identity_known, self->parent_exposed);
@@ -948,7 +974,8 @@ static int close_all(WorkspaceOwner *self) {
   }
   self->closed = self->captured_destination_fd < 0 &&
                  self->captured_destination_guard_fd < 0 && self->root_fd < 0 &&
-                 self->root_guard_fd < 0 && self->parent_fd < 0 &&
+                 self->root_guard_fd < 0 && self->replacement_lock_fd < 0 &&
+                 self->replacement_lock_guard_fd < 0 && self->parent_fd < 0 &&
                  self->parent_guard_fd < 0 && self->anchor_fd < 0 &&
                  self->anchor_guard_fd < 0;
   for (index = 0; index < self->directory_count; ++index) {
@@ -1624,7 +1651,8 @@ static int count_open_descriptors(uintmax_t *count) {
 
 static int preflight_descriptor_budget(WorkspaceOwner *self,
                                        const char *allowed_root,
-                                       const char *parent_path) {
+                                       const char *parent_path,
+                                       size_t additional_owner_pairs) {
   struct rlimit limit;
   size_t absolute_records;
   size_t relative_records;
@@ -1636,13 +1664,15 @@ static int preflight_descriptor_budget(WorkspaceOwner *self,
   relative_records = 1 + relative_component_count(parent_path);
   if (absolute_records > SIZE_MAX - relative_records - 1 ||
       absolute_records + relative_records + 1 >
-          SIZE_MAX - (size_t)self->directory_count) {
+          SIZE_MAX - (size_t)self->directory_count ||
+      absolute_records + relative_records + 1 + (size_t)self->directory_count >
+          SIZE_MAX - additional_owner_pairs) {
     PyErr_SetString(PyExc_OverflowError,
                     "workspace descriptor budget overflowed");
     return -1;
   }
-  owner_pairs =
-      absolute_records + relative_records + 1 + (size_t)self->directory_count;
+  owner_pairs = absolute_records + relative_records + 1 +
+                (size_t)self->directory_count + additional_owner_pairs;
   if (owner_pairs > (SIZE_MAX - 2 - CODENIB_FD_SAFETY_MARGIN) / (size_t)2) {
     PyErr_SetString(PyExc_OverflowError,
                     "workspace descriptor budget overflowed");
@@ -1755,6 +1785,8 @@ static PyObject *WorkspaceOwner_new(PyTypeObject *type, PyObject *args,
   self->parent_fd = -1;
   self->parent_guard_fd = -1;
   self->parent_exposed = 0;
+  self->replacement_lock_fd = -1;
+  self->replacement_lock_guard_fd = -1;
   self->root_fd = -1;
   self->root_guard_fd = -1;
   self->root_exposed = 0;
@@ -1763,6 +1795,7 @@ static PyObject *WorkspaceOwner_new(PyTypeObject *type, PyObject *args,
   self->captured_destination_exposed = 0;
   self->anchor_identity_known = 0;
   self->parent_identity_known = 0;
+  self->replacement_lock_identity_known = 0;
   self->root_identity_known = 0;
   self->captured_destination_identity_known = 0;
   self->destination_name = NULL;
@@ -1870,11 +1903,11 @@ WorkspaceOwner_claim_replacement_permit(WorkspaceOwner *self,
   if (require_owner_pid(self) < 0) {
     return NULL;
   }
-  if (self->closed || self->namespace_state != WORKSPACE_DESTINATION_CAPTURED ||
+  if (self->closed || self->namespace_state != WORKSPACE_DESTINATION_LEASED ||
       self->replacement_permit_claimed || self->replacement_permit_active ||
       self->publish_permit_claimed || self->publish_permit_active ||
-      self->namespace_created || self->root_fd >= 0 ||
-      self->root_guard_fd >= 0 ||
+      !self->replacement_lock_active || self->namespace_created ||
+      self->root_fd >= 0 || self->root_guard_fd >= 0 ||
       verify_captured_destination_binding(self) < 0) {
     PyErr_SetString(PyExc_RuntimeError,
                     "native workspace replacement permit is not claimable");
@@ -2007,7 +2040,7 @@ static PyObject *WorkspaceOwner_provision(WorkspaceOwner *self,
   if (split_destination(destination, &parent_path, &destination_name) < 0 ||
       parse_directories(self, directories_object, deadline_ns) < 0 ||
       validate_directory_plan(self, deadline_ns) < 0 ||
-      preflight_descriptor_budget(self, allowed_root, parent_path) < 0) {
+      preflight_descriptor_budget(self, allowed_root, parent_path, 0) < 0) {
     goto error;
   }
   destination_path = join_destination_path(allowed_root, destination);
@@ -2333,7 +2366,8 @@ static PyObject *WorkspaceOwner_capture_destination(WorkspaceOwner *self,
       self->replacement_permit_claimed || self->replacement_permit_active ||
       self->replacement_lock_active || self->anchor_fd >= 0 ||
       self->anchor_guard_fd >= 0 || self->parent_fd >= 0 ||
-      self->parent_guard_fd >= 0 || self->root_fd >= 0 ||
+      self->parent_guard_fd >= 0 || self->replacement_lock_fd >= 0 ||
+      self->replacement_lock_guard_fd >= 0 || self->root_fd >= 0 ||
       self->root_guard_fd >= 0 || self->captured_destination_fd >= 0 ||
       self->captured_destination_guard_fd >= 0 || self->directories != NULL ||
       self->directory_count != 0 || self->scratch_count != 0 ||
@@ -2345,8 +2379,8 @@ static PyObject *WorkspaceOwner_capture_destination(WorkspaceOwner *self,
       self->file_guard_fd >= 0 || self->file_name != NULL ||
       self->file_active || self->file_failed || self->receipt_generation != 0 ||
       self->allowed_root_policy_known || self->anchor_identity_known ||
-      self->parent_identity_known || self->root_identity_known ||
-      self->captured_destination_identity_known) {
+      self->parent_identity_known || self->replacement_lock_identity_known ||
+      self->root_identity_known || self->captured_destination_identity_known) {
     PyErr_SetString(PyExc_RuntimeError,
                     "native workspace owner is not empty for destination "
                     "capture");
@@ -2386,7 +2420,7 @@ static PyObject *WorkspaceOwner_capture_destination(WorkspaceOwner *self,
     goto error;
   }
   if (split_destination(destination, &parent_path, &destination_name) < 0 ||
-      preflight_descriptor_budget(self, allowed_root, parent_path) < 0) {
+      preflight_descriptor_budget(self, allowed_root, parent_path, 1) < 0) {
     goto error;
   }
   destination_path = join_destination_path(allowed_root, destination);
@@ -2459,6 +2493,34 @@ static PyObject *WorkspaceOwner_capture_destination(WorkspaceOwner *self,
     PyErr_SetString(PyExc_RuntimeError,
                     "workspace allowed-root binding changed during destination "
                     "capture");
+    goto error;
+  }
+  self->replacement_lock_fd = open_directory_at(self->parent_guard_fd, ".");
+  if (self->replacement_lock_fd < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  self->replacement_lock_guard_fd =
+      duplicate_cloexec(self->replacement_lock_fd);
+  if (self->replacement_lock_guard_fd < 0) {
+    int error_number = errno;
+    discard_uncommitted_pair(&self->replacement_lock_fd,
+                             &self->replacement_lock_guard_fd, error_number);
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  if (record_identity(self->replacement_lock_fd, &self->replacement_lock_device,
+                      &self->replacement_lock_inode, S_IFDIR) < 0) {
+    int error_number = errno;
+    discard_uncommitted_pair(&self->replacement_lock_fd,
+                             &self->replacement_lock_guard_fd, error_number);
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  self->replacement_lock_identity_known = 1;
+  if (verify_replacement_lock_authority(self) < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "workspace replacement lock authority is invalid");
     goto error;
   }
   if (native_fstatat_retry(self->parent_guard_fd, self->destination_name,
@@ -2549,7 +2611,9 @@ error:
 }
 
 static int verify_incumbent_at_destination(WorkspaceOwner *self) {
-  if (verify_parent_binding(self) < 0 ||
+  if (!self->replacement_lock_active ||
+      verify_replacement_lock_authority(self) < 0 ||
+      verify_parent_binding(self) < 0 ||
       verify_descriptor(self->captured_destination_fd,
                         self->captured_destination_guard_fd,
                         self->captured_destination_device,
@@ -2561,6 +2625,100 @@ static int verify_incumbent_at_destination(WorkspaceOwner *self) {
     return -1;
   }
   return 0;
+}
+
+static PyObject *
+WorkspaceOwner_acquire_replacement_lease(WorkspaceOwner *self,
+                                         PyObject *deadline_object) {
+  PyObject *error_type = NULL;
+  PyObject *error_value = NULL;
+  PyObject *error_traceback = NULL;
+  long long deadline_ns;
+
+  if (require_linux() < 0 || require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (!PyLong_CheckExact(deadline_object)) {
+    PyErr_SetString(PyExc_TypeError,
+                    "workspace replacement lease deadline must be an exact "
+                    "integer");
+    return NULL;
+  }
+  deadline_ns = PyLong_AsLongLong(deadline_object);
+  if (deadline_ns == -1 && PyErr_Occurred()) {
+    return NULL;
+  }
+  if (deadline_ns <= 0) {
+    PyErr_SetString(PyExc_ValueError,
+                    "workspace replacement lease deadline is invalid");
+    return NULL;
+  }
+  if (check_deadline(deadline_ns) < 0) {
+    return NULL;
+  }
+  if (self->namespace_state == WORKSPACE_DESTINATION_LEASED) {
+    if (self->closed || !self->replacement_lock_active ||
+        self->replacement_permit_claimed || self->replacement_permit_active ||
+        self->namespace_created || self->namespace_sync_pending ||
+        self->root_fd >= 0 || self->root_guard_fd >= 0 ||
+        self->replacement_slot_name != NULL || self->directories != NULL ||
+        verify_captured_destination_binding(self) < 0) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "native workspace owner is not replacement-lease-ready");
+      return NULL;
+    }
+    if (check_deadline(deadline_ns) < 0) {
+      return NULL;
+    }
+    Py_RETURN_NONE;
+  }
+  if (self->closed || self->namespace_state != WORKSPACE_DESTINATION_CAPTURED ||
+      self->replacement_lock_active || self->replacement_permit_claimed ||
+      self->replacement_permit_active || self->namespace_created ||
+      self->namespace_sync_pending || self->root_fd >= 0 ||
+      self->root_guard_fd >= 0 || self->replacement_slot_name != NULL ||
+      self->directories != NULL ||
+      verify_captured_destination_local_authority(self) < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace owner is not replacement-lease-ready");
+    return NULL;
+  }
+  if (native_flock_retry(self->replacement_lock_fd, LOCK_EX | LOCK_NB) < 0) {
+    if (errno == EWOULDBLOCK || errno == EAGAIN) {
+      return PyErr_SetFromErrno(PyExc_BlockingIOError);
+    }
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+
+  /* From this assignment onward every return boundary is settlement-owned.
+     The captured binding is deliberately revalidated only after the private,
+     independently opened parent OFD has become the cooperative single-writer
+     lease.  Namespace operations continue to use the original parent guard. */
+  self->replacement_lock_active = 1;
+  self->namespace_state = WORKSPACE_DESTINATION_LEASED;
+  if (check_deadline(deadline_ns) < 0) {
+    goto rollback_lease;
+  }
+  if (verify_captured_destination_binding(self) < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace captured destination changed before "
+                    "replacement lease");
+    goto rollback_lease;
+  }
+  if (check_deadline(deadline_ns) < 0) {
+    goto rollback_lease;
+  }
+  Py_RETURN_NONE;
+
+rollback_lease:
+  PyErr_Fetch(&error_type, &error_value, &error_traceback);
+  if (release_replacement_lock(self) < 0) {
+    enter_replacement_recovery(self);
+  } else {
+    self->namespace_state = WORKSPACE_DESTINATION_CAPTURED;
+  }
+  PyErr_Restore(error_type, error_value, error_traceback);
+  return NULL;
 }
 
 static PyObject *WorkspaceOwner_provision_replacement(WorkspaceOwner *self,
@@ -2592,11 +2750,11 @@ static PyObject *WorkspaceOwner_provision_replacement(WorkspaceOwner *self,
                   "descriptor, flock, and renameat2 syscalls");
   return NULL;
 #endif
-  if (self->closed || self->namespace_state != WORKSPACE_DESTINATION_CAPTURED ||
+  if (self->closed || self->namespace_state != WORKSPACE_DESTINATION_LEASED ||
       !self->replacement_permit_claimed || !self->replacement_permit_active ||
-      self->namespace_created || self->root_fd >= 0 ||
-      self->root_guard_fd >= 0 || self->replacement_slot_name != NULL ||
-      self->directories != NULL ||
+      !self->replacement_lock_active || self->namespace_created ||
+      self->root_fd >= 0 || self->root_guard_fd >= 0 ||
+      self->replacement_slot_name != NULL || self->directories != NULL ||
       verify_captured_destination_binding(self) < 0) {
     PyErr_SetString(PyExc_RuntimeError,
                     "native workspace owner is not replacement-ready");
@@ -2695,6 +2853,7 @@ static PyObject *WorkspaceOwner_provision_replacement(WorkspaceOwner *self,
     goto error;
   }
   self->namespace_state = WORKSPACE_REPLACEMENT_PROVISIONING;
+  self->namespace_sync_pending = 1;
   mutation_attempted = 1;
   if (mkdirat(self->parent_guard_fd, self->replacement_slot_name, 0700) < 0) {
     PyErr_SetFromErrno(PyExc_OSError);
@@ -2882,6 +3041,28 @@ static int verify_hidden_directory(int descriptor, dev_t device, ino_t inode) {
   return 0;
 }
 
+static int verify_replacement_lock_authority(WorkspaceOwner *self) {
+  int guard_flags;
+
+  if (!self->parent_identity_known || !self->replacement_lock_identity_known ||
+      self->replacement_lock_device != self->parent_device ||
+      self->replacement_lock_inode != self->parent_inode ||
+      verify_descriptor(
+          self->replacement_lock_fd, self->replacement_lock_guard_fd,
+          self->replacement_lock_device, self->replacement_lock_inode) < 0 ||
+      compare_open_file_description(self->replacement_lock_fd,
+                                    self->parent_guard_fd) != OFD_DIFFERENT ||
+      compare_open_file_description(self->replacement_lock_guard_fd,
+                                    self->parent_guard_fd) != OFD_DIFFERENT ||
+      (guard_flags =
+           native_fcntl_getfd_retry(self->replacement_lock_guard_fd)) < 0 ||
+      (guard_flags & FD_CLOEXEC) == 0) {
+    errno = ESTALE;
+    return -1;
+  }
+  return 0;
+}
+
 static int verify_absolute_chain(WorkspaceOwner *self) {
   Py_ssize_t index;
   int descriptor;
@@ -3051,15 +3232,16 @@ static int verify_replacement_binding(WorkspaceOwner *self) {
 
   if (self->closed || !self->destination_capture_started ||
       !self->namespace_created || !self->replacement_permit_claimed ||
-      self->publish_permit_claimed || self->publish_permit_active ||
-      self->destination_name == NULL || self->destination_path == NULL ||
-      self->replacement_slot_name == NULL || self->plan_digest == NULL ||
-      !self->root_identity_known ||
+      !self->replacement_lock_active || self->publish_permit_claimed ||
+      self->publish_permit_active || self->destination_name == NULL ||
+      self->destination_path == NULL || self->replacement_slot_name == NULL ||
+      self->plan_digest == NULL || !self->root_identity_known ||
       !self->captured_destination_identity_known || self->root_device == 0 ||
       self->root_inode == 0 || self->captured_destination_device == 0 ||
       self->captured_destination_inode == 0 ||
       self->root_device != self->parent_device ||
       self->captured_destination_device != self->parent_device ||
+      verify_replacement_lock_authority(self) < 0 ||
       verify_parent_binding(self) < 0 ||
       verify_descriptor(self->root_fd, self->root_guard_fd, self->root_device,
                         self->root_inode) < 0 ||
@@ -3101,14 +3283,12 @@ static int verify_replacement_binding(WorkspaceOwner *self) {
   return 0;
 }
 
-static int verify_captured_destination_binding(WorkspaceOwner *self) {
-  if (self->namespace_state != WORKSPACE_DESTINATION_CAPTURED || self->closed ||
-      !self->provision_started || !self->destination_capture_started ||
-      self->namespace_created || self->namespace_sync_pending ||
+static int verify_captured_destination_structure(WorkspaceOwner *self) {
+  if (self->closed || !self->provision_started ||
+      !self->destination_capture_started || self->namespace_created ||
       self->publish_permit_claimed || self->publish_permit_active ||
       self->replacement_permit_active > self->replacement_permit_claimed ||
-      self->replacement_lock_active || self->destination_name == NULL ||
-      self->destination_path == NULL ||
+      self->destination_name == NULL || self->destination_path == NULL ||
       !self->captured_destination_identity_known ||
       self->captured_destination_device == 0 ||
       self->captured_destination_inode == 0 || self->root_fd >= 0 ||
@@ -3119,16 +3299,76 @@ static int verify_captured_destination_binding(WorkspaceOwner *self) {
       self->initial_stage_name != NULL || self->stage_name != NULL ||
       self->replacement_slot_name != NULL || self->plan_digest != NULL ||
       self->orphan_name != NULL || self->receipt_generation != 0 ||
+      !self->anchor_identity_known || !self->parent_identity_known ||
+      !self->replacement_lock_identity_known || self->anchor_device == 0 ||
+      self->anchor_inode == 0 || self->parent_device == 0 ||
+      self->parent_inode == 0 || self->replacement_lock_device == 0 ||
+      self->replacement_lock_inode == 0 ||
       self->parent_device != self->anchor_device ||
-      self->captured_destination_device != self->parent_device ||
-      verify_parent_binding(self) < 0 ||
+      self->replacement_lock_device != self->parent_device ||
+      self->replacement_lock_inode != self->parent_inode ||
+      self->captured_destination_device != self->parent_device) {
+    errno = ESTALE;
+    return -1;
+  }
+  return 0;
+}
+
+static int verify_captured_destination_local_authority(WorkspaceOwner *self) {
+  if (verify_captured_destination_structure(self) < 0 ||
+      verify_descriptor(self->parent_fd, self->parent_guard_fd,
+                        self->parent_device, self->parent_inode) < 0 ||
+      verify_replacement_lock_authority(self) < 0 ||
       verify_descriptor(self->captured_destination_fd,
                         self->captured_destination_guard_fd,
                         self->captured_destination_device,
-                        self->captured_destination_inode) < 0 ||
+                        self->captured_destination_inode) < 0) {
+    errno = ESTALE;
+    return -1;
+  }
+  return 0;
+}
+
+static int verify_captured_destination_hidden_authority(WorkspaceOwner *self) {
+  if (verify_captured_destination_structure(self) < 0 ||
+      verify_hidden_directory(self->parent_guard_fd, self->parent_device,
+                              self->parent_inode) < 0 ||
+      verify_replacement_lock_authority(self) < 0 ||
+      verify_hidden_directory(self->captured_destination_guard_fd,
+                              self->captured_destination_device,
+                              self->captured_destination_inode) < 0) {
+    errno = ESTALE;
+    return -1;
+  }
+  return 0;
+}
+
+static int verify_captured_destination_authority(WorkspaceOwner *self) {
+  if (verify_captured_destination_local_authority(self) < 0 ||
+      verify_parent_binding(self) < 0 ||
       same_identity_at(self->parent_guard_fd, self->destination_name,
                        self->captured_destination_device,
                        self->captured_destination_inode) < 0) {
+    errno = ESTALE;
+    return -1;
+  }
+  return 0;
+}
+
+static int verify_captured_destination_binding(WorkspaceOwner *self) {
+  int expects_lease;
+
+  if (self->namespace_state == WORKSPACE_DESTINATION_CAPTURED) {
+    expects_lease = 0;
+  } else if (self->namespace_state == WORKSPACE_DESTINATION_LEASED) {
+    expects_lease = 1;
+  } else {
+    errno = ESTALE;
+    return -1;
+  }
+  if (!!self->replacement_lock_active != expects_lease ||
+      self->namespace_sync_pending ||
+      verify_captured_destination_authority(self) < 0) {
     errno = ESTALE;
     return -1;
   }
@@ -3194,8 +3434,7 @@ WorkspaceOwner_verify_replacement_binding(WorkspaceOwner *self,
   }
   if ((self->namespace_state != WORKSPACE_REPLACEMENT_PROVISIONED &&
        self->namespace_state != WORKSPACE_REPLACEMENT_ADOPTED &&
-       self->namespace_state != WORKSPACE_REPLACEMENT_EXCHANGED_UNRECEIPTED &&
-       self->namespace_state != WORKSPACE_REPLACEMENT_RECEIPTED) ||
+       self->namespace_state != WORKSPACE_REPLACEMENT_EXCHANGED_UNRECEIPTED) ||
       verify_replacement_binding(self) < 0) {
     PyErr_SetString(PyExc_RuntimeError,
                     "native workspace replacement binding changed");
@@ -3255,6 +3494,7 @@ static int workspace_state_is_adopted(WorkspaceOwner *self) {
 static int workspace_state_is_replacement(WorkspaceOwner *self) {
   return self->replacement_permit_claimed ||
          self->replacement_slot_name != NULL || self->replacement_lock_active ||
+         self->namespace_state == WORKSPACE_DESTINATION_LEASED ||
          self->namespace_state == WORKSPACE_REPLACEMENT_PROVISIONING ||
          self->namespace_state == WORKSPACE_REPLACEMENT_PROVISIONED ||
          self->namespace_state == WORKSPACE_REPLACEMENT_ADOPTED ||
@@ -4001,7 +4241,6 @@ WorkspaceReplacementPermit_exchange(WorkspaceReplacementPermit *permit,
   PyObject *receipt_token = NULL;
   int exchange_result;
   int exchange_error;
-  int deadline_expired;
   enum workspace_replacement_mapping mapping;
 
   if (self == NULL || permit->consumed || !self->replacement_permit_claimed ||
@@ -4053,8 +4292,8 @@ WorkspaceReplacementPermit_exchange(WorkspaceReplacementPermit *permit,
     goto error;
   }
   if (self->closed || self->namespace_state != WORKSPACE_REPLACEMENT_ADOPTED ||
-      self->file_active || self->file_failed || self->replacement_lock_active ||
-      verify_replacement_binding(self) < 0) {
+      self->file_active || self->file_failed ||
+      !self->replacement_lock_active || verify_replacement_binding(self) < 0) {
     PyErr_SetString(PyExc_RuntimeError,
                     "native workspace replacement is not exchange-ready");
     goto error;
@@ -4073,40 +4312,12 @@ WorkspaceReplacementPermit_exchange(WorkspaceReplacementPermit *permit,
   if (receipt_token == NULL) {
     goto error;
   }
+  if (check_deadline(deadline_ns) < 0) {
+    goto error;
+  }
 
   permit->consumed = 1;
   self->replacement_permit_active = 0;
-  if (native_flock_retry(self->parent_guard_fd, LOCK_EX | LOCK_NB) < 0) {
-    if (errno == EWOULDBLOCK || errno == EAGAIN) {
-      PyErr_SetFromErrno(PyExc_BlockingIOError);
-    } else {
-      PyErr_SetFromErrno(PyExc_OSError);
-    }
-    goto error;
-  }
-  self->replacement_lock_active = 1;
-  deadline_expired = check_deadline(deadline_ns) < 0;
-  if (verify_replacement_binding(self) < 0) {
-    enter_replacement_recovery(self);
-    if (!deadline_expired) {
-      PyErr_SetString(PyExc_RuntimeError,
-                      "native workspace replacement binding changed under "
-                      "its commit lease");
-    }
-    goto error;
-  }
-  if (deadline_expired) {
-    if (release_replacement_lock(self) < 0) {
-      enter_replacement_recovery(self);
-    }
-    goto error;
-  }
-  if (check_deadline(deadline_ns) < 0) {
-    if (release_replacement_lock(self) < 0) {
-      enter_replacement_recovery(self);
-    }
-    goto error;
-  }
 
   exchange_result =
       rename_exchange(self->parent_guard_fd, self->replacement_slot_name,
@@ -4142,18 +4353,6 @@ WorkspaceReplacementPermit_exchange(WorkspaceReplacementPermit *permit,
       PyErr_SetString(PyExc_RuntimeError,
                       "native workspace replacement binding changed after "
                       "its exchange attempt");
-      goto error;
-    }
-    if (release_replacement_lock(self) < 0) {
-      enter_replacement_recovery(self);
-      if (exchange_result < 0) {
-        errno = exchange_error;
-        PyErr_SetFromErrno(PyExc_OSError);
-      } else {
-        PyErr_SetString(PyExc_RuntimeError,
-                        "native workspace exchange reported success without "
-                        "swapping its exact roots");
-      }
       goto error;
     }
     if (exchange_result < 0) {
@@ -4347,10 +4546,80 @@ static int ensure_replacement_candidate_authority(WorkspaceOwner *self) {
   return 0;
 }
 
+static int
+verify_failed_replacement_provision_hidden_authority(WorkspaceOwner *self) {
+  Py_ssize_t index;
+
+  if (self->closed || !self->provision_started ||
+      !self->destination_capture_started || self->namespace_created ||
+      (self->namespace_state != WORKSPACE_REPLACEMENT_PROVISIONING &&
+       self->namespace_state != WORKSPACE_REPLACEMENT_RECOVERY_REQUIRED) ||
+      self->publish_permit_claimed || self->publish_permit_active ||
+      !self->replacement_permit_claimed ||
+      self->replacement_permit_active > self->replacement_permit_claimed ||
+      !self->replacement_lock_active || self->destination_name == NULL ||
+      self->destination_path == NULL || self->replacement_slot_name == NULL ||
+      self->plan_digest == NULL || !self->captured_destination_identity_known ||
+      self->captured_destination_device == 0 ||
+      self->captured_destination_inode == 0 || self->root_fd >= 0 ||
+      self->root_guard_fd >= 0 || self->root_identity_known ||
+      self->file_fd >= 0 || self->file_guard_fd >= 0 || self->file_active ||
+      self->file_failed || self->file_name != NULL ||
+      self->initial_stage_name != NULL || self->stage_name != NULL ||
+      self->orphan_name != NULL || self->receipt_generation != 0 ||
+      !self->anchor_identity_known || !self->parent_identity_known ||
+      !self->replacement_lock_identity_known || self->anchor_device == 0 ||
+      self->anchor_inode == 0 || self->parent_device == 0 ||
+      self->parent_inode == 0 || self->replacement_lock_device == 0 ||
+      self->replacement_lock_inode == 0 ||
+      self->parent_device != self->anchor_device ||
+      self->replacement_lock_device != self->parent_device ||
+      self->replacement_lock_inode != self->parent_inode ||
+      self->captured_destination_device != self->parent_device ||
+      (self->directory_count == 0 && self->directories != NULL) ||
+      (self->directory_count > 0 && self->directories == NULL) ||
+      verify_allowed_root_policy(self) < 0 ||
+      verify_hidden_directory(self->parent_guard_fd, self->parent_device,
+                              self->parent_inode) < 0 ||
+      verify_replacement_lock_authority(self) < 0 ||
+      verify_hidden_directory(self->captured_destination_guard_fd,
+                              self->captured_destination_device,
+                              self->captured_destination_inode) < 0 ||
+      same_identity_at(self->parent_guard_fd, self->destination_name,
+                       self->captured_destination_device,
+                       self->captured_destination_inode) < 0) {
+    errno = ESTALE;
+    return -1;
+  }
+  for (index = 0; index < self->directory_count; ++index) {
+    if (self->directories[index].path == NULL ||
+        self->directories[index].fd >= 0 ||
+        self->directories[index].guard_fd >= 0 ||
+        self->directories[index].identity_known ||
+        self->directories[index].exposed) {
+      errno = ESTALE;
+      return -1;
+    }
+  }
+  return 0;
+}
+
+static int replacement_slot_is_definitely_absent(WorkspaceOwner *self) {
+  struct stat metadata;
+
+  if (native_fstatat_retry(self->parent_guard_fd, self->replacement_slot_name,
+                           &metadata, AT_SYMLINK_NOFOLLOW) < 0 &&
+      errno == ENOENT) {
+    return 1;
+  }
+  return 0;
+}
+
 static int settle_replacement_namespace_internal(WorkspaceOwner *self) {
   enum workspace_replacement_mapping mapping;
   int reverse_result;
   int reverse_error;
+  int failed_provision_without_candidate = 0;
 
   if (!workspace_state_is_replacement(self)) {
     return 0;
@@ -4366,13 +4635,25 @@ static int settle_replacement_namespace_internal(WorkspaceOwner *self) {
     }
     return 0;
   }
-  if (self->namespace_created) {
-    if (!self->replacement_lock_active) {
-      if (native_flock_retry(self->parent_guard_fd, LOCK_EX | LOCK_NB) < 0) {
-        return -1;
-      }
-      self->replacement_lock_active = 1;
+  if (self->namespace_state == WORKSPACE_QUARANTINED) {
+    if (self->replacement_lock_active) {
+      errno = ESTALE;
+      return -1;
     }
+    return 0;
+  }
+  if (self->namespace_state == WORKSPACE_DESTINATION_CAPTURED &&
+      !self->namespace_created && !self->replacement_lock_active) {
+    self->replacement_permit_active = 0;
+    self->replacement_permit_claimed = 0;
+    return 0;
+  }
+  if (!self->replacement_lock_active) {
+    enter_replacement_recovery(self);
+    errno = ESTALE;
+    return -1;
+  }
+  if (self->namespace_created) {
     if (verify_parent_binding(self) < 0 ||
         ensure_replacement_candidate_authority(self) < 0 ||
         verify_descriptor(self->captured_destination_fd,
@@ -4404,6 +4685,24 @@ static int settle_replacement_namespace_internal(WorkspaceOwner *self) {
       errno = ESTALE;
       return -1;
     }
+  } else {
+    if (self->replacement_slot_name != NULL) {
+      if (verify_failed_replacement_provision_hidden_authority(self) < 0 ||
+          !replacement_slot_is_definitely_absent(self)) {
+        enter_replacement_recovery(self);
+        errno = ESTALE;
+        return -1;
+      }
+      self->namespace_sync_pending = 1;
+      failed_provision_without_candidate = 1;
+    } else if ((self->namespace_state != WORKSPACE_DESTINATION_LEASED &&
+                self->namespace_state !=
+                    WORKSPACE_REPLACEMENT_RECOVERY_REQUIRED) ||
+               verify_captured_destination_hidden_authority(self) < 0) {
+      enter_replacement_recovery(self);
+      errno = ESTALE;
+      return -1;
+    }
   }
   if (self->namespace_sync_pending) {
     if (native_fsync_retry(self->parent_guard_fd) < 0) {
@@ -4412,15 +4711,21 @@ static int settle_replacement_namespace_internal(WorkspaceOwner *self) {
     }
     self->namespace_sync_pending = 0;
   }
-  if (self->namespace_created &&
-      (verify_parent_binding(self) < 0 ||
-       ensure_replacement_candidate_authority(self) < 0 ||
-       verify_descriptor(self->captured_destination_fd,
-                         self->captured_destination_guard_fd,
-                         self->captured_destination_device,
-                         self->captured_destination_inode) < 0 ||
-       classify_replacement_mapping(self) !=
-           WORKSPACE_REPLACEMENT_MAPPING_PREEXCHANGE)) {
+  if ((self->namespace_created &&
+       (verify_parent_binding(self) < 0 ||
+        ensure_replacement_candidate_authority(self) < 0 ||
+        verify_descriptor(self->captured_destination_fd,
+                          self->captured_destination_guard_fd,
+                          self->captured_destination_device,
+                          self->captured_destination_inode) < 0 ||
+        classify_replacement_mapping(self) !=
+            WORKSPACE_REPLACEMENT_MAPPING_PREEXCHANGE)) ||
+      (!self->namespace_created &&
+       ((failed_provision_without_candidate &&
+         (verify_failed_replacement_provision_hidden_authority(self) < 0 ||
+          !replacement_slot_is_definitely_absent(self))) ||
+        (!failed_provision_without_candidate &&
+         verify_captured_destination_hidden_authority(self) < 0)))) {
     enter_replacement_recovery(self);
     errno = ESTALE;
     return -1;
@@ -4431,6 +4736,13 @@ static int settle_replacement_namespace_internal(WorkspaceOwner *self) {
   }
   if (self->namespace_created) {
     self->namespace_state = WORKSPACE_QUARANTINED;
+  } else {
+    if (failed_provision_without_candidate) {
+      free_unprovisioned_replacement_configuration(self);
+    }
+    self->namespace_state = WORKSPACE_DESTINATION_CAPTURED;
+    self->replacement_permit_active = 0;
+    self->replacement_permit_claimed = 0;
   }
   return 0;
 }
@@ -4650,12 +4962,13 @@ static PyObject *WorkspaceOwner_get_parent_descriptor(WorkspaceOwner *self,
   (void)closure;
   if (require_owner_pid(self) < 0 || self->closed ||
       (self->destination_capture_started &&
-       !workspace_state_is_provisioned(self) &&
-       !workspace_state_is_adopted(self)) ||
+       self->namespace_state != WORKSPACE_DESTINATION_CAPTURED &&
+       self->namespace_state != WORKSPACE_DESTINATION_LEASED &&
+       self->namespace_state != WORKSPACE_REPLACEMENT_PROVISIONED &&
+       self->namespace_state != WORKSPACE_REPLACEMENT_ADOPTED) ||
       self->parent_fd < 0 ||
-      (workspace_state_is_replacement(self)
-           ? verify_owner_authority(self)
-           : verify_parent_binding(self)) < 0) {
+      (self->destination_capture_started ? verify_owner_authority(self)
+                                         : verify_parent_binding(self)) < 0) {
     if (!PyErr_Occurred()) {
       PyErr_SetString(PyExc_RuntimeError,
                       "native workspace parent descriptor is unavailable");
@@ -4735,6 +5048,9 @@ static PyObject *WorkspaceOwner_get_state(WorkspaceOwner *self, void *closure) {
       break;
     case WORKSPACE_DESTINATION_CAPTURED:
       state = "destination-captured";
+      break;
+    case WORKSPACE_DESTINATION_LEASED:
+      state = "destination-leased";
       break;
     case WORKSPACE_REPLACEMENT_PROVISIONING:
       state = "replacement-provisioning";
@@ -5103,6 +5419,14 @@ static PyObject *module_capture_owner_destination_exact(PyObject *module,
                                       WorkspaceOwner_capture_destination);
 }
 
+static PyObject *module_acquire_owner_replacement_lease_exact(PyObject *module,
+                                                              PyObject *args) {
+  (void)module;
+  return dispatch_owner_argument_exact(
+      args, "acquire_owner_replacement_lease_exact",
+      WorkspaceOwner_acquire_replacement_lease);
+}
+
 static PyObject *module_provision_owner_replacement_exact(PyObject *module,
                                                           PyObject *args) {
   (void)module;
@@ -5368,7 +5692,7 @@ static PyObject *module_require_owner_exact(PyObject *module, PyObject *owner) {
   return owner;
 }
 
-#define CODENIB_WORKSPACE_OWNER_PROTOCOL_VERSION 4
+#define CODENIB_WORKSPACE_OWNER_PROTOCOL_VERSION 5
 
 static PyObject *module_require_support(PyObject *module,
                                         PyObject *Py_UNUSED(ignored)) {
@@ -5414,6 +5738,9 @@ static PyMethodDef workspace_module_methods[] = {
     {"capture_owner_destination_exact",
      (PyCFunction)module_capture_owner_destination_exact, METH_VARARGS,
      "Capture one existing destination through exact native-owner dispatch."},
+    {"acquire_owner_replacement_lease_exact",
+     (PyCFunction)module_acquire_owner_replacement_lease_exact, METH_VARARGS,
+     "Lease and revalidate one exact captured destination parent."},
     {"provision_owner_replacement_exact",
      (PyCFunction)module_provision_owner_replacement_exact, METH_VARARGS,
      "Provision one candidate beside an exact captured destination."},

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -631,10 +631,12 @@ def test_registry_publishers_use_separate_workflows() -> None:
         in wheel_env["CIBW_REPAIR_WHEEL_COMMAND_LINUX"]
     )
     wheel_smoke = wheel_env["CIBW_TEST_COMMAND"]
-    assert "workspace_owner_protocol_version == 4" in wheel_smoke
+    assert "workspace_owner_protocol_version == 5" in wheel_smoke
     for symbol in (
         "capture_owner_destination_exact",
+        "acquire_owner_replacement_lease_exact",
         "verify_owner_destination_binding_exact",
+        "borrow_owner_parent_descriptor_exact",
         "borrow_owner_destination_descriptor_exact",
         "claim_owner_replacement_permit_exact",
         "provision_owner_replacement_exact",
@@ -643,6 +645,8 @@ def test_registry_publishers_use_separate_workflows() -> None:
     ):
         assert symbol in wheel_smoke
     for symbol in (
+        "acquire_owner_replacement_lease",
+        "borrow_owner_parent_descriptor",
         "claim_owner_replacement_permit",
         "provision_owner_replacement",
         "verify_owner_replacement_binding",
@@ -650,6 +654,14 @@ def test_registry_publishers_use_separate_workflows() -> None:
         "_bind_owner_replacement_permit",
     ):
         assert symbol in wheel_smoke
+    assert "destination-leased" in wheel_smoke
+    assert wheel_smoke.index(
+        "_workspace_owner.acquire_owner_replacement_lease("
+    ) < wheel_smoke.index("_workspace_owner.claim_owner_replacement_permit(")
+    assert wheel_smoke.index(
+        "_workspace_owner.acquire_owner_replacement_lease("
+    ) < wheel_smoke.index("_workspace_owner.provision_owner_replacement(")
+    assert "not os.get_inheritable(parent_descriptor)" in wheel_smoke
     assert "implementation.require_support() is None" in wheel_smoke
     assert "_workspace_owner.require_support()" in wheel_smoke
 
@@ -718,10 +730,12 @@ def test_registry_publishers_use_separate_workflows() -> None:
         "run"
     ]
     assert 'name == "_workspace_owner_impl.abi3.so"' in abi3_exercise
-    assert "workspace_owner_protocol_version == 4" in abi3_exercise
+    assert "workspace_owner_protocol_version == 5" in abi3_exercise
     for symbol in (
         "capture_owner_destination_exact",
+        "acquire_owner_replacement_lease_exact",
         "verify_owner_destination_binding_exact",
+        "borrow_owner_parent_descriptor_exact",
         "borrow_owner_destination_descriptor_exact",
         "claim_owner_replacement_permit_exact",
         "provision_owner_replacement_exact",
@@ -741,10 +755,26 @@ def test_registry_publishers_use_separate_workflows() -> None:
     assert "receipt_owner.closed" in abi3_exercise
     assert "_workspace_owner.capture_owner_destination(" in abi3_exercise
     assert "destination-captured" in abi3_exercise
+    assert abi3_exercise.count("_workspace_owner.acquire_owner_replacement_lease(") == 2
+    assert "destination-leased" in abi3_exercise
+    assert "_workspace_owner.borrow_owner_parent_descriptor(" in abi3_exercise
     assert "_workspace_owner.verify_owner_destination_binding(" in abi3_exercise
     assert "_workspace_owner.borrow_owner_destination_descriptor(" in abi3_exercise
     assert "stat.S_ISDIR(descriptor_metadata.st_mode)" in abi3_exercise
     assert "not os.get_inheritable(destination_descriptor)" in abi3_exercise
+    assert "not os.get_inheritable(parent_descriptor)" in abi3_exercise
+    assert abi3_exercise.index(
+        "_workspace_owner.acquire_owner_replacement_lease("
+    ) < abi3_exercise.index("_workspace_owner.claim_owner_replacement_permit(")
+    assert abi3_exercise.index(
+        "_workspace_owner.acquire_owner_replacement_lease("
+    ) < abi3_exercise.index("_workspace_owner.provision_owner_replacement(")
+    assert abi3_exercise.rindex(
+        "_workspace_owner.acquire_owner_replacement_lease("
+    ) < abi3_exercise.rindex("_workspace_owner.claim_owner_replacement_permit(")
+    assert abi3_exercise.rindex(
+        "_workspace_owner.acquire_owner_replacement_lease("
+    ) < abi3_exercise.rindex("_workspace_owner.provision_owner_replacement(")
     assert "_workspace_owner.claim_owner_replacement_permit(" in abi3_exercise
     assert "_workspace_owner.provision_owner_replacement(" in abi3_exercise
     assert "replacement-provisioned" in abi3_exercise
@@ -769,6 +799,12 @@ def test_registry_publishers_use_separate_workflows() -> None:
     assert 'owner_state(captured_owner) == "closed"' in abi3_exercise
     assert "assert output.read_bytes() == replacement_payload" in abi3_exercise
     assert "replacement.joinpath" in abi3_exercise
+    assert abi3_exercise.count("_workspace_owner.exchange_owner_replacement(") == 2
+    assert "_workspace_owner.abort_owner(rollback_owner)" in abi3_exercise
+    assert 'owner_state(rollback_owner) == "closed"' in abi3_exercise
+    assert "rollback_incumbent_identity" in abi3_exercise
+    assert "rollback_identity" in abi3_exercise
+    assert "rollback_payload" in abi3_exercise
 
     compatible_install_steps = {
         "abi3-smoke": "Install the compatible ABI3 wheel",
@@ -802,7 +838,7 @@ def test_registry_publishers_use_separate_workflows() -> None:
                 assert all(character in "0123456789abcdef" for character in revision)
 
 
-def test_both_release_wheel_architectures_run_protocol_v4_exchange_smoke() -> None:
+def test_both_release_wheel_architectures_run_protocol_v5_exchange_smoke() -> None:
     root = Path(__file__).resolve().parents[1]
     with (root / ".github/workflows/release-verify.yml").open(
         encoding="utf-8"
@@ -827,7 +863,9 @@ def test_both_release_wheel_architectures_run_protocol_v4_exchange_smoke() -> No
         assert f"platform.machine() == {architecture!r}" in smoke
         for operation in (
             "capture_owner_destination(",
+            "acquire_owner_replacement_lease(",
             "verify_owner_destination_binding(",
+            "borrow_owner_parent_descriptor(",
             "claim_owner_replacement_permit(",
             "provision_owner_replacement(",
             "verify_owner_adoption_binding(",
@@ -840,6 +878,14 @@ def test_both_release_wheel_architectures_run_protocol_v4_exchange_smoke() -> No
             "verify_owner_replacement_binding(",
         ):
             assert f"_workspace_owner.{operation}" in smoke
+        assert smoke.index(
+            "_workspace_owner.acquire_owner_replacement_lease("
+        ) < smoke.index("_workspace_owner.claim_owner_replacement_permit(")
+        assert smoke.index(
+            "_workspace_owner.acquire_owner_replacement_lease("
+        ) < smoke.index("_workspace_owner.provision_owner_replacement(")
+        assert "destination-leased" in smoke
+        assert "not os.get_inheritable(parent_descriptor)" in smoke
         assert smoke.count("_workspace_owner.exchange_owner_replacement(") == 2
         assert smoke.count("_workspace_owner.commit_owner_receipt(") == 2
         assert "success_committed = True" in smoke
@@ -855,7 +901,7 @@ def test_both_release_wheel_architectures_run_protocol_v4_exchange_smoke() -> No
         assert "os.close(" not in smoke
 
 
-def test_protocol_v4_workspace_replacement_limits_are_documented() -> None:
+def test_protocol_v5_workspace_replacement_limits_are_documented() -> None:
     root = Path(__file__).resolve().parents[1]
     provider = (root / "docs/development/local-workspace-provider.md").read_text(
         encoding="utf-8"
@@ -866,6 +912,7 @@ def test_protocol_v4_workspace_replacement_limits_are_documented() -> None:
     for text in (provider, roadmap):
         prose = " ".join(text.split())
         assert "protocol v4" in text.lower()
+        assert "protocol v5" in text.lower()
         assert "renameat2(RENAME_EXCHANGE)" in text
         assert "flock(LOCK_EX | LOCK_NB)" in text
         assert "open-file-description (OFD)" in text
@@ -888,11 +935,21 @@ def test_protocol_v4_workspace_replacement_limits_are_documented() -> None:
         assert "auto-adopt" in prose
         assert "does not generate" in prose
         assert "randomness" in prose
+        assert "destination-leased" in text
+        assert "before candidate mutation" in prose
+        assert "zero candidate mutation" in prose
+        assert "cross-process" in prose
+        assert "fork" in prose
+        assert "receipted" in prose
+        assert "live-name verifier" in prose
+        assert "hostile same-UID" in text
+        assert "crash journal" in prose
 
     assert "There is no portable or multi-rename fallback" in provider
     assert "this is live atomicity, not crash recovery" in provider_prose
     assert "borrowers must never close them" in provider_prose
     for symbol in (
+        "acquire_owner_replacement_lease_exact",
         "claim_owner_replacement_permit_exact",
         "provision_owner_replacement_exact",
         "verify_owner_replacement_binding_exact",

--- a/test/test_workspace_owner.py
+++ b/test/test_workspace_owner.py
@@ -119,6 +119,10 @@ def _provision_replacement(
 ) -> tuple[object, WorkspacePlan, object, int]:
     selected_plan = _file_plan() if plan is None else plan
     owner = _capture_existing_destination(root, destination)
+    workspace_owner.acquire_owner_replacement_lease(
+        owner,
+        time.monotonic_ns() + 10_000_000_000,
+    )
     incumbent_descriptor = workspace_owner.borrow_owner_destination_descriptor(owner)
     replacement_permit = workspace_owner.claim_owner_replacement_permit(owner)
     workspace_owner.provision_owner_replacement(
@@ -207,6 +211,7 @@ def _compile_exchange_fault_shim(tmp_path: Path) -> Path:
             #include <stdlib.h>
             #include <string.h>
             #include <sys/file.h>
+            #include <sys/stat.h>
             #include <sys/syscall.h>
             #include <unistd.h>
 
@@ -217,10 +222,13 @@ def _compile_exchange_fault_shim(tmp_path: Path) -> Path:
             typedef long (*syscall_function)(long, ...);
             typedef int (*fsync_function)(int);
             typedef int (*flock_function)(int, int);
+            typedef int (*fcntl_function)(int, int, ...);
 
             static syscall_function real_syscall;
             static fsync_function real_fsync;
             static flock_function real_flock;
+            static fcntl_function real_fcntl;
+            static fcntl_function real_fcntl64;
             static int exchange_calls;
             static int exchange_live;
             static int fsync_failed;
@@ -229,6 +237,12 @@ def _compile_exchange_fault_shim(tmp_path: Path) -> Path:
             static int post_exchange_fsyncs;
             static int lock_rebind_injected;
             static int lock_delay_injected;
+            static int exclusive_lock_calls;
+            static int lease_unlocked;
+            static int close_kcmp_failed;
+            static int close_fcntl_failed;
+            static int replacement_mkdir_calls;
+            static int settlement_slot_stat_failures;
 
             static const char *fault_mode(void) {
               const char *mode = getenv("CODENIB_EXCHANGE_FAULT");
@@ -244,6 +258,12 @@ def _compile_exchange_fault_shim(tmp_path: Path) -> Path:
               }
               if (real_flock == NULL) {
                 real_flock = (flock_function)dlsym(RTLD_NEXT, "flock");
+              }
+              if (real_fcntl == NULL) {
+                real_fcntl = (fcntl_function)dlsym(RTLD_NEXT, "fcntl");
+              }
+              if (real_fcntl64 == NULL) {
+                real_fcntl64 = (fcntl_function)dlsym(RTLD_NEXT, "fcntl64");
               }
             }
 
@@ -279,18 +299,30 @@ def _compile_exchange_fault_shim(tmp_path: Path) -> Path:
               fourth = va_arg(arguments, long);
               if (number == SYS_newfstatat) {
                 va_end(arguments);
-                if (strcmp(mode, "provision-identity-fail") == 0 &&
-                    second != 0 &&
+                if (second != 0 &&
                     strcmp((const char *)second, ".replacement") == 0 &&
-                    ++slot_stats == 2) {
-                  errno = EIO;
-                  return -1;
+                    (strcmp(mode, "provision-identity-fail") == 0 ||
+                     strcmp(mode, "mkdir-fail-stat-ambiguous") == 0)) {
+                  ++slot_stats;
+                  if (slot_stats == 2) {
+                    if (strcmp(mode, "mkdir-fail-stat-ambiguous") == 0) {
+                      ++settlement_slot_stat_failures;
+                    }
+                    errno = EIO;
+                    return -1;
+                  }
                 }
                 return real_syscall(number, first, second, third, fourth);
               }
               fifth = va_arg(arguments, long);
               if (number == SYS_kcmp) {
                 va_end(arguments);
+                if (lease_unlocked && !close_kcmp_failed &&
+                    strcmp(mode, "close-auth-error-once") == 0) {
+                  close_kcmp_failed = 1;
+                  errno = EPERM;
+                  return -1;
+                }
                 return real_syscall(number, first, second, third, fourth, fifth);
               }
               if (number == SYS_renameat2) {
@@ -364,12 +396,49 @@ def _compile_exchange_fault_shim(tmp_path: Path) -> Path:
               return real_fsync(descriptor);
             }
 
+            int mkdirat(int descriptor, const char *path, mode_t mode) {
+              int result;
+              const char *fault;
+
+              resolve_symbols();
+              if (real_syscall == NULL) {
+                errno = ENOSYS;
+                return -1;
+              }
+              fault = fault_mode();
+              if (path != NULL && strcmp(path, ".replacement") == 0 &&
+                  (strcmp(fault, "mkdir-fail-before-create") == 0 ||
+                   strcmp(fault, "mkdir-fail-stat-ambiguous") == 0 ||
+                   strcmp(fault, "mkdir-error-after-create") == 0)) {
+                ++replacement_mkdir_calls;
+                if (strcmp(fault, "mkdir-error-after-create") != 0) {
+                  errno = EIO;
+                  return -1;
+                }
+                result = (int)real_syscall(SYS_mkdirat, descriptor, path, mode);
+                if (result == 0) {
+                  errno = EIO;
+                  return -1;
+                }
+                return result;
+              }
+              return (int)real_syscall(SYS_mkdirat, descriptor, path, mode);
+            }
+
             int flock(int descriptor, int operation) {
               int result;
               resolve_symbols();
               if (real_flock == NULL) {
                 errno = ENOSYS;
                 return -1;
+              }
+              if (operation == (LOCK_EX | LOCK_NB)) {
+                ++exclusive_lock_calls;
+                if (exclusive_lock_calls > 1 &&
+                    strcmp(fault_mode(), "second-lock-fail") == 0) {
+                  errno = EBUSY;
+                  return -1;
+                }
               }
               if (!unlock_failed && exchange_live && operation == LOCK_UN &&
                   strcmp(fault_mode(), "unlock-fail-once") == 0) {
@@ -378,13 +447,19 @@ def _compile_exchange_fault_shim(tmp_path: Path) -> Path:
                 return -1;
               }
               if (!unlock_failed && operation == LOCK_UN &&
-                  strcmp(fault_mode(),
-                         "deadline-after-lock-unlock-fail") == 0) {
+                  (strcmp(fault_mode(),
+                          "deadline-after-lock-unlock-fail") == 0 ||
+                   strcmp(fault_mode(),
+                          "destination-rebind-after-lock-unlock-fail") == 0)) {
                 unlock_failed = 1;
                 errno = EIO;
                 return -1;
               }
               result = real_flock(descriptor, operation);
+              if (result == 0 && operation == LOCK_UN &&
+                  strcmp(fault_mode(), "close-auth-error-once") == 0) {
+                lease_unlocked = 1;
+              }
               if (result == 0 && !lock_delay_injected &&
                   operation == (LOCK_EX | LOCK_NB) &&
                   strcmp(fault_mode(),
@@ -394,8 +469,10 @@ def _compile_exchange_fault_shim(tmp_path: Path) -> Path:
               }
               if (result == 0 && !lock_rebind_injected &&
                   operation == (LOCK_EX | LOCK_NB) &&
-                  strcmp(fault_mode(), "slot-rebind-after-lock") == 0) {
-                if (real_syscall(SYS_renameat2, descriptor, ".replacement",
+                  (strcmp(fault_mode(), "destination-rebind-after-lock") == 0 ||
+                   strcmp(fault_mode(),
+                          "destination-rebind-after-lock-unlock-fail") == 0)) {
+                if (real_syscall(SYS_renameat2, descriptor, "published",
                                  descriptor, ".foreign", RENAME_EXCHANGE) != 0) {
                   int exchange_error = errno;
                   real_flock(descriptor, LOCK_UN);
@@ -405,6 +482,74 @@ def _compile_exchange_fault_shim(tmp_path: Path) -> Path:
                 lock_rebind_injected = 1;
               }
               return result;
+            }
+
+            int fcntl(int descriptor, int command, ...) {
+              va_list arguments;
+              int integer_argument;
+              void *pointer_argument;
+
+              resolve_symbols();
+              if (real_fcntl == NULL) {
+                errno = ENOSYS;
+                return -1;
+              }
+              if (command == F_GETFL && lease_unlocked && close_kcmp_failed &&
+                  !close_fcntl_failed &&
+                  strcmp(fault_mode(), "close-auth-error-once") == 0) {
+                close_fcntl_failed = 1;
+                errno = EIO;
+                return -1;
+              }
+              if (command == F_GETFD || command == F_GETFL ||
+                  command == F_GETOWN || command == F_GETSIG) {
+                return real_fcntl(descriptor, command);
+              }
+              va_start(arguments, command);
+              if (command == F_DUPFD || command == F_DUPFD_CLOEXEC ||
+                  command == F_SETFD || command == F_SETFL ||
+                  command == F_SETOWN || command == F_SETSIG) {
+                integer_argument = va_arg(arguments, int);
+                va_end(arguments);
+                return real_fcntl(descriptor, command, integer_argument);
+              }
+              pointer_argument = va_arg(arguments, void *);
+              va_end(arguments);
+              return real_fcntl(descriptor, command, pointer_argument);
+            }
+
+            int fcntl64(int descriptor, int command, ...) {
+              va_list arguments;
+              int integer_argument;
+              void *pointer_argument;
+
+              resolve_symbols();
+              if (real_fcntl64 == NULL) {
+                errno = ENOSYS;
+                return -1;
+              }
+              if (command == F_GETFL && lease_unlocked && close_kcmp_failed &&
+                  !close_fcntl_failed &&
+                  strcmp(fault_mode(), "close-auth-error-once") == 0) {
+                close_fcntl_failed = 1;
+                errno = EIO;
+                return -1;
+              }
+              if (command == F_GETFD || command == F_GETFL ||
+                  command == F_GETOWN || command == F_GETSIG) {
+                return real_fcntl64(descriptor, command);
+              }
+              va_start(arguments, command);
+              if (command == F_DUPFD || command == F_DUPFD_CLOEXEC ||
+                  command == F_SETFD || command == F_SETFL ||
+                  command == F_SETOWN || command == F_SETSIG) {
+                integer_argument = va_arg(arguments, int);
+                va_end(arguments);
+                return real_fcntl64(descriptor, command, integer_argument);
+              }
+              pointer_argument = va_arg(arguments, void *);
+              va_end(arguments);
+              return real_fcntl64(descriptor, command, pointer_argument);
             }
 
             int codenib_exchange_fault_exchange_calls(void) {
@@ -433,6 +578,26 @@ def _compile_exchange_fault_shim(tmp_path: Path) -> Path:
 
             int codenib_exchange_fault_lock_delay_injected(void) {
               return lock_delay_injected;
+            }
+
+            int codenib_exchange_fault_exclusive_lock_calls(void) {
+              return exclusive_lock_calls;
+            }
+
+            int codenib_exchange_fault_close_kcmp_failed(void) {
+              return close_kcmp_failed;
+            }
+
+            int codenib_exchange_fault_close_fcntl_failed(void) {
+              return close_fcntl_failed;
+            }
+
+            int codenib_exchange_fault_replacement_mkdir_calls(void) {
+              return replacement_mkdir_calls;
+            }
+
+            int codenib_exchange_fault_settlement_slot_stat_failures(void) {
+              return settlement_slot_stat_failures;
             }
             """
         ),
@@ -553,7 +718,7 @@ def test_workspace_owner_facade_rejects_symbol_complete_protocol_v2() -> None:
     )
 
 
-def test_workspace_owner_facade_rejects_symbol_complete_protocol_v3() -> None:
+def test_workspace_owner_facade_rejects_symbol_complete_protocol_v4() -> None:
     required_symbols = (
         "require_support",
         "create_owner_exact",
@@ -563,6 +728,7 @@ def test_workspace_owner_facade_rejects_symbol_complete_protocol_v3() -> None:
         "close_owner_exact",
         "provision_owner_exact",
         "capture_owner_destination_exact",
+        "acquire_owner_replacement_lease_exact",
         "provision_owner_replacement_exact",
         "verify_owner_authority_exact",
         "verify_owner_adoption_binding_exact",
@@ -593,7 +759,7 @@ def test_workspace_owner_facade_rejects_symbol_complete_protocol_v3() -> None:
         import types
 
         implementation = types.ModuleType("codenib._workspace_owner_impl")
-        implementation.workspace_owner_protocol_version = 3
+        implementation.workspace_owner_protocol_version = 4
         for name in {required_symbols!r}:
             setattr(implementation, name, lambda *args, **kwargs: None)
         sys.modules[implementation.__name__] = implementation
@@ -606,7 +772,7 @@ def test_workspace_owner_facade_rejects_symbol_complete_protocol_v3() -> None:
         except RuntimeError as error:
             assert "workspace-owner extension" in str(error)
         else:
-            raise AssertionError("protocol-v3 implementation was accepted")
+            raise AssertionError("protocol-v4 implementation was accepted")
         """
     )
     repository_root = Path(__file__).resolve().parents[1]
@@ -625,7 +791,7 @@ def test_workspace_owner_facade_rejects_symbol_complete_protocol_v3() -> None:
     )
 
 
-def test_workspace_owner_facade_rejects_each_incomplete_protocol_v4_abi() -> None:
+def test_workspace_owner_facade_rejects_each_incomplete_protocol_v5_abi() -> None:
     required_symbols = (
         "require_support",
         "create_owner_exact",
@@ -635,6 +801,7 @@ def test_workspace_owner_facade_rejects_each_incomplete_protocol_v4_abi() -> Non
         "close_owner_exact",
         "provision_owner_exact",
         "capture_owner_destination_exact",
+        "acquire_owner_replacement_lease_exact",
         "provision_owner_replacement_exact",
         "verify_owner_authority_exact",
         "verify_owner_adoption_binding_exact",
@@ -674,7 +841,7 @@ def test_workspace_owner_facade_rejects_each_incomplete_protocol_v4_abi() -> Non
         )
         for missing in required:
             implementation = types.ModuleType("codenib._workspace_owner_impl")
-            implementation.workspace_owner_protocol_version = 4
+            implementation.workspace_owner_protocol_version = 5
             for name in required:
                 if name != missing:
                     setattr(implementation, name, lambda *args, **kwargs: None)
@@ -693,7 +860,7 @@ def test_workspace_owner_facade_rejects_each_incomplete_protocol_v4_abi() -> Non
             except RuntimeError as error:
                 assert "workspace-owner extension" in str(error)
             else:
-                raise AssertionError(f"incomplete protocol-v4 ABI accepted: {{missing}}")
+                raise AssertionError(f"incomplete protocol-v5 ABI accepted: {{missing}}")
         """
     )
     repository_root = Path(__file__).resolve().parents[1]
@@ -994,6 +1161,99 @@ def test_native_low_available_fd_failure_is_cleanup_atomic(tmp_path: Path) -> No
 
 
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="requires Linux")
+def test_native_capture_budgets_hidden_replacement_lease_pair(tmp_path: Path) -> None:
+    probe_owner = _require_native_owner()
+    workspace_owner.close_owner_exact(probe_owner)
+    root = tmp_path / "capture-low-fd"
+    (root / "published").mkdir(parents=True)
+    root.chmod(0o700)
+    script = textwrap.dedent(
+        """
+        import errno
+        import gc
+        import os
+        import resource
+        import sys
+        import time
+        from pathlib import Path
+
+        import codenib._workspace_owner as workspace_owner
+
+        root_path = Path(sys.argv[1])
+        root = os.fsencode(root_path)
+        owner = workspace_owner.create_owner()
+        _soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+        selected_limit = (
+            256 if hard_limit == resource.RLIM_INFINITY else min(hard_limit, 256)
+        )
+        absolute_records = len(root_path.parts)
+        owner_pairs_without_hidden_lease = absolute_records + 1 + 1
+        prior_required = owner_pairs_without_hidden_lease * 2 + 2 + 64
+        if selected_limit <= prior_required + 1:
+            raise SystemExit(77)
+        resource.setrlimit(resource.RLIMIT_NOFILE, (selected_limit, hard_limit))
+        pressure = []
+        try:
+            while True:
+                pressure.append(
+                    os.open("/dev/null", os.O_RDONLY | getattr(os, "O_CLOEXEC", 0))
+                )
+        except OSError as error:
+            assert error.errno == errno.EMFILE
+        for descriptor in pressure[-(prior_required + 1) :]:
+            os.close(descriptor)
+        del pressure[-(prior_required + 1) :]
+
+        try:
+            workspace_owner.capture_owner_destination(
+                owner,
+                root,
+                b"published",
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        except OSError as error:
+            assert error.errno == errno.EMFILE
+        else:
+            raise AssertionError("capture omitted the hidden lease-pair budget")
+
+        assert workspace_owner.owner_state(owner) == "empty"
+        workspace_owner.abort_owner(owner)
+        assert workspace_owner.owner_closed(owner)
+        del owner
+        gc.collect()
+        retained_targets = []
+        for name in os.listdir("/proc/self/fd"):
+            try:
+                target = os.readlink(f"/proc/self/fd/{name}")
+            except OSError:
+                continue
+            if os.fspath(root_path) in target:
+                retained_targets.append(target)
+        assert retained_targets == []
+        assert (root_path / "published").is_dir()
+        for descriptor in pressure:
+            os.close(descriptor)
+        """
+    )
+    repository_root = Path(__file__).resolve().parents[1]
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (str(repository_root), environment.get("PYTHONPATH", ""))
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script, os.fspath(root)],
+        cwd=repository_root,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode == 77:
+        pytest.skip("RLIMIT_NOFILE is too low for the capture lease-pair probe")
+    assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="requires Linux")
 def test_native_replacement_additional_fd_budget_fails_before_mkdir(
     tmp_path: Path,
 ) -> None:
@@ -1019,6 +1279,10 @@ def test_native_replacement_additional_fd_budget_fails_before_mkdir(
             owner,
             root,
             b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        workspace_owner.acquire_owner_replacement_lease(
+            owner,
             time.monotonic_ns() + 10_000_000_000,
         )
         permit = workspace_owner.claim_owner_replacement_permit(owner)
@@ -1054,7 +1318,7 @@ def test_native_replacement_additional_fd_budget_fails_before_mkdir(
             assert error.errno == errno.EMFILE
         else:
             raise AssertionError("replacement descriptor preflight succeeded")
-        assert workspace_owner.owner_state(owner) == "destination-captured"
+        assert workspace_owner.owner_state(owner) == "destination-leased"
         assert not os.path.exists(os.path.join(os.fsdecode(root), ".replacement"))
 
         workspace_owner.abort_owner(owner)
@@ -1749,6 +2013,7 @@ def test_native_owner_captures_existing_destination_without_mutation(
     (destination / "payload.txt").write_bytes(b"retained")
     before = _tree_fingerprint(root)
     expected = destination.stat()
+    expected_parent = destination.parent.stat()
 
     owner = _capture_existing_destination(root, b"nested/published")
 
@@ -1757,6 +2022,14 @@ def test_native_owner_captures_existing_destination_without_mutation(
     assert workspace_owner.require_exact_owner(owner) is owner
     assert workspace_owner.verify_owner_authority(owner) is None
     assert workspace_owner.verify_owner_destination_binding(owner) is None
+    parent_descriptor = workspace_owner.borrow_owner_parent_descriptor(owner)
+    assert workspace_owner.borrow_owner_parent_descriptor(owner) == parent_descriptor
+    observed_parent = os.fstat(parent_descriptor)
+    assert (observed_parent.st_dev, observed_parent.st_ino) == (
+        expected_parent.st_dev,
+        expected_parent.st_ino,
+    )
+    assert fcntl.fcntl(parent_descriptor, fcntl.F_GETFD) & fcntl.FD_CLOEXEC
     descriptor = workspace_owner.borrow_owner_destination_descriptor(owner)
     assert workspace_owner.borrow_owner_destination_descriptor(owner) == descriptor
     observed = os.fstat(descriptor)
@@ -1834,9 +2107,859 @@ def test_native_destination_capture_symbols_require_the_exact_owner_type(
             time.monotonic_ns() + 10_000_000_000,
         )
     with pytest.raises(TypeError, match="invalid native type"):
+        workspace_owner.acquire_owner_replacement_lease(
+            candidate,
+            time.monotonic_ns() + 10_000_000_000,
+        )
+    with pytest.raises(TypeError, match="invalid native type"):
         workspace_owner.verify_owner_destination_binding(candidate)
     with pytest.raises(TypeError, match="invalid native type"):
         workspace_owner.borrow_owner_destination_descriptor(candidate)
+
+
+def test_native_replacement_lease_requires_exact_deadline_and_captured_state(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    (root / "published").mkdir(parents=True)
+    root.chmod(0o700)
+    owner = _capture_existing_destination(root, b"published")
+
+    with pytest.raises(RuntimeError, match="not claimable"):
+        workspace_owner.claim_owner_replacement_permit(owner)
+    with pytest.raises(RuntimeError, match="not replacement-ready"):
+        workspace_owner.provision_owner_replacement(
+            owner,
+            b".replacement",
+            b"0" * 64,
+            0o700,
+            (),
+            time.monotonic_ns() + 10_000_000_000,
+        )
+    for deadline, error_type in (
+        (True, TypeError),
+        (1.0, TypeError),
+        (0, ValueError),
+        (-1, ValueError),
+        (time.monotonic_ns() - 1, TimeoutError),
+    ):
+        with pytest.raises(error_type):
+            workspace_owner.acquire_owner_replacement_lease(
+                owner,
+                deadline,  # type: ignore[arg-type]
+            )
+        assert workspace_owner.owner_state(owner) == "destination-captured"
+        assert not (root / ".replacement").exists()
+
+    workspace_owner.acquire_owner_replacement_lease(
+        owner,
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    assert workspace_owner.owner_state(owner) == "destination-leased"
+    assert workspace_owner.verify_owner_destination_binding(owner) is None
+    assert (
+        workspace_owner.acquire_owner_replacement_lease(
+            owner,
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        is None
+    )
+    permit = workspace_owner.claim_owner_replacement_permit(owner)
+    with pytest.raises(RuntimeError, match="not replacement-lease-ready"):
+        workspace_owner.acquire_owner_replacement_lease(
+            owner,
+            time.monotonic_ns() + 10_000_000_000,
+        )
+    del permit
+    workspace_owner.abort_owner(owner)
+    assert workspace_owner.owner_closed(owner)
+
+
+def test_native_replacement_lease_return_interruption_retains_settlement(
+    tmp_path: Path,
+) -> None:
+    library = _compile_exchange_fault_shim(tmp_path)
+    root = tmp_path / "authority"
+    script = textwrap.dedent(
+        """
+        import ctypes
+        import errno
+        import fcntl
+        import os
+        import sys
+        import time
+        from pathlib import Path
+
+        import codenib._workspace_owner as workspace_owner
+
+        root = Path(sys.argv[1])
+        faults = ctypes.CDLL(sys.argv[2])
+        faults.codenib_exchange_fault_exclusive_lock_calls.restype = ctypes.c_int
+
+        def assert_parent_lease_held():
+            child = os.fork()
+            if child == 0:
+                os.environ.pop("CODENIB_EXCHANGE_FAULT", None)
+                descriptor = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+                try:
+                    fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except OSError as error:
+                    os.close(descriptor)
+                    os._exit(
+                        0 if error.errno in (errno.EAGAIN, errno.EWOULDBLOCK) else 2
+                    )
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+                os.close(descriptor)
+                os._exit(3)
+            waited, status = os.waitpid(child, 0)
+            assert waited == child
+            assert os.waitstatus_to_exitcode(status) == 0
+
+        destination = root / "published"
+        destination.mkdir(parents=True)
+        root.chmod(0o700)
+        owner = workspace_owner.create_owner()
+        workspace_owner.capture_owner_destination(
+            owner,
+            os.fsencode(root),
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        interruption = KeyboardInterrupt("after native replacement lease")
+
+        def interrupt_after_lease(result, label):
+            assert result is None
+            assert label == "replacement-lease"
+            assert workspace_owner.owner_state(owner) == "destination-leased"
+            raise interruption
+
+        original = workspace_owner._require_none_result
+        workspace_owner._require_none_result = interrupt_after_lease
+        try:
+            try:
+                workspace_owner.acquire_owner_replacement_lease(
+                    owner,
+                    time.monotonic_ns() + 10_000_000_000,
+                )
+            except KeyboardInterrupt as error:
+                assert error is interruption
+            else:
+                raise AssertionError("replacement lease interruption was hidden")
+        finally:
+            workspace_owner._require_none_result = original
+
+        assert workspace_owner.owner_state(owner) == "destination-leased"
+        assert faults.codenib_exchange_fault_exclusive_lock_calls() == 1
+        assert_parent_lease_held()
+
+        assert workspace_owner.acquire_owner_replacement_lease(
+            owner,
+            time.monotonic_ns() + 10_000_000_000,
+        ) is None
+        assert faults.codenib_exchange_fault_exclusive_lock_calls() == 1
+
+        try:
+            workspace_owner.acquire_owner_replacement_lease(
+                owner,
+                time.monotonic_ns() - 1,
+            )
+        except TimeoutError:
+            pass
+        else:
+            raise AssertionError("expired replacement lease retry succeeded")
+        assert workspace_owner.owner_state(owner) == "destination-leased"
+        assert faults.codenib_exchange_fault_exclusive_lock_calls() == 1
+        assert_parent_lease_held()
+
+        moved = root / ".stale"
+        destination.rename(moved)
+        try:
+            workspace_owner.acquire_owner_replacement_lease(
+                owner,
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("stale replacement lease retry succeeded")
+        assert workspace_owner.owner_state(owner) == "destination-leased"
+        assert faults.codenib_exchange_fault_exclusive_lock_calls() == 1
+        assert_parent_lease_held()
+        assert not (root / ".replacement").exists()
+
+        moved.rename(destination)
+        workspace_owner.abort_owner(owner)
+        assert workspace_owner.owner_closed(owner)
+        os.environ.pop("CODENIB_EXCHANGE_FAULT", None)
+        independent_parent = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+        fcntl.flock(independent_parent, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(independent_parent, fcntl.LOCK_UN)
+        os.close(independent_parent)
+        """
+    )
+    _run_exchange_fault_script(root, library, "second-lock-fail", script)
+
+
+def test_native_replacement_lease_contention_is_clean_before_candidate_mutation(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    (root / "first").mkdir(parents=True)
+    (root / "second").mkdir()
+    root.chmod(0o700)
+    first_owner = _capture_existing_destination(root, b"first")
+    second_owner = _capture_existing_destination(root, b"second")
+
+    workspace_owner.acquire_owner_replacement_lease(
+        first_owner,
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    with pytest.raises(BlockingIOError):
+        workspace_owner.acquire_owner_replacement_lease(
+            second_owner,
+            time.monotonic_ns() + 10_000_000_000,
+        )
+
+    assert workspace_owner.owner_state(first_owner) == "destination-leased"
+    assert workspace_owner.owner_state(second_owner) == "destination-captured"
+    assert not (root / ".first-replacement").exists()
+    assert not (root / ".second-replacement").exists()
+    workspace_owner.abort_owner(second_owner)
+    workspace_owner.abort_owner(first_owner)
+    assert workspace_owner.owner_closed(first_owner)
+    assert workspace_owner.owner_closed(second_owner)
+
+
+def test_native_borrowed_parent_unlock_cannot_release_replacement_lease(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    (root / "published").mkdir(parents=True)
+    root.chmod(0o700)
+    gc.collect()
+    baseline_fd_count = len(os.listdir("/proc/self/fd"))
+    owner = _capture_existing_destination(root, b"published")
+    borrowed_parent = workspace_owner.borrow_owner_parent_descriptor(owner)
+    workspace_owner.acquire_owner_replacement_lease(
+        owner,
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    contender = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+
+    fcntl.flock(borrowed_parent, fcntl.LOCK_UN)
+    assert workspace_owner.owner_state(owner) == "destination-leased"
+    assert workspace_owner.verify_owner_destination_binding(owner) is None
+    with pytest.raises(BlockingIOError):
+        fcntl.flock(contender, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    workspace_owner.abort_owner(owner)
+    assert workspace_owner.owner_closed(owner)
+    assert len(os.listdir("/proc/self/fd")) == baseline_fd_count + 1
+    fcntl.flock(contender, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    fcntl.flock(contender, fcntl.LOCK_UN)
+    os.close(contender)
+    del owner
+    gc.collect()
+    assert len(os.listdir("/proc/self/fd")) == baseline_fd_count
+
+
+def test_native_replacement_lease_rejects_reused_borrowed_parent_before_flock(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    (root / "published").mkdir(parents=True)
+    root.chmod(0o700)
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    owner = _capture_existing_destination(root, b"published")
+    borrowed_parent = workspace_owner.borrow_owner_parent_descriptor(owner)
+    os.close(borrowed_parent)
+    foreign_source = os.open(
+        foreign,
+        os.O_RDONLY
+        | os.O_DIRECTORY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_CLOEXEC", 0),
+    )
+    if foreign_source != borrowed_parent:
+        os.dup2(foreign_source, borrowed_parent, inheritable=False)
+        os.close(foreign_source)
+    fcntl.flock(borrowed_parent, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    independent_foreign = os.open(foreign, os.O_RDONLY | os.O_DIRECTORY)
+    independent_parent = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        with pytest.raises(RuntimeError, match="not replacement-lease-ready"):
+            workspace_owner.acquire_owner_replacement_lease(
+                owner,
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        assert workspace_owner.owner_state(owner) == "destination-captured"
+        assert not (root / ".replacement").exists()
+        with pytest.raises(BlockingIOError):
+            fcntl.flock(
+                independent_foreign,
+                fcntl.LOCK_EX | fcntl.LOCK_NB,
+            )
+        fcntl.flock(independent_parent, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(independent_parent, fcntl.LOCK_UN)
+
+        with pytest.raises(OSError):
+            workspace_owner.abort_owner(owner)
+        assert workspace_owner.owner_closed(owner)
+        os.fstat(borrowed_parent)
+        with pytest.raises(BlockingIOError):
+            fcntl.flock(
+                independent_foreign,
+                fcntl.LOCK_EX | fcntl.LOCK_NB,
+            )
+    finally:
+        fcntl.flock(borrowed_parent, fcntl.LOCK_UN)
+        os.close(borrowed_parent)
+        os.close(independent_foreign)
+        os.close(independent_parent)
+
+
+@pytest.mark.parametrize("descriptor_kind", ("parent", "destination"))
+def test_native_replacement_lease_rejects_reused_borrowed_fd_before_flock(
+    tmp_path: Path,
+    descriptor_kind: str,
+) -> None:
+    library = _compile_exchange_fault_shim(tmp_path)
+    root = tmp_path / "authority"
+    script = textwrap.dedent(
+        f"""
+        import ctypes
+        import os
+        import sys
+        import time
+        from pathlib import Path
+
+        import codenib._workspace_owner as workspace_owner
+
+        root = Path(sys.argv[1])
+        faults = ctypes.CDLL(sys.argv[2])
+        faults.codenib_exchange_fault_exclusive_lock_calls.restype = ctypes.c_int
+        destination = root / "published"
+        destination.mkdir(parents=True)
+        root.chmod(0o700)
+        descriptor_kind = {descriptor_kind!r}
+        foreign = root.parent / ("foreign-" + descriptor_kind)
+        foreign.mkdir()
+
+        owner = workspace_owner.create_owner()
+        workspace_owner.capture_owner_destination(
+            owner,
+            os.fsencode(root),
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        borrower = (
+            workspace_owner.borrow_owner_parent_descriptor
+            if descriptor_kind == "parent"
+            else workspace_owner.borrow_owner_destination_descriptor
+        )
+        borrowed = borrower(owner)
+        os.close(borrowed)
+        foreign_source = os.open(
+            foreign,
+            os.O_RDONLY
+            | os.O_DIRECTORY
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0),
+        )
+        if foreign_source != borrowed:
+            os.dup2(foreign_source, borrowed, inheritable=False)
+            os.close(foreign_source)
+
+        try:
+            workspace_owner.acquire_owner_replacement_lease(
+                owner,
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        except RuntimeError as error:
+            assert "not replacement-lease-ready" in str(error)
+        else:
+            raise AssertionError("reused captured descriptor was accepted")
+        assert faults.codenib_exchange_fault_exclusive_lock_calls() == 0
+        assert workspace_owner.owner_state(owner) == "destination-captured"
+        assert not (root / ".replacement").exists()
+
+        try:
+            workspace_owner.abort_owner(owner)
+        except OSError:
+            pass
+        else:
+            raise AssertionError("reused captured descriptor cleanup was accepted")
+        assert workspace_owner.owner_closed(owner)
+        assert faults.codenib_exchange_fault_exclusive_lock_calls() == 0
+        assert os.fstat(borrowed).st_ino == foreign.stat().st_ino
+        os.close(borrowed)
+        """
+    )
+    _run_exchange_fault_script(root, library, "second-lock-fail", script)
+
+
+def test_native_no_candidate_settlement_is_retryable_after_close_auth_failure(
+    tmp_path: Path,
+) -> None:
+    library = _compile_exchange_fault_shim(tmp_path)
+    root = tmp_path / "authority"
+    script = textwrap.dedent(
+        """
+        import ctypes
+        import errno
+        import fcntl
+        import os
+        import sys
+        import time
+        from pathlib import Path
+
+        import codenib._workspace_owner as workspace_owner
+
+        root = Path(sys.argv[1])
+        faults = ctypes.CDLL(sys.argv[2])
+        faults.codenib_exchange_fault_close_kcmp_failed.restype = ctypes.c_int
+        faults.codenib_exchange_fault_close_fcntl_failed.restype = ctypes.c_int
+
+        destination = root / "published"
+        destination.mkdir(parents=True)
+        root.chmod(0o700)
+        foreign = root.parent / "foreign-lock"
+        foreign.mkdir()
+        foreign_holder = os.open(foreign, os.O_RDONLY | os.O_DIRECTORY)
+        foreign_contender = os.open(foreign, os.O_RDONLY | os.O_DIRECTORY)
+        fcntl.flock(foreign_holder, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+        owner = workspace_owner.create_owner()
+        workspace_owner.capture_owner_destination(
+            owner,
+            os.fsencode(root),
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        workspace_owner.acquire_owner_replacement_lease(
+            owner,
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        permit = workspace_owner.claim_owner_replacement_permit(owner)
+        try:
+            workspace_owner.provision_owner_replacement(
+                owner,
+                b"not-hidden",
+                b"0" * 64,
+                0o700,
+                (),
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("invalid replacement slot was accepted")
+        assert workspace_owner.owner_state(owner) == "destination-leased"
+        assert not (root / ".replacement").exists()
+
+        borrowed_parent = workspace_owner.borrow_owner_parent_descriptor(owner)
+        assert os.fstat(borrowed_parent).st_ino == root.stat().st_ino
+        independent_parent = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            workspace_owner.abort_owner(owner)
+        except OSError as error:
+            assert error.errno == errno.EIO
+        else:
+            raise AssertionError("one-shot close authentication error was hidden")
+        assert faults.codenib_exchange_fault_close_kcmp_failed() == 1
+        assert faults.codenib_exchange_fault_close_fcntl_failed() == 1
+        assert workspace_owner.owner_state(owner) == "destination-captured"
+        assert not workspace_owner.owner_closed(owner)
+        assert not (root / ".replacement").exists()
+        os.fstat(borrowed_parent)
+
+        fcntl.flock(independent_parent, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(independent_parent, fcntl.LOCK_UN)
+        try:
+            fcntl.flock(foreign_contender, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            pass
+        else:
+            raise AssertionError("unrelated foreign lock was released")
+
+        workspace_owner.close_owner_exact(owner)
+        assert workspace_owner.owner_closed(owner)
+        try:
+            workspace_owner.exchange_owner_replacement(
+                permit,
+                b".replacement",
+                b"published",
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        except RuntimeError as error:
+            assert "unavailable" in str(error)
+        else:
+            raise AssertionError("stale replacement permit remained usable")
+
+        os.close(independent_parent)
+        fcntl.flock(foreign_holder, fcntl.LOCK_UN)
+        os.close(foreign_contender)
+        os.close(foreign_holder)
+        retained_targets = []
+        for name in os.listdir("/proc/self/fd"):
+            try:
+                target = os.readlink(f"/proc/self/fd/{name}")
+            except OSError:
+                continue
+            if os.fspath(root) in target:
+                retained_targets.append(target)
+        assert retained_targets == []
+        """
+    )
+    _run_exchange_fault_script(root, library, "close-auth-error-once", script)
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="requires Linux")
+def test_native_failed_replacement_mkdir_settles_without_lock_or_fd_leak(
+    tmp_path: Path,
+) -> None:
+    library = _compile_exchange_fault_shim(tmp_path)
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "incumbent.txt").write_bytes(b"incumbent")
+    script = textwrap.dedent(
+        """
+        import ctypes
+        import errno
+        import fcntl
+        import gc
+        import os
+        import sys
+        import time
+        from pathlib import Path
+
+        import codenib._workspace_owner as workspace_owner
+
+        root = Path(sys.argv[1])
+        faults = ctypes.CDLL(sys.argv[2])
+        counter = faults.codenib_exchange_fault_replacement_mkdir_calls
+        counter.restype = ctypes.c_int
+        gc.collect()
+        baseline_fd_count = len(os.listdir("/proc/self/fd"))
+
+        for iteration in range(6):
+            owner = workspace_owner.create_owner()
+            workspace_owner.capture_owner_destination(
+                owner,
+                os.fsencode(root),
+                b"published",
+                time.monotonic_ns() + 10_000_000_000,
+            )
+            workspace_owner.acquire_owner_replacement_lease(
+                owner,
+                time.monotonic_ns() + 10_000_000_000,
+            )
+            permit = workspace_owner.claim_owner_replacement_permit(owner)
+            try:
+                workspace_owner.provision_owner_replacement(
+                    owner,
+                    b".replacement",
+                    b"0" * 64,
+                    0o700,
+                    (),
+                    time.monotonic_ns() + 10_000_000_000,
+                )
+            except OSError as error:
+                assert error.errno == errno.EIO
+            else:
+                raise AssertionError("pre-creation mkdir failure was hidden")
+
+            assert workspace_owner.owner_state(owner) == "replacement-provisioning"
+            assert not (root / ".replacement").exists()
+            contender = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                fcntl.flock(contender, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                pass
+            else:
+                raise AssertionError("failed provision released its lease early")
+
+            if iteration % 2 == 0:
+                workspace_owner.abort_owner(owner)
+                assert workspace_owner.owner_closed(owner)
+                try:
+                    workspace_owner.exchange_owner_replacement(
+                        permit,
+                        b".replacement",
+                        b"published",
+                        time.monotonic_ns() + 10_000_000_000,
+                    )
+                except RuntimeError as error:
+                    assert "unavailable" in str(error)
+                else:
+                    raise AssertionError("settled replacement permit stayed active")
+                del permit
+                del owner
+                gc.collect()
+            else:
+                sentinel = KeyboardInterrupt(f"sentinel-{iteration}")
+                try:
+                    raise sentinel
+                except BaseException:  # noqa: B036 - preserve active exception
+                    del permit
+                    del owner
+                    gc.collect()
+                    assert sys.exc_info()[1] is sentinel
+
+            assert len(os.listdir("/proc/self/fd")) == baseline_fd_count + 1
+            fcntl.flock(contender, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            fcntl.flock(contender, fcntl.LOCK_UN)
+            os.close(contender)
+            assert len(os.listdir("/proc/self/fd")) == baseline_fd_count
+            assert not (root / ".replacement").exists()
+
+        assert counter() == 6
+        retained_targets = []
+        for name in os.listdir("/proc/self/fd"):
+            try:
+                target = os.readlink(f"/proc/self/fd/{name}")
+            except OSError:
+                continue
+            if os.fspath(root) in target:
+                retained_targets.append(target)
+        assert retained_targets == []
+        assert (root / "published" / "incumbent.txt").read_bytes() == b"incumbent"
+        """
+    )
+    _run_exchange_fault_script(root, library, "mkdir-fail-before-create", script)
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="requires Linux")
+def test_native_apparent_replacement_mkdir_keeps_recovery_lease_and_config(
+    tmp_path: Path,
+) -> None:
+    library = _compile_exchange_fault_shim(tmp_path)
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "incumbent.txt").write_bytes(b"incumbent")
+    script = textwrap.dedent(
+        """
+        import ctypes
+        import errno
+        import fcntl
+        import gc
+        import os
+        import sys
+        import time
+        from pathlib import Path
+
+        import codenib._workspace_owner as workspace_owner
+
+        root = Path(sys.argv[1])
+        faults = ctypes.CDLL(sys.argv[2])
+        counter = faults.codenib_exchange_fault_replacement_mkdir_calls
+        counter.restype = ctypes.c_int
+        gc.collect()
+        baseline_fd_count = len(os.listdir("/proc/self/fd"))
+        owner = workspace_owner.create_owner()
+        workspace_owner.capture_owner_destination(
+            owner,
+            os.fsencode(root),
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        workspace_owner.acquire_owner_replacement_lease(
+            owner,
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        permit = workspace_owner.claim_owner_replacement_permit(owner)
+        try:
+            workspace_owner.provision_owner_replacement(
+                owner,
+                b".replacement",
+                b"0" * 64,
+                0o700,
+                (),
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        except OSError as error:
+            assert error.errno == errno.EIO
+        else:
+            raise AssertionError("post-create mkdir error was hidden")
+
+        slot = root / ".replacement"
+        assert counter() == 1
+        assert slot.is_dir()
+        assert workspace_owner.owner_state(owner) == "replacement-provisioning"
+        contender = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            workspace_owner.abort_owner(owner)
+        except OSError as error:
+            assert error.errno == errno.ESTALE
+        else:
+            raise AssertionError("ambiguous created slot was settled")
+        assert workspace_owner.owner_state(owner) == (
+            "replacement-recovery-required"
+        )
+        assert not workspace_owner.owner_closed(owner)
+        assert slot.is_dir()
+        try:
+            fcntl.flock(contender, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            pass
+        else:
+            raise AssertionError("ambiguous slot released the recovery lease")
+        try:
+            workspace_owner.exchange_owner_replacement(
+                permit,
+                b".replacement",
+                b"published",
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        except RuntimeError as error:
+            assert "not exchange-ready" in str(error)
+        else:
+            raise AssertionError("ambiguous replacement became exchange-ready")
+
+        slot.rmdir()
+        workspace_owner.abort_owner(owner)
+        assert workspace_owner.owner_closed(owner)
+        assert len(os.listdir("/proc/self/fd")) == baseline_fd_count + 1
+        fcntl.flock(contender, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(contender, fcntl.LOCK_UN)
+        os.close(contender)
+        try:
+            workspace_owner.exchange_owner_replacement(
+                permit,
+                b".replacement",
+                b"published",
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        except RuntimeError as error:
+            assert "unavailable" in str(error)
+        else:
+            raise AssertionError("recovered replacement permit stayed active")
+        del permit
+        del owner
+        gc.collect()
+        assert len(os.listdir("/proc/self/fd")) == baseline_fd_count
+        assert not slot.exists()
+        assert (root / "published" / "incumbent.txt").read_bytes() == b"incumbent"
+        """
+    )
+    _run_exchange_fault_script(root, library, "mkdir-error-after-create", script)
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="requires Linux")
+def test_native_replacement_slot_stat_ambiguity_retains_recovery_lease(
+    tmp_path: Path,
+) -> None:
+    library = _compile_exchange_fault_shim(tmp_path)
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "incumbent.txt").write_bytes(b"incumbent")
+    script = textwrap.dedent(
+        """
+        import ctypes
+        import errno
+        import fcntl
+        import gc
+        import os
+        import sys
+        import time
+        from pathlib import Path
+
+        import codenib._workspace_owner as workspace_owner
+
+        root = Path(sys.argv[1])
+        faults = ctypes.CDLL(sys.argv[2])
+        mkdir_calls = faults.codenib_exchange_fault_replacement_mkdir_calls
+        mkdir_calls.restype = ctypes.c_int
+        slot_stats = faults.codenib_exchange_fault_slot_stats
+        slot_stats.restype = ctypes.c_int
+        stat_failures = faults.codenib_exchange_fault_settlement_slot_stat_failures
+        stat_failures.restype = ctypes.c_int
+        gc.collect()
+        baseline_fd_count = len(os.listdir("/proc/self/fd"))
+        owner = workspace_owner.create_owner()
+        workspace_owner.capture_owner_destination(
+            owner,
+            os.fsencode(root),
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        workspace_owner.acquire_owner_replacement_lease(
+            owner,
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        permit = workspace_owner.claim_owner_replacement_permit(owner)
+        try:
+            workspace_owner.provision_owner_replacement(
+                owner,
+                b".replacement",
+                b"0" * 64,
+                0o700,
+                (),
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        except OSError as error:
+            assert error.errno == errno.EIO
+        else:
+            raise AssertionError("pre-creation mkdir failure was hidden")
+
+        assert mkdir_calls() == 1
+        assert slot_stats() == 1
+        assert not (root / ".replacement").exists()
+        contender = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            workspace_owner.abort_owner(owner)
+        except OSError as error:
+            assert error.errno == errno.ESTALE
+        else:
+            raise AssertionError("ambiguous slot stat was treated as ENOENT")
+        assert slot_stats() == 2
+        assert stat_failures() == 1
+        assert workspace_owner.owner_state(owner) == (
+            "replacement-recovery-required"
+        )
+        assert not workspace_owner.owner_closed(owner)
+        try:
+            fcntl.flock(contender, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            pass
+        else:
+            raise AssertionError("ambiguous slot stat released the recovery lease")
+
+        workspace_owner.abort_owner(owner)
+        assert workspace_owner.owner_closed(owner)
+        assert slot_stats() >= 4
+        assert stat_failures() == 1
+        assert len(os.listdir("/proc/self/fd")) == baseline_fd_count + 1
+        fcntl.flock(contender, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(contender, fcntl.LOCK_UN)
+        os.close(contender)
+        try:
+            workspace_owner.exchange_owner_replacement(
+                permit,
+                b".replacement",
+                b"published",
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        except RuntimeError as error:
+            assert "unavailable" in str(error)
+        else:
+            raise AssertionError("settled replacement permit stayed active")
+        del permit
+        del owner
+        gc.collect()
+        assert len(os.listdir("/proc/self/fd")) == baseline_fd_count
+        assert not (root / ".replacement").exists()
+        assert (root / "published" / "incumbent.txt").read_bytes() == b"incumbent"
+        """
+    )
+    _run_exchange_fault_script(root, library, "mkdir-fail-stat-ambiguous", script)
 
 
 def test_native_captured_destination_rejects_every_legacy_owner_operation(
@@ -1874,7 +2997,6 @@ def test_native_captured_destination_rejects_every_legacy_owner_operation(
             b".stage",
             b"0" * 64,
         ),
-        lambda: workspace_owner.borrow_owner_parent_descriptor(owner),
         lambda: workspace_owner.borrow_owner_root_descriptor(owner),
         lambda: workspace_owner.borrow_owner_directory_descriptor(owner, b"views"),
         lambda: workspace_owner.begin_owner_file(owner, b"", b"new", 0o600),
@@ -2394,6 +3516,7 @@ def test_native_owner_atomically_exchanges_exact_replacement_and_commits_receipt
     _adopt_and_fill_replacement(root, owner, plan)
     assert workspace_owner.owner_state(owner) == "replacement-adopted"
     assert workspace_owner.verify_owner_replacement_binding(owner) is None
+    assert workspace_owner.borrow_owner_parent_descriptor(owner) == parent_descriptor
 
     receipt_token = workspace_owner.exchange_owner_replacement(
         permit,
@@ -2404,6 +3527,8 @@ def test_native_owner_atomically_exchanges_exact_replacement_and_commits_receipt
 
     assert workspace_owner.owner_state(owner) == ("replacement-exchanged-unreceipted")
     assert workspace_owner.verify_owner_replacement_binding(owner) is None
+    with pytest.raises(RuntimeError, match="unavailable"):
+        workspace_owner.borrow_owner_parent_descriptor(owner)
     assert (destination / "views/bm25/documents.json").read_bytes() == b"replacement"
     assert (root / ".replacement" / "incumbent.txt").read_bytes() == b"incumbent"
     assert (
@@ -2434,6 +3559,10 @@ def test_native_owner_atomically_exchanges_exact_replacement_and_commits_receipt
         workspace_owner.commit_owner_receipt(receipt_token)
         workspace_owner.commit_owner_receipt(receipt_token)
         assert workspace_owner.owner_state(owner) == "replacement-receipted"
+        with pytest.raises(RuntimeError, match="binding changed"):
+            workspace_owner.verify_owner_replacement_binding(owner)
+        with pytest.raises(RuntimeError, match="unavailable"):
+            workspace_owner.borrow_owner_parent_descriptor(owner)
         fcntl.flock(independent_parent, fcntl.LOCK_EX | fcntl.LOCK_NB)
         fcntl.flock(independent_parent, fcntl.LOCK_UN)
     finally:
@@ -2597,6 +3726,10 @@ def test_native_replacement_requires_exact_bounded_arguments(tmp_path: Path) -> 
         error_type,
     ) in invalid_arguments:
         owner = _capture_existing_destination(root, b"published")
+        workspace_owner.acquire_owner_replacement_lease(
+            owner,
+            time.monotonic_ns() + 10_000_000_000,
+        )
         replacement_permit = workspace_owner.claim_owner_replacement_permit(owner)
         with pytest.raises(error_type):
             workspace_owner.provision_owner_replacement(
@@ -2607,7 +3740,7 @@ def test_native_replacement_requires_exact_bounded_arguments(tmp_path: Path) -> 
                 directories,  # type: ignore[arg-type]
                 provision_deadline,
             )
-        assert workspace_owner.owner_state(owner) == "destination-captured"
+        assert workspace_owner.owner_state(owner) == "destination-leased"
         assert not (root / ".replacement").exists()
         del replacement_permit
         workspace_owner.abort_owner(owner)
@@ -2684,11 +3817,19 @@ def test_native_replacement_permit_drop_and_cross_owner_use_fail_closed(
     tmp_path: Path,
 ) -> None:
     root = tmp_path / "authority"
-    (root / "first").mkdir(parents=True)
-    (root / "second").mkdir()
+    (root / "first-parent" / "first").mkdir(parents=True)
+    (root / "second-parent" / "second").mkdir(parents=True)
     root.chmod(0o700)
-    first_owner = _capture_existing_destination(root, b"first")
-    second_owner = _capture_existing_destination(root, b"second")
+    first_owner = _capture_existing_destination(root, b"first-parent/first")
+    second_owner = _capture_existing_destination(root, b"second-parent/second")
+    workspace_owner.acquire_owner_replacement_lease(
+        first_owner,
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    workspace_owner.acquire_owner_replacement_lease(
+        second_owner,
+        time.monotonic_ns() + 10_000_000_000,
+    )
     first_permit = workspace_owner.claim_owner_replacement_permit(first_owner)
     second_permit = workspace_owner.claim_owner_replacement_permit(second_owner)
     workspace_owner.provision_owner_replacement(
@@ -2701,7 +3842,7 @@ def test_native_replacement_permit_drop_and_cross_owner_use_fail_closed(
     )
     workspace_owner.verify_owner_adoption_binding(
         second_owner,
-        os.fsencode(root / "second"),
+        os.fsencode(root / "second-parent" / "second"),
         b".second-replacement",
         b"0" * 64,
     )
@@ -2728,8 +3869,8 @@ def test_native_replacement_permit_drop_and_cross_owner_use_fail_closed(
             (),
             time.monotonic_ns() + 10_000_000_000,
         )
-    assert workspace_owner.owner_state(first_owner) == "destination-captured"
-    assert not (root / ".replacement").exists()
+    assert workspace_owner.owner_state(first_owner) == "destination-leased"
+    assert not (root / "first-parent" / ".replacement").exists()
     workspace_owner.abort_owner(first_owner)
     workspace_owner.abort_owner(second_owner)
     del second_permit
@@ -2867,6 +4008,8 @@ def test_native_preexchange_settlement_retains_lease_until_rebind_is_restored(
     with pytest.raises(OSError):
         workspace_owner.abort_owner(owner)
     assert workspace_owner.owner_state(owner) == "replacement-recovery-required"
+    with pytest.raises(RuntimeError, match="unavailable"):
+        workspace_owner.borrow_owner_parent_descriptor(owner)
     with pytest.raises(OSError):
         workspace_owner.close_owner_exact(owner)
 
@@ -2989,15 +4132,24 @@ def test_native_parent_commit_lease_serializes_cooperative_sibling_replacements(
     root.chmod(0o700)
     (first_destination / "old.txt").write_bytes(b"first")
     (second_destination / "old.txt").write_bytes(b"second")
-    first_owner, first_plan, first_permit, _ = _provision_replacement(
-        root,
-        destination=b"first",
-        slot=b".first-replacement",
+    first_owner = _capture_existing_destination(root, b"first")
+    second_owner = _capture_existing_destination(root, b"second")
+    workspace_owner.acquire_owner_replacement_lease(
+        first_owner,
+        time.monotonic_ns() + 10_000_000_000,
     )
-    second_owner, second_plan, second_permit, _ = _provision_replacement(
-        root,
-        destination=b"second",
-        slot=b".second-replacement",
+    first_plan = _file_plan()
+    first_permit = workspace_owner.claim_owner_replacement_permit(first_owner)
+    workspace_owner.provision_owner_replacement(
+        first_owner,
+        b".first-replacement",
+        first_plan.digest.encode("ascii"),
+        first_plan.root_mode,
+        tuple(
+            (os.fsencode(item.path.as_posix()), item.mode)
+            for item in first_plan.directories
+        ),
+        time.monotonic_ns() + 10_000_000_000,
     )
     _adopt_and_fill_replacement(
         root,
@@ -3007,34 +4159,29 @@ def test_native_parent_commit_lease_serializes_cooperative_sibling_replacements(
         slot=b".first-replacement",
         payload=b"first-new",
     )
-    _adopt_and_fill_replacement(
-        root,
-        second_owner,
-        second_plan,
-        destination=b"second",
-        slot=b".second-replacement",
-        payload=b"second-new",
-    )
+
+    with pytest.raises(BlockingIOError):
+        workspace_owner.acquire_owner_replacement_lease(
+            second_owner,
+            time.monotonic_ns() + 10_000_000_000,
+        )
+    assert workspace_owner.owner_state(second_owner) == "destination-captured"
+    assert not (root / ".second-replacement").exists()
+
     first_token = workspace_owner.exchange_owner_replacement(
         first_permit,
         b".first-replacement",
         b"first",
         time.monotonic_ns() + 10_000_000_000,
     )
-
-    with pytest.raises(BlockingIOError):
-        workspace_owner.exchange_owner_replacement(
-            second_permit,
-            b".second-replacement",
-            b"second",
-            time.monotonic_ns() + 10_000_000_000,
-        )
-    assert workspace_owner.owner_state(second_owner) == "replacement-adopted"
-    with pytest.raises(BlockingIOError):
-        workspace_owner.abort_owner(second_owner)
-
     workspace_owner.commit_owner_receipt(first_token)
     workspace_owner.close_owner_exact(first_owner)
+
+    workspace_owner.acquire_owner_replacement_lease(
+        second_owner,
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    assert workspace_owner.owner_state(second_owner) == "destination-leased"
     workspace_owner.abort_owner(second_owner)
     assert workspace_owner.owner_closed(second_owner)
     assert (first_destination / "views/bm25/documents.json").read_bytes() == (
@@ -3076,40 +4223,21 @@ def test_native_preexchange_contention_dealloc_closes_only_the_losing_owner(
     gc.collect()
     baseline_fd_count = len(os.listdir("/proc/self/fd"))
 
-    second_owner, second_plan, second_permit, _ = _provision_replacement(
-        root,
-        destination=b"second",
-        slot=b".second-replacement",
-    )
-    _adopt_and_fill_replacement(
-        root,
-        second_owner,
-        second_plan,
-        destination=b"second",
-        slot=b".second-replacement",
-        payload=b"second-new",
-    )
+    second_owner = _capture_existing_destination(root, b"second")
     before_cleanup = _tree_fingerprint(root)
     with pytest.raises(BlockingIOError):
-        workspace_owner.exchange_owner_replacement(
-            second_permit,
-            b".second-replacement",
-            b"second",
+        workspace_owner.acquire_owner_replacement_lease(
+            second_owner,
             time.monotonic_ns() + 10_000_000_000,
         )
-    with pytest.raises(BlockingIOError):
-        workspace_owner.abort_owner(second_owner)
-    with pytest.raises(BlockingIOError):
-        workspace_owner.close_owner_exact(second_owner)
     assert not workspace_owner.owner_closed(second_owner)
-    assert workspace_owner.owner_state(second_owner) == "replacement-adopted"
+    assert workspace_owner.owner_state(second_owner) == "destination-captured"
     assert _tree_fingerprint(root) == before_cleanup
 
     sentinel = KeyboardInterrupt("sentinel")
     try:
         raise sentinel
     except BaseException:  # noqa: B036 - assert dealloc preserves the exception
-        del second_permit
         del second_owner
         gc.collect()
         assert sys.exc_info()[1] is sentinel
@@ -3136,13 +4264,24 @@ def test_native_overlapping_same_destination_capture_fails_closed_after_commit(
     destination.mkdir(parents=True)
     root.chmod(0o700)
     (destination / "incumbent.txt").write_bytes(b"incumbent")
-    first_owner, first_plan, first_permit, _ = _provision_replacement(
-        root,
-        slot=b".first-replacement",
+    first_owner = _capture_existing_destination(root, b"published")
+    second_owner = _capture_existing_destination(root, b"published")
+    workspace_owner.acquire_owner_replacement_lease(
+        first_owner,
+        time.monotonic_ns() + 10_000_000_000,
     )
-    second_owner, second_plan, second_permit, _ = _provision_replacement(
-        root,
-        slot=b".second-replacement",
+    first_plan = _file_plan()
+    first_permit = workspace_owner.claim_owner_replacement_permit(first_owner)
+    workspace_owner.provision_owner_replacement(
+        first_owner,
+        b".first-replacement",
+        first_plan.digest.encode("ascii"),
+        first_plan.root_mode,
+        tuple(
+            (os.fsencode(item.path.as_posix()), item.mode)
+            for item in first_plan.directories
+        ),
+        time.monotonic_ns() + 10_000_000_000,
     )
     _adopt_and_fill_replacement(
         root,
@@ -3150,13 +4289,6 @@ def test_native_overlapping_same_destination_capture_fails_closed_after_commit(
         first_plan,
         slot=b".first-replacement",
         payload=b"first-candidate",
-    )
-    _adopt_and_fill_replacement(
-        root,
-        second_owner,
-        second_plan,
-        slot=b".second-replacement",
-        payload=b"second-candidate",
     )
     first_token = workspace_owner.exchange_owner_replacement(
         first_permit,
@@ -3166,38 +4298,187 @@ def test_native_overlapping_same_destination_capture_fails_closed_after_commit(
     )
     workspace_owner.commit_owner_receipt(first_token)
 
-    with pytest.raises(RuntimeError, match="not exchange-ready"):
-        workspace_owner.exchange_owner_replacement(
-            second_permit,
-            b".second-replacement",
-            b"published",
+    with pytest.raises(RuntimeError, match="changed before replacement lease"):
+        workspace_owner.acquire_owner_replacement_lease(
+            second_owner,
             time.monotonic_ns() + 10_000_000_000,
         )
-    assert workspace_owner.owner_state(second_owner) == "replacement-adopted"
-    with pytest.raises(OSError):
-        workspace_owner.abort_owner(second_owner)
-    assert workspace_owner.owner_state(second_owner) == (
-        "replacement-recovery-required"
-    )
+    assert workspace_owner.owner_state(second_owner) == "destination-captured"
+    assert not (root / ".second-replacement").exists()
     assert (destination / "views/bm25/documents.json").read_bytes() == (
         b"first-candidate"
     )
-    assert (
-        root / ".second-replacement" / "views/bm25/documents.json"
-    ).read_bytes() == b"second-candidate"
     independent_parent = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
     try:
-        with pytest.raises(BlockingIOError):
-            fcntl.flock(independent_parent, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(independent_parent, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(independent_parent, fcntl.LOCK_UN)
     finally:
         os.close(independent_parent)
 
-    temporary = root / ".restore-first-candidate"
-    destination.rename(temporary)
-    (root / ".first-replacement").rename(destination)
-    temporary.rename(root / ".first-replacement")
     workspace_owner.abort_owner(second_owner)
     workspace_owner.close_owner_exact(first_owner)
+
+
+def test_native_overlapping_capture_can_lease_after_prior_owner_aborts_exchange(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "incumbent.txt").write_bytes(b"incumbent")
+    first_owner = _capture_existing_destination(root, b"published")
+    second_owner = _capture_existing_destination(root, b"published")
+    workspace_owner.acquire_owner_replacement_lease(
+        first_owner,
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    first_plan = _file_plan()
+    first_permit = workspace_owner.claim_owner_replacement_permit(first_owner)
+    workspace_owner.provision_owner_replacement(
+        first_owner,
+        b".first-replacement",
+        first_plan.digest.encode("ascii"),
+        first_plan.root_mode,
+        tuple(
+            (os.fsencode(item.path.as_posix()), item.mode)
+            for item in first_plan.directories
+        ),
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    _adopt_and_fill_replacement(
+        root,
+        first_owner,
+        first_plan,
+        slot=b".first-replacement",
+        payload=b"candidate",
+    )
+    workspace_owner.exchange_owner_replacement(
+        first_permit,
+        b".first-replacement",
+        b"published",
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    workspace_owner.abort_owner(first_owner)
+
+    assert workspace_owner.owner_closed(first_owner)
+    assert (destination / "incumbent.txt").read_bytes() == b"incumbent"
+    assert workspace_owner.owner_state(second_owner) == "destination-captured"
+    assert not (root / ".second-replacement").exists()
+    workspace_owner.acquire_owner_replacement_lease(
+        second_owner,
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    assert workspace_owner.owner_state(second_owner) == "destination-leased"
+    assert workspace_owner.verify_owner_destination_binding(second_owner) is None
+    assert not (root / ".second-replacement").exists()
+    workspace_owner.abort_owner(second_owner)
+    assert workspace_owner.owner_closed(second_owner)
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
+def test_native_cross_process_stale_capture_releases_lease_without_candidate(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    destination = root / "published"
+    destination.mkdir(parents=True)
+    root.chmod(0o700)
+    (destination / "incumbent.txt").write_bytes(b"incumbent")
+    ready_read, ready_write = os.pipe()
+    proceed_read, proceed_write = os.pipe()
+    report_read, report_write = os.pipe()
+    child_pid = os.fork()
+    if child_pid == 0:
+        os.close(ready_read)
+        os.close(proceed_write)
+        os.close(report_read)
+        try:
+            owner = _capture_existing_destination(root, b"published")
+            os.write(ready_write, b"ready")
+            os.close(ready_write)
+            assert os.read(proceed_read, 1) == b"x"
+            os.close(proceed_read)
+            try:
+                workspace_owner.acquire_owner_replacement_lease(
+                    owner,
+                    time.monotonic_ns() + 10_000_000_000,
+                )
+            except RuntimeError as error:
+                assert "changed before replacement lease" in str(error)
+            else:
+                raise AssertionError("stale captured destination was leased")
+            assert workspace_owner.owner_state(owner) == "destination-captured"
+            assert not (root / ".second-replacement").exists()
+            independent_parent = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                fcntl.flock(
+                    independent_parent,
+                    fcntl.LOCK_EX | fcntl.LOCK_NB,
+                )
+                fcntl.flock(independent_parent, fcntl.LOCK_UN)
+            finally:
+                os.close(independent_parent)
+            workspace_owner.abort_owner(owner)
+            assert workspace_owner.owner_closed(owner)
+            report = b"ok"
+        except BaseException as error:  # noqa: B036 - report child failure
+            report = repr(error).encode("utf-8")
+        os.write(report_write, report)
+        os.close(report_write)
+        os._exit(0)
+
+    os.close(ready_write)
+    os.close(proceed_read)
+    os.close(report_write)
+    assert os.read(ready_read, 5) == b"ready"
+    os.close(ready_read)
+    first_owner = _capture_existing_destination(root, b"published")
+    workspace_owner.acquire_owner_replacement_lease(
+        first_owner,
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    first_plan = _file_plan()
+    first_permit = workspace_owner.claim_owner_replacement_permit(first_owner)
+    workspace_owner.provision_owner_replacement(
+        first_owner,
+        b".first-replacement",
+        first_plan.digest.encode("ascii"),
+        first_plan.root_mode,
+        tuple(
+            (os.fsencode(item.path.as_posix()), item.mode)
+            for item in first_plan.directories
+        ),
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    _adopt_and_fill_replacement(
+        root,
+        first_owner,
+        first_plan,
+        slot=b".first-replacement",
+        payload=b"first-candidate",
+    )
+    first_token = workspace_owner.exchange_owner_replacement(
+        first_permit,
+        b".first-replacement",
+        b"published",
+        time.monotonic_ns() + 10_000_000_000,
+    )
+    workspace_owner.commit_owner_receipt(first_token)
+    workspace_owner.close_owner_exact(first_owner)
+    os.write(proceed_write, b"x")
+    os.close(proceed_write)
+
+    report = os.read(report_read, 4096)
+    os.close(report_read)
+    waited_pid, status = os.waitpid(child_pid, 0)
+    assert waited_pid == child_pid
+    assert os.waitstatus_to_exitcode(status) == 0
+    assert report == b"ok"
+    assert (destination / "views/bm25/documents.json").read_bytes() == (
+        b"first-candidate"
+    )
+    assert not (root / ".second-replacement").exists()
 
 
 def test_native_replacement_fd_reuse_and_dealloc_preserve_primary_baseexception(
@@ -3227,6 +4508,10 @@ def test_native_replacement_fd_reuse_and_dealloc_preserve_primary_baseexception(
             time.monotonic_ns() + 10_000_000_000,
         )
         workspace_owner.borrow_owner_destination_descriptor(owner)
+        workspace_owner.acquire_owner_replacement_lease(
+            owner,
+            time.monotonic_ns() + 10_000_000_000,
+        )
         permit = workspace_owner.claim_owner_replacement_permit(owner)
         workspace_owner.provision_owner_replacement(
             owner,
@@ -3337,6 +4622,20 @@ def test_native_replacement_permit_cannot_cross_a_pid_boundary(
     child_pid = os.fork()
     if child_pid == 0:
         os.close(read_descriptor)
+        try:
+            workspace_owner.acquire_owner_replacement_lease(
+                owner,
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        except RuntimeError as error:
+            if "PID boundary" not in str(error):
+                os.write(write_descriptor, repr(error).encode())
+                os.close(write_descriptor)
+                os._exit(0)
+        else:
+            os.write(write_descriptor, b"cross-PID replacement lease succeeded")
+            os.close(write_descriptor)
+            os._exit(0)
         try:
             workspace_owner.exchange_owner_replacement(
                 permit,
@@ -3449,6 +4748,138 @@ def test_native_replacement_child_closes_fds_without_unlocking_or_mutating(
     "fault_mode",
     (
         "deadline-after-lock-unlock-fail",
+        "destination-rebind-after-lock",
+        "destination-rebind-after-lock-unlock-fail",
+    ),
+)
+def test_native_replacement_lease_faults_are_settled_exactly(
+    tmp_path: Path,
+    fault_mode: str,
+) -> None:
+    library = _compile_exchange_fault_shim(tmp_path)
+    root = tmp_path / "authority"
+    script = textwrap.dedent(
+        """
+        import ctypes
+        import fcntl
+        import os
+        import sys
+        import time
+        from pathlib import Path
+
+        import codenib._workspace_owner as workspace_owner
+
+        root = Path(sys.argv[1])
+        faults = ctypes.CDLL(sys.argv[2])
+        mode = os.environ["CODENIB_EXCHANGE_FAULT"]
+        for counter_name in (
+            "codenib_exchange_fault_exchange_calls",
+            "codenib_exchange_fault_unlock_failed",
+            "codenib_exchange_fault_lock_rebind_injected",
+            "codenib_exchange_fault_lock_delay_injected",
+        ):
+            getattr(faults, counter_name).restype = ctypes.c_int
+
+        def counter(name):
+            return getattr(faults, name)()
+
+        def parent_lease_is_held():
+            descriptor = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                try:
+                    fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    return True
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+                return False
+            finally:
+                os.close(descriptor)
+
+        destination = root / "published"
+        destination.mkdir(parents=True)
+        root.chmod(0o700)
+        (destination / "incumbent.txt").write_bytes(b"incumbent")
+        if mode in (
+            "destination-rebind-after-lock",
+            "destination-rebind-after-lock-unlock-fail",
+        ):
+            foreign = root / ".foreign"
+            foreign.mkdir()
+            (foreign / "foreign.txt").write_bytes(b"foreign")
+        owner = workspace_owner.create_owner()
+        workspace_owner.capture_owner_destination(
+            owner,
+            os.fsencode(root),
+            b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        deadline = (
+            time.monotonic_ns() + 20_000_000
+            if mode == "deadline-after-lock-unlock-fail"
+            else time.monotonic_ns() + 10_000_000_000
+        )
+
+        if mode == "deadline-after-lock-unlock-fail":
+            try:
+                workspace_owner.acquire_owner_replacement_lease(owner, deadline)
+            except TimeoutError:
+                pass
+            else:
+                raise AssertionError("post-lock lease deadline expiry was hidden")
+            assert counter("codenib_exchange_fault_lock_delay_injected") == 1
+            assert counter("codenib_exchange_fault_unlock_failed") == 1
+            assert workspace_owner.owner_state(owner) == (
+                "replacement-recovery-required"
+            )
+            assert parent_lease_is_held()
+            assert not (root / ".replacement").exists()
+            workspace_owner.abort_owner(owner)
+        else:
+            try:
+                workspace_owner.acquire_owner_replacement_lease(owner, deadline)
+            except RuntimeError as error:
+                assert "changed before replacement lease" in str(error)
+            else:
+                raise AssertionError("under-lease destination rebind was accepted")
+            assert counter("codenib_exchange_fault_lock_rebind_injected") == 1
+            assert not (root / ".replacement").exists()
+            if mode == "destination-rebind-after-lock-unlock-fail":
+                assert counter("codenib_exchange_fault_unlock_failed") == 1
+                assert workspace_owner.owner_state(owner) == (
+                    "replacement-recovery-required"
+                )
+                assert parent_lease_is_held()
+                workspace_owner.abort_owner(owner)
+                assert not parent_lease_is_held()
+                assert (destination / "foreign.txt").read_bytes() == b"foreign"
+                assert (root / ".foreign" / "incumbent.txt").read_bytes() == (
+                    b"incumbent"
+                )
+            else:
+                assert workspace_owner.owner_state(owner) == "destination-captured"
+                assert not parent_lease_is_held()
+                retained_foreign = root / ".retained-foreign"
+                (root / "published").rename(retained_foreign)
+                (root / ".foreign").rename(root / "published")
+                retained_foreign.rename(root / ".foreign")
+                workspace_owner.abort_owner(owner)
+                assert (root / ".foreign" / "foreign.txt").read_bytes() == (
+                    b"foreign"
+                )
+
+        assert counter("codenib_exchange_fault_exchange_calls") == 0
+        assert workspace_owner.owner_closed(owner)
+        if mode != "destination-rebind-after-lock-unlock-fail":
+            assert (destination / "incumbent.txt").read_bytes() == b"incumbent"
+        """
+    )
+    _run_exchange_fault_script(root, library, fault_mode, script)
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="requires Linux")
+@pytest.mark.parametrize(
+    "fault_mode",
+    (
         "success-without-swap",
         "error-after-swap",
         "forward-fsync-once",
@@ -3456,7 +4887,7 @@ def test_native_replacement_child_closes_fds_without_unlocking_or_mutating(
         "reverse-error-once",
         "reverse-fsync-once",
         "reverse-success-without-restore",
-        "slot-rebind-after-lock",
+        "second-lock-fail",
         "unlock-fail-once",
     ),
 )
@@ -3488,6 +4919,7 @@ def test_native_exchange_faults_are_classified_and_settled_exactly(
             "codenib_exchange_fault_post_exchange_fsyncs",
             "codenib_exchange_fault_lock_rebind_injected",
             "codenib_exchange_fault_lock_delay_injected",
+            "codenib_exchange_fault_exclusive_lock_calls",
         ):
             getattr(faults, counter_name).restype = ctypes.c_int
 
@@ -3518,6 +4950,10 @@ def test_native_exchange_faults_are_classified_and_settled_exactly(
             b"published",
             time.monotonic_ns() + 10_000_000_000,
         )
+        workspace_owner.acquire_owner_replacement_lease(
+            owner,
+            time.monotonic_ns() + 10_000_000_000,
+        )
         permit = workspace_owner.claim_owner_replacement_permit(owner)
         workspace_owner.provision_owner_replacement(
             owner,
@@ -3540,33 +4976,9 @@ def test_native_exchange_faults_are_classified_and_settled_exactly(
         workspace_owner.write_owner_file(owner, b"candidate")
         workspace_owner.finish_owner_file(owner, 0o600)
         workspace_owner.seal_owner_directories(owner)
-        if mode == "slot-rebind-after-lock":
-            foreign = root / ".foreign"
-            foreign.mkdir()
-            (foreign / "foreign.txt").write_bytes(b"foreign")
-        if mode == "deadline-after-lock-unlock-fail":
-            deadline = time.monotonic_ns() + 20_000_000
-        else:
-            deadline = time.monotonic_ns() + 10_000_000_000
+        deadline = time.monotonic_ns() + 10_000_000_000
 
-        if mode == "deadline-after-lock-unlock-fail":
-            try:
-                workspace_owner.exchange_owner_replacement(
-                    permit, b".replacement", b"published", deadline
-                )
-            except TimeoutError:
-                pass
-            else:
-                raise AssertionError("post-lock deadline expiry was hidden")
-            assert counter("codenib_exchange_fault_lock_delay_injected") == 1
-            assert counter("codenib_exchange_fault_unlock_failed") == 1
-            assert counter("codenib_exchange_fault_exchange_calls") == 0
-            assert workspace_owner.owner_state(owner) == (
-                "replacement-recovery-required"
-            )
-            assert parent_lease_is_held()
-            workspace_owner.abort_owner(owner)
-        elif mode == "success-without-swap":
+        if mode == "success-without-swap":
             try:
                 workspace_owner.exchange_owner_replacement(
                     permit, b".replacement", b"published", deadline
@@ -3578,7 +4990,7 @@ def test_native_exchange_faults_are_classified_and_settled_exactly(
             assert counter("codenib_exchange_fault_exchange_calls") == 1
             assert counter("codenib_exchange_fault_post_exchange_fsyncs") >= 1
             assert workspace_owner.owner_state(owner) == "replacement-adopted"
-            assert not parent_lease_is_held()
+            assert parent_lease_is_held()
             workspace_owner.abort_owner(owner)
         elif mode == "error-after-swap":
             token = workspace_owner.exchange_owner_replacement(
@@ -3682,27 +5094,13 @@ def test_native_exchange_faults_are_classified_and_settled_exactly(
                 counter("codenib_exchange_fault_post_exchange_fsyncs")
                 > syncs_before_retry
             )
-        elif mode == "slot-rebind-after-lock":
-            try:
-                workspace_owner.exchange_owner_replacement(
-                    permit, b".replacement", b"published", deadline
-                )
-            except RuntimeError as error:
-                assert "binding changed under" in str(error)
-            else:
-                raise AssertionError("under-lease slot rebind was accepted")
-            assert counter("codenib_exchange_fault_lock_rebind_injected") == 1
-            assert counter("codenib_exchange_fault_exchange_calls") == 0
-            assert workspace_owner.owner_state(owner) == (
-                "replacement-recovery-required"
+        elif mode == "second-lock-fail":
+            token = workspace_owner.exchange_owner_replacement(
+                permit, b".replacement", b"published", deadline
             )
-            assert parent_lease_is_held()
-            retained_foreign = root / ".retained-foreign"
-            (root / ".replacement").rename(retained_foreign)
-            (root / ".foreign").rename(root / ".replacement")
-            retained_foreign.rename(root / ".foreign")
-            workspace_owner.abort_owner(owner)
-            assert (root / ".foreign" / "foreign.txt").read_bytes() == b"foreign"
+            assert counter("codenib_exchange_fault_exclusive_lock_calls") == 1
+            workspace_owner.commit_owner_receipt(token)
+            workspace_owner.close_owner_exact(owner)
         elif mode == "unlock-fail-once":
             token = workspace_owner.exchange_owner_replacement(
                 permit, b".replacement", b"published", deadline
@@ -3734,7 +5132,7 @@ def test_native_exchange_faults_are_classified_and_settled_exactly(
             raise AssertionError(f"unexpected fault mode: {mode}")
 
         assert workspace_owner.owner_closed(owner)
-        if mode in ("error-after-swap", "unlock-fail-once"):
+        if mode in ("error-after-swap", "second-lock-fail", "unlock-fail-once"):
             assert not (destination / "incumbent.txt").exists()
             assert (
                 destination / "views/bm25/documents.json"
@@ -3781,6 +5179,10 @@ def test_native_unsupported_exchange_preserves_error_during_last_owner_dealloc(
             owner,
             os.fsencode(root),
             b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        workspace_owner.acquire_owner_replacement_lease(
+            owner,
             time.monotonic_ns() + 10_000_000_000,
         )
         permit = workspace_owner.claim_owner_replacement_permit(owner)
@@ -3857,6 +5259,10 @@ def test_native_partial_replacement_identity_failure_never_adopts_rebound_slot(
             owner,
             os.fsencode(root),
             b"published",
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        workspace_owner.acquire_owner_replacement_lease(
+            owner,
             time.monotonic_ns() + 10_000_000_000,
         )
         permit = workspace_owner.claim_owner_replacement_permit(owner)


### PR DESCRIPTION
## Summary

Move the native workspace-replacement lease ahead of candidate mutation and
hold it on a dedicated, never-exposed parent-directory OFD through
provisioning, exchange, receipt settlement, or authenticated rollback.

This remains a primitive-only protocol-v5 slice. `LocalWorkspaceProvider`
still rejects `provider-bound-exact`, so Gate C and M1 remain open. No compiler
or runtime route changes.

Related to #199.

## Changes

- Add protocol-v5 replacement-lease acquisition and fail-closed facade/ABI validation.
- Open and authenticate a hidden parent OFD pair, prove it is distinct from the borrowable parent authority, and flock only the hidden pair before revalidating the complete captured destination.
- Keep the parent-wide hidden lease across provisioning, exchange, receipt commit, abort, and recovery while preserving clean contention and stale-capture settlement.
- Settle a failed pre-creation attempt only after exact slot `ENOENT` checks around parent `fsync`; retain recovery authority for created, rebound, or ambiguous slots.
- Cover retry, descriptor reuse, FD budgeting, pre/post-create failures, stat ambiguity, cross-process contention, stale captures, receipt recovery, and fork-child ownership boundaries.
- Extend shared-wheel and ABI3 release lifecycle verification for the protocol-v5 ordering and state contract.
- Document the cooperative private-root threat model and keep provider integration, Gate C, and M1 explicitly open.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- Focused workspace-owner, release-artifact, local-provider, and strict-BM25 surface: `192 passed`.
- Native workspace-owner suite: `99 passed`.
- Release-artifact suite: `30 passed`.
- Full unit marker: `6985 passed, 71 skipped, 190 deselected` in a fresh read-only namespace; the direct host run stopped only at the known absent `/usr/bin/docker` infrastructure check.
- Protocol-v5 shared-wheel and ABI3 lifecycle templates cover commit and rollback; required Release CI exercises the production wheel paths.
- Black 24.8, isort 5.13.2 with the Black profile, flake8 7.1.1 plus bugbear, clang-format 18, limited-ABI compilation, diff checks, and strict documentation/public-boundary builds passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
