### PR TITLE
feat(wiki): add OpenAI-compatible visual fact extraction

### DIFF
--- a/codenib/wiki/__init__.py
+++ b/codenib/wiki/__init__.py
@@ -24,9 +24,11 @@ from .media_knowledge import (
     get_visual_evidence,
     search_visual_context,
 )
+from .media_vlm import OpenAICompatibleVisualFactExtractor
 
 __all__ = [
     "WikiBuilder",
+    "OpenAICompatibleVisualFactExtractor",
     "build_media_evidence_pack",
     "build_multimodal_knowledge_view",
     "build_visual_facts_manifest",

--- a/codenib/wiki/media_facts.py
+++ b/codenib/wiki/media_facts.py
@@ -277,10 +277,26 @@ def build_visual_facts_manifest(
     return manifest.to_dict()
 
 
-def normalize_visual_fact_pack(value: Mapping[str, Any]) -> dict[str, Any]:
-    """Normalize extractor output into the canonical visual fact pack schema."""
+def normalize_visual_fact_pack(
+    value: Mapping[str, Any],
+    *,
+    artifact: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Normalize untrusted extractor output under trusted artifact provenance."""
 
-    return _fact_pack_from_mapping(value).to_dict()
+    artifact_path = _safe_relative_path(artifact.get("path"))
+    if not artifact_path:
+        raise ValueError("visual fact artifact path must be repository-relative")
+    normalized = _fact_pack_from_mapping(
+        value,
+        artifact_path=artifact_path,
+        artifact_sha256=_safe_text(artifact.get("sha256")),
+        role_hint=_safe_text(artifact.get("role_hint") or "repository_image"),
+    )
+    payload = normalized.to_dict()
+    if _json_size(payload) > _MAX_FACT_PACK_BYTES:
+        raise ValueError("visual fact pack exceeds the byte limit")
+    return payload
 
 
 def _artifact_prompt_payload(artifact: Mapping[str, Any]) -> dict[str, Any]:

--- a/codenib/wiki/media_facts.py
+++ b/codenib/wiki/media_facts.py
@@ -277,6 +277,12 @@ def build_visual_facts_manifest(
     return manifest.to_dict()
 
 
+def normalize_visual_fact_pack(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalize extractor output into the canonical visual fact pack schema."""
+
+    return _fact_pack_from_mapping(value).to_dict()
+
+
 def _artifact_prompt_payload(artifact: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "path": _safe_text(artifact.get("path")),
@@ -556,4 +562,5 @@ __all__ = [
     "build_visual_fact_extraction_prompt",
     "build_visual_facts_manifest",
     "deterministic_visual_facts",
+    "normalize_visual_fact_pack",
 ]

--- a/codenib/wiki/media_vlm.py
+++ b/codenib/wiki/media_vlm.py
@@ -7,23 +7,24 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import math
-import os
+import re
+import stat
 import urllib.request
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Mapping
 from urllib.parse import urlsplit
 
-from .media_facts import (
-    build_visual_fact_extraction_prompt,
-    normalize_visual_fact_pack,
-)
+from ._safe_file_reads import read_regular_bytes
+from .media_facts import build_visual_fact_extraction_prompt, normalize_visual_fact_pack
 
 _MAX_MODEL_LENGTH = 256
 _MAX_PROVIDER_LENGTH = 128
 _MAX_URL_LENGTH = 4096
 _MAX_TIMEOUT_SECONDS = 600.0
+_MAX_REQUEST_BYTES = 24 * 1024 * 1024
 _MAX_RESPONSE_BYTES = 8 * 1024 * 1024
 _MAX_IMAGE_BYTES = 16 * 1024 * 1024
 _SUPPORTED_MIME_TYPES = frozenset(
@@ -48,12 +49,16 @@ class OpenAICompatibleVisualFactExtractor:
         timeout: float = 120.0,
         urlopen: Callable[..., Any] | None = None,
         provider: str = "openai-compatible",
+        repo_path: str | Path | None = None,
     ) -> None:
         self.model = str(model or "").strip()
         self.api_base = str(api_base or "").strip()
         self.api_key = _validated_api_key(api_key)
         self.timeout = _validated_timeout(timeout)
         self.provider = str(provider or "").strip()
+        self.repo_path = (
+            Path(repo_path).expanduser().resolve() if repo_path is not None else None
+        )
         self._urlopen = urlopen or urllib.request.urlopen
         if not self.model:
             raise ValueError("visual fact model is required")
@@ -77,12 +82,13 @@ class OpenAICompatibleVisualFactExtractor:
 
         prompt = build_visual_fact_extraction_prompt(artifact)
         content: list[dict[str, Any]] = [{"type": "text", "text": prompt}]
-        if repo_path is not None:
+        source_repo = repo_path if repo_path is not None else self.repo_path
+        if source_repo is not None:
             content.append(
                 {
                     "type": "image_url",
                     "image_url": {
-                        "url": _artifact_data_url(repo_path, artifact),
+                        "url": _artifact_data_url(source_repo, artifact),
                     },
                 }
             )
@@ -103,25 +109,33 @@ class OpenAICompatibleVisualFactExtractor:
         }
         response = self._post_json(payload)
         extracted = _response_content_json(response)
-        extracted.setdefault("artifact_path", str(artifact.get("path") or ""))
-        extracted.setdefault("artifact_sha256", str(artifact.get("sha256") or ""))
-        extracted.setdefault("role_hint", str(artifact.get("role_hint") or ""))
         extracted["extractor"] = self.provider
-        metadata = dict(extracted.get("metadata") or {})
-        metadata.update({"model": self.model, "provider": self.provider})
-        extracted["metadata"] = metadata
-        return normalize_visual_fact_pack(extracted)
+        extracted["metadata"] = {"model": self.model, "provider": self.provider}
+        return normalize_visual_fact_pack(extracted, artifact=artifact)
 
     def __call__(self, artifact: Mapping[str, Any]) -> dict[str, Any]:
+        if self.repo_path is None:
+            raise ValueError(
+                "visual fact repo_path must be configured when the extractor "
+                "is used with build_visual_facts_manifest"
+            )
         return self.extract(artifact)
 
     def _post_json(self, payload: Mapping[str, Any]) -> dict[str, Any]:
         headers = {"Content-Type": "application/json"}
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
+        encoded = json.dumps(
+            payload,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        if len(encoded) > _MAX_REQUEST_BYTES:
+            raise ValueError("visual fact request exceeds the byte limit")
         request = urllib.request.Request(
             self.endpoint,
-            data=json.dumps(payload).encode("utf-8"),
+            data=encoded,
             headers=headers,
             method="POST",
         )
@@ -157,18 +171,28 @@ def _response_content_json(response: Mapping[str, Any]) -> dict[str, Any]:
 def _artifact_data_url(repo_path: str | Path, artifact: Mapping[str, Any]) -> str:
     root = Path(repo_path).expanduser().resolve()
     relative = _safe_relative_path(artifact.get("path"))
-    path = (root / relative).resolve()
-    if not (path == root or root in path.parents):
-        raise ValueError("visual artifact path is outside the repository")
-    if path.is_symlink() or not path.is_file():
+    path = root.joinpath(*relative.parts)
+    if _has_symlink_parent(root, relative):
+        raise ValueError("visual artifact path must not traverse a symlink")
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise ValueError("visual artifact must be a regular file") from exc
+    if not stat.S_ISREG(metadata.st_mode):
         raise ValueError("visual artifact must be a regular file")
     mime_type = str(artifact.get("mime_type") or "").strip()
     if mime_type not in _SUPPORTED_MIME_TYPES:
         raise ValueError("visual artifact MIME type is unsupported")
-    size = path.stat().st_size
-    if size < 0 or size > _MAX_IMAGE_BYTES:
+    if metadata.st_size < 0 or metadata.st_size > _MAX_IMAGE_BYTES:
         raise ValueError("visual artifact exceeds the byte limit")
-    data = _read_bounded_file(path, max_bytes=_MAX_IMAGE_BYTES)
+    data = read_regular_bytes(path, max_bytes=_MAX_IMAGE_BYTES)
+    if data is None:
+        raise ValueError("visual artifact could not be read as a stable regular file")
+    expected_sha256 = str(artifact.get("sha256") or "").strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", expected_sha256):
+        raise ValueError("visual artifact sha256 is invalid")
+    if hashlib.sha256(data).hexdigest() != expected_sha256:
+        raise ValueError("visual artifact content does not match the media manifest")
     return f"data:{mime_type};base64,{base64.b64encode(data).decode('ascii')}"
 
 
@@ -182,16 +206,16 @@ def _safe_relative_path(value: Any) -> Path:
     return Path(*path.parts)
 
 
-def _read_bounded_file(path: Path, *, max_bytes: int) -> bytes:
-    chunks = []
-    consumed = 0
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            consumed += len(chunk)
-            if consumed > max_bytes:
-                raise ValueError("visual artifact exceeds the byte limit")
-            chunks.append(chunk)
-    return b"".join(chunks)
+def _has_symlink_parent(root: Path, relative: Path) -> bool:
+    current = root
+    for part in relative.parts[:-1]:
+        current = current / part
+        try:
+            if current.is_symlink():
+                return True
+        except OSError:
+            return True
+    return False
 
 
 def _validated_timeout(value: Any) -> float:

--- a/codenib/wiki/media_vlm.py
+++ b/codenib/wiki/media_vlm.py
@@ -168,9 +168,7 @@ def _artifact_data_url(repo_path: str | Path, artifact: Mapping[str, Any]) -> st
     size = path.stat().st_size
     if size < 0 or size > _MAX_IMAGE_BYTES:
         raise ValueError("visual artifact exceeds the byte limit")
-    data = path.read_bytes()
-    if len(data) > _MAX_IMAGE_BYTES:
-        raise ValueError("visual artifact exceeds the byte limit")
+    data = _read_bounded_file(path, max_bytes=_MAX_IMAGE_BYTES)
     return f"data:{mime_type};base64,{base64.b64encode(data).decode('ascii')}"
 
 
@@ -182,6 +180,18 @@ def _safe_relative_path(value: Any) -> Path:
     if path.is_absolute() or ".." in path.parts or path.as_posix() != text:
         raise ValueError("visual artifact path must be repository-relative")
     return Path(*path.parts)
+
+
+def _read_bounded_file(path: Path, *, max_bytes: int) -> bytes:
+    chunks = []
+    consumed = 0
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            consumed += len(chunk)
+            if consumed > max_bytes:
+                raise ValueError("visual artifact exceeds the byte limit")
+            chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def _validated_timeout(value: Any) -> float:

--- a/codenib/wiki/media_vlm.py
+++ b/codenib/wiki/media_vlm.py
@@ -1,0 +1,243 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenAI-compatible VLM extraction for repository media artifacts."""
+
+from __future__ import annotations
+
+import base64
+import json
+import math
+import os
+import urllib.request
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable, Mapping
+from urllib.parse import urlsplit
+
+from .media_facts import (
+    build_visual_fact_extraction_prompt,
+    normalize_visual_fact_pack,
+)
+
+_MAX_MODEL_LENGTH = 256
+_MAX_PROVIDER_LENGTH = 128
+_MAX_URL_LENGTH = 4096
+_MAX_TIMEOUT_SECONDS = 600.0
+_MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+_MAX_IMAGE_BYTES = 16 * 1024 * 1024
+_SUPPORTED_MIME_TYPES = frozenset(
+    {
+        "image/jpeg",
+        "image/png",
+        "image/svg+xml",
+        "image/webp",
+    }
+)
+
+
+class OpenAICompatibleVisualFactExtractor:
+    """Extract structured visual facts through an OpenAI-compatible chat API."""
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        api_base: str,
+        api_key: str | None = None,
+        timeout: float = 120.0,
+        urlopen: Callable[..., Any] | None = None,
+        provider: str = "openai-compatible",
+    ) -> None:
+        self.model = str(model or "").strip()
+        self.api_base = str(api_base or "").strip()
+        self.api_key = _validated_api_key(api_key)
+        self.timeout = _validated_timeout(timeout)
+        self.provider = str(provider or "").strip()
+        self._urlopen = urlopen or urllib.request.urlopen
+        if not self.model:
+            raise ValueError("visual fact model is required")
+        if len(self.model) > _MAX_MODEL_LENGTH:
+            raise ValueError("visual fact model is too long")
+        if not self.provider or len(self.provider) > _MAX_PROVIDER_LENGTH:
+            raise ValueError("visual fact provider is invalid")
+        self._endpoint = _chat_completions_endpoint(self.api_base)
+
+    @property
+    def endpoint(self) -> str:
+        return self._endpoint
+
+    def extract(
+        self,
+        artifact: Mapping[str, Any],
+        *,
+        repo_path: str | Path | None = None,
+    ) -> dict[str, Any]:
+        """Extract one canonical visual fact pack for *artifact*."""
+
+        prompt = build_visual_fact_extraction_prompt(artifact)
+        content: list[dict[str, Any]] = [{"type": "text", "text": prompt}]
+        if repo_path is not None:
+            content.append(
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": _artifact_data_url(repo_path, artifact),
+                    },
+                }
+            )
+        payload = {
+            "model": self.model,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You extract structured repository visual facts. "
+                        "Return JSON only."
+                    ),
+                },
+                {"role": "user", "content": content},
+            ],
+            "temperature": 0,
+            "response_format": {"type": "json_object"},
+        }
+        response = self._post_json(payload)
+        extracted = _response_content_json(response)
+        extracted.setdefault("artifact_path", str(artifact.get("path") or ""))
+        extracted.setdefault("artifact_sha256", str(artifact.get("sha256") or ""))
+        extracted.setdefault("role_hint", str(artifact.get("role_hint") or ""))
+        extracted["extractor"] = self.provider
+        metadata = dict(extracted.get("metadata") or {})
+        metadata.update({"model": self.model, "provider": self.provider})
+        extracted["metadata"] = metadata
+        return normalize_visual_fact_pack(extracted)
+
+    def __call__(self, artifact: Mapping[str, Any]) -> dict[str, Any]:
+        return self.extract(artifact)
+
+    def _post_json(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        request = urllib.request.Request(
+            self.endpoint,
+            data=json.dumps(payload).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+        with self._urlopen(request, timeout=self.timeout) as response:
+            raw = response.read(_MAX_RESPONSE_BYTES + 1)
+        if len(raw) > _MAX_RESPONSE_BYTES:
+            raise ValueError("visual fact response exceeds the byte limit")
+        data = json.loads(raw.decode("utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError("visual fact response must be a JSON object")
+        return data
+
+
+def _response_content_json(response: Mapping[str, Any]) -> dict[str, Any]:
+    choices = response.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise ValueError("visual fact response must contain choices[0]")
+    first = choices[0]
+    if not isinstance(first, Mapping):
+        raise ValueError("visual fact response choice must be an object")
+    message = first.get("message")
+    if not isinstance(message, Mapping):
+        raise ValueError("visual fact response choice must contain message")
+    content = message.get("content")
+    if not isinstance(content, str):
+        raise ValueError("visual fact response message content must be a string")
+    parsed = json.loads(content)
+    if not isinstance(parsed, dict):
+        raise ValueError("visual fact response content must decode to a JSON object")
+    return parsed
+
+
+def _artifact_data_url(repo_path: str | Path, artifact: Mapping[str, Any]) -> str:
+    root = Path(repo_path).expanduser().resolve()
+    relative = _safe_relative_path(artifact.get("path"))
+    path = (root / relative).resolve()
+    if not (path == root or root in path.parents):
+        raise ValueError("visual artifact path is outside the repository")
+    if path.is_symlink() or not path.is_file():
+        raise ValueError("visual artifact must be a regular file")
+    mime_type = str(artifact.get("mime_type") or "").strip()
+    if mime_type not in _SUPPORTED_MIME_TYPES:
+        raise ValueError("visual artifact MIME type is unsupported")
+    size = path.stat().st_size
+    if size < 0 or size > _MAX_IMAGE_BYTES:
+        raise ValueError("visual artifact exceeds the byte limit")
+    data = path.read_bytes()
+    if len(data) > _MAX_IMAGE_BYTES:
+        raise ValueError("visual artifact exceeds the byte limit")
+    return f"data:{mime_type};base64,{base64.b64encode(data).decode('ascii')}"
+
+
+def _safe_relative_path(value: Any) -> Path:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError("visual artifact path is required")
+    path = PurePosixPath(text)
+    if path.is_absolute() or ".." in path.parts or path.as_posix() != text:
+        raise ValueError("visual artifact path must be repository-relative")
+    return Path(*path.parts)
+
+
+def _validated_timeout(value: Any) -> float:
+    if isinstance(value, bool):
+        raise ValueError("visual fact timeout must be a positive number")
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("visual fact timeout must be a positive number") from exc
+    if not math.isfinite(timeout) or not 0 < timeout <= _MAX_TIMEOUT_SECONDS:
+        raise ValueError(
+            f"visual fact timeout must be between 0 and {_MAX_TIMEOUT_SECONDS:g} seconds"
+        )
+    return timeout
+
+
+def _validated_api_key(value: Any) -> str | None:
+    if value is None:
+        return None
+    api_key = str(value)
+    if len(api_key) > 8192 or any(
+        ord(character) < 0x20 or ord(character) == 0x7F for character in api_key
+    ):
+        raise ValueError("visual fact API key is invalid")
+    return api_key
+
+
+def _validated_http_url(value: str, *, label: str) -> str:
+    url = str(value or "").strip()
+    if not url or len(url) > _MAX_URL_LENGTH:
+        raise ValueError(f"{label} is invalid")
+    if any(
+        character.isspace() or ord(character) < 0x20 or ord(character) == 0x7F
+        for character in url
+    ):
+        raise ValueError(f"{label} is invalid")
+    try:
+        parsed = urlsplit(url)
+        hostname = parsed.hostname
+        _ = parsed.port
+    except ValueError as exc:
+        raise ValueError(f"{label} is invalid") from exc
+    if parsed.scheme.lower() not in {"http", "https"} or not hostname:
+        raise ValueError(f"{label} must be an HTTP(S) URL")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError(f"{label} must not contain credentials")
+    return url
+
+
+def _chat_completions_endpoint(api_base: str) -> str:
+    base = _validated_http_url(api_base, label="visual fact api_base")
+    parsed = urlsplit(base)
+    path = parsed.path.rstrip("/")
+    if not path.endswith("/chat/completions"):
+        path = f"{path}/chat/completions"
+    return parsed._replace(path=path, fragment="").geturl()
+
+
+__all__ = ["OpenAICompatibleVisualFactExtractor"]

--- a/docs/experiments/multimodal_repository_knowledge.md
+++ b/docs/experiments/multimodal_repository_knowledge.md
@@ -113,10 +113,11 @@ extractor = OpenAICompatibleVisualFactExtractor(
     model="qwen-vl",
     api_base="http://localhost:8000/v1",
     api_key=None,
+    repo_path=repo,
 )
 
 facts = build_visual_facts_manifest(
     media,
-    extractor=lambda artifact: extractor.extract(artifact, repo_path=repo),
+    extractor=extractor,
 )
 ```

--- a/docs/experiments/multimodal_repository_knowledge.md
+++ b/docs/experiments/multimodal_repository_knowledge.md
@@ -51,6 +51,12 @@ The local `deterministic_visual_facts()` fallback extracts conservative facts
 from artifact metadata only. Future VLM backends can replace that extractor
 while keeping the same schema.
 
+`OpenAICompatibleVisualFactExtractor` provides the first provider-neutral VLM
+adapter. It targets an OpenAI-compatible `/chat/completions` endpoint, sends a
+bounded local artifact as a data URL, asks for JSON-only structured visual
+facts, and normalizes the response into the same `VisualFactPack` schema. This
+keeps the multimodal knowledge pipeline independent of a specific model family.
+
 ### VisualGroundingManifest
 
 `codenib.wiki.media_grounding` grounds extracted visual entities to repository
@@ -99,3 +105,18 @@ print(view["entry_count"])
 
 This creates a deterministic local view. A VLM extractor can be added later by
 passing a custom extractor into `build_visual_facts_manifest()`.
+
+```python
+from codenib.wiki import OpenAICompatibleVisualFactExtractor
+
+extractor = OpenAICompatibleVisualFactExtractor(
+    model="qwen-vl",
+    api_base="http://localhost:8000/v1",
+    api_key=None,
+)
+
+facts = build_visual_facts_manifest(
+    media,
+    extractor=lambda artifact: extractor.extract(artifact, repo_path=repo),
+)
+```

--- a/test/wiki/test_media_vlm.py
+++ b/test/wiki/test_media_vlm.py
@@ -4,11 +4,13 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 
 import pytest
 
 import codenib.wiki.media_vlm as media_vlm
+from codenib.wiki.media_facts import build_visual_facts_manifest
 from codenib.wiki.media_vlm import OpenAICompatibleVisualFactExtractor
 
 
@@ -31,7 +33,7 @@ def _artifact():
     return {
         "path": "docs/assets/architecture.png",
         "mime_type": "image/png",
-        "sha256": "abc123",
+        "sha256": hashlib.sha256(b"png-bytes").hexdigest(),
         "role_hint": "architecture_diagram",
         "caption": "IndexCompiler architecture",
         "surrounding_text": "IndexCompiler writes to VectorStore.",
@@ -52,6 +54,9 @@ def test_openai_compatible_visual_fact_extractor_posts_image_and_normalizes(tmp_
                         "message": {
                             "content": json.dumps(
                                 {
+                                    "artifact_path": "../../forged.png",
+                                    "artifact_sha256": "forged",
+                                    "role_hint": "forged",
                                     "entities": [
                                         {
                                             "name": "IndexCompiler",
@@ -91,11 +96,17 @@ def test_openai_compatible_visual_fact_extractor_posts_image_and_normalizes(tmp_
         api_key="secret",
         timeout=7,
         urlopen=fake_urlopen,
+        repo_path=tmp_path,
     )
-    facts = extractor.extract(_artifact(), repo_path=tmp_path)
+    manifest = build_visual_facts_manifest(
+        {"manifest_sha256": "media-hash", "artifacts": [_artifact()]},
+        extractor=extractor,
+    )
+    facts = manifest["facts"][0]
 
     assert facts["artifact_path"] == "docs/assets/architecture.png"
-    assert facts["artifact_sha256"] == "abc123"
+    assert facts["artifact_sha256"] == _artifact()["sha256"]
+    assert facts["role_hint"] == "architecture_diagram"
     assert facts["extractor"] == "openai-compatible"
     assert facts["entities"][0]["name"] == "IndexCompiler"
     assert facts["metadata"]["model"] == "qwen-vl"
@@ -138,6 +149,45 @@ def test_visual_fact_extractor_rejects_unsafe_artifact_path(tmp_path):
 
     with pytest.raises(ValueError, match="repository-relative"):
         extractor.extract(artifact, repo_path=tmp_path)
+
+
+def test_visual_fact_extractor_requires_repo_for_manifest_callable():
+    extractor = OpenAICompatibleVisualFactExtractor(
+        model="qwen-vl",
+        api_base="https://api.example/v1",
+        urlopen=lambda _request, timeout: _Response({"choices": []}),
+    )
+
+    with pytest.raises(ValueError, match="repo_path must be configured"):
+        extractor(_artifact())
+
+
+def test_visual_fact_extractor_rejects_content_changed_since_manifest(tmp_path):
+    (tmp_path / "docs" / "assets").mkdir(parents=True)
+    (tmp_path / "docs" / "assets" / "architecture.png").write_bytes(b"changed")
+    extractor = OpenAICompatibleVisualFactExtractor(
+        model="qwen-vl",
+        api_base="https://api.example/v1",
+        urlopen=lambda *_args, **_kwargs: pytest.fail("request must not be sent"),
+    )
+
+    with pytest.raises(ValueError, match="does not match the media manifest"):
+        extractor.extract(_artifact(), repo_path=tmp_path)
+
+
+def test_visual_fact_extractor_rejects_symlinked_artifact(tmp_path):
+    (tmp_path / "docs" / "assets").mkdir(parents=True)
+    target = tmp_path / "actual.png"
+    target.write_bytes(b"png-bytes")
+    (tmp_path / "docs" / "assets" / "architecture.png").symlink_to(target)
+    extractor = OpenAICompatibleVisualFactExtractor(
+        model="qwen-vl",
+        api_base="https://api.example/v1",
+        urlopen=lambda *_args, **_kwargs: pytest.fail("request must not be sent"),
+    )
+
+    with pytest.raises(ValueError, match="regular file"):
+        extractor.extract(_artifact(), repo_path=tmp_path)
 
 
 def test_visual_fact_extractor_rejects_unsupported_mime_type(tmp_path):

--- a/test/wiki/test_media_vlm.py
+++ b/test/wiki/test_media_vlm.py
@@ -184,6 +184,23 @@ def test_visual_fact_extractor_bounds_response_bytes(tmp_path, monkeypatch):
         extractor.extract(_artifact())
 
 
+def test_visual_fact_extractor_bounds_image_bytes_during_read(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(media_vlm, "_MAX_IMAGE_BYTES", 2)
+    (tmp_path / "docs" / "assets").mkdir(parents=True)
+    (tmp_path / "docs" / "assets" / "architecture.png").write_bytes(b"png")
+    extractor = OpenAICompatibleVisualFactExtractor(
+        model="qwen-vl",
+        api_base="https://api.example/v1",
+        urlopen=lambda _request, timeout: _Response({"choices": []}),
+    )
+
+    with pytest.raises(ValueError, match="artifact exceeds"):
+        extractor.extract(_artifact(), repo_path=tmp_path)
+
+
 def test_visual_fact_extractor_rejects_non_json_content():
     extractor = OpenAICompatibleVisualFactExtractor(
         model="qwen-vl",

--- a/test/wiki/test_media_vlm.py
+++ b/test/wiki/test_media_vlm.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import codenib.wiki.media_vlm as media_vlm
+from codenib.wiki.media_vlm import OpenAICompatibleVisualFactExtractor
+
+
+class _Response:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return None
+
+    def read(self, size: int = -1) -> bytes:
+        payload = json.dumps(self._payload).encode("utf-8")
+        return payload if size < 0 else payload[:size]
+
+
+def _artifact():
+    return {
+        "path": "docs/assets/architecture.png",
+        "mime_type": "image/png",
+        "sha256": "abc123",
+        "role_hint": "architecture_diagram",
+        "caption": "IndexCompiler architecture",
+        "surrounding_text": "IndexCompiler writes to VectorStore.",
+    }
+
+
+def test_openai_compatible_visual_fact_extractor_posts_image_and_normalizes(tmp_path):
+    (tmp_path / "docs" / "assets").mkdir(parents=True)
+    (tmp_path / "docs" / "assets" / "architecture.png").write_bytes(b"png-bytes")
+    requests = []
+
+    def fake_urlopen(request, timeout):
+        requests.append((request, timeout))
+        return _Response(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": json.dumps(
+                                {
+                                    "entities": [
+                                        {
+                                            "name": "IndexCompiler",
+                                            "type": "component",
+                                            "evidence": "visual label",
+                                            "confidence": 0.9,
+                                            "grounding_candidates": ["IndexCompiler"],
+                                        }
+                                    ],
+                                    "relations": [
+                                        {
+                                            "source": "IndexCompiler",
+                                            "relation": "writes_to",
+                                            "target": "VectorStore",
+                                            "evidence": "arrow",
+                                            "confidence": 0.8,
+                                        }
+                                    ],
+                                    "claims": [
+                                        {
+                                            "text": "IndexCompiler writes to VectorStore.",
+                                            "evidence": "arrow",
+                                            "confidence": 0.8,
+                                        }
+                                    ],
+                                }
+                            )
+                        }
+                    }
+                ]
+            }
+        )
+
+    extractor = OpenAICompatibleVisualFactExtractor(
+        model="qwen-vl",
+        api_base="https://api.example/v1",
+        api_key="secret",
+        timeout=7,
+        urlopen=fake_urlopen,
+    )
+    facts = extractor.extract(_artifact(), repo_path=tmp_path)
+
+    assert facts["artifact_path"] == "docs/assets/architecture.png"
+    assert facts["artifact_sha256"] == "abc123"
+    assert facts["extractor"] == "openai-compatible"
+    assert facts["entities"][0]["name"] == "IndexCompiler"
+    assert facts["metadata"]["model"] == "qwen-vl"
+    request, timeout = requests[0]
+    assert request.full_url == "https://api.example/v1/chat/completions"
+    assert request.get_header("Authorization") == "Bearer secret"
+    assert timeout == 7
+    body = json.loads(request.data.decode("utf-8"))
+    assert body["model"] == "qwen-vl"
+    content = body["messages"][1]["content"]
+    assert content[0]["type"] == "text"
+    assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"api_base": "file:///tmp"}, "api_base"),
+        ({"api_base": "https://user:secret@example.test/v1"}, "credentials"),
+        ({"api_key": "secret\nheader"}, "API key"),
+        ({"timeout": True}, "positive number"),
+        ({"timeout": 601}, "between 0"),
+    ],
+)
+def test_visual_fact_extractor_rejects_unsafe_configuration(overrides, message):
+    arguments = {"model": "qwen-vl", "api_base": "https://api.example/v1"}
+    arguments.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        OpenAICompatibleVisualFactExtractor(**arguments)
+
+
+def test_visual_fact_extractor_rejects_unsafe_artifact_path(tmp_path):
+    extractor = OpenAICompatibleVisualFactExtractor(
+        model="qwen-vl",
+        api_base="https://api.example/v1",
+        urlopen=lambda _request, timeout: _Response({"choices": []}),
+    )
+    artifact = {**_artifact(), "path": "../secret.png"}
+
+    with pytest.raises(ValueError, match="repository-relative"):
+        extractor.extract(artifact, repo_path=tmp_path)
+
+
+def test_visual_fact_extractor_rejects_unsupported_mime_type(tmp_path):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "asset.gif").write_bytes(b"gif")
+    extractor = OpenAICompatibleVisualFactExtractor(
+        model="qwen-vl",
+        api_base="https://api.example/v1",
+        urlopen=lambda _request, timeout: _Response({"choices": []}),
+    )
+
+    with pytest.raises(ValueError, match="MIME"):
+        extractor.extract(
+            {
+                "path": "docs/asset.gif",
+                "mime_type": "image/gif",
+                "sha256": "abc123",
+            },
+            repo_path=tmp_path,
+        )
+
+
+def test_visual_fact_extractor_bounds_response_bytes(tmp_path, monkeypatch):
+    monkeypatch.setattr(media_vlm, "_MAX_RESPONSE_BYTES", 16)
+
+    class OversizedResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return None
+
+        def read(self, size):
+            assert size == 17
+            return b"x" * size
+
+    extractor = OpenAICompatibleVisualFactExtractor(
+        model="qwen-vl",
+        api_base="https://api.example/v1",
+        urlopen=lambda _request, timeout: OversizedResponse(),
+    )
+
+    with pytest.raises(ValueError, match="response exceeds"):
+        extractor.extract(_artifact())
+
+
+def test_visual_fact_extractor_rejects_non_json_content():
+    extractor = OpenAICompatibleVisualFactExtractor(
+        model="qwen-vl",
+        api_base="https://api.example/v1",
+        urlopen=lambda _request, timeout: _Response(
+            {"choices": [{"message": {"content": "not-json"}}]}
+        ),
+    )
+
+    with pytest.raises(json.JSONDecodeError):
+        extractor.extract(_artifact())


### PR DESCRIPTION
## Summary

Adds the PR3 slice for #655: optional OpenAI-compatible VLM extraction on top of the repository media and visual-fact contracts merged in #665.

This is the upstream-restacked form of MarinaMackay/CodeNib#11. The original feature commits retain MarinaMackay as their author; the branch is now based directly on current upstream `main` so this PR contains only the VLM slice.

## Changes

- Add `OpenAICompatibleVisualFactExtractor` for OpenAI-compatible chat/VLM endpoints.
- Attach bounded repository media as data URLs through a directly callable pipeline extractor.
- Anchor untrusted model output to the trusted media path, digest, and role from `MediaManifest`.
- Verify media bytes against the manifest digest and reject symlinked, unstable, oversized, or unsupported inputs before making a provider request.
- Bound request and response payloads and normalize provider metadata through the existing visual-fact contract.
- Document the local VLM path and add focused adapter, provenance, path, MIME, hashing, and bounds tests.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

Commands run locally:

```text
python -m pytest test/wiki -q
# 402 passed

python -m py_compile codenib/wiki/media_vlm.py codenib/wiki/media_facts.py codenib/wiki/__init__.py

python -m isort --profile black --check-only codenib/wiki/media_vlm.py codenib/wiki/media_facts.py codenib/wiki/__init__.py test/wiki/test_media_vlm.py
python -m black --check codenib/wiki/media_vlm.py codenib/wiki/media_facts.py codenib/wiki/__init__.py test/wiki/test_media_vlm.py
python -m flake8 codenib/wiki/media_vlm.py codenib/wiki/media_facts.py codenib/wiki/__init__.py test/wiki/test_media_vlm.py
git diff --check origin/main...HEAD
```

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented code where the behavior is not obvious
- [x] My changes generate no new warnings
- [x] The dependent PR2 changes are merged in #665
