### PR TITLE
feat(wiki): support pluggable visual grounding scorers

### DIFF
--- a/codenib/wiki/__init__.py
+++ b/codenib/wiki/__init__.py
@@ -15,6 +15,7 @@ from .media_artifacts import discover_media_manifest
 from .media_evidence import build_media_evidence_pack
 from .media_facts import build_visual_facts_manifest, deterministic_visual_facts
 from .media_grounding import (
+    VisualGroundingScorer,
     discover_source_symbol_candidates,
     ground_visual_facts_to_sources,
 )
@@ -29,6 +30,7 @@ from .media_vlm import OpenAICompatibleVisualFactExtractor
 __all__ = [
     "WikiBuilder",
     "OpenAICompatibleVisualFactExtractor",
+    "VisualGroundingScorer",
     "build_media_evidence_pack",
     "build_multimodal_knowledge_view",
     "build_visual_facts_manifest",

--- a/codenib/wiki/media_grounding.py
+++ b/codenib/wiki/media_grounding.py
@@ -8,11 +8,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import re
 from dataclasses import asdict, dataclass
 from itertools import islice
 from pathlib import Path, PurePosixPath
-from typing import Any, Iterable, Mapping
+from typing import Any, Callable, Iterable, Mapping
 
 from ..languages import extension_to_language_map
 from ..repository_filters import walk_repository_files
@@ -39,6 +40,9 @@ _SYMBOL_RE = re.compile(
     r"\b(?:class|def|function|const|let|var|interface|type|struct|enum)\s+([A-Za-z_][A-Za-z0-9_]*)"
 )
 _CAMEL_RE = re.compile(r"\b[A-Z][A-Za-z0-9_]{2,}\b")
+VisualGroundingScorer = Callable[
+    [Mapping[str, Any], Mapping[str, Any]], Mapping[str, Any] | None
+]
 
 
 @dataclass(frozen=True)
@@ -162,14 +166,22 @@ def ground_visual_facts_to_sources(
     source_candidates: Iterable[Mapping[str, Any]],
     *,
     max_bindings_per_entity: int = _MAX_BINDINGS_PER_ENTITY,
+    scorer: VisualGroundingScorer | None = None,
 ) -> dict[str, Any]:
-    """Ground visual entities to a source inventory using deterministic scoring."""
+    """Ground visual entities to a source inventory.
+
+    The default scorer is deterministic and lexical. Callers can pass a scorer
+    backed by BM25, embeddings, CodeGraph, LSP facts, or FactQueryIndex without
+    changing the visual-code binding manifest schema.
+    """
 
     binding_limit = _validated_limit(
         max_bindings_per_entity,
         name="max_bindings_per_entity",
         maximum=_MAX_BINDINGS_PER_ENTITY,
     )
+    if scorer is not None and not callable(scorer):
+        raise ValueError("scorer must be callable")
     candidates_by_key: dict[tuple[str, str, str, int], SourceSymbolCandidate] = {}
     for value in _mapping_items(source_candidates, limit=_MAX_CANDIDATES):
         candidate = _candidate_from_mapping(value)
@@ -178,6 +190,11 @@ def ground_visual_facts_to_sources(
         key = (candidate.path, candidate.symbol, candidate.kind, candidate.line)
         candidates_by_key.setdefault(key, candidate)
     candidates = list(candidates_by_key.values())
+    candidate_payloads = (
+        {candidate: candidate.to_dict() for candidate in candidates}
+        if scorer is not None
+        else {}
+    )
     bindings: list[VisualCodeBinding] = []
     entity_count = 0
     for fact_pack in _mapping_items(
@@ -212,11 +229,14 @@ def ground_visual_facts_to_sources(
             scored = [
                 binding
                 for binding in (
-                    _score_candidate(
+                    _score_with_optional_scorer(
                         artifact_path=artifact_path,
+                        entity=entity,
                         entity_name=entity_name,
                         hints=hints,
                         candidate=candidate,
+                        candidate_payload=candidate_payloads.get(candidate),
+                        scorer=scorer,
                     )
                     for candidate in candidates
                 )
@@ -259,6 +279,51 @@ def _candidate_from_mapping(value: Mapping[str, Any]) -> SourceSymbolCandidate:
         symbol=_safe_text(value.get("symbol")),
         kind=_safe_text(value.get("kind") or "source"),
         line=_positive_int(value.get("line")),
+    )
+
+
+def _score_with_optional_scorer(
+    *,
+    artifact_path: str,
+    entity: Mapping[str, Any],
+    entity_name: str,
+    hints: list[str],
+    candidate: SourceSymbolCandidate,
+    candidate_payload: Mapping[str, Any] | None,
+    scorer: VisualGroundingScorer | None,
+) -> VisualCodeBinding | None:
+    if scorer is None:
+        return _score_candidate(
+            artifact_path=artifact_path,
+            entity_name=entity_name,
+            hints=hints,
+            candidate=candidate,
+        )
+    scorer_entity = {
+        "name": entity_name,
+        "type": _safe_text(entity.get("type") or "unknown"),
+        "evidence": _safe_text(entity.get("evidence")),
+        "confidence": _confidence(entity.get("confidence")),
+        "grounding_candidates": [_safe_text(hint) for hint in hints[1:]],
+    }
+    raw = scorer(
+        scorer_entity,
+        candidate_payload if candidate_payload is not None else candidate.to_dict(),
+    )
+    if not isinstance(raw, Mapping):
+        return None
+    score = _confidence(raw.get("score"))
+    if score <= 0:
+        return None
+    return VisualCodeBinding(
+        artifact_path=artifact_path,
+        entity_name=entity_name,
+        source_path=candidate.path,
+        symbol=candidate.symbol,
+        kind=candidate.kind,
+        line=candidate.line,
+        score=round(score, 4),
+        evidence=_safe_text(raw.get("evidence") or "custom scorer"),
     )
 
 
@@ -381,6 +446,18 @@ def _validated_limit(value: Any, *, name: str, maximum: int) -> int:
     return value
 
 
+def _confidence(value: Any) -> float:
+    if isinstance(value, bool):
+        return 0.0
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if not math.isfinite(confidence):
+        return 0.0
+    return min(1.0, max(0.0, confidence))
+
+
 def _sha256_json(payload: Mapping[str, Any]) -> str:
     encoded = json.dumps(
         payload,
@@ -421,6 +498,7 @@ __all__ = [
     "MEDIA_GROUNDING_SCHEMA",
     "MEDIA_GROUNDING_VERSION",
     "SourceSymbolCandidate",
+    "VisualGroundingScorer",
     "VisualCodeBinding",
     "VisualGroundingManifest",
     "discover_source_symbol_candidates",

--- a/codenib/wiki/media_grounding.py
+++ b/codenib/wiki/media_grounding.py
@@ -312,7 +312,7 @@ def _score_with_optional_scorer(
     )
     if not isinstance(raw, Mapping):
         return None
-    score = _confidence(raw.get("score"))
+    score = _positive_score(raw.get("score"))
     if score <= 0:
         return None
     return VisualCodeBinding(
@@ -456,6 +456,18 @@ def _confidence(value: Any) -> float:
     if not math.isfinite(confidence):
         return 0.0
     return min(1.0, max(0.0, confidence))
+
+
+def _positive_score(value: Any) -> float:
+    if isinstance(value, bool):
+        return 0.0
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if not math.isfinite(score) or score <= 0:
+        return 0.0
+    return score
 
 
 def _sha256_json(payload: Mapping[str, Any]) -> str:

--- a/docs/experiments/multimodal_repository_knowledge.md
+++ b/docs/experiments/multimodal_repository_knowledge.md
@@ -63,7 +63,10 @@ keeps the multimodal knowledge pipeline independent of a specific model family.
 files and symbols. The first implementation uses deterministic lexical scoring
 against a bounded source-symbol inventory derived from the shared language
 registry. Later versions can replace the scorer with BM25, embeddings,
-CodeGraph, LSP facts, or `FactQueryIndex` / `FactBatch`.
+CodeGraph, LSP facts, or `FactQueryIndex` /
+`FactBatch`. The `ground_visual_facts_to_sources(..., scorer=...)` hook already
+accepts a custom scorer, so graph/fact-backed ranking can be added without
+changing the binding manifest schema.
 
 ### MultimodalKnowledgeView
 

--- a/docs/experiments/multimodal_repository_knowledge.md
+++ b/docs/experiments/multimodal_repository_knowledge.md
@@ -66,7 +66,8 @@ registry. Later versions can replace the scorer with BM25, embeddings,
 CodeGraph, LSP facts, or `FactQueryIndex` /
 `FactBatch`. The `ground_visual_facts_to_sources(..., scorer=...)` hook already
 accepts a custom scorer, so graph/fact-backed ranking can be added without
-changing the binding manifest schema.
+changing the binding manifest schema. Custom scorers return a positive, finite
+relevance score; values are not clipped, so backend ranking order is preserved.
 
 ### MultimodalKnowledgeView
 

--- a/test/wiki/test_media_grounding.py
+++ b/test/wiki/test_media_grounding.py
@@ -362,3 +362,42 @@ def test_grounding_rejects_invalid_or_nonfinite_custom_scores():
     )
 
     assert manifest["binding_count"] == 0
+
+
+def test_custom_scorer_preserves_ranking_above_one():
+    visual_facts = {
+        "manifest_sha256": "visual-facts-hash",
+        "facts": [
+            {
+                "artifact_path": "docs/architecture.svg",
+                "entities": [{"name": "DiagramBox"}],
+            }
+        ],
+    }
+    candidates = [
+        {
+            "path": "src/a_low.py",
+            "symbol": "LowRank",
+            "kind": "symbol",
+            "line": 1,
+        },
+        {
+            "path": "src/z_high.py",
+            "symbol": "HighRank",
+            "kind": "symbol",
+            "line": 2,
+        },
+    ]
+
+    def scorer(entity, candidate):
+        return {"score": 8.0 if candidate["symbol"] == "HighRank" else 2.0}
+
+    manifest = ground_visual_facts_to_sources(
+        visual_facts,
+        candidates,
+        max_bindings_per_entity=1,
+        scorer=scorer,
+    )
+
+    assert manifest["bindings"][0]["symbol"] == "HighRank"
+    assert manifest["bindings"][0]["score"] == 8.0

--- a/test/wiki/test_media_grounding.py
+++ b/test/wiki/test_media_grounding.py
@@ -284,3 +284,81 @@ def test_grounding_rejects_limits_above_contract_maximum(tmp_path):
         discover_source_symbol_candidates(tmp_path, max_candidates=8193)
     with pytest.raises(ValueError, match="max_bindings_per_entity"):
         ground_visual_facts_to_sources({}, (), max_bindings_per_entity=6)
+
+
+def test_ground_visual_facts_to_sources_accepts_custom_scorer():
+    visual_facts = {
+        "manifest_sha256": "visual-facts-hash",
+        "facts": [
+            {
+                "artifact_path": "docs/architecture.svg",
+                "entities": [{"name": "DiagramBox"}],
+            }
+        ],
+    }
+
+    def scorer(entity, candidate):
+        if entity["name"] == "DiagramBox" and candidate["symbol"] == "WikiService":
+            return {
+                "score": 0.88,
+                "evidence": "graph scorer match",
+                "source_path": "../../forged.py",
+            }
+        return None
+
+    manifest = ground_visual_facts_to_sources(
+        visual_facts,
+        [
+            {
+                "path": "codenib/wiki/service.py",
+                "symbol": "WikiService",
+                "kind": "symbol",
+                "line": 17,
+            }
+        ],
+        scorer=scorer,
+    )
+
+    assert manifest["bindings"] == [
+        {
+            "artifact_path": "docs/architecture.svg",
+            "entity_name": "DiagramBox",
+            "source_path": "codenib/wiki/service.py",
+            "symbol": "WikiService",
+            "kind": "symbol",
+            "line": 17,
+            "score": 0.88,
+            "evidence": "graph scorer match",
+        }
+    ]
+
+
+def test_grounding_rejects_invalid_or_nonfinite_custom_scores():
+    visual_facts = {
+        "manifest_sha256": "visual-facts-hash",
+        "facts": [
+            {
+                "artifact_path": "docs/architecture.svg",
+                "entities": [{"name": "DiagramBox"}],
+            }
+        ],
+    }
+    candidates = [
+        {
+            "path": "codenib/wiki/service.py",
+            "symbol": "WikiService",
+            "kind": "symbol",
+            "line": 17,
+        }
+    ]
+
+    with pytest.raises(ValueError, match="scorer must be callable"):
+        ground_visual_facts_to_sources(visual_facts, candidates, scorer="invalid")
+
+    manifest = ground_visual_facts_to_sources(
+        visual_facts,
+        candidates,
+        scorer=lambda entity, candidate: {"score": float("inf")},
+    )
+
+    assert manifest["binding_count"] == 0


### PR DESCRIPTION
## Summary

Restacks and integrates [MarinaMackay/CodeNib#5](https://github.com/MarinaMackay/CodeNib/pull/5) as the next independent slice of #655.

Adds a pluggable visual-grounding scorer so BM25, embeddings, CodeGraph, LSP facts, or FactQueryIndex-backed rankers can replace lexical scoring without changing the binding manifest schema.

## Changes

- Add the public `VisualGroundingScorer` hook and optional `scorer` argument.
- Preserve the deterministic lexical scorer as the default.
- Pass bounded, canonical entity and source-candidate payloads to custom scorers.
- Anchor bindings to trusted source candidates even if a scorer returns forged location fields.
- Reject invalid/non-finite custom scores while preserving positive unbounded ranking order for BM25-style backends.
- Document the extension point and its score contract.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] `pytest test/wiki -q` (405 passed)
- [x] `python -m flake8 codenib/wiki/__init__.py codenib/wiki/media_grounding.py test/wiki/test_media_grounding.py`
- [x] `git diff --check origin/main...HEAD`

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published