### PR TITLE
feat(storage): bind exact workspace replacement requests

### DIFF
--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -42,6 +42,7 @@ from ._atomic_directory import (
     _rename_noreplace_at,
     _require_matching_ownership,
     _require_rename_noreplace_platform,
+    _TreeOwnership,
     _validate_ownership_inventory_budget,
     directory_ownership_entry_identities,
     directory_ownership_file_records,
@@ -93,6 +94,7 @@ _WORKSPACE_RECEIPT_EMPTY = object()
 _WORKSPACE_RECEIPT_CLOSED = object()
 _WORKSPACE_RECEIPT_CLOSE = object()
 _WORKSPACE_OWNER_RECOVERY_LIMIT = 64
+_TREE_OWNERSHIP_TYPE = _TreeOwnership
 _WorkspaceResult = TypeVar("_WorkspaceResult")
 
 
@@ -648,6 +650,58 @@ class _WorkspaceCleanup:
     attempted: bool = False
 
 
+@dataclass(frozen=True, slots=True, init=False)
+class PublishedWorkspaceDestinationBinding:
+    """Immutable exact destination authority minted by an active receipt owner."""
+
+    destination: Path
+    parent_identity: tuple[int, ...]
+    ownership: _TreeOwnership
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        raise TypeError(
+            "published workspace destination bindings are minted by an active "
+            "receipt owner"
+        )
+
+
+# Keep authority checks independent from later mutation of the public module
+# attribute.  Trusted providers may import the type, but cannot replace the
+# discriminator used by already-live owners.
+_PUBLISHED_WORKSPACE_DESTINATION_BINDING_TYPE = PublishedWorkspaceDestinationBinding
+
+
+def _freeze_published_workspace_destination_binding_minter(
+    *,
+    destination: Path,
+    parent_identity: tuple[int, ...],
+) -> Callable[[_TreeOwnership], PublishedWorkspaceDestinationBinding]:
+    """Freeze one private binding constructor before publication callbacks."""
+
+    lexical_destination = lexical_directory_path(destination)
+    if (
+        type(parent_identity) is not tuple
+        or len(parent_identity) < 2
+        or any(type(value) is not int for value in parent_identity)
+    ):
+        raise TypeError("published workspace parent identity is invalid")
+    binding_type = _PUBLISHED_WORKSPACE_DESTINATION_BINDING_TYPE
+    ownership_type = _TREE_OWNERSHIP_TYPE
+    binding_new = object.__new__
+    binding_setattr = object.__setattr__
+
+    def mint(ownership: _TreeOwnership) -> PublishedWorkspaceDestinationBinding:
+        if type(ownership) is not ownership_type:
+            raise TypeError("published workspace ownership token is invalid")
+        binding = binding_new(binding_type)
+        binding_setattr(binding, "destination", lexical_destination)
+        binding_setattr(binding, "parent_identity", parent_identity)
+        binding_setattr(binding, "ownership", ownership)
+        return binding
+
+    return mint
+
+
 class PublishedWorkspaceReceipt:
     """Borrowed exact-generation receipt controlled by its caller-owned slot."""
 
@@ -662,6 +716,7 @@ class PublishedWorkspaceReceipt:
         "_transfer",
         "_native_receipt_token",
         "_owner_pid",
+        "_destination_binding",
     )
 
     def __init__(
@@ -671,14 +726,19 @@ class PublishedWorkspaceReceipt:
         path: Path,
         plan: WorkspacePlan,
         sealed_ownership: object,
-        published_ownership: object,
+        published_ownership: _TreeOwnership,
         parent_identity: tuple[int, ...],
+        destination_binding: PublishedWorkspaceDestinationBinding,
         orphan: DirectoryOrphan | None,
         native_receipt_token: object | None,
     ) -> None:
         # Store the shared aggregate first.  A constructor interruption can
         # therefore be reconciled against the same transfer held by the owner.
         self._transfer = transfer
+        # Freeze the replacement authority before storing the mutable public
+        # compatibility projections below.  Only the active receipt owner can
+        # later expose this private binding to another strict request.
+        self._destination_binding = destination_binding
         self.path = path
         self._plan = _snapshot_workspace_plan(plan)
         self.sealed_ownership = sealed_ownership
@@ -783,6 +843,26 @@ class PublishedWorkspaceReceiptOwner:
                     f"{self._state_locked()}, expected active"
                 )
             return self._slot
+
+        return self._lock.run(borrow)
+
+    @property
+    def destination_binding(self) -> PublishedWorkspaceDestinationBinding:
+        """Project the exact destination binding from this active generation."""
+
+        self._require_owner_pid()
+
+        def borrow() -> PublishedWorkspaceDestinationBinding:
+            self._normalize_closed_locked()
+            if type(self._slot) is not _PUBLISHED_WORKSPACE_RECEIPT_TYPE:
+                raise RuntimeError(
+                    "published workspace receipt owner is "
+                    f"{self._state_locked()}, expected active"
+                )
+            binding = self._slot._destination_binding
+            if type(binding) is not _PUBLISHED_WORKSPACE_DESTINATION_BINDING_TYPE:
+                raise RuntimeError("published workspace destination binding is invalid")
+            return binding
 
         return self._lock.run(borrow)
 
@@ -2076,7 +2156,7 @@ class OwnedWorkspaceAuthority:
         self._destination: Path | None = None
         self._stage_path: Path | None = None
         self._plan: WorkspacePlan | None = None
-        self._expected_destination: object | None = None
+        self._destination_binding: PublishedWorkspaceDestinationBinding | None = None
         self._root_descriptor = -1
         self._root_identity: tuple[int, ...] | None = None
         self._directory_descriptors: dict[str, int] = {}
@@ -2122,17 +2202,19 @@ class OwnedWorkspaceAuthority:
         return self._lock.run(get_destination)
 
     @property
-    def expected_destination_ownership(self) -> object | None:
-        """Return the exact adopted destination token, or ``None`` if missing."""
+    def expected_destination_binding(
+        self,
+    ) -> PublishedWorkspaceDestinationBinding | None:
+        """Return the exact adopted destination binding, or ``None`` if missing."""
 
         self._require_owner_pid()
 
-        def get_expected_destination() -> object | None:
+        def get_destination_binding() -> PublishedWorkspaceDestinationBinding | None:
             if self._destination is None:
                 raise RuntimeError("owned workspace authority has not been adopted")
-            return self._expected_destination
+            return self._destination_binding
 
-        return self._lock.run(get_expected_destination)
+        return self._lock.run(get_destination_binding)
 
     @classmethod
     def create(cls, *_args: object, **_kwargs: object) -> OwnedWorkspaceAuthority:
@@ -2154,7 +2236,7 @@ class OwnedWorkspaceAuthority:
             int,
         ],
         plan: WorkspacePlan,
-        expected_destination: object | None,
+        destination_binding: PublishedWorkspaceDestinationBinding | None,
     ) -> None:
         """Adopt a pre-opened sibling root and exact empty-file skeleton."""
 
@@ -2172,7 +2254,7 @@ class OwnedWorkspaceAuthority:
                 root_descriptor=root_descriptor,
                 directory_descriptors=directory_descriptors,
                 plan=plan,
-                expected_destination=expected_destination,
+                destination_binding=destination_binding,
             )
         )
 
@@ -2184,7 +2266,7 @@ class OwnedWorkspaceAuthority:
         provisioned_owner: object,
         publication_permit: object,
         plan: WorkspacePlan,
-        expected_destination: object | None,
+        destination_binding: PublishedWorkspaceDestinationBinding | None,
     ) -> None:
         """Adopt a native-owned skeleton without duplicating its descriptors."""
 
@@ -2201,7 +2283,7 @@ class OwnedWorkspaceAuthority:
                 provisioned_owner=provisioned_owner,
                 publication_permit=publication_permit,
                 plan=plan,
-                expected_destination=expected_destination,
+                destination_binding=destination_binding,
             )
         )
 
@@ -2213,12 +2295,18 @@ class OwnedWorkspaceAuthority:
         provisioned_owner: object,
         publication_permit: object,
         plan: WorkspacePlan,
-        expected_destination: object | None,
+        destination_binding: PublishedWorkspaceDestinationBinding | None,
     ) -> None:
         self._require_owner_pid()
         if self._state != "empty" or self._native_owner is not None:
             raise RuntimeError("owned workspace authority is not empty")
-        if expected_destination is not None:
+        if (
+            destination_binding is not None
+            and type(destination_binding)
+            is not _PUBLISHED_WORKSPACE_DESTINATION_BINDING_TYPE
+        ):
+            raise TypeError("workspace destination binding is invalid")
+        if destination_binding is not None:
             raise UnsupportedWorkspaceCreation(
                 "native local workspaces currently require a missing destination"
             )
@@ -2258,7 +2346,7 @@ class OwnedWorkspaceAuthority:
                 ),
                 directory_descriptors=directory_descriptors,
                 plan=detached_plan,
-                expected_destination=None,
+                destination_binding=None,
                 native_publication_permit=publication_permit,
             )
         except BaseException as adoption_error:  # noqa: B036 - settle owner
@@ -2287,7 +2375,7 @@ class OwnedWorkspaceAuthority:
             int,
         ],
         plan: WorkspacePlan,
-        expected_destination: object | None,
+        destination_binding: PublishedWorkspaceDestinationBinding | None,
         native_publication_permit: object | None = None,
     ) -> None:
         self._require_owner_pid()
@@ -2310,6 +2398,19 @@ class OwnedWorkspaceAuthority:
         stage_path = destination_path.parent / stage_relative.name
         if stage_path == destination_path:
             raise ValueError("workspace stage and destination must differ")
+        if (
+            destination_binding is not None
+            and type(destination_binding)
+            is not _PUBLISHED_WORKSPACE_DESTINATION_BINDING_TYPE
+        ):
+            raise TypeError("workspace destination binding is invalid")
+        if (
+            destination_binding is not None
+            and destination_binding.destination != destination_path
+        ):
+            raise ValueError(
+                "workspace destination binding differs from its destination"
+            )
 
         expected_directory_paths = {item.path.as_posix() for item in plan.directories}
         normalized_descriptors: dict[str, int] = {}
@@ -2333,15 +2434,11 @@ class OwnedWorkspaceAuthority:
                 "workspace directory descriptors must exactly match the plan"
             )
 
-        if expected_destination is not None:
-            # Validate the private token before acquiring any authority.
-            directory_ownership_root_identity(expected_destination)
-
         self._state = "adopting"
         self._destination = destination_path
         self._stage_path = stage_path
         self._plan = plan
-        self._expected_destination = expected_destination
+        self._destination_binding = destination_binding
         self._file_specs = {item.path.as_posix(): item for item in plan.files}
         try:
             if self._native_owner is None:
@@ -2365,6 +2462,13 @@ class OwnedWorkspaceAuthority:
                     authority_owner=self._parent_owner,
                 )
             authority = self._require_parent_authority()
+            if (
+                destination_binding is not None
+                and authority.identity != destination_binding.parent_identity
+            ):
+                raise RuntimeError(
+                    "workspace destination parent differs from its binding"
+                )
             flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
             flags |= getattr(os, "O_CLOEXEC", 0) | getattr(
                 os,
@@ -2488,7 +2592,7 @@ class OwnedWorkspaceAuthority:
                 path=destination_path,
                 label="owned workspace destination",
             )
-            if expected_destination is None:
+            if destination_binding is None:
                 if destination_metadata is not None:
                     raise RuntimeError(
                         "owned workspace destination was expected missing"
@@ -2502,7 +2606,7 @@ class OwnedWorkspaceAuthority:
                     label="owned workspace destination",
                     allow_empty_root=True,
                 )
-                if observed_destination != expected_destination:
+                if observed_destination != destination_binding.ownership:
                     raise RuntimeError("owned workspace destination changed")
             authority.verify_path_binding()
             self._refresh_locked(require_complete=False)
@@ -2933,6 +3037,8 @@ class OwnedWorkspaceAuthority:
         destination = self._destination
         plan = self._plan
         authority = self._require_parent_authority()
+        parent_identity = authority.identity
+        receipt_plan = _snapshot_workspace_plan(plan)
         # Freeze every token-receiving Python callable before either validator
         # runs.  Fault-injection may replace these before publish_into enters,
         # but validator-time module/class mutation cannot intercept the private
@@ -2941,10 +3047,16 @@ class OwnedWorkspaceAuthority:
         receipt_new = receipt_type.__new__
         receipt_init = receipt_type.__init__
         install_receipt_exact = PublishedWorkspaceReceiptOwner._install
+        mint_destination_binding_exact = (
+            _freeze_published_workspace_destination_binding_minter(
+                destination=destination,
+                parent_identity=parent_identity,
+            )
+        )
 
         def install_receipt(
             committed_sealed: object,
-            published_ownership: object,
+            published_ownership: _TreeOwnership,
             previous_orphan: DirectoryOrphan | None,
             native_receipt_token: object | None,
         ) -> None:
@@ -2956,15 +3068,17 @@ class OwnedWorkspaceAuthority:
                 label="published workspace",
                 allow_root_rename=True,
             )
+            destination_binding = mint_destination_binding_exact(published_ownership)
             receipt = receipt_new(receipt_type)
             receipt_init(
                 receipt,
                 transfer=transfer,
                 path=destination,
-                plan=_snapshot_workspace_plan(plan),
+                plan=receipt_plan,
                 sealed_ownership=sealed_ownership,
                 published_ownership=published_ownership,
-                parent_identity=authority.identity,
+                parent_identity=parent_identity,
+                destination_binding=destination_binding,
                 orphan=previous_orphan,
                 native_receipt_token=native_receipt_token,
             )
@@ -2980,7 +3094,11 @@ class OwnedWorkspaceAuthority:
             self._stage_path,
             self._destination,
             expected_stage_root_ownership=sealed_ownership,
-            expected_destination_ownership=self._expected_destination,
+            expected_destination_ownership=(
+                None
+                if self._destination_binding is None
+                else self._destination_binding.ownership
+            ),
             validate_staged_directory=validate_staged_directory,
             validate_published_destination=validate_published_destination,
             commit_callback=install_receipt,
@@ -4309,6 +4427,7 @@ __all__ = [
     "CapturedDirectoryReader",
     "OwnedDirectoryStage",
     "OwnedWorkspaceAuthority",
+    "PublishedWorkspaceDestinationBinding",
     "PublishedWorkspaceReceipt",
     "PublishedWorkspaceReceiptOwner",
     "UnsupportedWorkspaceCreation",

--- a/codenib/_local_workspace_provider.py
+++ b/codenib/_local_workspace_provider.py
@@ -143,7 +143,7 @@ class LocalWorkspaceProvider:
             raise TypeError("strict workspace request has an invalid type")
         if type(receipt_owner) is not PublishedWorkspaceReceiptOwner:
             raise TypeError("strict workspace receipt owner has an invalid type")
-        if request.destination_expectation != "missing":
+        if request.destination_binding is not None:
             raise UnsupportedWorkspaceCreation(
                 "local workspace provider currently requires a missing destination"
             )
@@ -205,7 +205,7 @@ class LocalWorkspaceProvider:
                 provisioned_owner=native_owner,
                 publication_permit=publication_permit,
                 plan=detached_plan,
-                expected_destination=None,
+                destination_binding=request.destination_binding,
             )
             return run_adopted_workspace_operation(
                 request,

--- a/codenib/_workspace_provider.py
+++ b/codenib/_workspace_provider.py
@@ -26,6 +26,7 @@ from ._atomic_directory import (
 )
 from ._captured_directory import (
     OwnedWorkspaceAuthority,
+    PublishedWorkspaceDestinationBinding,
     PublishedWorkspaceReceiptOwner,
     WorkspacePlan,
     _snapshot_workspace_plan,
@@ -36,6 +37,7 @@ from ._owned_file_publication import _CancellationSafeRLock
 _OperationResult = TypeVar("_OperationResult")
 _ValidationResult = TypeVar("_ValidationResult")
 DestinationExpectation = Literal["missing", "provider-bound-exact"]
+_PUBLISHED_WORKSPACE_DESTINATION_BINDING_TYPE = PublishedWorkspaceDestinationBinding
 _SESSION_RECOVERY_LIMIT = 64
 _UNSET_RESULT = object()
 _CONSUMED_SESSION_PROVENANCE = object()
@@ -119,7 +121,7 @@ class StrictWorkspaceRequest:
     purpose: str
     destination: Path
     plan: WorkspacePlan
-    destination_expectation: DestinationExpectation = "missing"
+    destination_binding: PublishedWorkspaceDestinationBinding | None = None
 
     def __post_init__(self) -> None:
         if (
@@ -139,10 +141,24 @@ class StrictWorkspaceRequest:
             raise ValueError("strict workspace destination must name one directory")
         destination = Path(os.path.abspath(os.fspath(requested_destination)))
         plan = _snapshot_workspace_plan(self.plan)
-        if self.destination_expectation not in {"missing", "provider-bound-exact"}:
-            raise ValueError("strict workspace destination expectation is invalid")
+        binding = self.destination_binding
+        if (
+            binding is not None
+            and type(binding) is not _PUBLISHED_WORKSPACE_DESTINATION_BINDING_TYPE
+        ):
+            raise TypeError("strict workspace destination binding is invalid")
+        if binding is not None and binding.destination != destination:
+            raise ValueError(
+                "strict workspace destination binding differs from its destination"
+            )
         object.__setattr__(self, "destination", destination)
         object.__setattr__(self, "plan", plan)
+
+    @property
+    def destination_expectation(self) -> DestinationExpectation:
+        """Describe the destination mode derived from its exact binding."""
+
+        return "missing" if self.destination_binding is None else "provider-bound-exact"
 
 
 class StrictWorkspaceSession(Protocol):
@@ -241,14 +257,12 @@ class _AdoptedWorkspaceSession:
             raise ValueError("adopted workspace plan differs from its request")
         if self._workspace.destination != self._request.destination:
             raise ValueError("adopted workspace destination differs from its request")
-        expected = (
-            "missing"
-            if self._workspace.expected_destination_ownership is None
-            else "provider-bound-exact"
-        )
-        if expected != self._request.destination_expectation:
+        if (
+            self._workspace.expected_destination_binding
+            != self._request.destination_binding
+        ):
             raise ValueError(
-                "adopted workspace destination expectation differs from its request"
+                "adopted workspace destination binding differs from its request"
             )
 
     def _require_operation_request(self, request: StrictWorkspaceRequest) -> None:

--- a/codenib/artifacts/strict_bm25.py
+++ b/codenib/artifacts/strict_bm25.py
@@ -1175,6 +1175,15 @@ def _publish_planned_bm25_view_with_identity(
     forbidden_paths: tuple[Path, ...],
     environ: Mapping[str, str],
 ) -> dict[str, Any]:
+    destination_binding = source_generation.destination_binding
+    if (
+        destination_binding.destination != source_receipt.path
+        or destination_binding.parent_identity != source_receipt.parent_identity
+        or destination_binding.ownership != source_receipt.ownership
+    ):
+        raise RuntimeError(
+            "strict BM25 source receipt differs from its destination binding"
+        )
     config_digest, forbidden, authenticated_files = _policy(
         repository_identity,
         view_config,
@@ -1191,7 +1200,7 @@ def _publish_planned_bm25_view_with_identity(
         purpose="portable-bm25-normalization",
         destination=lexical_destination,
         plan=planned.plan,
-        destination_expectation="provider-bound-exact",
+        destination_binding=destination_binding,
     )
 
     def operation(session: StrictWorkspaceSession) -> None:
@@ -1423,7 +1432,7 @@ def _publish_recaptured_bm25_view_with_identity(
         purpose="portable-bm25-recapture",
         destination=lexical_destination,
         plan=planned.plan,
-        destination_expectation="missing",
+        destination_binding=None,
     )
 
     def operation(session: StrictWorkspaceSession) -> None:

--- a/codenib/artifacts/strict_context.py
+++ b/codenib/artifacts/strict_context.py
@@ -1003,7 +1003,7 @@ def _publish_frozen(
         purpose="portable-context-generation",
         destination=lexical_destination,
         plan=planned.plan,
-        destination_expectation="missing",
+        destination_binding=None,
     )
 
     owners = dict(inputs.view_generations)

--- a/codenib/artifacts/strict_vector.py
+++ b/codenib/artifacts/strict_vector.py
@@ -1526,7 +1526,7 @@ def _publish_recaptured_vector_view_with_identity(
         purpose="portable-vector-recapture",
         destination=lexical_destination,
         plan=planned.plan,
-        destination_expectation="missing",
+        destination_binding=None,
     )
 
     def operation(session: StrictWorkspaceSession) -> None:

--- a/codenib/compiler/manifest_materialization.py
+++ b/codenib/compiler/manifest_materialization.py
@@ -1611,7 +1611,7 @@ def _publish_plan(
         purpose="retained-context-materialization",
         destination=destination,
         plan=planned.workspace,
-        destination_expectation="missing",
+        destination_binding=None,
     )
 
     def operation(session: StrictWorkspaceSession) -> None:

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -33,10 +33,22 @@ trusted internal code remains owner-owned and must never be closed by the
 borrower.
 
 This primitive does not change `LocalWorkspaceProvider`: the provider remains
-missing-only and still rejects the strict BM25 producer's
-`provider-bound-exact` destination mode. Provider integration is a separate
-Gate C change, so Gate C and M1 remain open even though the protocol-v5
-primitive is available.
+missing-only. The strict request seam now represents a missing destination only
+as `destination_binding=None`; an existing destination requires an immutable
+`PublishedWorkspaceDestinationBinding` projected by an active
+`PublishedWorkspaceReceiptOwner`. That binding freezes the lexical destination,
+the receipt's parent identity, and its full `_TreeOwnership`. Request
+construction requires the binding path to equal the normalized destination,
+generic authority adoption verifies the same parent and complete live tree, and
+the callback session compares the complete adopted binding with the request.
+The `destination_expectation` label remains only a derived diagnostic property,
+so a string or raw ownership token cannot select replacement. Strict BM25 now
+derives this binding from `source_generation` and cross-checks the borrowed
+receipt. The standard shared and provider-specific support probes still run
+first; `LocalWorkspaceProvider` then rejects every non-`None` binding before
+provisioning or namespace mutation. Provider integration is a separate Gate C
+change, so Gate C and M1 remain open even though the protocol-v5 primitive and
+request-authentication seam are available.
 
 ## Publish a normal index build
 
@@ -506,10 +518,11 @@ default requires its own A2 decision and does not satisfy that full
 compatibility gate. The independent gate C
 `provider-bound-exact` native provider is still required before M1 closes.
 Protocol v4 supplies a primitive-only exact exchange; it does not wire that
-primitive into `LocalWorkspaceProvider` or authorize the strict BM25 route to
-use it. This harness does not add M2 generic generation publication or fenced
-jobs, M3 hot switching or request pins, or M5 retention and garbage
-collection.
+primitive into `LocalWorkspaceProvider`. The strict BM25 route now carries its
+receipt-derived destination binding to the provider boundary, but the local
+provider still rejects that binding and cannot execute the exchange. This
+harness does not add M2 generic generation publication or fenced jobs, M3 hot
+switching or request pins, or M5 retention and garbage collection.
 
 ## Lifecycle
 
@@ -731,4 +744,5 @@ descriptors remain owned by the aggregate and are valid only for its lifetime;
 borrowers must never close them. The primitive remains an authority boundary
 for trusted internal code, not a Python sandbox or full `_TreeOwnership`.
 `LocalWorkspaceProvider` does not yet integrate it, continues to reject
-`provider-bound-exact`, and therefore does not close Gate C or M1.
+the non-`None` binding whose derived expectation is `provider-bound-exact`, and
+therefore does not close Gate C or M1.

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -434,10 +434,18 @@ later quiescent reclamation instead of recursively deleting an online path.
 This is still a local compatibility publication path, not a catalog receipt.
 `StrictWorkspaceProvider` builds on the foundation with a callback-scoped
 contract for a trusted provider to supply a pre-opened
-`OwnedWorkspaceAuthority`, exact workspace plan, destination expectation, and
-retained publication receipt owner. Session writes, validation, publication,
-and revocation share one cancellation-safe gate so a provider callback cannot
-publish after it escapes. The gate records the exact callback result or
+`OwnedWorkspaceAuthority`, exact workspace plan, receipt-derived destination
+binding (or `None` for a missing destination), and retained publication receipt
+owner. `PublishedWorkspaceDestinationBinding` is private-construction and
+immutable: an active receipt owner projects the lexical destination, parent
+identity, and full `_TreeOwnership` as one unit. Request construction rejects a
+different path or any non-exact binding type; generic adoption authenticates
+the bound parent and complete live destination tree; and the callback session
+requires full binding equality. The categorical destination expectation is now
+derived only, so neither a string nor a raw ownership token can authorize
+replacement. Session writes, validation, publication, and revocation share one
+cancellation-safe gate so a provider callback cannot publish after it escapes.
+The gate records the exact callback result or
 `BaseException`; a provider cannot substitute its return value or swallow a
 callback failure. The strict BM25 producer now captures one detached,
 authenticated repository identity, plans canonical document and metadata bytes
@@ -450,10 +458,11 @@ profile or durable job payload. Strict whole-context and retained
 materialization APIs are now available as injectable library producers. The
 Linux local provider deliberately accepts only missing destinations, so
 whole-context retained materialization can use it explicitly, while strict BM25
-replacement requests `provider-bound-exact` and still lacks a concrete
-production provider. Protocol v4 now supplies the lower-level exact exchange
-primitive, but `LocalWorkspaceProvider` still rejects the request and does not
-select that primitive. Provider integration remains separate Gate C work. The
+replacement now sends the active source generation's exact destination binding
+and still lacks a concrete production provider. Protocol v4 now supplies the
+lower-level exact exchange primitive, but `LocalWorkspaceProvider` rejects the
+non-`None` binding before mutation and does not select that primitive. Provider
+integration remains separate Gate C work. The
 explicit retained workflows can now construct the whole-context producer for one
 existing catalog selection, publish normal compiler output, and load one
 selected generation at MCP cold start, but no default compiler/runtime route
@@ -807,8 +816,9 @@ of the explicit compiler and runtime routes remains outstanding M1 work; graph
 and Zoekt cache ingress and fenced job publication remain M2 or later work.
 Strict BM25 replacement also still lacks the `provider-bound-exact` production
 provider. Protocol v4 implements the primitive-only exact exchange, but
-`LocalWorkspaceProvider` continues to reject that expectation and no strict
-producer is wired to the new operation. Provider integration remains separate.
+`LocalWorkspaceProvider` continues to reject the receipt-derived binding. The
+strict producer is now wired to the authenticated request seam, but no provider
+selects the new operation. Provider integration remains separate.
 
 #### Retained storage promotion protocol
 
@@ -825,7 +835,7 @@ that collecting a fast result cannot silently approve a production route:
 | B1 | Promote BM25 compiler publication to a configured default. | Pending A2 compiler. |
 | B2 | Promote query-only BM25 retained cold start to a configured default. | Pending A2 query-only runtime; this does not replace source-bound manifest MCP. |
 | B2 source-bound | Promote a specifically scoped source-bound BM25 retained cold start. | Pending A2 source-bound BM25 runtime; it cannot satisfy the full manifest-compatibility gate. |
-| C | Supply the `provider-bound-exact` strict BM25 native provider. | Protocol v4 introduced the Linux-only, same-parent `RENAME_EXCHANGE` primitive; protocol v5 moves a parent-wide cross-process flock before candidate mutation and retains receipt settlement and bounded same-process rollback. `LocalWorkspaceProvider` still rejects this expectation and no strict producer selects the primitive. Gate C remains pending and required before M1 closes. |
+| C | Supply the `provider-bound-exact` strict BM25 native provider. | Protocol v4 introduced the Linux-only, same-parent `RENAME_EXCHANGE` primitive; protocol v5 moves a parent-wide cross-process flock before candidate mutation and retains receipt settlement and bounded same-process rollback. The request-authentication half is implemented: strict BM25 sends a private-construction binding projected by its active source receipt owner, and generic adoption verifies its lexical destination, parent identity, and full tree ownership. `LocalWorkspaceProvider` still rejects every exact binding and does not select the primitive, so Gate C remains pending and required before M1 closes. |
 
 The A1 harness fixes the BM25 `fast` compiler/runtime comparison rather than
 accepting arbitrary route substitutions. For compiler cold start, arm A runs

--- a/test/artifacts/test_strict_bm25_publication.py
+++ b/test/artifacts/test_strict_bm25_publication.py
@@ -81,11 +81,9 @@ class _TestWorkspaceProvider:
     def __init__(
         self,
         *,
-        expected_destination: object | None,
         workspace_plan: WorkspacePlan | None = None,
         support_hook: Callable[[], None] | None = None,
     ) -> None:
-        self.expected_destination = expected_destination
         self.workspace_plan = workspace_plan
         self.support_hook = support_hook
         self.support_count = 0
@@ -136,7 +134,7 @@ class _TestWorkspaceProvider:
                 root_descriptor=root_descriptor,
                 directory_descriptors=directory_descriptors,
                 plan=plan,
-                expected_destination=self.expected_destination,
+                destination_binding=request.destination_binding,
             )
             try:
                 return run_adopted_workspace_operation(
@@ -206,7 +204,7 @@ def _publish_source(
         plan=plan,
     )
     owner = PublishedWorkspaceReceiptOwner()
-    provider = _TestWorkspaceProvider(expected_destination=None)
+    provider = _TestWorkspaceProvider()
 
     def publish(session: StrictWorkspaceSession) -> None:
         written = session.write_file("documents.json", (documents,))
@@ -305,9 +303,7 @@ def test_strict_bm25_plans_replays_and_serves_same_query_semantics(
         (fixture.destination / "bm25_metadata.json").read_text(encoding="utf-8")
     )
     output_owner = PublishedWorkspaceReceiptOwner()
-    provider = _TestWorkspaceProvider(
-        expected_destination=fixture.source_owner.receipt.ownership,
-    )
+    provider = _TestWorkspaceProvider()
     try:
         adjustments = publish_planned_bm25_view_strict(
             fixture.destination,
@@ -322,6 +318,10 @@ def test_strict_bm25_plans_replays_and_serves_same_query_semantics(
         assert provider.run_count == 1
         assert provider.support_count == 1
         assert provider.requests[0].destination_expectation == "provider-bound-exact"
+        assert (
+            provider.requests[0].destination_binding
+            is fixture.source_owner.destination_binding
+        )
         assert output_owner.active
         assert fixture.source_owner.active
         assert output_owner.receipt.plan == planned.plan
@@ -357,6 +357,57 @@ def test_strict_bm25_plans_replays_and_serves_same_query_semantics(
             doc.page_content for doc in after.retriever.invoke("VALUE")
         ]
     finally:
+        output_owner.close()
+
+
+def test_strict_bm25_rejects_source_receipt_projection_binding_mismatch(
+    strict_generation,
+) -> None:
+    fixture = strict_generation
+    planned = plan_bm25_view_strict(
+        fixture.source_owner,
+        repository_source=fixture.repository_source,
+        view_config={},
+        environ={},
+    )
+    original_documents = (fixture.destination / "documents.json").read_bytes()
+    original_metadata = (fixture.destination / "bm25_metadata.json").read_bytes()
+    source_receipt = fixture.source_owner.receipt
+    original_parent_identity = source_receipt.parent_identity
+    object.__setattr__(source_receipt, "parent_identity", (0, 0))
+    provider = _TestWorkspaceProvider()
+    output_owner = PublishedWorkspaceReceiptOwner()
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match="source receipt differs from its destination binding",
+        ):
+            publish_planned_bm25_view_strict(
+                fixture.destination,
+                planned=planned,
+                source_generation=fixture.source_owner,
+                repository_source=fixture.repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_config={},
+                environ={},
+            )
+        assert provider.support_count == 0
+        assert provider.run_count == 0
+        assert output_owner.state == "empty"
+        assert fixture.source_owner.active
+        assert (
+            fixture.destination / "documents.json"
+        ).read_bytes() == original_documents
+        assert (
+            fixture.destination / "bm25_metadata.json"
+        ).read_bytes() == original_metadata
+    finally:
+        object.__setattr__(
+            source_receipt,
+            "parent_identity",
+            original_parent_identity,
+        )
         output_owner.close()
 
 
@@ -409,7 +460,7 @@ def test_strict_bm25_recaptures_raw_directory_with_missing_test_provider(
     source_documents, source_metadata = _write_raw_bm25_source(source, repository)
     repository_source = capture_repository_source(repository)
     output_owner = PublishedWorkspaceReceiptOwner()
-    provider = _TestWorkspaceProvider(expected_destination=None)
+    provider = _TestWorkspaceProvider()
     view_config = {"builder_schema": 2, "tokenizer": "code-aware-v1"}
     try:
         planned = strict_bm25_module._plan_recaptured_bm25_view(
@@ -454,6 +505,7 @@ def test_strict_bm25_recaptures_raw_directory_with_missing_test_provider(
         assert provider.support_count == 1
         assert provider.run_count == 1
         assert provider.requests[0].destination_expectation == "missing"
+        assert provider.requests[0].destination_binding is None
         assert provider.requests[0].plan == planned.plan
         assert output_owner.active
         assert output_owner.receipt.path == destination
@@ -542,7 +594,7 @@ def test_strict_bm25_recapture_accepts_excluded_source_inside_repository(
     )
     destination = tmp_path / "strict-output" / "bm25"
     output_owner = PublishedWorkspaceReceiptOwner()
-    provider = _TestWorkspaceProvider(expected_destination=None)
+    provider = _TestWorkspaceProvider()
     try:
         identity = repository_source.authenticated_identity_snapshot()
         assert not any(
@@ -616,7 +668,7 @@ def test_strict_bm25_recapture_rejects_destination_preflight_without_mutation(
         destination = repository / "strict-output"
         marker = None
     output_owner = PublishedWorkspaceReceiptOwner()
-    provider = _TestWorkspaceProvider(expected_destination=None)
+    provider = _TestWorkspaceProvider()
 
     def forbidden_capture(*_args, **_kwargs):
         raise AssertionError("source capture ran after invalid destination preflight")
@@ -666,7 +718,7 @@ def test_strict_bm25_recapture_rejects_source_drift_before_provider(
     )
     (source / "documents.json").write_bytes(_canonical_bytes([]))
     output_owner = PublishedWorkspaceReceiptOwner()
-    provider = _TestWorkspaceProvider(expected_destination=None)
+    provider = _TestWorkspaceProvider()
     try:
         with pytest.raises(ValueError, match="another source generation"):
             strict_bm25_module._publish_recaptured_bm25_view(
@@ -712,7 +764,7 @@ def test_strict_bm25_recapture_rejects_plan_tamper_before_source_reopen(
         ),
     )
     output_owner = PublishedWorkspaceReceiptOwner()
-    provider = _TestWorkspaceProvider(expected_destination=None)
+    provider = _TestWorkspaceProvider()
 
     def forbidden_capture(*_args, **_kwargs):
         raise AssertionError("source was recaptured before plan validation")
@@ -763,7 +815,6 @@ def test_strict_bm25_recapture_detects_tamper_at_reopen_and_rolls_back(
 
     output_owner = PublishedWorkspaceReceiptOwner()
     provider = _TestWorkspaceProvider(
-        expected_destination=None,
         support_hook=tamper_before_workspace,
     )
     try:
@@ -798,7 +849,7 @@ def test_strict_bm25_recapture_rejects_forbidden_policy_postflight(
     forbidden = tmp_path / "private-build-root"
     repository_source = capture_repository_source(repository)
     output_owner = PublishedWorkspaceReceiptOwner()
-    provider = _TestWorkspaceProvider(expected_destination=None)
+    provider = _TestWorkspaceProvider()
     candidate_calls = 0
     real_candidate_records = strict_bm25_module._candidate_records
 
@@ -887,9 +938,7 @@ def test_strict_bm25_high_level_freezes_caller_mappings_once(
     config = _ReadOnceMapping({"builder_schema": 2})
     environment = _ReadOnceMapping({"SAFE_VALUE": "public"})
     output_owner = PublishedWorkspaceReceiptOwner()
-    provider = _TestWorkspaceProvider(
-        expected_destination=fixture.source_owner.receipt.ownership,
-    )
+    provider = _TestWorkspaceProvider()
     try:
         normalize_owned_query_view_strict(
             fixture.destination,
@@ -953,9 +1002,7 @@ def test_strict_bm25_high_level_uses_one_detached_source_identity(
     )
     monkeypatch.setattr(strict_bm25_module, "_policy", mutate_public_projection)
     output_owner = PublishedWorkspaceReceiptOwner()
-    provider = _TestWorkspaceProvider(
-        expected_destination=fixture.source_owner.receipt.ownership,
-    )
+    provider = _TestWorkspaceProvider()
     try:
         normalize_owned_query_view_strict(
             fixture.destination,
@@ -1024,7 +1071,6 @@ def test_strict_bm25_invokes_provider_support_once_after_freezing_inputs(
         environ["CODENIB_STRICT_TEST"] = "mutated"
 
     provider = _TestWorkspaceProvider(
-        expected_destination=fixture.source_owner.receipt.ownership,
         support_hook=mutate_caller_inputs,
     )
     try:
@@ -1176,9 +1222,7 @@ def test_strict_bm25_rejects_physical_repository_alias_before_source_consume(
     alias.symlink_to(repository, target_is_directory=True)
     repository_source = capture_repository_source(repository)
     output_owner = PublishedWorkspaceReceiptOwner()
-    provider = _TestWorkspaceProvider(
-        expected_destination=source_owner.receipt.ownership,
-    )
+    provider = _TestWorkspaceProvider()
     retained_destination = retained / "state" / "bm25"
     original_documents = (retained_destination / "documents.json").read_bytes()
     original_metadata = (retained_destination / "bm25_metadata.json").read_bytes()
@@ -1226,9 +1270,7 @@ def test_strict_bm25_rejects_repository_overlap_before_source_consume(
     destination, source_owner = _publish_source(repository, repository)
     repository_source = capture_repository_source(repository)
     output_owner = PublishedWorkspaceReceiptOwner()
-    provider = _TestWorkspaceProvider(
-        expected_destination=source_owner.receipt.ownership,
-    )
+    provider = _TestWorkspaceProvider()
     original_documents = (destination / "documents.json").read_bytes()
     original_metadata = (destination / "bm25_metadata.json").read_bytes()
     consume_calls = 0
@@ -1282,9 +1324,7 @@ def test_strict_bm25_rejects_wrong_destination_before_source_consume(
 ) -> None:
     fixture = strict_generation
     output_owner = PublishedWorkspaceReceiptOwner()
-    provider = _TestWorkspaceProvider(
-        expected_destination=fixture.source_owner.receipt.ownership,
-    )
+    provider = _TestWorkspaceProvider()
     consume_calls = 0
     real_consume = PublishedWorkspaceReceiptOwner.consume
 
@@ -1444,9 +1484,7 @@ def test_strict_bm25_rejects_tampered_plan_before_provider(
         ),
     )
     output_owner = PublishedWorkspaceReceiptOwner()
-    provider = _TestWorkspaceProvider(
-        expected_destination=fixture.source_owner.receipt.ownership,
-    )
+    provider = _TestWorkspaceProvider()
 
     class ForgedPlan(PlannedBm25View):
         pass
@@ -1534,9 +1572,7 @@ def test_strict_bm25_detects_source_drift_between_plan_and_replay(
     )
     (fixture.destination / "documents.json").write_bytes(_canonical_bytes([]))
     output_owner = PublishedWorkspaceReceiptOwner()
-    provider = _TestWorkspaceProvider(
-        expected_destination=fixture.source_owner.receipt.ownership,
-    )
+    provider = _TestWorkspaceProvider()
     try:
         with pytest.raises(RuntimeError, match="changed|differs"):
             publish_planned_bm25_view_strict(
@@ -1568,9 +1604,7 @@ def test_strict_bm25_rolls_back_when_repository_changes_during_publication(
     original_documents = (fixture.destination / "documents.json").read_bytes()
     original_metadata = (fixture.destination / "bm25_metadata.json").read_bytes()
     output_owner = PublishedWorkspaceReceiptOwner()
-    provider = _TestWorkspaceProvider(
-        expected_destination=fixture.source_owner.receipt.ownership,
-    )
+    provider = _TestWorkspaceProvider()
     candidate_calls = 0
     real_candidate_records = strict_bm25_module._candidate_records
 
@@ -1618,7 +1652,7 @@ def test_strict_bm25_rolls_back_when_repository_changes_during_publication(
         output_owner.close()
 
 
-def test_strict_bm25_rejects_provider_plan_and_expectation_mismatch(
+def test_strict_bm25_rejects_provider_plan_mismatch(
     strict_generation,
 ) -> None:
     fixture = strict_generation
@@ -1632,34 +1666,26 @@ def test_strict_bm25_rejects_provider_plan_and_expectation_mismatch(
         subject_digest=hashlib.sha256(b"wrong-workspace-plan").hexdigest(),
         files=planned.plan.files,
     )
-    providers = (
-        _TestWorkspaceProvider(
-            expected_destination=fixture.source_owner.receipt.ownership,
-            workspace_plan=wrong_plan,
-        ),
-        _TestWorkspaceProvider(expected_destination=None),
+    provider = _TestWorkspaceProvider(
+        workspace_plan=wrong_plan,
     )
-    for provider in providers:
-        output_owner = PublishedWorkspaceReceiptOwner()
-        try:
-            with pytest.raises(
-                (RuntimeError, ValueError),
-                match="plan|expectation|expected missing",
-            ):
-                publish_planned_bm25_view_strict(
-                    fixture.destination,
-                    planned=planned,
-                    source_generation=fixture.source_owner,
-                    repository_source=fixture.repository_source,
-                    workspace_provider=provider,
-                    output_receipt_owner=output_owner,
-                    view_config={},
-                    environ={},
-                )
-            assert provider.run_count == 1
-            assert output_owner.state == "empty"
-        finally:
-            output_owner.close()
+    output_owner = PublishedWorkspaceReceiptOwner()
+    try:
+        with pytest.raises((RuntimeError, ValueError), match="plan"):
+            publish_planned_bm25_view_strict(
+                fixture.destination,
+                planned=planned,
+                source_generation=fixture.source_owner,
+                repository_source=fixture.repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_config={},
+                environ={},
+            )
+        assert provider.run_count == 1
+        assert output_owner.state == "empty"
+    finally:
+        output_owner.close()
 
 
 def test_strict_bm25_validates_staged_and_published_generations(
@@ -1674,9 +1700,7 @@ def test_strict_bm25_validates_staged_and_published_generations(
         environ={},
     )
     output_owner = PublishedWorkspaceReceiptOwner()
-    provider = _TestWorkspaceProvider(
-        expected_destination=fixture.source_owner.receipt.ownership,
-    )
+    provider = _TestWorkspaceProvider()
     calls = 0
     real_candidate_records = strict_bm25_module._candidate_records
 
@@ -1741,9 +1765,7 @@ def test_strict_bm25_never_falls_back_for_vector(
 ) -> None:
     fixture = strict_generation
     output_owner = PublishedWorkspaceReceiptOwner()
-    provider = _TestWorkspaceProvider(
-        expected_destination=fixture.source_owner.receipt.ownership,
-    )
+    provider = _TestWorkspaceProvider()
     try:
         with pytest.raises(ValueError, match="only bm25"):
             normalize_owned_query_view_strict(

--- a/test/artifacts/test_strict_context_publication.py
+++ b/test/artifacts/test_strict_context_publication.py
@@ -206,7 +206,7 @@ class _TestWorkspaceProvider:
                 root_descriptor=root_descriptor,
                 directory_descriptors=directory_descriptors,
                 plan=plan,
-                expected_destination=None,
+                destination_binding=None,
             )
             try:
                 return run_adopted_workspace_operation(

--- a/test/artifacts/test_strict_vector_publication.py
+++ b/test/artifacts/test_strict_vector_publication.py
@@ -41,9 +41,7 @@ from codenib.index.embedding.artifact_integrity import (
     vector_config_artifact_record,
 )
 from codenib.index.embedding.vector_store import CodeVectorStore
-from codenib.native_index_authorization import (
-    _mint_trusted_local_admin_authorization,
-)
+from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.source_fingerprint import capture_repository_source
 
@@ -118,7 +116,7 @@ class _TestWorkspaceProvider:
                 root_descriptor=root_descriptor,
                 directory_descriptors=directory_descriptors,
                 plan=request.plan,
-                expected_destination=None,
+                destination_binding=None,
             )
             try:
                 return run_adopted_workspace_operation(

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -211,7 +211,7 @@ class _TestWorkspaceProvider:
                 root_descriptor=root_descriptor,
                 directory_descriptors=directory_descriptors,
                 plan=plan,
-                expected_destination=None,
+                destination_binding=None,
             )
             try:
                 return run_adopted_workspace_operation(

--- a/test/compiler/test_manifest_import.py
+++ b/test/compiler/test_manifest_import.py
@@ -153,7 +153,7 @@ class _TestWorkspaceProvider:
                 root_descriptor=root_descriptor,
                 directory_descriptors=directory_descriptors,
                 plan=plan,
-                expected_destination=None,
+                destination_binding=None,
             )
             try:
                 return run_adopted_workspace_operation(

--- a/test/test_captured_directory.py
+++ b/test/test_captured_directory.py
@@ -21,14 +21,17 @@ import codenib._atomic_directory as atomic_directory
 import codenib._captured_directory as captured_directory
 import codenib._windows_fs_authority as windows_authority
 from codenib._atomic_directory import (
+    _TreeOwnership,
     capture_directory_ownership,
     directory_ownership_file_records,
+    publication_parent_identity,
 )
 from codenib._captured_directory import (
     AuthenticatedSnapshotReader,
     CapturedDirectoryReader,
     OwnedDirectoryStage,
     OwnedWorkspaceAuthority,
+    PublishedWorkspaceDestinationBinding,
     PublishedWorkspaceReceipt,
     PublishedWorkspaceReceiptOwner,
     UnsupportedWorkspaceCreation,
@@ -72,6 +75,53 @@ def _preopened_workspace(
             os.close(descriptor)
         os.close(root_descriptor)
         os.close(parent_descriptor)
+
+
+def _publish_payload_generation(
+    parent: Path,
+    *,
+    destination_name: str = "published",
+    stage_name: str = ".source-stage",
+    payload: bytes = b"same bytes",
+) -> tuple[Path, WorkspacePlan, PublishedWorkspaceReceiptOwner]:
+    """Publish one real generation and retain its caller-owned receipt."""
+
+    parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    destination = parent / destination_name
+    stage = parent / stage_name
+    stage.mkdir(mode=0o700)
+    plan = WorkspacePlan(
+        subject_digest="f" * 64,
+        files=(WorkspaceFile("payload", max_bytes=len(payload)),),
+    )
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_descriptor = os.open(parent, flags)
+    root_descriptor = os.open(stage, flags)
+    workspace = OwnedWorkspaceAuthority()
+    owner = PublishedWorkspaceReceiptOwner()
+    try:
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_descriptor,
+            root_descriptor=root_descriptor,
+            directory_descriptors={},
+            plan=plan,
+            destination_binding=None,
+        )
+        workspace.write_file("payload", (payload,))
+        workspace.seal()
+        workspace.publish_into(owner)
+    except BaseException:
+        if owner.state == "empty":
+            workspace.close()
+        owner.close()
+        raise
+    finally:
+        os.close(root_descriptor)
+        os.close(parent_descriptor)
+    return destination, plan, owner
 
 
 def _as_windows_ownership(ownership: object) -> object:
@@ -1176,7 +1226,7 @@ def test_workspace_plan_and_publication_preserve_raw_filesystem_paths(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.write_file(raw_name, [b"raw"])
         workspace.seal()
@@ -1361,10 +1411,10 @@ def test_preopened_workspace_writes_only_planned_files_without_mkdir(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         assert workspace.destination == destination
-        assert workspace.expected_destination_ownership is None
+        assert workspace.expected_destination_binding is None
         root_record = workspace.write_file("root.bin", [b"root"])
         nested_record = workspace.write_file("nested/payload.bin", [b"payload"])
         ownership = workspace.seal()
@@ -1419,7 +1469,7 @@ def test_preopened_workspace_rejects_root_name_replacement(
                 root_descriptor=root_fd,
                 directory_descriptors=directories,
                 plan=plan,
-                expected_destination=None,
+                destination_binding=None,
             )
 
         assert not (stage / "payload").exists()
@@ -1450,7 +1500,7 @@ def test_preopened_workspace_rejects_nested_handle_replacement(
                 root_descriptor=root_fd,
                 directory_descriptors=directories,
                 plan=plan,
-                expected_destination=None,
+                destination_binding=None,
             )
 
         assert not (nested / "payload").exists()
@@ -1476,7 +1526,7 @@ def test_preopened_workspace_rejects_any_unplanned_skeleton_file(
                 root_descriptor=root_fd,
                 directory_descriptors=directories,
                 plan=plan,
-                expected_destination=None,
+                destination_binding=None,
             )
 
         assert (stage / "foreign").read_bytes() == b"preserve"
@@ -1502,7 +1552,7 @@ def test_preopened_workspace_rejects_existing_destination_when_missing_expected(
                 root_descriptor=root_fd,
                 directory_descriptors=directories,
                 plan=plan,
-                expected_destination=None,
+                destination_binding=None,
             )
 
 
@@ -1523,7 +1573,7 @@ def test_preopened_workspace_noreplace_refuses_foreign_planned_leaf(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         (stage / "payload").write_bytes(b"evil")
 
@@ -1579,7 +1629,7 @@ def test_preopened_workspace_rejects_darwin_before_state_or_resource_acquisition
                     root_descriptor=root_fd,
                     directory_descriptors=directories,
                     plan=plan,
-                    expected_destination=None,
+                    destination_binding=None,
                 )
 
         assert workspace.state == "empty"
@@ -1611,7 +1661,7 @@ def test_preopened_workspace_seal_rejects_external_hardlink(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.write_file("payload", [b"safe"])
         os.link(stage / "payload", tmp_path / "external-alias")
@@ -1637,7 +1687,7 @@ def test_preopened_workspace_seal_is_idempotently_recoverable(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.write_file("payload", [b"safe"])
 
@@ -1665,7 +1715,7 @@ def test_preopened_workspace_seal_return_interruption_keeps_token_recoverable(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.write_file("payload", [b"safe"])
 
@@ -1708,7 +1758,7 @@ def test_preopened_workspace_rejects_producer_reentrant_close(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
 
         def chunks() -> Iterator[bytes]:
@@ -1740,7 +1790,7 @@ def test_preopened_workspace_retains_file_owner_after_persistent_close_eio(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         real_close = os.close
         retained: set[int] = set()
@@ -1785,7 +1835,7 @@ def test_preopened_workspace_close_reconciliation_preserves_first_error(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         real_close = os.close
         armed = [False]
@@ -1854,7 +1904,7 @@ def test_preopened_workspace_iterator_close_lookup_preserves_primary_and_fds(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         with pytest.raises(RuntimeError, match="producer primary") as caught:
             workspace.write_file("payload", RaisingCloseLookup())
@@ -1891,7 +1941,7 @@ def test_preopened_workspace_record_install_interruption_terminally_fails(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace._written_files = InterruptingRecords()
 
@@ -1922,7 +1972,7 @@ def test_preopened_workspace_record_construction_interruption_terminally_fails(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
 
         def interrupt_record(*_args, **_kwargs):
@@ -1956,7 +2006,7 @@ def test_owned_workspace_child_closes_inherited_resources_without_parent_effect(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         authority = workspace._parent_owner.authority
         assert authority is not None
@@ -2076,7 +2126,7 @@ def test_owned_workspace_adopt_skeleton_validation_is_linear(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
 
         assert count <= calls < count * 20
@@ -2104,7 +2154,7 @@ def test_owned_workspace_seal_flushes_directories_bottom_up(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         descriptor_paths = {
             descriptor: path
@@ -2144,7 +2194,7 @@ def test_owned_workspace_publish_installs_fresh_durable_receipt(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.write_file("payload", [b"durable"])
         sealed = workspace.seal()
@@ -2174,6 +2224,206 @@ def test_owned_workspace_publish_installs_fresh_durable_receipt(
         assert receipt.closed
 
 
+def test_published_destination_binding_is_private_and_active_owner_derived(
+    tmp_path: Path,
+) -> None:
+    empty_owner = PublishedWorkspaceReceiptOwner()
+    with pytest.raises(RuntimeError, match="empty, expected active"):
+        _ = empty_owner.destination_binding
+    empty_owner.close()
+    with pytest.raises(RuntimeError, match="closed, expected active"):
+        _ = empty_owner.destination_binding
+
+    destination, _plan, owner = _publish_payload_generation(tmp_path / "binding-parent")
+    try:
+        binding = owner.destination_binding
+        receipt = owner.receipt
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        flags |= getattr(os, "O_CLOEXEC", 0)
+        parent_descriptor = os.open(destination.parent, flags)
+        try:
+            assert type(binding) is PublishedWorkspaceDestinationBinding
+            assert binding.destination == destination
+            assert binding.parent_identity == publication_parent_identity(
+                parent_descriptor
+            )
+        finally:
+            os.close(parent_descriptor)
+        assert type(binding.ownership) is _TreeOwnership
+        assert binding.ownership == capture_directory_ownership(destination)
+        assert binding is owner.destination_binding
+        assert (
+            owner.consume(lambda _receipt, _reader: owner.destination_binding)
+            is binding
+        )
+
+        with pytest.raises(TypeError, match="minted by an active receipt owner"):
+            PublishedWorkspaceDestinationBinding(
+                destination=destination,
+                parent_identity=binding.parent_identity,
+                ownership=binding.ownership,
+            )
+        with pytest.raises(AttributeError):
+            binding.destination = tmp_path / "forged"  # type: ignore[misc]
+
+        original_path = receipt.path
+        original_parent = receipt.parent_identity
+        original_ownership = receipt.ownership
+        object.__setattr__(receipt, "path", tmp_path / "wrong-receipt-path")
+        object.__setattr__(receipt, "parent_identity", (0, 0))
+        object.__setattr__(
+            receipt,
+            "ownership",
+            capture_directory_ownership(destination.parent, allow_empty_root=True),
+        )
+        try:
+            assert owner.destination_binding is binding
+            assert binding.destination == destination
+            assert binding.parent_identity != receipt.parent_identity
+            assert binding.ownership != receipt.ownership
+        finally:
+            object.__setattr__(receipt, "path", original_path)
+            object.__setattr__(receipt, "parent_identity", original_parent)
+            object.__setattr__(receipt, "ownership", original_ownership)
+    finally:
+        owner.close()
+
+    with pytest.raises(RuntimeError, match="closed, expected active"):
+        _ = owner.destination_binding
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_published_destination_binding_cannot_cross_pid_boundary(
+    tmp_path: Path,
+) -> None:
+    _destination, _plan, owner = _publish_payload_generation(
+        tmp_path / "binding-parent"
+    )
+    child = os.fork()
+    if child == 0:  # pragma: no branch - exact child result via exit
+        try:
+            _ = owner.destination_binding
+        except RuntimeError as error:
+            os._exit(0 if "PID boundary" in str(error) else 81)
+        except BaseException:  # noqa: B036 - child reports exact failure
+            os._exit(82)
+        os._exit(83)
+
+    _pid, status = os.waitpid(child, 0)
+    assert os.WIFEXITED(status)
+    assert os.WEXITSTATUS(status) == 0
+    assert owner.active
+    owner.close()
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error_type", "message"),
+    [
+        ("wrong-path", ValueError, "binding differs from its destination"),
+        ("wrong-parent", RuntimeError, "parent differs from its binding"),
+        ("wrong-tree", RuntimeError, "destination changed"),
+        ("same-bytes-new-inode", RuntimeError, "destination changed"),
+        ("raw-tree-token", TypeError, "destination binding is invalid"),
+    ],
+)
+def test_owned_workspace_rejects_inauthentic_destination_binding(
+    tmp_path: Path,
+    mutation: str,
+    error_type: type[Exception],
+    message: str,
+) -> None:
+    payload = b"same bytes"
+    parent = tmp_path / "binding-parent"
+    destination, plan, owner = _publish_payload_generation(
+        parent,
+        payload=payload,
+    )
+    binding: object = owner.destination_binding
+    adopted_destination = destination
+
+    if mutation == "wrong-path":
+        adopted_destination = parent / "wrong-destination"
+    elif mutation == "wrong-parent":
+        parked_parent = tmp_path / "original-binding-parent"
+        parent.rename(parked_parent)
+        parent.mkdir(mode=0o700)
+        destination.mkdir(mode=0o700)
+        (destination / "payload").write_bytes(payload)
+    elif mutation == "wrong-tree":
+        (destination / "payload").write_bytes(b"wrong tree")
+    elif mutation == "same-bytes-new-inode":
+        original_inode = os.stat(destination, follow_symlinks=False).st_ino
+        destination.rename(parent / "original-generation")
+        destination.mkdir(mode=0o700)
+        (destination / "payload").write_bytes(payload)
+        assert os.stat(destination, follow_symlinks=False).st_ino != original_inode
+    else:
+        assert mutation == "raw-tree-token"
+        binding = capture_directory_ownership(destination)
+
+    stage = adopted_destination.parent / ".replacement-stage"
+    stage.mkdir(mode=plan.root_mode)
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_descriptor = os.open(adopted_destination.parent, flags)
+    root_descriptor = os.open(stage, flags)
+    workspace = OwnedWorkspaceAuthority()
+    try:
+        with pytest.raises(error_type, match=message):
+            workspace.adopt(
+                destination=adopted_destination,
+                stage_name=stage.name,
+                parent_descriptor=parent_descriptor,
+                root_descriptor=root_descriptor,
+                directory_descriptors={},
+                plan=plan,
+                destination_binding=binding,  # type: ignore[arg-type]
+            )
+    finally:
+        workspace.close()
+        os.close(root_descriptor)
+        os.close(parent_descriptor)
+        owner.close()
+
+
+def test_owned_workspace_rejects_binding_from_wrong_active_receipt(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "binding-parent"
+    destination, plan, owner = _publish_payload_generation(parent)
+    _other, _other_plan, wrong_owner = _publish_payload_generation(
+        parent,
+        destination_name="other-published",
+        stage_name=".other-source-stage",
+    )
+    stage = parent / ".replacement-stage"
+    stage.mkdir(mode=plan.root_mode)
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_descriptor = os.open(parent, flags)
+    root_descriptor = os.open(stage, flags)
+    workspace = OwnedWorkspaceAuthority()
+    try:
+        with pytest.raises(ValueError, match="binding differs from its destination"):
+            workspace.adopt(
+                destination=destination,
+                stage_name=stage.name,
+                parent_descriptor=parent_descriptor,
+                root_descriptor=root_descriptor,
+                directory_descriptors={},
+                plan=plan,
+                destination_binding=wrong_owner.destination_binding,
+            )
+        assert owner.active
+        assert wrong_owner.active
+    finally:
+        workspace.close()
+        os.close(root_descriptor)
+        os.close(parent_descriptor)
+        wrong_owner.close()
+        owner.close()
+
+
 def test_owned_workspace_publish_runs_staged_and_published_validators(
     tmp_path: Path,
 ) -> None:
@@ -2191,7 +2441,7 @@ def test_owned_workspace_publish_runs_staged_and_published_validators(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         record = workspace.write_file("payload", [b"validated"])
         workspace.seal()
@@ -2228,6 +2478,74 @@ def test_owned_workspace_publish_runs_staged_and_published_validators(
         receipt_owner.close()
 
 
+def test_published_validator_cannot_intercept_destination_binding_mint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="3" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            destination_binding=None,
+        )
+        workspace.write_file("payload", (b"safe",))
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+
+        forged = object.__new__(PublishedWorkspaceDestinationBinding)
+        object.__setattr__(forged, "destination", tmp_path / "forged")
+        object.__setattr__(forged, "parent_identity", (0, 0))
+        object.__setattr__(
+            forged,
+            "ownership",
+            capture_directory_ownership(stage, allow_empty_root=True),
+        )
+        intercepted: list[dict[str, object]] = []
+
+        def intercept_freeze(**kwargs: object) -> object:
+            intercepted.append(kwargs)
+            return lambda _ownership: forged
+
+        class ForgedPublicBinding:
+            pass
+
+        def replace_public_symbols(_reader: object) -> None:
+            monkeypatch.setattr(
+                captured_directory,
+                "_freeze_published_workspace_destination_binding_minter",
+                intercept_freeze,
+            )
+            monkeypatch.setattr(
+                captured_directory,
+                "PublishedWorkspaceDestinationBinding",
+                ForgedPublicBinding,
+            )
+
+        workspace.publish_into(
+            receipt_owner,
+            validate_published_destination=replace_public_symbols,
+        )
+
+        binding = receipt_owner.destination_binding
+        assert intercepted == []
+        assert type(binding) is PublishedWorkspaceDestinationBinding
+        assert binding is not forged
+        assert binding.destination == destination
+        assert binding.parent_identity == publication_parent_identity(parent_fd)
+        assert binding.ownership == capture_directory_ownership(destination)
+        receipt_owner.close()
+
+
 @pytest.mark.parametrize(
     ("validator_name", "message"),
     [
@@ -2252,7 +2570,7 @@ def test_owned_workspace_rejects_noncallable_validator_before_transfer(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.seal()
         receipt_owner = PublishedWorkspaceReceiptOwner()
@@ -2307,7 +2625,7 @@ def test_owned_workspace_detaches_caller_and_public_plan_mutation(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
 
         object.__setattr__(source_directory, "path", PurePosixPath("rebound"))
@@ -2370,7 +2688,7 @@ def test_owned_workspace_rejects_polluted_plan_before_resource_acquisition(
                 root_descriptor=root_fd,
                 directory_descriptors=directories,
                 plan=plan,
-                expected_destination=None,
+                destination_binding=None,
             )
 
         assert workspace.state == "empty"
@@ -2395,7 +2713,7 @@ def test_published_workspace_child_closes_transfer_without_parent_effect(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.seal()
         receipt_owner = PublishedWorkspaceReceiptOwner()
@@ -2485,7 +2803,7 @@ def test_owned_workspace_publish_reserves_transfer_before_atomic_helper(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.seal()
         receipt_owner = PublishedWorkspaceReceiptOwner()
@@ -2526,7 +2844,7 @@ def test_owned_workspace_install_after_store_interruption_keeps_active_owner(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.write_file("payload", [b"safe"])
         workspace.seal()
@@ -2572,7 +2890,7 @@ def test_owned_workspace_parent_fsync_failure_installs_no_receipt(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.seal()
         receipt_owner = PublishedWorkspaceReceiptOwner()
@@ -2618,7 +2936,7 @@ def test_owned_workspace_receipt_rejects_suppressed_authentication_failure(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.write_file("payload", [b"safe"])
         workspace.seal()
@@ -2652,7 +2970,7 @@ def test_owned_workspace_receipt_rejects_post_publish_root_change(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.seal()
         receipt_owner = PublishedWorkspaceReceiptOwner()
@@ -2679,7 +2997,7 @@ def test_owned_workspace_receipt_close_persistent_eio_is_retryable(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.seal()
         receipt_owner = PublishedWorkspaceReceiptOwner()
@@ -2708,37 +3026,46 @@ def test_owned_workspace_receipt_close_persistent_eio_is_retryable(
 def test_owned_workspace_existing_destination_receipt_retains_exact_orphan(
     tmp_path: Path,
 ) -> None:
+    parent = tmp_path / "workspace-parent"
+    destination, _initial_plan, initial_owner = _publish_payload_generation(
+        parent,
+        destination_name="destination",
+        payload=b"old",
+    )
     plan = WorkspacePlan(
         subject_digest="a" * 64,
         files=(WorkspaceFile("new", max_bytes=3),),
     )
-    with _preopened_workspace(tmp_path, plan) as opened:
-        destination, stage, parent_fd, root_fd, directories = opened
-        destination.mkdir(mode=0o700)
-        (destination / "old").write_bytes(b"old")
-        expected_destination = capture_directory_ownership(destination)
-        workspace = OwnedWorkspaceAuthority()
+    stage = parent / ".replacement-stage"
+    stage.mkdir(mode=plan.root_mode)
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_fd = os.open(parent, flags)
+    root_fd = os.open(stage, flags)
+    workspace = OwnedWorkspaceAuthority()
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    binding = initial_owner.destination_binding
+    try:
         workspace.adopt(
             destination=destination,
             stage_name=stage.name,
             parent_descriptor=parent_fd,
             root_descriptor=root_fd,
-            directory_descriptors=directories,
+            directory_descriptors={},
             plan=plan,
-            expected_destination=expected_destination,
+            destination_binding=binding,
         )
         assert workspace.destination == destination
-        assert workspace.expected_destination_ownership == expected_destination
+        assert workspace.expected_destination_binding is binding
         workspace.write_file("new", [b"new"])
         workspace.seal()
-        receipt_owner = PublishedWorkspaceReceiptOwner()
 
         workspace.publish_into(receipt_owner)
 
         orphan = receipt_owner.receipt.orphan
         assert orphan is not None
         assert (
-            orphan.reopen(lambda reader: reader.read_bytes("old", max_bytes=3))
+            orphan.reopen(lambda reader: reader.read_bytes("payload", max_bytes=3))
             == b"old"
         )
         assert (
@@ -2747,7 +3074,13 @@ def test_owned_workspace_existing_destination_receipt_retains_exact_orphan(
             )
             == b"new"
         )
+    finally:
+        if receipt_owner.state == "empty":
+            workspace.close()
         receipt_owner.close()
+        initial_owner.close()
+        os.close(root_fd)
+        os.close(parent_fd)
 
 
 def test_owned_workspace_receipt_constructor_interruption_keeps_cleanup_owner(
@@ -2765,7 +3098,7 @@ def test_owned_workspace_receipt_constructor_interruption_keeps_cleanup_owner(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.seal()
         receipt_owner = PublishedWorkspaceReceiptOwner()
@@ -2806,7 +3139,7 @@ def test_owned_workspace_reservation_after_store_interruption_is_cleanup_owned(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.seal()
         receipt_owner = PublishedWorkspaceReceiptOwner()
@@ -2847,7 +3180,7 @@ def test_owned_workspace_child_closes_reserved_publication_resources(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.seal()
         receipt_owner = PublishedWorkspaceReceiptOwner()
@@ -2917,7 +3250,7 @@ def test_owned_workspace_first_transfer_store_interruption_is_reconciled(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.seal()
         receipt_owner = PublishedWorkspaceReceiptOwner()
@@ -2961,7 +3294,7 @@ def test_owned_workspace_post_install_failure_does_not_deadlock_owner_state(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.seal()
         receipt_owner = PublishedWorkspaceReceiptOwner()
@@ -3040,7 +3373,7 @@ def test_owned_workspace_consume_and_close_are_linear(
             root_descriptor=root_fd,
             directory_descriptors=directories,
             plan=plan,
-            expected_destination=None,
+            destination_binding=None,
         )
         workspace.seal()
         receipt_owner = PublishedWorkspaceReceiptOwner()

--- a/test/test_local_workspace_provider.py
+++ b/test/test_local_workspace_provider.py
@@ -18,6 +18,7 @@ import codenib._local_workspace_provider as local_provider_module
 import codenib._workspace_owner as workspace_owner
 from codenib._atomic_directory import publication_parent_identity
 from codenib._captured_directory import (
+    PublishedWorkspaceDestinationBinding,
     PublishedWorkspaceReceiptOwner,
     UnsupportedWorkspaceCreation,
     WorkspaceDirectory,
@@ -26,7 +27,6 @@ from codenib._captured_directory import (
 )
 from codenib._local_workspace_provider import LocalWorkspaceProvider
 from codenib._workspace_provider import (
-    DestinationExpectation,
     StrictWorkspaceRequest,
     StrictWorkspaceSession,
     run_strict_workspace,
@@ -61,13 +61,13 @@ def _plan() -> WorkspacePlan:
 def _request(
     root: Path,
     *,
-    expectation: DestinationExpectation = "missing",
+    destination_binding: PublishedWorkspaceDestinationBinding | None = None,
 ) -> StrictWorkspaceRequest:
     return StrictWorkspaceRequest(
         purpose="test-local-workspace-provider",
         destination=root / "published",
         plan=_plan(),
-        destination_expectation=expectation,
+        destination_binding=destination_binding,
     )
 
 
@@ -388,24 +388,76 @@ def test_local_provider_preserves_an_existing_destination(tmp_path: Path) -> Non
     assert receipt_owner.state == "empty"
 
 
-def test_local_provider_rejects_bound_exact_expectation_before_mutation(
+def test_local_provider_rejects_receipt_bound_exact_before_mutation(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     root = tmp_path / "authority"
     provider = _require_native_provider(root)
-    request = _request(root, expectation="provider-bound-exact")
+    source_owner = PublishedWorkspaceReceiptOwner()
+    source_request = _request(root)
+    run_strict_workspace(
+        provider,
+        source_request,
+        receipt_owner=source_owner,
+        operation=lambda session: _write_and_publish(session, b"old"),
+    )
+    binding = source_owner.destination_binding
+    request = _request(root, destination_binding=binding)
     receipt_owner = PublishedWorkspaceReceiptOwner()
+    before = tuple(sorted(path.name for path in root.iterdir()))
+    support_calls = 0
+    mutation_calls: list[str] = []
+    real_require_support = LocalWorkspaceProvider.require_support
 
-    with pytest.raises(UnsupportedWorkspaceCreation, match="missing destination"):
-        run_strict_workspace(
-            provider,
-            request,
-            receipt_owner=receipt_owner,
-            operation=lambda session: _write_and_publish(session, b"forbidden"),
-        )
+    def counted_require_support(self: LocalWorkspaceProvider) -> None:
+        nonlocal support_calls
+        support_calls += 1
+        real_require_support(self)
 
-    assert tuple(root.iterdir()) == ()
-    assert receipt_owner.state == "empty"
+    def forbid_native_owner() -> object:
+        mutation_calls.append("create")
+        raise AssertionError("exact rejection reached native owner creation")
+
+    def forbid_native_provision(*_args: object, **_kwargs: object) -> None:
+        mutation_calls.append("provision")
+        raise AssertionError("exact rejection reached native provisioning")
+
+    monkeypatch.setattr(
+        LocalWorkspaceProvider,
+        "require_support",
+        counted_require_support,
+    )
+    monkeypatch.setattr(workspace_owner, "create_owner", forbid_native_owner)
+    monkeypatch.setattr(
+        workspace_owner,
+        "provision_owner",
+        forbid_native_provision,
+    )
+
+    try:
+        with pytest.raises(UnsupportedWorkspaceCreation, match="missing destination"):
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=receipt_owner,
+                operation=lambda session: _write_and_publish(
+                    session,
+                    b"forbidden",
+                ),
+            )
+
+        assert tuple(sorted(path.name for path in root.iterdir())) == before
+        assert not tuple(root.glob(".codenib-workspace-stage-*"))
+        assert not tuple(root.glob(".codenib-workspace-orphan-*"))
+        assert request.destination.joinpath("data/result.json").read_bytes() == b"old"
+        assert source_owner.active
+        assert receipt_owner.state == "empty"
+        assert support_calls == 1
+        assert mutation_calls == []
+    finally:
+        receipt_owner.close()
+        source_owner.close()
 
 
 def test_local_provider_fails_closed_without_the_complete_native_abi(

--- a/test/test_workspace_owner.py
+++ b/test/test_workspace_owner.py
@@ -1453,7 +1453,7 @@ def test_native_owner_publishes_through_the_caller_receipt(
         provisioned_owner=owner,
         publication_permit=publication_permit,
         plan=plan,
-        expected_destination=None,
+        destination_binding=None,
     )
     record = workspace.write_file(
         "views/bm25/documents.json",
@@ -1488,7 +1488,7 @@ def test_native_publication_binds_exact_rename_before_validators(
         provisioned_owner=owner,
         publication_permit=publication_permit,
         plan=plan,
-        expected_destination=None,
+        destination_binding=None,
     )
     workspace.write_file("views/bm25/documents.json", (b"{}",))
     workspace.seal()
@@ -1538,7 +1538,7 @@ def test_native_publication_binds_receipt_installation_before_validators(
         provisioned_owner=owner,
         publication_permit=publication_permit,
         plan=plan,
-        expected_destination=None,
+        destination_binding=None,
     )
     workspace.write_file("views/bm25/documents.json", (b"{}",))
     workspace.seal()
@@ -1594,7 +1594,7 @@ def test_native_workspace_close_aborts_before_receipt_publication(
         provisioned_owner=owner,
         publication_permit=publication_permit,
         plan=plan,
-        expected_destination=None,
+        destination_binding=None,
     )
 
     workspace.close()
@@ -1619,7 +1619,7 @@ def test_native_post_rename_validation_failure_aborts_the_candidate(
         provisioned_owner=owner,
         publication_permit=publication_permit,
         plan=plan,
-        expected_destination=None,
+        destination_binding=None,
     )
     workspace.write_file("views/bm25/documents.json", (b"{}",))
     workspace.seal()
@@ -1654,7 +1654,7 @@ def test_staged_validator_cannot_mint_native_publication_authority(
         provisioned_owner=owner,
         publication_permit=publication_permit,
         plan=plan,
-        expected_destination=None,
+        destination_binding=None,
     )
     workspace.write_file("views/bm25/documents.json", (b"{}",))
     workspace.seal()
@@ -1702,7 +1702,7 @@ def test_published_validator_cannot_forge_native_receipt_commit(
         provisioned_owner=owner,
         publication_permit=publication_permit,
         plan=plan,
-        expected_destination=None,
+        destination_binding=None,
     )
     workspace.write_file("views/bm25/documents.json", (b"{}",))
     workspace.seal()
@@ -1813,7 +1813,7 @@ def test_native_receipt_slot_store_is_the_publication_authority_boundary(
         provisioned_owner=owner,
         publication_permit=publication_permit,
         plan=plan,
-        expected_destination=None,
+        destination_binding=None,
     )
     workspace.write_file("views/bm25/documents.json", (b"{}",))
     workspace.seal()
@@ -1862,7 +1862,7 @@ def test_native_receipt_commit_return_interruption_keeps_active_authority(
         provisioned_owner=owner,
         publication_permit=publication_permit,
         plan=plan,
-        expected_destination=None,
+        destination_binding=None,
     )
     workspace.write_file("views/bm25/documents.json", (b"{}",))
     workspace.seal()

--- a/test/test_workspace_provider.py
+++ b/test/test_workspace_provider.py
@@ -17,13 +17,14 @@ import codenib._workspace_provider as workspace_provider
 from codenib._atomic_directory import capture_directory_ownership
 from codenib._captured_directory import (
     OwnedWorkspaceAuthority,
+    PublishedWorkspaceDestinationBinding,
     PublishedWorkspaceReceiptOwner,
     UnsupportedWorkspaceCreation,
     WorkspaceFile,
     WorkspacePlan,
 )
 
-_DEFAULT_EXPECTATION = object()
+_DEFAULT_BINDING = object()
 from codenib._workspace_provider import (
     StrictWorkspaceRequest,
     StrictWorkspaceSession,
@@ -75,13 +76,13 @@ class _TestProvider:
         self,
         *,
         adopted_destination: Path | None = None,
-        expected_destination: object = _DEFAULT_EXPECTATION,
+        destination_binding: object = _DEFAULT_BINDING,
     ) -> None:
         self.support_checks = 0
         self.runs = 0
         self.last_workspace: OwnedWorkspaceAuthority | None = None
         self.adopted_destination = adopted_destination
-        self.expected_destination = expected_destination
+        self.destination_binding = destination_binding
 
     def require_support(self) -> None:
         self.support_checks += 1
@@ -105,16 +106,9 @@ class _TestProvider:
         root_descriptor = os.open(stage, flags)
         workspace = OwnedWorkspaceAuthority()
         self.last_workspace = workspace
-        expected_destination = self.expected_destination
-        if expected_destination is _DEFAULT_EXPECTATION:
-            expected_destination = (
-                capture_directory_ownership(
-                    destination,
-                    allow_empty_root=True,
-                )
-                if request.destination_expectation == "provider-bound-exact"
-                else None
-            )
+        destination_binding = self.destination_binding
+        if destination_binding is _DEFAULT_BINDING:
+            destination_binding = request.destination_binding
         try:
             workspace.adopt(
                 destination=destination,
@@ -123,7 +117,7 @@ class _TestProvider:
                 root_descriptor=root_descriptor,
                 directory_descriptors={},
                 plan=request.plan,
-                expected_destination=expected_destination,
+                destination_binding=destination_binding,  # type: ignore[arg-type]
             )
             return run_adopted_workspace_operation(
                 request,
@@ -136,6 +130,31 @@ class _TestProvider:
             os.close(parent_descriptor)
             if receipt_owner.state == "empty":
                 workspace.close()
+
+
+def _publish_generation(
+    destination: Path,
+    *,
+    payload: bytes = b"same bytes",
+) -> PublishedWorkspaceReceiptOwner:
+    owner = PublishedWorkspaceReceiptOwner()
+    request = StrictWorkspaceRequest("binding-source", destination, _plan())
+
+    def publish(session: StrictWorkspaceSession) -> None:
+        session.write_file("payload.bin", (payload,))
+        session.publish_validated(lambda _reader: None)
+
+    try:
+        run_strict_workspace(
+            _TestProvider(),
+            request,
+            receipt_owner=owner,
+            operation=publish,
+        )
+    except BaseException:
+        owner.close()
+        raise
+    return owner
 
 
 def _run_thread(
@@ -209,14 +228,16 @@ def test_request_is_lexical_and_rejects_invalid_contract(tmp_path: Path) -> None
     request = StrictWorkspaceRequest("bm25-normalize", destination, _plan())
 
     assert request.destination == Path(os.path.abspath(destination))
+    assert request.destination_binding is None
+    assert request.destination_expectation == "missing"
     with pytest.raises(ValueError, match="purpose"):
         StrictWorkspaceRequest("bad\nname", destination, _plan())
-    with pytest.raises(ValueError, match="expectation"):
+    with pytest.raises(TypeError, match="unexpected keyword"):
         StrictWorkspaceRequest(
             "test",
             destination,
             _plan(),
-            destination_expectation="ambient",  # type: ignore[arg-type]
+            destination_expectation="provider-bound-exact",  # type: ignore[call-arg]
         )
     with pytest.raises(ValueError, match="name one directory"):
         StrictWorkspaceRequest("test", tmp_path / "parent" / "..", _plan())
@@ -239,6 +260,55 @@ def test_request_is_lexical_and_rejects_invalid_contract(tmp_path: Path) -> None
     object.__setattr__(original, "digest", "0" * 64)
     with pytest.raises(ValueError, match="digest is inconsistent"):
         StrictWorkspaceRequest("test", destination, original)
+
+
+def test_request_accepts_only_exact_binding_for_its_lexical_destination(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "parent" / "published"
+    source_owner = _publish_generation(destination)
+    try:
+        binding = source_owner.destination_binding
+        request = StrictWorkspaceRequest(
+            "replace",
+            destination,
+            _plan(),
+            destination_binding=binding,
+        )
+        assert request.destination_binding is binding
+        assert request.destination_expectation == "provider-bound-exact"
+
+        with pytest.raises(ValueError, match="binding differs from its destination"):
+            StrictWorkspaceRequest(
+                "replace",
+                tmp_path / "wrong" / "published",
+                _plan(),
+                destination_binding=binding,
+            )
+        with pytest.raises(TypeError, match="destination binding is invalid"):
+            StrictWorkspaceRequest(
+                "replace",
+                destination,
+                _plan(),
+                destination_binding=capture_directory_ownership(destination),  # type: ignore[arg-type]
+            )
+
+        class DerivedBinding(PublishedWorkspaceDestinationBinding):
+            pass
+
+        forged = object.__new__(DerivedBinding)
+        object.__setattr__(forged, "destination", binding.destination)
+        object.__setattr__(forged, "parent_identity", binding.parent_identity)
+        object.__setattr__(forged, "ownership", binding.ownership)
+        with pytest.raises(TypeError, match="destination binding is invalid"):
+            StrictWorkspaceRequest(
+                "replace",
+                destination,
+                _plan(),
+                destination_binding=forged,
+            )
+    finally:
+        source_owner.close()
 
 
 def test_provider_runs_one_callback_scoped_validated_publication(
@@ -616,11 +686,11 @@ def test_adopted_workspace_rejects_exact_binding_for_missing_request(
     tmp_path: Path,
 ) -> None:
     destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old").write_bytes(b"old")
-    exact = capture_directory_ownership(destination)
+    source_owner = _publish_generation(destination)
     request = StrictWorkspaceRequest("test", destination, _plan())
-    provider = _TestProvider(expected_destination=exact)
+    provider = _TestProvider(
+        destination_binding=source_owner.destination_binding,
+    )
     owner = PublishedWorkspaceReceiptOwner()
     called = False
 
@@ -628,30 +698,37 @@ def test_adopted_workspace_rejects_exact_binding_for_missing_request(
         nonlocal called
         called = True
 
-    with pytest.raises(ValueError, match="expectation differs"):
-        run_strict_workspace(
-            provider,
-            request,
-            receipt_owner=owner,
-            operation=operation,
-        )
+    try:
+        with pytest.raises(ValueError, match="binding differs"):
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=owner,
+                operation=operation,
+            )
 
-    assert called is False
-    assert owner.state == "empty"
-    assert (destination / "old").read_bytes() == b"old"
+        assert called is False
+        assert owner.state == "empty"
+        assert destination.joinpath("payload.bin").read_bytes() == b"same bytes"
+    finally:
+        owner.close()
+        source_owner.close()
 
 
 def test_adopted_workspace_rejects_missing_binding_for_exact_request(
     tmp_path: Path,
 ) -> None:
     destination = tmp_path / "published"
+    source_owner = _publish_generation(destination)
+    binding = source_owner.destination_binding
+    destination.rename(tmp_path / "parked-generation")
     request = StrictWorkspaceRequest(
         "test",
         destination,
         _plan(),
-        destination_expectation="provider-bound-exact",
+        destination_binding=binding,
     )
-    provider = _TestProvider(expected_destination=None)
+    provider = _TestProvider(destination_binding=None)
     owner = PublishedWorkspaceReceiptOwner()
     called = False
 
@@ -659,30 +736,34 @@ def test_adopted_workspace_rejects_missing_binding_for_exact_request(
         nonlocal called
         called = True
 
-    with pytest.raises(ValueError, match="expectation differs"):
-        run_strict_workspace(
-            provider,
-            request,
-            receipt_owner=owner,
-            operation=operation,
-        )
+    try:
+        with pytest.raises(ValueError, match="binding differs"):
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=owner,
+                operation=operation,
+            )
 
-    assert called is False
-    assert owner.state == "empty"
-    assert not destination.exists()
+        assert called is False
+        assert owner.state == "empty"
+        assert not destination.exists()
+    finally:
+        owner.close()
+        source_owner.close()
 
 
 def test_provider_bound_exact_request_replaces_only_captured_destination(
     tmp_path: Path,
 ) -> None:
     destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old").write_bytes(b"old")
+    source_owner = _publish_generation(destination, payload=b"old")
+    binding = source_owner.destination_binding
     request = StrictWorkspaceRequest(
         "test",
         destination,
         _plan(),
-        destination_expectation="provider-bound-exact",
+        destination_binding=binding,
     )
     provider = _TestProvider()
     owner = PublishedWorkspaceReceiptOwner()
@@ -705,9 +786,93 @@ def test_provider_bound_exact_request_replaces_only_captured_destination(
         )
         assert owner.active
         assert owner.receipt.orphan is not None
+        assert provider.last_workspace is not None
+        assert provider.last_workspace.expected_destination_binding is binding
         assert destination.joinpath("payload.bin").read_bytes() == b"owned"
     finally:
         owner.close()
+        source_owner.close()
+
+
+def test_session_compares_entire_genuine_destination_binding(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    first_owner = _publish_generation(destination)
+    first_binding = first_owner.destination_binding
+    destination.rename(tmp_path / "first-generation")
+    second_owner = _publish_generation(destination)
+    second_binding = second_owner.destination_binding
+    assert first_binding.destination == second_binding.destination
+    assert first_binding.parent_identity == second_binding.parent_identity
+    assert first_binding.ownership != second_binding.ownership
+
+    request = StrictWorkspaceRequest(
+        "replace",
+        destination,
+        _plan(),
+        destination_binding=first_binding,
+    )
+    provider = _TestProvider(destination_binding=second_binding)
+    output_owner = PublishedWorkspaceReceiptOwner()
+    called = False
+
+    def operation(_session: StrictWorkspaceSession) -> None:
+        nonlocal called
+        called = True
+
+    try:
+        with pytest.raises(ValueError, match="binding differs"):
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=output_owner,
+                operation=operation,
+            )
+        assert called is False
+        assert output_owner.state == "empty"
+        assert destination.joinpath("payload.bin").read_bytes() == b"same bytes"
+    finally:
+        output_owner.close()
+        second_owner.close()
+        first_owner.close()
+
+
+def test_provider_cannot_launder_independently_captured_tree_token(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    source_owner = _publish_generation(destination)
+    request = StrictWorkspaceRequest(
+        "replace",
+        destination,
+        _plan(),
+        destination_binding=source_owner.destination_binding,
+    )
+    provider = _TestProvider(
+        destination_binding=capture_directory_ownership(destination),
+    )
+    output_owner = PublishedWorkspaceReceiptOwner()
+    called = False
+
+    def operation(_session: StrictWorkspaceSession) -> None:
+        nonlocal called
+        called = True
+
+    try:
+        with pytest.raises(TypeError, match="destination binding is invalid"):
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=output_owner,
+                operation=operation,
+            )
+        assert called is False
+        assert output_owner.state == "empty"
+        assert source_owner.active
+    finally:
+        output_owner.close()
+        source_owner.close()
 
 
 def test_adopted_workspace_rechecks_destination_before_write(tmp_path: Path) -> None:
@@ -732,7 +897,7 @@ def test_adopted_workspace_rechecks_destination_before_write(tmp_path: Path) -> 
     assert not request.destination.exists()
 
 
-def test_adopted_workspace_rechecks_expectation_after_staged_validator(
+def test_adopted_workspace_rechecks_binding_after_staged_validator(
     tmp_path: Path,
 ) -> None:
     request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
@@ -744,12 +909,12 @@ def test_adopted_workspace_rechecks_expectation_after_staged_validator(
 
         def validate(_reader) -> None:
             assert provider.last_workspace is not None
-            provider.last_workspace._expected_destination = object()  # type: ignore[attr-defined]  # noqa: SLF001
+            provider.last_workspace._destination_binding = object()  # type: ignore[attr-defined]  # noqa: SLF001
 
         session.publish_validated(validate)
 
     try:
-        with pytest.raises(ValueError, match="expectation differs"):
+        with pytest.raises(ValueError, match="binding differs"):
             run_strict_workspace(
                 provider,
                 request,


### PR DESCRIPTION
## Summary

Bind strict workspace replacement requests to an immutable destination binding
projected by the active published receipt owner. Authenticate the lexical
destination, parent identity, and full tree ownership across request
construction, generic adoption, provider callbacks, and strict BM25 source
selection.

This is request-binding work only. `LocalWorkspaceProvider` still rejects exact
bindings and does not invoke the native exchange primitive. Dual-root
publication, displaced-incumbent orphan handoff, Gate C, and M1 remain open. No
default compiler or runtime route changes.

Related to #199.

## Changes

- Add a private-construction, immutable `PublishedWorkspaceDestinationBinding`
  projected from an active published receipt owner.
- Carry one binding through `StrictWorkspaceRequest` and derive
  `destination_expectation` from its presence instead of accepting an
  independent categorical authority.
- Authenticate the lexical destination, exact parent identity, and complete
  live tree ownership during generic adoption, then require full binding
  equality at the callback session boundary.
- Derive strict BM25 replacement authority from `source_generation` and
  cross-check it against the borrowed source receipt.
- Keep `LocalWorkspaceProvider` missing-only and reject non-`None` bindings
  before provisioning or namespace mutation.
- Migrate missing-destination callers and cover construction, substitution,
  path/parent/tree mismatch, PID/reentrancy, provider interception, source
  receipt mismatch, cancellation, and `BaseException` boundaries.
- Document the authenticated request seam while keeping provider integration,
  Gate C, and M1 explicitly open.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- Focused request-binding, workspace-owner/provider, strict-publication, and
  migrated-caller surface: `375 passed`.
- Full unit marker: `6,998 passed, 71 skipped, 190 deselected` in a fresh
  read-only Docker-shim namespace after the sole host-only missing
  `/usr/bin/docker` infrastructure failure.
- Strict Python style, diff, documentation, and public-boundary checks passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
