### PR TITLE
feat(storage): add dual-root replacement publication

### DIFF
--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -68,6 +68,7 @@ _MAX_ORDERED_ACTION_CANCELLATION_RETRIES = 8
 _DURABLE_PUBLICATION_FSYNC_BACKENDS = frozenset(
     {"linux-native-workspace-owner", "linux-renameat2"}
 )
+_NATIVE_REPLACEMENT_PUBLICATION_BACKEND = "linux-native-workspace-replacement"
 _WINDOWS_RESERVED_BASENAMES = frozenset(
     {"CON", "PRN", "AUX", "NUL"}
     | {f"COM{number}" for number in range(1, 10)}
@@ -3371,6 +3372,704 @@ def _adopt_native_posix_publication_authority(
     return authority
 
 
+class _NativeReplacementPublication:
+    """One borrowed dual-root view of a native replacement transaction.
+
+    The native aggregate remains the sole descriptor owner.  Before receipt
+    settlement this facade authenticates the candidate and incumbent through
+    distinct, already-borrowed root descriptors.  After settlement it becomes
+    candidate-only: the displaced incumbent is represented solely by its
+    independently reopenable :class:`DirectoryOrphan` locator.
+    """
+
+    __slots__ = (
+        "candidate_descriptor",
+        "candidate_identity",
+        "destination_name",
+        "display_parent",
+        "exchanged",
+        "incumbent_descriptor",
+        "incumbent_identity",
+        "native_owner",
+        "parent_descriptor",
+        "parent_identity",
+        "receipted",
+        "replacement_slot",
+        "_authority_pair_verifier",
+        "_exchange_callback",
+        "_native_state_callback",
+        "_verify_native_callback",
+        "_verify_parent_path_callback",
+    )
+
+    def __init__(
+        self,
+        *,
+        display_parent: Path,
+        native_owner: object,
+        parent_descriptor: int,
+        candidate_descriptor: int,
+        incumbent_descriptor: int,
+        destination_name: str,
+        replacement_slot: str,
+        exchange_callback: Callable[[bytes, bytes, int], object],
+        expected_parent_identity: tuple[int, ...],
+        expected_incumbent_identity: tuple[int, ...],
+    ) -> None:
+        if not sys.platform.startswith("linux"):
+            raise RuntimeError("native workspace replacement requires Linux")
+        self.display_parent = lexical_directory_path(display_parent)
+        self.native_owner = _native_workspace_owner.require_exact_owner(native_owner)
+        self.parent_descriptor = parent_descriptor
+        self.candidate_descriptor = candidate_descriptor
+        self.incumbent_descriptor = incumbent_descriptor
+        self.destination_name = _simple_child_name(
+            destination_name,
+            label="workspace replacement destination",
+        )
+        self.replacement_slot = _simple_child_name(
+            replacement_slot,
+            label="workspace replacement slot",
+        )
+        if self.destination_name == self.replacement_slot:
+            raise ValueError("workspace replacement roots must have distinct names")
+        if not callable(exchange_callback):
+            raise TypeError("workspace replacement exchange callback is invalid")
+        self._exchange_callback = exchange_callback
+        verify_native_exact = _native_workspace_owner.verify_owner_authority
+        native_state_exact = _native_workspace_owner.owner_state
+        verify_parent_path_exact = _require_publication_parent_path
+        self._verify_native_callback = lambda: verify_native_exact(self.native_owner)
+        self._native_state_callback = lambda: native_state_exact(self.native_owner)
+        self._verify_parent_path_callback = lambda: verify_parent_path_exact(
+            self.display_parent,
+            self.parent_identity,
+        )
+        self._authority_pair_verifier: (
+            Callable[[_PublicationAuthority], None] | None
+        ) = None
+        self.parent_identity = publication_parent_identity(parent_descriptor)
+        self.candidate_identity = self._descriptor_identity(
+            candidate_descriptor,
+            label="workspace replacement candidate",
+        )
+        self.incumbent_identity = self._descriptor_identity(
+            incumbent_descriptor,
+            label="workspace replacement incumbent",
+        )
+        if self.parent_identity != expected_parent_identity:
+            raise RuntimeError("workspace replacement parent authority changed")
+        if self.incumbent_identity != expected_incumbent_identity:
+            raise RuntimeError("workspace replacement incumbent authority changed")
+        if self.candidate_identity == self.incumbent_identity:
+            raise RuntimeError("workspace replacement roots are not distinct")
+        if (
+            self.candidate_identity[0] != self.parent_identity[0]
+            or self.incumbent_identity[0] != self.parent_identity[0]
+        ):
+            raise ValueError("workspace replacement roots cross the parent device")
+        self.exchanged = False
+        self.receipted = False
+        self.verify_current()
+
+    @staticmethod
+    def _descriptor_identity(descriptor: int, *, label: str) -> tuple[int, ...]:
+        if type(descriptor) is not int or descriptor < 0:
+            raise ValueError(f"{label} descriptor is invalid")
+        metadata = os.fstat(descriptor)
+        if _is_link_or_reparse(metadata) or not stat.S_ISDIR(metadata.st_mode):
+            raise RuntimeError(f"{label} descriptor is not a directory")
+        identity = _directory_inode_identity(metadata)
+        if not identity[0] or not identity[1]:
+            raise RuntimeError(f"{label} has no reliable identity")
+        return identity
+
+    def _linked_identity(self, name: str, *, label: str) -> tuple[int, ...]:
+        try:
+            metadata = os.stat(
+                name,
+                dir_fd=self.parent_descriptor,
+                follow_symlinks=False,
+            )
+        except OSError as exc:
+            raise RuntimeError(f"{label} namespace binding changed") from exc
+        if _is_link_or_reparse(metadata) or not stat.S_ISDIR(metadata.st_mode):
+            raise RuntimeError(f"{label} namespace binding changed")
+        return _directory_inode_identity(metadata)
+
+    def _verify_descriptor_identities(self) -> None:
+        if publication_parent_identity(self.parent_descriptor) != self.parent_identity:
+            raise RuntimeError("workspace replacement parent authority changed")
+        if (
+            self._descriptor_identity(
+                self.candidate_descriptor,
+                label="workspace replacement candidate",
+            )
+            != self.candidate_identity
+            or self._descriptor_identity(
+                self.incumbent_descriptor,
+                label="workspace replacement incumbent",
+            )
+            != self.incumbent_identity
+        ):
+            raise RuntimeError("workspace replacement descriptor authority changed")
+
+    def _verify_candidate_only(self) -> None:
+        if not self.receipted or not self.exchanged:
+            raise RuntimeError("workspace replacement is not receipted")
+        if publication_parent_identity(self.parent_descriptor) != self.parent_identity:
+            raise RuntimeError("workspace replacement parent authority changed")
+        if (
+            self._descriptor_identity(
+                self.candidate_descriptor,
+                label="workspace replacement candidate",
+            )
+            != self.candidate_identity
+            or self._linked_identity(
+                self.destination_name,
+                label="workspace replacement candidate",
+            )
+            != self.candidate_identity
+        ):
+            raise RuntimeError("workspace replacement candidate authority changed")
+        self._verify_parent_path_callback()
+
+    def verify_current(self) -> None:
+        if self.receipted:
+            self._verify_candidate_only()
+            return
+        self._verify_native_callback()
+        self._verify_descriptor_identities()
+        expected_candidate = (
+            self.destination_name if self.exchanged else self.replacement_slot
+        )
+        expected_incumbent = (
+            self.replacement_slot if self.exchanged else self.destination_name
+        )
+        if (
+            self._linked_identity(
+                expected_candidate,
+                label="workspace replacement candidate",
+            )
+            != self.candidate_identity
+            or self._linked_identity(
+                expected_incumbent,
+                label="workspace replacement incumbent",
+            )
+            != self.incumbent_identity
+        ):
+            raise RuntimeError("workspace replacement dual-root binding changed")
+
+    def _read_descriptor(
+        self,
+        *,
+        descriptor: int,
+        identity: tuple[int, ...],
+        name: str,
+        display_path: Path,
+        label: str,
+        expected_ownership: _TreeOwnership | None,
+        callback: Callable[[_PublicationTreeReader], _T],
+        verify: Callable[[], None],
+    ) -> _T:
+        verify()
+        if self._linked_identity(name, label=label) != identity:
+            raise RuntimeError(f"{label} namespace binding changed")
+        reader: _PublicationTreeReader | None = None
+
+        def deactivate_reader() -> None:
+            if reader is not None:
+                reader._deactivate()
+
+        cleanup_actions = (
+            _OrderedAction(
+                label="publication reader deactivation also failed",
+                action=deactivate_reader,
+                complete=lambda: reader is None or not reader._lifetime.active,
+                retry_incomplete="cancellation",
+            ),
+        )
+        with _run_context_with_cleanup_actions(cleanup_actions):
+            reader = _PublicationTreeReader(
+                display_path,
+                identity,
+                lambda required_root_file, allow_empty_root, entry_policy: (
+                    _capture_posix_directory_descriptor(
+                        descriptor,
+                        display_path,
+                        required_root_file=required_root_file,
+                        allow_empty_root=allow_empty_root,
+                        entry_policy=entry_policy,
+                    )
+                ),
+                lambda relative, max_bytes, expected: (
+                    _open_posix_authenticated_file(
+                        descriptor,
+                        display_path,
+                        relative,
+                        max_bytes=max_bytes,
+                        expected=expected,
+                    )
+                ),
+                expected_ownership,
+            )
+
+            def validate_binding() -> None:
+                if self._linked_identity(name, label=label) != identity:
+                    raise RuntimeError(f"{label} namespace binding changed")
+                verify()
+
+            return _run_publication_reader_callback(
+                reader,
+                callback,
+                validate_binding,
+            )
+
+    @property
+    def candidate_name(self) -> str:
+        return self.destination_name if self.exchanged else self.replacement_slot
+
+    @property
+    def incumbent_name(self) -> str:
+        if self.receipted:
+            raise RuntimeError("receipted replacement has no incumbent reader")
+        return self.replacement_slot if self.exchanged else self.destination_name
+
+    def candidate_metadata(
+        self,
+        name: str,
+        display_path: Path,
+        label: str,
+    ) -> os.stat_result:
+        if name != self.candidate_name:
+            raise RuntimeError(f"{label} is not the replacement candidate")
+        self.verify_current()
+        metadata = os.stat(
+            name,
+            dir_fd=self.parent_descriptor,
+            follow_symlinks=False,
+        )
+        if _directory_inode_identity(metadata) != self.candidate_identity:
+            raise RuntimeError(f"{label} namespace binding changed: {display_path}")
+        return metadata
+
+    def read_candidate(
+        self,
+        name: str,
+        display_path: Path,
+        label: str,
+        expected_ownership: _TreeOwnership | None,
+        callback: Callable[[_PublicationTreeReader], _T],
+    ) -> _T:
+        if name != self.candidate_name:
+            raise RuntimeError(f"{label} is not the replacement candidate")
+        return self._read_descriptor(
+            descriptor=self.candidate_descriptor,
+            identity=self.candidate_identity,
+            name=name,
+            display_path=display_path,
+            label=label,
+            expected_ownership=expected_ownership,
+            callback=callback,
+            verify=self.verify_current,
+        )
+
+    def read_incumbent(
+        self,
+        name: str,
+        display_path: Path,
+        label: str,
+        expected_ownership: _TreeOwnership | None,
+        callback: Callable[[_PublicationTreeReader], _T],
+    ) -> _T:
+        if self.receipted or name != self.incumbent_name:
+            raise RuntimeError(f"{label} is not the replacement incumbent")
+        return self._read_descriptor(
+            descriptor=self.incumbent_descriptor,
+            identity=self.incumbent_identity,
+            name=name,
+            display_path=display_path,
+            label=label,
+            expected_ownership=expected_ownership,
+            callback=callback,
+            verify=self.verify_current,
+        )
+
+    def capture_incumbent(
+        self,
+        *,
+        path: Path,
+        label: str,
+    ) -> _TreeOwnership:
+        return self.read_incumbent(
+            self.incumbent_name,
+            path,
+            label,
+            None,
+            lambda reader: reader.capture_ownership(allow_empty_root=True),
+        )
+
+    def exchange(self, deadline_ns: int) -> object:
+        if self.receipted or self.exchanged:
+            raise RuntimeError("workspace replacement exchange is unavailable")
+        token = self._exchange_callback(
+            os.fsencode(self.replacement_slot),
+            os.fsencode(self.destination_name),
+            deadline_ns,
+        )
+        self.exchanged = True
+        return token
+
+    def mark_receipted(self) -> None:
+        if not self.exchanged:
+            raise RuntimeError("workspace replacement was not exchanged")
+        if self._native_state_callback() != "replacement-receipted":
+            raise RuntimeError("native workspace replacement is not receipted")
+        self.receipted = True
+
+    def _seal_publication_authority(
+        self,
+        authority: _PublicationAuthority,
+        *,
+        metadata_callback: Callable[[str, Path, str], object | None],
+        reader_callback: Callable[
+            [
+                str,
+                Path,
+                str,
+                _TreeOwnership | None,
+                Callable[[_PublicationTreeReader], _T],
+            ],
+            _T,
+        ],
+        verify_callback: Callable[[], None],
+    ) -> None:
+        """One-shot seal this context to its exact callback authority."""
+
+        if self._authority_pair_verifier is not None:
+            raise RuntimeError("workspace replacement authority is already sealed")
+        if (
+            getattr(metadata_callback, "__self__", None) is not self
+            or getattr(reader_callback, "__self__", None) is not self
+            or getattr(verify_callback, "__self__", None) is not self
+        ):
+            raise RuntimeError("workspace replacement callbacks are not bound")
+        authority_type = _PublicationAuthority
+        expected_parent = self.display_parent
+        expected_identity = self.parent_identity
+        expected_resource = self.parent_descriptor
+
+        def verify_pair(candidate: _PublicationAuthority) -> None:
+            if type(candidate) is not authority_type or candidate is not authority:
+                raise TypeError("workspace replacement authority pairing is invalid")
+            if (
+                candidate.display_parent != expected_parent
+                or candidate.identity != expected_identity
+                or candidate.backend_tag != _NATIVE_REPLACEMENT_PUBLICATION_BACKEND
+                or candidate._resource != expected_resource
+                or candidate._metadata_callback is not metadata_callback
+                or candidate._reader_callback is not reader_callback
+                or candidate._verify_callback is not verify_callback
+            ):
+                raise RuntimeError("workspace replacement authority seal changed")
+
+        verify_pair(authority)
+        self._authority_pair_verifier = verify_pair
+
+
+_NATIVE_REPLACEMENT_PUBLICATION_TYPE = _NativeReplacementPublication
+
+
+def _adopt_native_posix_replacement_authority(
+    path: Path,
+    *,
+    native_owner: object,
+    parent_descriptor: int,
+    candidate_descriptor: int,
+    incumbent_descriptor: int,
+    expected_parent_identity: tuple[int, ...],
+    expected_incumbent_identity: tuple[int, ...],
+    destination_name: str,
+    replacement_slot: str,
+    exchange_callback: Callable[[bytes, bytes, int], object],
+    authority_owner: _PublicationAuthorityOwner,
+) -> tuple[_PublicationAuthority, _NativeReplacementPublication]:
+    """Adopt separate candidate/incumbent readers from one native owner."""
+
+    if not sys.platform.startswith("linux"):
+        raise RuntimeError("native workspace replacement adoption requires Linux")
+    if authority_owner.authority is not None:
+        raise RuntimeError("publication authority owner is already active")
+    owner = _native_workspace_owner.require_exact_owner(native_owner)
+    replacement = _NativeReplacementPublication(
+        display_parent=path,
+        native_owner=owner,
+        parent_descriptor=parent_descriptor,
+        candidate_descriptor=candidate_descriptor,
+        incumbent_descriptor=incumbent_descriptor,
+        destination_name=destination_name,
+        replacement_slot=replacement_slot,
+        exchange_callback=exchange_callback,
+        expected_parent_identity=expected_parent_identity,
+        expected_incumbent_identity=expected_incumbent_identity,
+    )
+
+    def reject_generic_rename(_source: str, _destination: str) -> object | None:
+        raise RuntimeError(
+            "native workspace replacement requires its dedicated exchange path"
+        )
+
+    def reject_generic_sync() -> None:
+        raise RuntimeError(
+            "native workspace replacement parent sync is owned by settlement"
+        )
+
+    facade_closed = False
+
+    def close_callback(_resource: int) -> None:
+        nonlocal facade_closed
+        facade_closed = True
+
+    metadata_callback = replacement.candidate_metadata
+    reader_callback = replacement.read_candidate
+    verify_callback = replacement.verify_current
+    authority = _PublicationAuthority(
+        display_parent=replacement.display_parent,
+        identity=replacement.parent_identity,
+        backend_tag=_NATIVE_REPLACEMENT_PUBLICATION_BACKEND,
+        resource=parent_descriptor,
+        close_callback=close_callback,
+        metadata_callback=metadata_callback,
+        reader_callback=reader_callback,
+        rename_callback=reject_generic_rename,
+        verify_callback=verify_callback,
+        close_complete_callback=lambda: facade_closed,
+        sync_callback=reject_generic_sync,
+    )
+    try:
+        replacement._seal_publication_authority(
+            authority,
+            metadata_callback=metadata_callback,
+            reader_callback=reader_callback,
+            verify_callback=verify_callback,
+        )
+        replacement.verify_current()
+        authority_owner.install(authority)
+    except BaseException as primary_error:  # noqa: B036 - facade-only cleanup
+        if authority_owner.authority is authority:
+            authority_owner.close_after_error(primary_error)
+        raise
+    return authority, replacement
+
+
+def _publish_native_replacement_with_authority(
+    publication_authority: _PublicationAuthority,
+    replacement: _NativeReplacementPublication,
+    stage: Path,
+    destination: Path,
+    *,
+    expected_stage_root_ownership: _TreeOwnership,
+    expected_destination_ownership: _TreeOwnership,
+    deadline_ns: int,
+    validate_staged_directory: (
+        Callable[[PublicationDirectoryReader], None] | None
+    ) = None,
+    validate_published_destination: (
+        Callable[[PublicationDirectoryReader], None] | None
+    ) = None,
+    commit_callback: Callable[
+        [_TreeOwnership, _TreeOwnership, DirectoryOrphan, object],
+        None,
+    ],
+) -> DirectoryOrphan:
+    """Publish one native replacement without generic isolation or sync."""
+
+    stage_display = lexical_directory_path(stage)
+    destination_display = lexical_directory_path(destination)
+    if type(replacement) is not _NATIVE_REPLACEMENT_PUBLICATION_TYPE:
+        raise TypeError("workspace replacement context is invalid")
+    verify_authority_pair_exact = replacement._authority_pair_verifier
+    if not callable(verify_authority_pair_exact):
+        raise RuntimeError("workspace replacement authority is not sealed")
+    verify_authority_pair_exact(publication_authority)
+    if publication_authority.backend_tag != _NATIVE_REPLACEMENT_PUBLICATION_BACKEND:
+        raise TypeError("workspace replacement publication authority is invalid")
+    if stage_display.parent != destination_display.parent:
+        raise ValueError("workspace replacement roots must share one parent")
+    if stage_display.parent != publication_authority.display_parent:
+        raise ValueError("workspace replacement roots differ from their authority")
+    if (
+        stage_display.name != replacement.replacement_slot
+        or destination_display.name != replacement.destination_name
+    ):
+        raise ValueError("workspace replacement names differ from their authority")
+    if type(expected_stage_root_ownership) is not _TreeOwnership:
+        raise TypeError("workspace replacement candidate ownership is invalid")
+    if type(expected_destination_ownership) is not _TreeOwnership:
+        raise TypeError("workspace replacement incumbent ownership is invalid")
+    if type(deadline_ns) is not int or deadline_ns <= 0:
+        raise ValueError("workspace replacement deadline is invalid")
+    if validate_staged_directory is not None and not callable(
+        validate_staged_directory
+    ):
+        raise TypeError("workspace replacement staged validator is invalid")
+    if validate_published_destination is not None and not callable(
+        validate_published_destination
+    ):
+        raise TypeError("workspace replacement published validator is invalid")
+    if not callable(commit_callback):
+        raise TypeError("workspace replacement commit callback is invalid")
+
+    # Freeze every authority method, capability receiver, ownership check, and
+    # receipt constructor before either validator runs.  A validator may
+    # mutate public/private module or class attributes for fault injection, but
+    # it cannot intercept the native exchange/receipt token in this frame.
+    verify_replacement_exact = replacement.verify_current
+    capture_incumbent_exact = replacement.capture_incumbent
+    exchange_replacement_exact = replacement.exchange
+    read_candidate_exact = publication_authority.read_child
+    verify_path_binding_exact = publication_authority.verify_path_binding
+    capture_ownership_exact = _PublicationTreeReader.capture_ownership
+    require_publishable_exact = require_publishable_directory_ownership
+    require_matching_exact = _require_matching_ownership
+    locator_type = _DirectoryOrphanLocator
+    locator_new = object.__new__
+    locator_init = locator_type.__init__
+    orphan_type = DirectoryOrphan
+    orphan_new = object.__new__
+    orphan_init = orphan_type.__init__
+
+    def capture_candidate_exact(
+        name: str,
+        *,
+        path: Path,
+        label: str,
+    ) -> _TreeOwnership:
+        return read_candidate_exact(
+            name,
+            path=path,
+            label=label,
+            expected_ownership=None,
+            callback=lambda reader: capture_ownership_exact(
+                reader,
+                allow_empty_root=True,
+            ),
+        )
+
+    verify_replacement_exact()
+    staged = capture_candidate_exact(
+        stage_display.name,
+        path=stage_display,
+        label="workspace replacement candidate",
+    )
+    require_publishable_exact(
+        staged,
+        label="workspace replacement candidate",
+    )
+    if staged != expected_stage_root_ownership:
+        raise RuntimeError("workspace replacement candidate changed before exchange")
+    if validate_staged_directory is not None:
+        read_candidate_exact(
+            stage_display.name,
+            path=stage_display,
+            label="workspace replacement candidate",
+            expected_ownership=staged,
+            callback=validate_staged_directory,
+        )
+        verify_authority_pair_exact(publication_authority)
+        if (
+            capture_candidate_exact(
+                stage_display.name,
+                path=stage_display,
+                label="workspace replacement candidate",
+            )
+            != staged
+        ):
+            raise RuntimeError(
+                "workspace replacement candidate changed during validation"
+            )
+
+    incumbent = capture_incumbent_exact(
+        path=destination_display,
+        label="workspace replacement incumbent",
+    )
+    if incumbent != expected_destination_ownership:
+        raise RuntimeError("workspace replacement incumbent changed before exchange")
+    verify_authority_pair_exact(publication_authority)
+    verify_replacement_exact()
+
+    receipt_token = exchange_replacement_exact(deadline_ns)
+    verify_replacement_exact()
+
+    published = capture_candidate_exact(
+        destination_display.name,
+        path=destination_display,
+        label="published workspace replacement candidate",
+    )
+    require_matching_exact(
+        published,
+        staged,
+        label="published workspace replacement candidate",
+        allow_root_rename=True,
+    )
+    if validate_published_destination is not None:
+        read_candidate_exact(
+            destination_display.name,
+            path=destination_display,
+            label="published workspace replacement candidate",
+            expected_ownership=published,
+            callback=validate_published_destination,
+        )
+        verify_authority_pair_exact(publication_authority)
+    published = capture_candidate_exact(
+        destination_display.name,
+        path=destination_display,
+        label="published workspace replacement candidate",
+    )
+    require_matching_exact(
+        published,
+        staged,
+        label="published workspace replacement candidate",
+        allow_root_rename=True,
+    )
+
+    displaced = capture_incumbent_exact(
+        path=stage_display,
+        label="displaced workspace incumbent",
+    )
+    require_matching_exact(
+        displaced,
+        incumbent,
+        label="displaced workspace incumbent",
+        allow_root_rename=True,
+    )
+    locator = locator_new(locator_type)
+    locator_init(
+        locator,
+        parent_path=publication_authority.display_parent,
+        child_name=stage_display.name,
+        # Reopening uses the ordinary Linux parent authority.  The native
+        # replacement backend exists only for this live transaction.
+        backend_tag="linux-renameat2",
+        parent_identity=publication_authority.identity,
+        ownership=displaced,
+    )
+    previous_orphan = orphan_new(orphan_type)
+    orphan_init(
+        previous_orphan,
+        locator=locator,
+        ownership_digest=displaced.digest,
+        entries=displaced.entries,
+        byte_count=displaced.byte_count,
+        verified_at_isolation=True,
+    )
+    verify_replacement_exact()
+    verify_authority_pair_exact(publication_authority)
+    verify_path_binding_exact()
+    commit_callback(staged, published, previous_orphan, receipt_token)
+    return previous_orphan
+
+
 def _require_publication_parent_path(
     path: Path,
     expected_identity: tuple[int, ...],
@@ -6238,6 +6937,10 @@ def _publish_staged_directory_with_authority(
     if stage_display.parent != publication_authority.display_parent:
         raise ValueError(
             "staged and destination directories must match the authority parent"
+        )
+    if publication_authority.backend_tag == _NATIVE_REPLACEMENT_PUBLICATION_BACKEND:
+        raise RuntimeError(
+            "native workspace replacement requires its dedicated exchange path"
         )
     if commit_callback is not None:
         if not callable(commit_callback):

--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -33,11 +33,15 @@ from ._atomic_directory import (
     PublicationDirectoryReader,
     TreeFileRecord,
     _adopt_native_posix_publication_authority,
+    _adopt_native_posix_replacement_authority,
     _annotate_secondary_error,
+    _capture_posix_directory_descriptor,
+    _NativeReplacementPublication,
     _open_publication_authority,
     _PosixResourceOwner,
     _PublicationAuthority,
     _PublicationAuthorityOwner,
+    _publish_native_replacement_with_authority,
     _publish_staged_directory_with_authority,
     _rename_noreplace_at,
     _require_matching_ownership,
@@ -635,6 +639,10 @@ class _WorkspacePublicationTransfer:
     """Shared aggregate owner installed before any publication mutation."""
 
     workspace: "OwnedWorkspaceAuthority"
+    native_receipt_commit: Callable[[object], None]
+    native_owner_closed: Callable[[object], bool]
+    native_owner_state: Callable[[object], str]
+    mark_replacement_receipted: Callable[[], None] | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -2171,6 +2179,12 @@ class OwnedWorkspaceAuthority:
         self._publication_transfer: _WorkspacePublicationTransfer | None = None
         self._resources_transferred = False
         self._native_owner: object | None = None
+        self._native_replacement: _NativeReplacementPublication | None = None
+        self._replacement_exchange: Callable[[bytes, bytes, int], object] | None = None
+        self._replacement_parent_descriptor = -1
+        self._replacement_parent_identity: tuple[int, ...] | None = None
+        self._replacement_incumbent_descriptor = -1
+        self._replacement_incumbent_identity: tuple[int, ...] | None = None
 
     @property
     def state(self) -> str:
@@ -2223,6 +2237,302 @@ class OwnedWorkspaceAuthority:
         raise UnsupportedWorkspaceCreation(
             "strict workspace creation requires a trusted pre-opened skeleton"
         )
+
+    def bind_replacement_source(
+        self,
+        source_owner: PublishedWorkspaceReceiptOwner,
+        *,
+        destination_binding: PublishedWorkspaceDestinationBinding,
+        native_owner: object,
+        stage_name: str,
+        plan: WorkspacePlan,
+    ) -> None:
+        """Bind one leased native owner to an active incumbent generation.
+
+        This is the first phase of exact replacement.  The active receipt is
+        consumed synchronously, while the native owner still holds the same
+        incumbent and parent under its cooperative lease.  The one-shot native
+        exchange permit remains private to this authority; no detached request
+        binding or replayable replacement capability is returned.
+        """
+
+        self._require_owner_pid()
+        if not sys.platform.startswith("linux"):
+            raise UnsupportedWorkspaceCreation(
+                "native workspace replacement binding requires Linux"
+            )
+        if type(source_owner) is not PublishedWorkspaceReceiptOwner:
+            raise TypeError(
+                "replacement source owner must be an exact "
+                "PublishedWorkspaceReceiptOwner"
+            )
+        if (
+            type(destination_binding)
+            is not _PUBLISHED_WORKSPACE_DESTINATION_BINDING_TYPE
+        ):
+            raise TypeError("workspace destination binding is invalid")
+        self._reject_reentrant("bind replacement source")
+        detached_plan = _snapshot_workspace_plan(plan)
+        destination = lexical_directory_path(destination_binding.destination)
+        stage_relative = _relative_path(stage_name)
+        if len(stage_relative.parts) != 1 or not stage_relative.name.startswith("."):
+            raise ValueError(
+                "workspace replacement stage must be one hidden child name"
+            )
+        if stage_relative.name == destination.name:
+            raise ValueError("workspace replacement roots must have distinct names")
+        owner = _native_workspace_owner.require_exact_owner(native_owner)
+        consume_source_exact = PublishedWorkspaceReceiptOwner.consume
+        capture_ownership_exact = PublicationDirectoryReader.capture_ownership
+
+        def bind_active_source(
+            receipt: PublishedWorkspaceReceipt,
+            reader: PublicationDirectoryReader,
+        ) -> None:
+            if type(receipt) is not _PUBLISHED_WORKSPACE_RECEIPT_TYPE:
+                raise RuntimeError("workspace replacement source receipt is invalid")
+            if receipt._destination_binding is not destination_binding:
+                raise RuntimeError("workspace replacement source binding is not active")
+            if (
+                receipt.path != destination
+                or receipt.parent_identity != destination_binding.parent_identity
+                or receipt.ownership != destination_binding.ownership
+            ):
+                raise RuntimeError(
+                    "workspace replacement source binding fields changed"
+                )
+            source_ownership = capture_ownership_exact(
+                reader,
+                allow_empty_root=True,
+            )
+            if source_ownership != destination_binding.ownership:
+                raise RuntimeError("workspace replacement source generation changed")
+            self._lock.run(
+                lambda: self._bind_replacement_source_locked(
+                    destination=destination,
+                    stage_name=stage_relative.name,
+                    plan=detached_plan,
+                    destination_binding=destination_binding,
+                    source_ownership=source_ownership,
+                    native_owner=owner,
+                )
+            )
+
+        try:
+            consume_source_exact(source_owner, bind_active_source)
+        except BaseException as bind_error:  # noqa: B036 - settle transferred owner
+            primary_error = bind_error
+
+            def settle_failed_bind() -> None:
+                if self._native_owner is not owner or self._state == "closed":
+                    return
+                self._state = "failed"
+                self._close_resources_after_error_locked(primary_error)
+
+            try:
+                self._lock.run(settle_failed_bind)
+            except BaseException as cleanup_error:  # noqa: B036 - keep primary
+                _annotate_secondary_error(
+                    primary_error,
+                    "workspace replacement bind cleanup also failed",
+                    cleanup_error,
+                )
+            raise
+
+    def _bind_replacement_source_locked(
+        self,
+        *,
+        destination: Path,
+        stage_name: str,
+        plan: WorkspacePlan,
+        destination_binding: PublishedWorkspaceDestinationBinding,
+        source_ownership: _TreeOwnership,
+        native_owner: object,
+    ) -> None:
+        self._require_owner_pid()
+        if self._state != "empty" or self._native_owner is not None:
+            raise RuntimeError("owned workspace authority is not empty")
+
+        # From this store onward workspace cleanup is the sole Python mutation
+        # authority for the leased aggregate.  Every later failure aborts it,
+        # reverses any unreceipted exchange natively, and releases the lease.
+        self._native_owner = native_owner
+        self._state = "binding-replacement"
+        try:
+            if _native_workspace_owner.owner_state(native_owner) != (
+                "destination-leased"
+            ):
+                raise RuntimeError("native workspace destination is not leased")
+            _native_workspace_owner.verify_owner_destination_binding(native_owner)
+            parent_descriptor = _native_workspace_owner.borrow_owner_parent_descriptor(
+                native_owner
+            )
+            incumbent_descriptor = (
+                _native_workspace_owner.borrow_owner_destination_descriptor(
+                    native_owner
+                )
+            )
+            parent_identity = publication_parent_identity(parent_descriptor)
+            incumbent_identity = _root_identity(os.fstat(incumbent_descriptor))
+            native_incumbent = _capture_posix_directory_descriptor(
+                incumbent_descriptor,
+                destination,
+                required_root_file=None,
+                allow_empty_root=True,
+                entry_policy=None,
+            )
+            if parent_identity != destination_binding.parent_identity:
+                raise RuntimeError(
+                    "native workspace parent differs from the active source"
+                )
+            if (
+                native_incumbent != destination_binding.ownership
+                or native_incumbent != source_ownership
+            ):
+                raise RuntimeError(
+                    "native workspace incumbent differs from the active source"
+                )
+            _native_workspace_owner.verify_owner_destination_binding(native_owner)
+            if publication_parent_identity(parent_descriptor) != parent_identity:
+                raise RuntimeError(
+                    "native workspace parent changed during source binding"
+                )
+            if _root_identity(os.fstat(incumbent_descriptor)) != incumbent_identity:
+                raise RuntimeError(
+                    "native workspace incumbent changed during source binding"
+                )
+            replacement_permit = _native_workspace_owner.claim_owner_replacement_permit(
+                native_owner
+            )
+            exchange = _native_workspace_owner._bind_owner_replacement_permit(
+                replacement_permit
+            )
+
+            self._destination = destination
+            self._stage_path = destination.parent / stage_name
+            self._plan = plan
+            self._destination_binding = destination_binding
+            self._replacement_exchange = exchange
+            self._replacement_parent_descriptor = parent_descriptor
+            self._replacement_parent_identity = parent_identity
+            self._replacement_incumbent_descriptor = incumbent_descriptor
+            self._replacement_incumbent_identity = incumbent_identity
+            self._state = "replacement-bound"
+        except BaseException as bind_error:  # noqa: B036 - settle leased owner
+            self._state = "failed"
+            self._close_resources_after_error_locked(bind_error)
+            raise
+
+    def provision_bound_replacement(self, *, deadline_ns: int) -> None:
+        """Provision and adopt the candidate retained by phase-one binding."""
+
+        self._require_owner_pid()
+        if not sys.platform.startswith("linux"):
+            raise UnsupportedWorkspaceCreation(
+                "native workspace replacement provisioning requires Linux"
+            )
+        if type(deadline_ns) is not int or deadline_ns <= 0:
+            raise ValueError("workspace replacement deadline is invalid")
+        self._reject_reentrant("provision bound replacement")
+        self._lock.run(
+            lambda: self._provision_bound_replacement_locked(deadline_ns=deadline_ns)
+        )
+
+    def _provision_bound_replacement_locked(self, *, deadline_ns: int) -> None:
+        self._require_owner_pid()
+        if self._state != "replacement-bound":
+            raise RuntimeError(
+                "owned workspace replacement is not bound for provisioning"
+            )
+        owner = self._native_owner
+        destination = self._destination
+        stage_path = self._stage_path
+        plan = self._plan
+        destination_binding = self._destination_binding
+        exchange = self._replacement_exchange
+        parent_descriptor = self._replacement_parent_descriptor
+        parent_identity = self._replacement_parent_identity
+        incumbent_descriptor = self._replacement_incumbent_descriptor
+        incumbent_identity = self._replacement_incumbent_identity
+        if (
+            owner is None
+            or destination is None
+            or stage_path is None
+            or plan is None
+            or destination_binding is None
+            or exchange is None
+            or parent_descriptor < 0
+            or parent_identity is None
+            or incumbent_descriptor < 0
+            or incumbent_identity is None
+        ):
+            raise RuntimeError("owned workspace replacement binding is incomplete")
+
+        self._state = "provisioning-replacement"
+        try:
+            if publication_parent_identity(parent_descriptor) != parent_identity:
+                raise RuntimeError("workspace replacement parent authority changed")
+            if _root_identity(os.fstat(incumbent_descriptor)) != incumbent_identity:
+                raise RuntimeError("workspace replacement incumbent authority changed")
+            _native_workspace_owner.verify_owner_destination_binding(owner)
+            _native_workspace_owner.provision_owner_replacement(
+                owner,
+                os.fsencode(stage_path.name),
+                plan.digest.encode("ascii"),
+                plan.root_mode,
+                tuple(
+                    (os.fsencode(item.path.as_posix()), item.mode)
+                    for item in plan.directories
+                ),
+                deadline_ns,
+            )
+            _native_workspace_owner.verify_owner_adoption_binding(
+                owner,
+                os.fsencode(destination),
+                os.fsencode(stage_path.name),
+                plan.digest.encode("ascii"),
+            )
+            root_descriptor = _native_workspace_owner.borrow_owner_root_descriptor(
+                owner
+            )
+            directory_descriptors = {
+                item.path.as_posix(): (
+                    _native_workspace_owner.borrow_owner_directory_descriptor(
+                        owner,
+                        os.fsencode(item.path.as_posix()),
+                    )
+                )
+                for item in plan.directories
+            }
+            _authority, replacement = _adopt_native_posix_replacement_authority(
+                destination.parent,
+                native_owner=owner,
+                parent_descriptor=parent_descriptor,
+                candidate_descriptor=root_descriptor,
+                incumbent_descriptor=incumbent_descriptor,
+                expected_parent_identity=parent_identity,
+                expected_incumbent_identity=incumbent_identity,
+                destination_name=destination.name,
+                replacement_slot=stage_path.name,
+                exchange_callback=exchange,
+                authority_owner=self._parent_owner,
+            )
+            self._native_replacement = replacement
+            self._adopt_locked(
+                destination=destination,
+                stage_name=stage_path.name,
+                parent_descriptor=parent_descriptor,
+                root_descriptor=root_descriptor,
+                directory_descriptors=directory_descriptors,
+                plan=plan,
+                destination_binding=destination_binding,
+                native_replacement=replacement,
+            )
+        except BaseException as provision_error:  # noqa: B036 - settle owner
+            if self._state != "closed":
+                self._state = "failed"
+                self._abort_native_after_error_locked(provision_error)
+            raise
 
     def adopt(
         self,
@@ -2377,9 +2687,18 @@ class OwnedWorkspaceAuthority:
         plan: WorkspacePlan,
         destination_binding: PublishedWorkspaceDestinationBinding | None,
         native_publication_permit: object | None = None,
+        native_replacement: _NativeReplacementPublication | None = None,
     ) -> None:
         self._require_owner_pid()
-        if self._state != "empty":
+        replacement_adoption = native_replacement is not None
+        if replacement_adoption:
+            if (
+                type(native_replacement) is not _NativeReplacementPublication
+                or self._state != "provisioning-replacement"
+                or self._native_replacement is not native_replacement
+            ):
+                raise RuntimeError("owned workspace replacement adoption is not active")
+        elif self._state != "empty":
             raise RuntimeError("owned workspace authority is not empty")
         plan = _snapshot_workspace_plan(plan)
         if (
@@ -2410,6 +2729,15 @@ class OwnedWorkspaceAuthority:
         ):
             raise ValueError(
                 "workspace destination binding differs from its destination"
+            )
+        if replacement_adoption and (
+            self._destination != destination_path
+            or self._stage_path != stage_path
+            or self._plan != plan
+            or self._destination_binding is not destination_binding
+        ):
+            raise RuntimeError(
+                "workspace replacement slot, plan, or source binding changed"
             )
 
         expected_directory_paths = {item.path.as_posix() for item in plan.directories}
@@ -2450,7 +2778,7 @@ class OwnedWorkspaceAuthority:
                     ),
                     authority_owner=self._parent_owner,
                 )
-            else:
+            elif not replacement_adoption:
                 if native_publication_permit is None:
                     raise RuntimeError(
                         "native workspace publication capability is missing"
@@ -2587,31 +2915,46 @@ class OwnedWorkspaceAuthority:
                 self._directory_descriptors[path] = descriptor
                 self._directory_identities[path] = identity
 
-            destination_metadata = authority.child_metadata(
-                destination_path.name,
-                path=destination_path,
-                label="owned workspace destination",
-            )
-            if destination_binding is None:
-                if destination_metadata is not None:
+            if replacement_adoption:
+                assert native_replacement is not None
+                if destination_binding is None:
                     raise RuntimeError(
-                        "owned workspace destination was expected missing"
+                        "workspace replacement destination binding is missing"
                     )
-            else:
-                if destination_metadata is None:
-                    raise RuntimeError("owned workspace destination disappeared")
-                observed_destination = authority.capture_child(
-                    destination_path.name,
+                observed_destination = native_replacement.capture_incumbent(
                     path=destination_path,
-                    label="owned workspace destination",
-                    allow_empty_root=True,
+                    label="owned workspace replacement incumbent",
                 )
                 if observed_destination != destination_binding.ownership:
                     raise RuntimeError("owned workspace destination changed")
+            else:
+                destination_metadata = authority.child_metadata(
+                    destination_path.name,
+                    path=destination_path,
+                    label="owned workspace destination",
+                )
+                if destination_binding is None:
+                    if destination_metadata is not None:
+                        raise RuntimeError(
+                            "owned workspace destination was expected missing"
+                        )
+                else:
+                    if destination_metadata is None:
+                        raise RuntimeError("owned workspace destination disappeared")
+                    observed_destination = authority.capture_child(
+                        destination_path.name,
+                        path=destination_path,
+                        label="owned workspace destination",
+                        allow_empty_root=True,
+                    )
+                    if observed_destination != destination_binding.ownership:
+                        raise RuntimeError("owned workspace destination changed")
             authority.verify_path_binding()
             self._refresh_locked(require_complete=False)
             if self._native_owner is not None:
                 _native_workspace_owner.mark_owner_adopted(self._native_owner)
+            if native_replacement is not None:
+                native_replacement.verify_current()
             self._state = "adopted"
         except BaseException as refresh_error:
             self._state = "failed"
@@ -2987,7 +3330,7 @@ class OwnedWorkspaceAuthority:
             validate_published_destination
         ):
             raise TypeError("published workspace validator must be callable")
-        transfer = _WorkspacePublicationTransfer(self)
+        transfer = self._lock.run(self._new_publication_transfer_locked)
         reservation = _WorkspaceReservation(transfer)
         try:
             self._lock.run(
@@ -3008,6 +3351,66 @@ class OwnedWorkspaceAuthority:
             )
             raise
 
+    def publish_replacement_into(
+        self,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        *,
+        deadline_ns: int,
+        validate_staged_directory: (
+            Callable[[PublicationDirectoryReader], None] | None
+        ) = None,
+        validate_published_destination: (
+            Callable[[PublicationDirectoryReader], None] | None
+        ) = None,
+    ) -> None:
+        """Exchange a sealed replacement and install its exact receipt."""
+
+        self._require_owner_pid()
+        self._reject_reentrant("publish replacement")
+        if type(receipt_owner) is not PublishedWorkspaceReceiptOwner:
+            raise TypeError("receipt_owner must be a PublishedWorkspaceReceiptOwner")
+        if type(deadline_ns) is not int or deadline_ns <= 0:
+            raise ValueError("workspace replacement deadline is invalid")
+        if validate_staged_directory is not None and not callable(
+            validate_staged_directory
+        ):
+            raise TypeError("staged workspace validator must be callable")
+        if validate_published_destination is not None and not callable(
+            validate_published_destination
+        ):
+            raise TypeError("published workspace validator must be callable")
+        transfer = self._lock.run(self._new_publication_transfer_locked)
+        reservation = _WorkspaceReservation(transfer)
+        try:
+            self._lock.run(
+                lambda: self._publish_replacement_into_locked(
+                    receipt_owner,
+                    transfer,
+                    reservation,
+                    deadline_ns,
+                    validate_staged_directory,
+                    validate_published_destination,
+                )
+            )
+        except BaseException as primary_error:  # noqa: B036 - reconcile owners
+            self._reconcile_publish_failure_outside_lock(
+                receipt_owner,
+                transfer,
+                reservation,
+                primary_error,
+            )
+            raise
+
+    def _new_publication_transfer_locked(self) -> _WorkspacePublicationTransfer:
+        replacement = self._native_replacement
+        return _WorkspacePublicationTransfer(
+            self,
+            _native_workspace_owner.commit_owner_receipt,
+            _native_workspace_owner.owner_closed,
+            _native_workspace_owner.owner_state,
+            None if replacement is None else replacement.mark_receipted,
+        )
+
     def _publish_into_locked(
         self,
         receipt_owner: PublishedWorkspaceReceiptOwner,
@@ -3023,6 +3426,10 @@ class OwnedWorkspaceAuthority:
             raise RuntimeError(f"owned workspace cannot publish while {self._state}")
         if self._destination is None or self._stage_path is None or self._plan is None:
             raise RuntimeError("owned workspace publication state is incomplete")
+        if self._native_replacement is not None:
+            raise RuntimeError(
+                "owned workspace replacement requires publish_replacement_into"
+            )
 
         # This first ownership store and every later publication operation are
         # covered by publish_into's outer exception reconciliation.  Keeping
@@ -3047,6 +3454,8 @@ class OwnedWorkspaceAuthority:
         receipt_new = receipt_type.__new__
         receipt_init = receipt_type.__init__
         install_receipt_exact = PublishedWorkspaceReceiptOwner._install
+        require_matching_exact = _require_matching_ownership
+        ensure_receipted_exact = self._ensure_native_receipted_locked
         mint_destination_binding_exact = (
             _freeze_published_workspace_destination_binding_minter(
                 destination=destination,
@@ -3062,7 +3471,7 @@ class OwnedWorkspaceAuthority:
         ) -> None:
             if committed_sealed != sealed_ownership:
                 raise RuntimeError("published workspace sealed token changed")
-            _require_matching_ownership(
+            require_matching_exact(
                 published_ownership,
                 sealed_ownership,
                 label="published workspace",
@@ -3086,7 +3495,7 @@ class OwnedWorkspaceAuthority:
             # Before it, reconciliation aborts a native candidate; after it,
             # every active/retain path idempotently commits that candidate.
             install_receipt_exact(receipt_owner, reservation, receipt)
-            self._ensure_native_receipted_locked(native_receipt_token)
+            ensure_receipted_exact(native_receipt_token, transfer)
             self._state = "published"
 
         _publish_staged_directory_with_authority(
@@ -3099,6 +3508,107 @@ class OwnedWorkspaceAuthority:
                 if self._destination_binding is None
                 else self._destination_binding.ownership
             ),
+            validate_staged_directory=validate_staged_directory,
+            validate_published_destination=validate_published_destination,
+            commit_callback=install_receipt,
+        )
+
+    def _publish_replacement_into_locked(
+        self,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        transfer: _WorkspacePublicationTransfer,
+        reservation: _WorkspaceReservation,
+        deadline_ns: int,
+        validate_staged_directory: Callable[[PublicationDirectoryReader], None] | None,
+        validate_published_destination: (
+            Callable[[PublicationDirectoryReader], None] | None
+        ),
+    ) -> None:
+        self._require_owner_pid()
+        replacement = self._native_replacement
+        if self._state != "sealed" or self._sealed_ownership is None:
+            raise RuntimeError(
+                f"owned workspace cannot publish replacement while {self._state}"
+            )
+        if (
+            self._destination is None
+            or self._stage_path is None
+            or self._plan is None
+            or self._destination_binding is None
+            or replacement is None
+            or transfer.mark_replacement_receipted is None
+        ):
+            raise RuntimeError("owned workspace replacement state is incomplete")
+
+        self._store_publication_transfer_locked(transfer)
+        self._resources_transferred = True
+        self._state = "reserving-publication"
+        receipt_owner._reserve(reservation)
+        self._state = "publishing"
+        sealed_ownership = self._sealed_ownership
+        destination = self._destination
+        stage_path = self._stage_path
+        destination_binding = self._destination_binding
+        plan = self._plan
+        authority = self._require_parent_authority()
+        parent_identity = authority.identity
+        receipt_plan = _snapshot_workspace_plan(plan)
+        receipt_type = _PUBLISHED_WORKSPACE_RECEIPT_TYPE
+        receipt_new = receipt_type.__new__
+        receipt_init = receipt_type.__init__
+        install_receipt_exact = PublishedWorkspaceReceiptOwner._install
+        require_matching_exact = _require_matching_ownership
+        ensure_receipted_exact = self._ensure_native_receipted_locked
+        mint_destination_binding_exact = (
+            _freeze_published_workspace_destination_binding_minter(
+                destination=destination,
+                parent_identity=parent_identity,
+            )
+        )
+
+        def install_receipt(
+            committed_sealed: _TreeOwnership,
+            published_ownership: _TreeOwnership,
+            previous_orphan: DirectoryOrphan,
+            native_receipt_token: object,
+        ) -> None:
+            if committed_sealed != sealed_ownership:
+                raise RuntimeError("published workspace sealed token changed")
+            require_matching_exact(
+                published_ownership,
+                sealed_ownership,
+                label="published workspace replacement",
+                allow_root_rename=True,
+            )
+            destination_binding = mint_destination_binding_exact(published_ownership)
+            receipt = receipt_new(receipt_type)
+            receipt_init(
+                receipt,
+                transfer=transfer,
+                path=destination,
+                plan=receipt_plan,
+                sealed_ownership=sealed_ownership,
+                published_ownership=published_ownership,
+                parent_identity=parent_identity,
+                destination_binding=destination_binding,
+                orphan=previous_orphan,
+                native_receipt_token=native_receipt_token,
+            )
+            # The owner slot is the only Python linearization point.  Native
+            # abort reverses an exchange before this store; after the store,
+            # active/retain reconciliation idempotently commits the receipt.
+            install_receipt_exact(receipt_owner, reservation, receipt)
+            ensure_receipted_exact(native_receipt_token, transfer)
+            self._state = "published"
+
+        _publish_native_replacement_with_authority(
+            authority,
+            replacement,
+            stage_path,
+            destination,
+            expected_stage_root_ownership=sealed_ownership,
+            expected_destination_ownership=destination_binding.ownership,
+            deadline_ns=deadline_ns,
             validate_staged_directory=validate_staged_directory,
             validate_published_destination=validate_published_destination,
             commit_callback=install_receipt,
@@ -3205,7 +3715,7 @@ class OwnedWorkspaceAuthority:
             if self._publication_transfer is not transfer:
                 return
             if transfer_state in {"active", "cleanup-retain"}:
-                self._ensure_native_receipted_locked(native_receipt_token)
+                self._ensure_native_receipted_locked(native_receipt_token, transfer)
                 self._state = "published"
                 return
             if transfer_state == "cleanup-abort":
@@ -3291,7 +3801,10 @@ class OwnedWorkspaceAuthority:
                 or self._plan != receipt._plan
             ):
                 raise RuntimeError("published workspace receipt is not active")
-            self._ensure_native_receipted_locked(receipt._native_receipt_token)
+            self._ensure_native_receipted_locked(
+                receipt._native_receipt_token,
+                receipt._transfer,
+            )
             authority = self._require_parent_authority()
             if authority.identity != receipt.parent_identity:
                 raise RuntimeError("published workspace parent authority changed")
@@ -3380,6 +3893,7 @@ class OwnedWorkspaceAuthority:
                 self._close_resources_locked(
                     abort_unreceipted=abort_unreceipted,
                     native_receipt_token=native_receipt_token,
+                    native_receipt_settlement=transfer,
                 )
             except BaseException as close_error:  # noqa: B036 - reconcile transfer
                 primary_error = close_error
@@ -3436,28 +3950,41 @@ class OwnedWorkspaceAuthority:
     def _ensure_native_receipted_locked(
         self,
         native_receipt_token: object | None,
+        settlement: _WorkspacePublicationTransfer,
     ) -> None:
         owner = self._native_owner
         if owner is None:
             return
-        if _native_workspace_owner.owner_closed(owner):
+        if settlement.workspace is not self:
+            raise RuntimeError("native workspace receipt settlement changed")
+        if settlement.native_owner_closed(owner):
             if self._state != "closed":
                 raise RuntimeError(
                     "native workspace owner closed before receipt settlement"
                 )
             return
-        if _native_workspace_owner.owner_state(owner) != "receipted":
+        expected_state = (
+            "replacement-receipted"
+            if settlement.mark_replacement_receipted is not None
+            else "receipted"
+        )
+        if settlement.native_owner_state(owner) != expected_state:
             if native_receipt_token is None:
                 raise RuntimeError("native workspace receipt capability is missing")
-            _native_workspace_owner.commit_owner_receipt(native_receipt_token)
-        if _native_workspace_owner.owner_state(owner) != "receipted":
+            settlement.native_receipt_commit(native_receipt_token)
+        if settlement.native_owner_state(owner) != expected_state:
             raise RuntimeError("native workspace receipt did not commit")
+        if settlement.mark_replacement_receipted is not None:
+            settlement.mark_replacement_receipted()
 
     def _abort_native_owner_locked(self) -> None:
         owner = self._native_owner
         if owner is None or _native_workspace_owner.owner_closed(owner):
             return
-        if _native_workspace_owner.owner_state(owner) == "receipted":
+        if _native_workspace_owner.owner_state(owner) in {
+            "receipted",
+            "replacement-receipted",
+        }:
             raise RuntimeError("receipted native workspace cannot be aborted")
         _native_workspace_owner.abort_owner(owner)
         if not _native_workspace_owner.owner_closed(owner):
@@ -3852,6 +4379,7 @@ class OwnedWorkspaceAuthority:
         *,
         abort_unreceipted: bool = True,
         native_receipt_token: object | None = None,
+        native_receipt_settlement: _WorkspacePublicationTransfer | None = None,
     ) -> None:
         if self._state == "closed":
             return
@@ -3861,7 +4389,14 @@ class OwnedWorkspaceAuthority:
                 if abort_unreceipted:
                     self._abort_native_owner_locked()
                 else:
-                    self._ensure_native_receipted_locked(native_receipt_token)
+                    if native_receipt_settlement is None:
+                        raise RuntimeError(
+                            "native workspace receipt settlement is missing"
+                        )
+                    self._ensure_native_receipted_locked(
+                        native_receipt_token,
+                        native_receipt_settlement,
+                    )
                     _native_workspace_owner.close_owner_exact(self._native_owner)
             except BaseException as close_error:  # noqa: B036 - cleanup all
                 primary_error = close_error

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -32,9 +32,44 @@ incumbent, and candidate descriptors throughout; every descriptor borrowed by
 trusted internal code remains owner-owned and must never be closed by the
 borrower.
 
-This primitive does not change `LocalWorkspaceProvider`: the provider remains
-missing-only. The strict request seam now represents a missing destination only
-as `destination_binding=None`; an existing destination requires an immutable
+The Python authority now exposes the fail-closed half needed to use that
+primitive, but this does not change `LocalWorkspaceProvider`: the provider
+remains missing-only. Exact replacement has three explicit authority phases:
+
+1. `bind_replacement_source(...)` synchronously consumes an active source
+   receipt while a separately supplied protocol-v5 owner already holds the
+   captured destination under its native lease. It requires the exact private
+   destination-binding object from that receipt, matches both the retained
+   parent descriptor and a complete incumbent descriptor scan, revalidates the
+   native binding after the scan, then privately claims and binds the one-shot
+   replacement permit. No permit, receipt token, or detached replayable
+   replacement authorization is returned.
+2. `provision_bound_replacement(...)` is the only provisioning entry after
+   that handoff. It calls native provisioning itself and adopts the candidate
+   from the same native owner, frozen hidden slot, and exact workspace plan.
+   Provider code cannot mutate the handed-off owner between provision and
+   adoption.
+3. After write and seal, `publish_replacement_into(...)` uses a dedicated
+   `RENAME_EXCHANGE` path. Candidate and incumbent bytes are read through
+   separate retained descriptors. It never enters the generic
+   isolate-and-rename helper and never performs a generic post-exchange parent
+   sync; the native exchange and receipt settlement own durability ordering.
+
+The caller-owned receipt slot remains the linearization point. Before its store,
+failure reconciliation invokes native abort, which authenticates and reverses
+an exchanged mapping before releasing the lease. After its store, active or
+cleanup-retain reconciliation idempotently commits the same native receipt
+token. A successful commit switches the live Python authority to candidate-only
+descriptor-backed verification of the live destination and parent binding; it
+no longer depends on the displaced incumbent, so a later live-name rebind makes
+receipt reads fail closed without preventing terminal owner close. The
+displaced incumbent is returned as a
+`DirectoryOrphan` whose locator deliberately names the ordinary
+`linux-renameat2` reopening backend, not the transaction-only native backend.
+Its reclamation remains a later cooperative-GC concern.
+
+The strict request seam represents a missing destination only as
+`destination_binding=None`; an existing destination requires an immutable
 `PublishedWorkspaceDestinationBinding` projected by an active
 `PublishedWorkspaceReceiptOwner`. That binding freezes the lexical destination,
 the receipt's parent identity, and its full `_TreeOwnership`. Request
@@ -46,9 +81,12 @@ so a string or raw ownership token cannot select replacement. Strict BM25 now
 derives this binding from `source_generation` and cross-checks the borrowed
 receipt. The standard shared and provider-specific support probes still run
 first; `LocalWorkspaceProvider` then rejects every non-`None` binding before
-provisioning or namespace mutation. Provider integration is a separate Gate C
-change, so Gate C and M1 remain open even though the protocol-v5 primitive and
-request-authentication seam are available.
+provisioning or namespace mutation. Gate C must still add a private, one-shot
+provider/session provenance path carrying the active source receipt owner
+separately from the frozen request binding, select the three-phase authority
+flow, and settle the old receipt/orphan handoff. Automatic orphan GC, a crash
+journal, and protection from hostile same-UID mutation are not part of this
+seam. Gate C and M1 therefore remain open.
 
 ## Publish a normal index build
 
@@ -744,5 +782,5 @@ descriptors remain owned by the aggregate and are valid only for its lifetime;
 borrowers must never close them. The primitive remains an authority boundary
 for trusted internal code, not a Python sandbox or full `_TreeOwnership`.
 `LocalWorkspaceProvider` does not yet integrate it, continues to reject
-the non-`None` binding whose derived expectation is `provider-bound-exact`, and
-therefore does not close Gate C or M1.
+the non-`None` binding whose derived expectation is `provider-bound-exact`.
+Gate C and M1 remain open.

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -289,8 +289,8 @@ permit. The caller-owned receipt slot is the publication-authority
 linearization point: unreceipted same-process failures quarantine the exact
 candidate, while a fork child authenticates and closes only its inherited
 descriptor pairs. The v3-compatible capture state authenticates the private
-root and exact destination name/device/inode binding without mutation. Protocol
-v4 added a distinct one-shot replacement permit and one aggregate for that
+root and exact destination name/device/inode binding without mutation. Protocol v4
+added a distinct one-shot replacement permit and one aggregate for that
 incumbent plus a hidden, same-parent candidate. Protocol v5 retains that atomic
 exchange history and inserts a required parent lease before candidate mutation.
 Its success states are `destination-captured` -> `destination-leased` ->
@@ -353,6 +353,32 @@ returns but Python return is interrupted, the owner remains
 second flock. A fork child cannot mutate, reverse, commit, or unlock the
 parent's lease; it only authenticates and closes its own inherited descriptor
 pairs.
+
+The protocol-v5 Python publication seam is now implemented without changing
+the native ABI. `OwnedWorkspaceAuthority.bind_replacement_source(...)` consumes
+an active source receipt and requires its exact private destination-binding
+object while the supplied native owner is already `destination-leased`. It
+borrows and retains the parent and incumbent descriptors before provisioning,
+matches the parent identity and complete incumbent ownership against that same
+active generation, repeats native binding and descriptor checks after the tree
+scan, and privately binds the one-shot replacement permit. No detached permit
+or replayable replacement token leaves the authority. The subsequent
+`provision_bound_replacement(...)` call alone provisions and adopts the
+candidate from that same owner, hidden slot, and frozen plan.
+
+Sealed replacements publish only through
+`publish_replacement_into(...)`, whose dedicated dual-root implementation uses
+separate candidate and incumbent descriptor readers and the permit-bound
+`RENAME_EXCHANGE`. The generic isolate/rename helper explicitly rejects the
+native replacement authority, and no generic parent sync runs after exchange.
+The receipt-owner slot store is the Python linearization point: native abort
+authenticates and reverses before the store, while active or cleanup-retain
+reconciliation idempotently commits after it. After native
+`replacement-receipted`, the live authority verifies only the candidate
+descriptor and destination binding; terminal close does not depend on that
+live-name check. The displaced incumbent receipt uses a normal
+`linux-renameat2` orphan locator so it can reopen after the transaction-only
+native aggregate closes.
 
 The receipted aggregate seals its path-based live-name verifier and new parent
 borrows, while earlier borrowed descriptors remain owner-owned until close.
@@ -459,10 +485,13 @@ materialization APIs are now available as injectable library producers. The
 Linux local provider deliberately accepts only missing destinations, so
 whole-context retained materialization can use it explicitly, while strict BM25
 replacement now sends the active source generation's exact destination binding
-and still lacks a concrete production provider. Protocol v4 now supplies the
-lower-level exact exchange primitive, but `LocalWorkspaceProvider` rejects the
-non-`None` binding before mutation and does not select that primitive. Provider
-integration remains separate Gate C work. The
+and still lacks a concrete production provider. Protocol v5 and the
+three-phase Python dual-root seam now supply the lower-level exact exchange and
+receipt settlement, but `LocalWorkspaceProvider` rejects the non-`None`
+binding before mutation and does not select that seam. Gate C must carry the
+active source receipt owner through a private one-shot provider/session
+provenance gate, separately from the frozen request binding, and settle the old
+receipt/orphan handoff. The
 explicit retained workflows can now construct the whole-context producer for one
 existing catalog selection, publish normal compiler output, and load one
 selected generation at MCP cold start, but no default compiler/runtime route
@@ -815,10 +844,13 @@ advance refs, or make retained storage the default. Benchmark-backed promotion
 of the explicit compiler and runtime routes remains outstanding M1 work; graph
 and Zoekt cache ingress and fenced job publication remain M2 or later work.
 Strict BM25 replacement also still lacks the `provider-bound-exact` production
-provider. Protocol v4 implements the primitive-only exact exchange, but
-`LocalWorkspaceProvider` continues to reject the receipt-derived binding. The
-strict producer is now wired to the authenticated request seam, but no provider
-selects the new operation. Provider integration remains separate.
+provider. Protocol v5 and the dual-root publication authority implement exact
+preprovision binding, same-owner candidate adoption, exchange, receipt
+settlement, and displaced-incumbent handoff, but `LocalWorkspaceProvider`
+continues to reject the receipt-derived binding. The strict producer is wired
+to the authenticated request seam, but no provider supplies the separately
+active source-owner provenance needed to select the new operation. Provider
+integration remains separate.
 
 #### Retained storage promotion protocol
 
@@ -835,7 +867,7 @@ that collecting a fast result cannot silently approve a production route:
 | B1 | Promote BM25 compiler publication to a configured default. | Pending A2 compiler. |
 | B2 | Promote query-only BM25 retained cold start to a configured default. | Pending A2 query-only runtime; this does not replace source-bound manifest MCP. |
 | B2 source-bound | Promote a specifically scoped source-bound BM25 retained cold start. | Pending A2 source-bound BM25 runtime; it cannot satisfy the full manifest-compatibility gate. |
-| C | Supply the `provider-bound-exact` strict BM25 native provider. | Protocol v4 introduced the Linux-only, same-parent `RENAME_EXCHANGE` primitive; protocol v5 moves a parent-wide cross-process flock before candidate mutation and retains receipt settlement and bounded same-process rollback. The request-authentication half is implemented: strict BM25 sends a private-construction binding projected by its active source receipt owner, and generic adoption verifies its lexical destination, parent identity, and full tree ownership. `LocalWorkspaceProvider` still rejects every exact binding and does not select the primitive, so Gate C remains pending and required before M1 closes. |
+| C | Supply the `provider-bound-exact` strict BM25 native provider. | Protocol v5 provides the leased Linux-only `RENAME_EXCHANGE` primitive, and the Python authority now implements active-receipt preprovision binding, same-owner/slot/plan candidate adoption, separate dual-root validation, receipt-slot settlement, candidate-only postreceipt authority, and a reopenable displaced-incumbent orphan. The request still carries only its immutable destination binding: no provider/session path supplies the separately active source receipt owner required by `bind_replacement_source(...)`. `LocalWorkspaceProvider` therefore continues to reject every exact binding and cannot select this seam. Gate C remains pending and required before M1 closes; automatic GC, a crash journal, and hostile same-UID defense are outside this gate. |
 
 The A1 harness fixes the BM25 `fast` compiler/runtime comparison rather than
 accepting arbitrary route substitutions. For compiler cold start, arm A runs

--- a/test/test_atomic_directory.py
+++ b/test/test_atomic_directory.py
@@ -33,6 +33,140 @@ def _write_tree(root: Path, name: str, value: str) -> None:
     (root / name).write_text(value, encoding="utf-8")
 
 
+def _adopt_fake_native_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    events: list[str] | None = None,
+) -> SimpleNamespace:
+    """Adopt the real dual-root facade around test-owned POSIX descriptors."""
+
+    parent = tmp_path / "authority"
+    parent.mkdir()
+    stage = parent / ".candidate"
+    destination = parent / "published"
+    _write_tree(stage, "payload.bin", "new")
+    _write_tree(destination, "payload.bin", "old")
+    parent_descriptor = os.open(parent, os.O_RDONLY | os.O_DIRECTORY)
+    candidate_descriptor = os.open(stage, os.O_RDONLY | os.O_DIRECTORY)
+    incumbent_descriptor = os.open(destination, os.O_RDONLY | os.O_DIRECTORY)
+    native_owner = object()
+    native_state = {"value": "replacement-adopted"}
+    receipt_token = object()
+    exchange_calls: list[tuple[bytes, bytes, int]] = []
+
+    def require_owner(candidate: object) -> object:
+        if candidate is not native_owner:
+            raise TypeError("wrong native owner")
+        return candidate
+
+    def verify_owner(candidate: object) -> None:
+        if candidate is not native_owner:
+            raise TypeError("wrong native owner")
+
+    def exchange(source: bytes, target: bytes, deadline_ns: int) -> object:
+        exchange_calls.append((source, target, deadline_ns))
+        if events is not None:
+            events.append("exchange")
+        source_name = os.fsdecode(source)
+        target_name = os.fsdecode(target)
+        swap_name = ".test-only-exchange-swap"
+        os.rename(
+            source_name,
+            swap_name,
+            src_dir_fd=parent_descriptor,
+            dst_dir_fd=parent_descriptor,
+        )
+        os.rename(
+            target_name,
+            source_name,
+            src_dir_fd=parent_descriptor,
+            dst_dir_fd=parent_descriptor,
+        )
+        os.rename(
+            swap_name,
+            target_name,
+            src_dir_fd=parent_descriptor,
+            dst_dir_fd=parent_descriptor,
+        )
+        native_state["value"] = "replacement-exchanged-unreceipted"
+        return receipt_token
+
+    native_module = atomic_module._native_workspace_owner
+    monkeypatch.setattr(native_module, "require_exact_owner", require_owner)
+    monkeypatch.setattr(native_module, "verify_owner_authority", verify_owner)
+
+    def forbidden_late_borrow(_candidate: object) -> int:
+        raise AssertionError("replacement adoption borrowed a descriptor late")
+
+    monkeypatch.setattr(
+        native_module,
+        "borrow_owner_parent_descriptor",
+        forbidden_late_borrow,
+    )
+    monkeypatch.setattr(
+        native_module,
+        "borrow_owner_root_descriptor",
+        forbidden_late_borrow,
+    )
+    monkeypatch.setattr(
+        native_module,
+        "owner_state",
+        lambda candidate: (
+            native_state["value"] if candidate is native_owner else "wrong-native-owner"
+        ),
+    )
+    authority_owner = atomic_module._PublicationAuthorityOwner()
+    try:
+        authority, replacement = (
+            atomic_module._adopt_native_posix_replacement_authority(
+                parent,
+                native_owner=native_owner,
+                parent_descriptor=parent_descriptor,
+                candidate_descriptor=candidate_descriptor,
+                incumbent_descriptor=incumbent_descriptor,
+                expected_parent_identity=publication_parent_identity(parent_descriptor),
+                expected_incumbent_identity=(
+                    atomic_module._directory_inode_identity(
+                        os.fstat(incumbent_descriptor)
+                    )
+                ),
+                destination_name=destination.name,
+                replacement_slot=stage.name,
+                exchange_callback=exchange,
+                authority_owner=authority_owner,
+            )
+        )
+    except BaseException:
+        authority_owner.close()
+        os.close(incumbent_descriptor)
+        os.close(candidate_descriptor)
+        os.close(parent_descriptor)
+        raise
+    return SimpleNamespace(
+        authority=authority,
+        authority_owner=authority_owner,
+        candidate_descriptor=candidate_descriptor,
+        destination=destination,
+        exchange_calls=exchange_calls,
+        incumbent_descriptor=incumbent_descriptor,
+        native_owner=native_owner,
+        native_state=native_state,
+        parent=parent,
+        parent_descriptor=parent_descriptor,
+        receipt_token=receipt_token,
+        replacement=replacement,
+        stage=stage,
+    )
+
+
+def _close_fake_native_replacement(prepared: SimpleNamespace) -> None:
+    prepared.authority_owner.close()
+    os.close(prepared.incumbent_descriptor)
+    os.close(prepared.candidate_descriptor)
+    os.close(prepared.parent_descriptor)
+
+
 def _exception_notes(error: BaseException) -> tuple[str, ...]:
     return (
         *tuple(getattr(error, "__notes__", ())),
@@ -10298,3 +10432,482 @@ def test_posix_nested_exit_handoff_defers_cleanup_to_authority(
     assert owners[0].closed
     assert authority_owners[0].authority is None
     assert atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS == []
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="native workspace replacement is Linux-only",
+)
+def test_native_replacement_dual_readers_never_cross_route_and_receipt_is_candidate_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prepared = _adopt_fake_native_replacement(tmp_path, monkeypatch)
+    replacement = prepared.replacement
+    candidate_before = capture_directory_ownership(prepared.stage)
+    incumbent_before = capture_directory_ownership(prepared.destination)
+
+    def payload(reader: atomic_module.PublicationDirectoryReader) -> bytes:
+        return reader.read_bytes("payload.bin", max_bytes=16)
+
+    try:
+        assert (
+            prepared.authority.read_child(
+                prepared.stage.name,
+                path=prepared.stage,
+                label="candidate",
+                expected_ownership=candidate_before,
+                callback=payload,
+            )
+            == b"new"
+        )
+        assert (
+            replacement.read_incumbent(
+                prepared.destination.name,
+                prepared.destination,
+                "incumbent",
+                incumbent_before,
+                payload,
+            )
+            == b"old"
+        )
+        with pytest.raises(RuntimeError, match="not the replacement candidate"):
+            replacement.read_candidate(
+                prepared.destination.name,
+                prepared.destination,
+                "candidate",
+                None,
+                payload,
+            )
+        with pytest.raises(RuntimeError, match="not the replacement incumbent"):
+            replacement.read_incumbent(
+                prepared.stage.name,
+                prepared.stage,
+                "incumbent",
+                None,
+                payload,
+            )
+
+        assert replacement.exchange(1) is prepared.receipt_token
+        candidate_after = replacement.read_candidate(
+            prepared.destination.name,
+            prepared.destination,
+            "candidate",
+            None,
+            lambda reader: reader.capture_ownership(allow_empty_root=True),
+        )
+        incumbent_after = replacement.read_incumbent(
+            prepared.stage.name,
+            prepared.stage,
+            "incumbent",
+            None,
+            lambda reader: reader.capture_ownership(allow_empty_root=True),
+        )
+        assert (
+            prepared.authority.read_child(
+                prepared.destination.name,
+                path=prepared.destination,
+                label="candidate",
+                expected_ownership=candidate_after,
+                callback=payload,
+            )
+            == b"new"
+        )
+        assert (
+            replacement.read_incumbent(
+                prepared.stage.name,
+                prepared.stage,
+                "incumbent",
+                incumbent_after,
+                payload,
+            )
+            == b"old"
+        )
+
+        prepared.native_state["value"] = "replacement-receipted"
+        replacement.mark_receipted()
+
+        def forbidden_native_verifier(_owner: object) -> None:
+            raise AssertionError("postreceipt read reached the native verifier")
+
+        monkeypatch.setattr(
+            atomic_module._native_workspace_owner,
+            "verify_owner_authority",
+            forbidden_native_verifier,
+        )
+        displaced = prepared.parent / ".displaced-incumbent"
+        prepared.stage.rename(displaced)
+        assert (
+            prepared.authority.read_child(
+                prepared.destination.name,
+                path=prepared.destination,
+                label="candidate",
+                expected_ownership=candidate_after,
+                callback=payload,
+            )
+            == b"new"
+        )
+        with pytest.raises(RuntimeError, match="no incumbent reader"):
+            _ = replacement.incumbent_name
+
+        prepared.authority_owner.close()
+        os.fstat(prepared.parent_descriptor)
+        os.fstat(prepared.candidate_descriptor)
+        os.fstat(prepared.incumbent_descriptor)
+    finally:
+        _close_fake_native_replacement(prepared)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="native workspace replacement is Linux-only",
+)
+def test_native_replacement_helper_orders_exchange_validation_commit_and_orphan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    prepared = _adopt_fake_native_replacement(
+        tmp_path,
+        monkeypatch,
+        events=events,
+    )
+    expected_candidate = capture_directory_ownership(prepared.stage)
+    expected_incumbent = capture_directory_ownership(prepared.destination)
+    observed: list[tuple[object, object, DirectoryOrphan, object]] = []
+    orphan: DirectoryOrphan | None = None
+
+    def validate_staged(reader: atomic_module.PublicationDirectoryReader) -> None:
+        assert reader.read_bytes("payload.bin", max_bytes=16) == b"new"
+        events.append("validate-staged")
+
+    def validate_published(reader: atomic_module.PublicationDirectoryReader) -> None:
+        assert reader.read_bytes("payload.bin", max_bytes=16) == b"new"
+        assert (prepared.stage / "payload.bin").read_bytes() == b"old"
+        events.append("validate-published")
+
+    def commit(
+        staged: object,
+        published: object,
+        displaced: DirectoryOrphan,
+        receipt_token: object,
+    ) -> None:
+        assert events == ["validate-staged", "exchange", "validate-published"]
+        assert receipt_token is prepared.receipt_token
+        observed.append((staged, published, displaced, receipt_token))
+        prepared.native_state["value"] = "replacement-receipted"
+        prepared.replacement.mark_receipted()
+        events.append("commit")
+
+    try:
+        orphan = atomic_module._publish_native_replacement_with_authority(
+            prepared.authority,
+            prepared.replacement,
+            prepared.stage,
+            prepared.destination,
+            expected_stage_root_ownership=expected_candidate,
+            expected_destination_ownership=expected_incumbent,
+            deadline_ns=1,
+            validate_staged_directory=validate_staged,
+            validate_published_destination=validate_published,
+            commit_callback=commit,
+        )
+        assert events == [
+            "validate-staged",
+            "exchange",
+            "validate-published",
+            "commit",
+        ]
+        assert len(observed) == 1
+        assert observed[0][0] == expected_candidate
+        assert observed[0][2] is orphan
+        assert orphan.locator.backend_tag == "linux-renameat2"
+        assert prepared.exchange_calls == [
+            (
+                os.fsencode(prepared.stage.name),
+                os.fsencode(prepared.destination.name),
+                1,
+            )
+        ]
+    finally:
+        _close_fake_native_replacement(prepared)
+
+    assert orphan is not None
+    assert (
+        orphan.reopen(lambda reader: reader.read_bytes("payload.bin", max_bytes=16))
+        == b"old"
+    )
+    parked = orphan.path.with_name(".parked-displaced-incumbent")
+    orphan.path.rename(parked)
+    _write_tree(orphan.path, "payload.bin", "old")
+    with pytest.raises(RuntimeError, match="directory orphan|root differs"):
+        orphan.reopen(lambda _reader: None)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="native workspace replacement is Linux-only",
+)
+def test_native_replacement_authority_traps_the_generic_publication_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prepared = _adopt_fake_native_replacement(tmp_path, monkeypatch)
+    expected_candidate = capture_directory_ownership(prepared.stage)
+    expected_incumbent = capture_directory_ownership(prepared.destination)
+    try:
+        with pytest.raises(RuntimeError, match="dedicated exchange path"):
+            atomic_module._publish_staged_directory_with_authority(
+                prepared.authority,
+                prepared.stage,
+                prepared.destination,
+                expected_stage_root_ownership=expected_candidate,
+                expected_destination_ownership=expected_incumbent,
+            )
+        assert prepared.exchange_calls == []
+        assert (prepared.stage / "payload.bin").read_bytes() == b"new"
+        assert (prepared.destination / "payload.bin").read_bytes() == b"old"
+        assert not tuple(prepared.parent.glob(".published.previous-*"))
+    finally:
+        _close_fake_native_replacement(prepared)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="native workspace replacement is Linux-only",
+)
+def test_native_replacement_helper_rejects_an_exact_wrong_authority_pair(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prepared = _adopt_fake_native_replacement(tmp_path, monkeypatch)
+    foreign_owner = atomic_module._PublicationAuthorityOwner()
+    events: list[str] = []
+
+    def forbidden_exchange(
+        _source: bytes,
+        _destination: bytes,
+        _deadline_ns: int,
+    ) -> object:
+        events.append("exchange")
+        raise AssertionError("wrong replacement pair reached its token callback")
+
+    foreign_authority, foreign_replacement = (
+        atomic_module._adopt_native_posix_replacement_authority(
+            prepared.parent,
+            native_owner=prepared.native_owner,
+            parent_descriptor=prepared.parent_descriptor,
+            candidate_descriptor=prepared.candidate_descriptor,
+            incumbent_descriptor=prepared.incumbent_descriptor,
+            expected_parent_identity=publication_parent_identity(
+                prepared.parent_descriptor
+            ),
+            expected_incumbent_identity=(
+                atomic_module._directory_inode_identity(
+                    os.fstat(prepared.incumbent_descriptor)
+                )
+            ),
+            destination_name=prepared.destination.name,
+            replacement_slot=prepared.stage.name,
+            exchange_callback=forbidden_exchange,
+            authority_owner=foreign_owner,
+        )
+    )
+    assert type(foreign_authority) is type(prepared.authority)
+    assert type(foreign_replacement) is type(prepared.replacement)
+    expected_candidate = capture_directory_ownership(prepared.stage)
+    expected_incumbent = capture_directory_ownership(prepared.destination)
+
+    try:
+        with pytest.raises(
+            TypeError,
+            match="authority.*pair|pair.*authority|pairing",
+        ):
+            atomic_module._publish_native_replacement_with_authority(
+                prepared.authority,
+                foreign_replacement,
+                prepared.stage,
+                prepared.destination,
+                expected_stage_root_ownership=expected_candidate,
+                expected_destination_ownership=expected_incumbent,
+                deadline_ns=1,
+                validate_staged_directory=lambda _reader: events.append(
+                    "validate-staged"
+                ),
+                validate_published_destination=lambda _reader: events.append(
+                    "validate-published"
+                ),
+                commit_callback=lambda *_args: events.append("commit"),
+            )
+
+        assert events == []
+        assert prepared.exchange_calls == []
+        assert not prepared.replacement.exchanged
+        assert not foreign_replacement.exchanged
+        assert (prepared.stage / "payload.bin").read_bytes() == b"new"
+        assert (prepared.destination / "payload.bin").read_bytes() == b"old"
+    finally:
+        foreign_owner.close()
+        _close_fake_native_replacement(prepared)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="native workspace replacement is Linux-only",
+)
+def test_native_replacement_helper_requires_the_exact_replacement_type(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prepared = _adopt_fake_native_replacement(tmp_path, monkeypatch)
+    events: list[str] = []
+
+    def forbidden(*_args: object, **_kwargs: object) -> object:
+        events.append("forged-callback")
+        raise AssertionError("forged replacement reached a protected callback")
+
+    forged = SimpleNamespace(
+        replacement_slot=prepared.stage.name,
+        destination_name=prepared.destination.name,
+        verify_current=forbidden,
+        capture_incumbent=forbidden,
+        exchange=forbidden,
+    )
+    expected_candidate = capture_directory_ownership(prepared.stage)
+    expected_incumbent = capture_directory_ownership(prepared.destination)
+    try:
+        with pytest.raises(TypeError, match="replacement.*invalid"):
+            atomic_module._publish_native_replacement_with_authority(
+                prepared.authority,
+                forged,  # type: ignore[arg-type]
+                prepared.stage,
+                prepared.destination,
+                expected_stage_root_ownership=expected_candidate,
+                expected_destination_ownership=expected_incumbent,
+                deadline_ns=1,
+                validate_staged_directory=lambda _reader: events.append(
+                    "validate-staged"
+                ),
+                validate_published_destination=lambda _reader: events.append(
+                    "validate-published"
+                ),
+                commit_callback=lambda *_args: events.append("commit"),
+            )
+
+        assert events == []
+        assert prepared.exchange_calls == []
+        assert not prepared.replacement.exchanged
+        assert (prepared.stage / "payload.bin").read_bytes() == b"new"
+        assert (prepared.destination / "payload.bin").read_bytes() == b"old"
+    finally:
+        _close_fake_native_replacement(prepared)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="native workspace replacement is Linux-only",
+)
+def test_native_replacement_validator_cannot_intercept_late_native_globals(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prepared = _adopt_fake_native_replacement(tmp_path, monkeypatch)
+    expected_candidate = capture_directory_ownership(prepared.stage)
+    expected_incumbent = capture_directory_ownership(prepared.destination)
+    interceptions: list[str] = []
+
+    def intercept_verify(_owner: object) -> None:
+        interceptions.append("verify")
+        raise AssertionError("validator intercepted native verification")
+
+    def intercept_state(_owner: object) -> str:
+        interceptions.append("state")
+        raise AssertionError("validator intercepted native receipt state")
+
+    def validate_staged(_reader: atomic_module.PublicationDirectoryReader) -> None:
+        monkeypatch.setattr(
+            atomic_module._native_workspace_owner,
+            "verify_owner_authority",
+            intercept_verify,
+        )
+        monkeypatch.setattr(
+            atomic_module._native_workspace_owner,
+            "owner_state",
+            intercept_state,
+        )
+
+    def commit(
+        _staged: object,
+        _published: object,
+        _displaced: DirectoryOrphan,
+        _receipt_token: object,
+    ) -> None:
+        prepared.native_state["value"] = "replacement-receipted"
+        prepared.replacement.mark_receipted()
+
+    try:
+        atomic_module._publish_native_replacement_with_authority(
+            prepared.authority,
+            prepared.replacement,
+            prepared.stage,
+            prepared.destination,
+            expected_stage_root_ownership=expected_candidate,
+            expected_destination_ownership=expected_incumbent,
+            deadline_ns=1,
+            validate_staged_directory=validate_staged,
+            commit_callback=commit,
+        )
+        assert interceptions == []
+        assert (prepared.destination / "payload.bin").read_bytes() == b"new"
+    finally:
+        _close_fake_native_replacement(prepared)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") or not hasattr(os, "fork"),
+    reason="native workspace replacement fork fencing requires Linux fork",
+)
+def test_native_replacement_authority_rejects_fork_without_closing_parent_fds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prepared = _adopt_fake_native_replacement(tmp_path, monkeypatch)
+    expected_candidate = capture_directory_ownership(prepared.stage)
+    child = os.fork()
+    if child == 0:  # pragma: no branch - child reports exact status
+        try:
+            prepared.authority.read_child(
+                prepared.stage.name,
+                path=prepared.stage,
+                label="candidate",
+                expected_ownership=expected_candidate,
+                callback=lambda _reader: None,
+            )
+        except RuntimeError as error:
+            os._exit(0 if "process boundary" in str(error) else 2)
+        except BaseException:  # noqa: B036 - child reports exact failure
+            os._exit(3)
+        os._exit(4)
+
+    try:
+        _, status = os.waitpid(child, 0)
+        assert os.WIFEXITED(status)
+        assert os.WEXITSTATUS(status) == 0
+        assert (
+            prepared.authority.read_child(
+                prepared.stage.name,
+                path=prepared.stage,
+                label="candidate",
+                expected_ownership=expected_candidate,
+                callback=lambda reader: reader.read_bytes(
+                    "payload.bin",
+                    max_bytes=16,
+                ),
+            )
+            == b"new"
+        )
+        os.fstat(prepared.parent_descriptor)
+        os.fstat(prepared.candidate_descriptor)
+        os.fstat(prepared.incumbent_descriptor)
+    finally:
+        _close_fake_native_replacement(prepared)

--- a/test/test_captured_directory.py
+++ b/test/test_captured_directory.py
@@ -10,9 +10,11 @@ import signal
 import stat
 import sys
 import threading
+import time
 from contextlib import contextmanager
 from dataclasses import replace
 from pathlib import Path, PurePosixPath
+from types import SimpleNamespace
 from typing import Iterator
 
 import pytest
@@ -20,6 +22,7 @@ import pytest
 import codenib._atomic_directory as atomic_directory
 import codenib._captured_directory as captured_directory
 import codenib._windows_fs_authority as windows_authority
+import codenib._workspace_owner as workspace_owner
 from codenib._atomic_directory import (
     _TreeOwnership,
     capture_directory_ownership,
@@ -122,6 +125,80 @@ def _publish_payload_generation(
         os.close(root_descriptor)
         os.close(parent_descriptor)
     return destination, plan, owner
+
+
+def _replacement_deadline_ns() -> int:
+    return time.monotonic_ns() + 10_000_000_000
+
+
+def _leased_native_replacement_owner(parent: Path, destination: Path) -> object:
+    if not sys.platform.startswith("linux"):
+        pytest.skip("native workspace replacement is Linux-only")
+    if not workspace_owner._workspace_owner_protocol_available:
+        pytest.skip("native workspace-owner protocol v5 is unavailable")
+    owner = workspace_owner.create_owner()
+    try:
+        workspace_owner.capture_owner_destination(
+            owner,
+            os.fsencode(parent),
+            os.fsencode(destination.name),
+            _replacement_deadline_ns(),
+        )
+        workspace_owner.acquire_owner_replacement_lease(
+            owner,
+            _replacement_deadline_ns(),
+        )
+    except BaseException:
+        if not workspace_owner.owner_closed(owner):
+            workspace_owner.abort_owner(owner)
+        raise
+    return owner
+
+
+@contextmanager
+def _bound_native_replacement(
+    tmp_path: Path,
+    *,
+    old_payload: bytes = b"old",
+) -> Iterator[SimpleNamespace]:
+    parent = tmp_path / "native-replacement-parent"
+    destination, plan, source_owner = _publish_payload_generation(
+        parent,
+        destination_name="published",
+        payload=old_payload,
+    )
+    native_owner = _leased_native_replacement_owner(parent, destination)
+    workspace = OwnedWorkspaceAuthority()
+    output_owner = PublishedWorkspaceReceiptOwner()
+    binding = source_owner.destination_binding
+    try:
+        workspace.bind_replacement_source(
+            source_owner,
+            destination_binding=binding,
+            native_owner=native_owner,
+            stage_name=".replacement-stage",
+            plan=plan,
+        )
+        yield SimpleNamespace(
+            binding=binding,
+            destination=destination,
+            native_owner=native_owner,
+            output_owner=output_owner,
+            parent=parent,
+            plan=plan,
+            source_owner=source_owner,
+            stage=parent / ".replacement-stage",
+            workspace=workspace,
+        )
+    finally:
+        if not output_owner.closed:
+            output_owner.close()
+        if workspace.state != "closed":
+            workspace.close()
+        if not workspace_owner.owner_closed(native_owner):
+            workspace_owner.abort_owner(native_owner)
+        if not source_owner.closed:
+            source_owner.close()
 
 
 def _as_windows_ownership(ownership: object) -> object:
@@ -3417,3 +3494,511 @@ def test_owned_workspace_consume_and_close_are_linear(
         assert consumer_done.is_set()
         assert close_done.is_set()
         assert receipt_owner.closed
+
+
+@pytest.mark.parametrize("source_state", ("wrong-owner", "closed-owner"))
+def test_replacement_bind_requires_the_active_owner_of_the_exact_binding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source_state: str,
+) -> None:
+    parent = tmp_path / "replacement-bind-owner"
+    destination, plan, source_owner = _publish_payload_generation(
+        parent,
+        destination_name="published",
+        stage_name=".first-source",
+        payload=b"old",
+    )
+    _other_destination, _other_plan, other_owner = _publish_payload_generation(
+        parent,
+        destination_name="other",
+        stage_name=".second-source",
+        payload=b"old",
+    )
+    binding = source_owner.destination_binding
+    selected_owner = other_owner
+    if source_state == "closed-owner":
+        source_owner.close()
+        selected_owner = source_owner
+    native_owner = _leased_native_replacement_owner(parent, destination)
+    workspace = OwnedWorkspaceAuthority()
+    provision_calls: list[object] = []
+
+    def forbidden_provision(*_args: object, **_kwargs: object) -> None:
+        provision_calls.append(object())
+        raise AssertionError("inactive binding reached candidate provisioning")
+
+    monkeypatch.setattr(
+        workspace_owner,
+        "provision_owner_replacement",
+        forbidden_provision,
+    )
+    try:
+        with pytest.raises(RuntimeError, match="active|closed"):
+            workspace.bind_replacement_source(
+                selected_owner,
+                destination_binding=binding,
+                native_owner=native_owner,
+                stage_name=".replacement-stage",
+                plan=plan,
+            )
+
+        assert provision_calls == []
+        assert workspace.state == "empty"
+        assert workspace_owner.owner_state(native_owner) == "destination-leased"
+        assert not parent.joinpath(".replacement-stage").exists()
+        assert destination.joinpath("payload").read_bytes() == b"old"
+    finally:
+        workspace.close()
+        if not workspace_owner.owner_closed(native_owner):
+            workspace_owner.abort_owner(native_owner)
+        if not source_owner.closed:
+            source_owner.close()
+        other_owner.close()
+
+
+@pytest.mark.parametrize("mismatch", ("parent", "incumbent"))
+def test_replacement_bind_rejects_native_mismatch_before_candidate_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mismatch: str,
+) -> None:
+    parent = tmp_path / "replacement-bind-mismatch"
+    destination, plan, source_owner = _publish_payload_generation(
+        parent,
+        destination_name="published",
+        payload=b"old",
+    )
+    binding = source_owner.destination_binding
+    native_owner = _leased_native_replacement_owner(parent, destination)
+    workspace = OwnedWorkspaceAuthority()
+    foreign_descriptor = -1
+    provision_calls: list[object] = []
+
+    if mismatch == "parent":
+        foreign_parent = tmp_path / "foreign-parent"
+        foreign_parent.mkdir()
+        foreign_descriptor = os.open(
+            foreign_parent,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+        )
+        monkeypatch.setattr(
+            workspace_owner,
+            "borrow_owner_parent_descriptor",
+            lambda _owner: foreign_descriptor,
+        )
+        expected_message = "parent differs"
+    else:
+        alternate = tmp_path / "alternate-incumbent"
+        alternate.mkdir()
+        alternate.joinpath("payload").write_bytes(b"old")
+        alternate_ownership = capture_directory_ownership(alternate)
+        monkeypatch.setattr(
+            captured_directory,
+            "_capture_posix_directory_descriptor",
+            lambda *_args, **_kwargs: alternate_ownership,
+        )
+        expected_message = "incumbent differs"
+
+    def forbidden_provision(*_args: object, **_kwargs: object) -> None:
+        provision_calls.append(object())
+        raise AssertionError("mismatched binding reached candidate provisioning")
+
+    monkeypatch.setattr(
+        workspace_owner,
+        "provision_owner_replacement",
+        forbidden_provision,
+    )
+    try:
+        with pytest.raises(RuntimeError, match=expected_message):
+            workspace.bind_replacement_source(
+                source_owner,
+                destination_binding=binding,
+                native_owner=native_owner,
+                stage_name=".replacement-stage",
+                plan=plan,
+            )
+
+        assert provision_calls == []
+        assert workspace.state == "closed"
+        assert workspace_owner.owner_closed(native_owner)
+        assert not parent.joinpath(".replacement-stage").exists()
+        assert destination.joinpath("payload").read_bytes() == b"old"
+        if foreign_descriptor >= 0:
+            os.fstat(foreign_descriptor)
+    finally:
+        if workspace.state != "closed":
+            workspace.close()
+        if not workspace_owner.owner_closed(native_owner):
+            workspace_owner.abort_owner(native_owner)
+        if foreign_descriptor >= 0:
+            os.close(foreign_descriptor)
+        source_owner.close()
+
+
+def test_real_v5_replacement_has_exact_order_and_candidate_only_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    with _bound_native_replacement(tmp_path) as prepared:
+        workspace = prepared.workspace
+        real_exchange = workspace._replacement_exchange
+        assert real_exchange is not None
+
+        def observed_exchange(
+            source: bytes,
+            destination: bytes,
+            deadline_ns: int,
+        ) -> object:
+            events.append("exchange")
+            return real_exchange(source, destination, deadline_ns)
+
+        workspace._replacement_exchange = observed_exchange
+        real_provision = workspace_owner.provision_owner_replacement
+
+        def observed_provision(*args: object, **kwargs: object) -> None:
+            events.append("provision")
+            real_provision(*args, **kwargs)
+
+        monkeypatch.setattr(
+            workspace_owner,
+            "provision_owner_replacement",
+            observed_provision,
+        )
+        assert workspace.state == "replacement-bound"
+        assert not prepared.stage.exists()
+        workspace.provision_bound_replacement(deadline_ns=_replacement_deadline_ns())
+        workspace.write_file("payload", (b"new",))
+        workspace.seal()
+
+        with pytest.raises(RuntimeError, match="replacement|dedicated"):
+            workspace.publish_into(prepared.output_owner)
+        assert prepared.output_owner.state == "empty"
+        assert prepared.destination.joinpath("payload").read_bytes() == b"old"
+
+        real_commit = workspace_owner.commit_owner_receipt
+
+        def observed_commit(token: object) -> None:
+            events.append("commit")
+            real_commit(token)
+
+        monkeypatch.setattr(
+            workspace_owner,
+            "commit_owner_receipt",
+            observed_commit,
+        )
+
+        def forbidden_global(*_args: object, **_kwargs: object) -> object:
+            raise AssertionError("validator intercepted a frozen native callback")
+
+        def validate_staged(
+            reader: atomic_directory.PublicationDirectoryReader,
+        ) -> None:
+            assert reader.read_bytes("payload", max_bytes=3) == b"new"
+            events.append("validate-staged")
+            monkeypatch.setattr(
+                workspace_owner,
+                "_exchange_owner_replacement_exact",
+                forbidden_global,
+            )
+            monkeypatch.setattr(
+                workspace_owner,
+                "commit_owner_receipt",
+                forbidden_global,
+            )
+            monkeypatch.setattr(
+                workspace_owner,
+                "verify_owner_authority",
+                forbidden_global,
+            )
+            monkeypatch.setattr(
+                workspace_owner,
+                "verify_owner_replacement_binding",
+                forbidden_global,
+            )
+            monkeypatch.setattr(
+                captured_directory,
+                "_publish_staged_directory_with_authority",
+                forbidden_global,
+            )
+            monkeypatch.setattr(
+                atomic_directory,
+                "DirectoryOrphan",
+                forbidden_global,
+            )
+            monkeypatch.setattr(
+                atomic_directory,
+                "_DirectoryOrphanLocator",
+                forbidden_global,
+            )
+            monkeypatch.setattr(
+                atomic_directory._NativeReplacementPublication,
+                "capture_incumbent",
+                forbidden_global,
+            )
+
+        def validate_published(
+            reader: atomic_directory.PublicationDirectoryReader,
+        ) -> None:
+            assert reader.read_bytes("payload", max_bytes=3) == b"new"
+            assert prepared.stage.joinpath("payload").read_bytes() == b"old"
+            events.append("validate-published")
+
+        workspace.publish_replacement_into(
+            prepared.output_owner,
+            deadline_ns=_replacement_deadline_ns(),
+            validate_staged_directory=validate_staged,
+            validate_published_destination=validate_published,
+        )
+
+        assert events == [
+            "provision",
+            "validate-staged",
+            "exchange",
+            "validate-published",
+            "commit",
+        ]
+        assert prepared.output_owner.active
+        assert (
+            workspace_owner.owner_state(prepared.native_owner)
+            == "replacement-receipted"
+        )
+        orphan = prepared.output_owner.receipt.orphan
+        assert orphan is not None
+        assert orphan.locator.backend_tag == "linux-renameat2"
+        assert (
+            orphan.reopen(lambda reader: reader.read_bytes("payload", max_bytes=3))
+            == b"old"
+        )
+        with pytest.raises(RuntimeError):
+            prepared.source_owner.consume(lambda _receipt, _reader: None)
+
+        parked = prepared.parent / ".parked-incumbent"
+        orphan.path.rename(parked)
+        assert (
+            prepared.output_owner.consume(
+                lambda _receipt, reader: reader.read_bytes(
+                    "payload",
+                    max_bytes=3,
+                )
+            )
+            == b"new"
+        )
+
+        parked_candidate = prepared.parent / ".parked-candidate"
+        prepared.destination.rename(parked_candidate)
+        prepared.destination.mkdir()
+        prepared.destination.joinpath("payload").write_bytes(b"new")
+        with pytest.raises(RuntimeError):
+            prepared.output_owner.consume(lambda _receipt, _reader: None)
+
+        prepared.output_owner.close()
+        assert workspace_owner.owner_closed(prepared.native_owner)
+        assert parked.joinpath("payload").read_bytes() == b"old"
+        parked.rename(orphan.path)
+        assert (
+            orphan.reopen(lambda reader: reader.read_bytes("payload", max_bytes=3))
+            == b"old"
+        )
+        parked = prepared.parent / ".original-displaced-incumbent"
+        orphan.path.rename(parked)
+        orphan.path.mkdir()
+        orphan.path.joinpath("payload").write_bytes(b"old")
+        with pytest.raises(RuntimeError):
+            orphan.reopen(lambda _reader: None)
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_bound_replacement_child_cleanup_cannot_affect_parent_lease_or_mapping(
+    tmp_path: Path,
+) -> None:
+    with _bound_native_replacement(tmp_path) as prepared:
+        workspace = prepared.workspace
+        workspace.provision_bound_replacement(deadline_ns=_replacement_deadline_ns())
+        descriptors = {
+            workspace._replacement_parent_descriptor,
+            workspace._replacement_incumbent_descriptor,
+            workspace._root_descriptor,
+            *workspace._directory_descriptors.values(),
+        }
+        descriptors.discard(-1)
+        child = os.fork()
+        if child == 0:  # pragma: no branch - child reports exact status
+            signal.signal(signal.SIGALRM, lambda *_args: os._exit(80))
+            signal.alarm(3)
+            try:
+                workspace.close()
+            except RuntimeError as error:
+                if "PID boundary" not in str(error):
+                    os._exit(81)
+            except BaseException:  # noqa: B036 - child reports exact failure
+                os._exit(82)
+            else:
+                os._exit(83)
+            for descriptor in descriptors:
+                try:
+                    os.fstat(descriptor)
+                except OSError as error:
+                    if error.errno != errno.EBADF:
+                        os._exit(84)
+                else:
+                    os._exit(85)
+            os._exit(0)
+
+        _pid, status = os.waitpid(child, 0)
+        assert os.WIFEXITED(status)
+        assert os.WEXITSTATUS(status) == 0
+        for descriptor in descriptors:
+            os.fstat(descriptor)
+        assert workspace_owner.owner_state(prepared.native_owner) == (
+            "replacement-adopted"
+        )
+        assert prepared.destination.joinpath("payload").read_bytes() == b"old"
+        assert prepared.stage.is_dir()
+
+        workspace.write_file("payload", (b"new",))
+        workspace.seal()
+        workspace.publish_replacement_into(
+            prepared.output_owner,
+            deadline_ns=_replacement_deadline_ns(),
+        )
+        assert (
+            prepared.output_owner.consume(
+                lambda _receipt, reader: reader.read_bytes(
+                    "payload",
+                    max_bytes=3,
+                )
+            )
+            == b"new"
+        )
+
+
+@pytest.mark.parametrize("install_point", ("before-store", "after-store"))
+def test_replacement_baseexception_settles_on_the_receipt_slot_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    install_point: str,
+) -> None:
+    with _bound_native_replacement(tmp_path) as prepared:
+        workspace = prepared.workspace
+        workspace.provision_bound_replacement(deadline_ns=_replacement_deadline_ns())
+        workspace.write_file("payload", (b"new",))
+        workspace.seal()
+        real_install = PublishedWorkspaceReceiptOwner._install
+        real_abort = workspace_owner.abort_owner
+        real_commit = workspace_owner.commit_owner_receipt
+        abort_calls: list[object] = []
+        commit_calls: list[object] = []
+        interruption = KeyboardInterrupt(install_point)
+
+        def observed_abort(owner: object) -> None:
+            abort_calls.append(owner)
+            real_abort(owner)
+
+        def observed_commit(token: object) -> None:
+            commit_calls.append(token)
+            real_commit(token)
+
+        def interrupted_install(self, reservation, receipt) -> None:
+            if install_point == "after-store":
+                real_install(self, reservation, receipt)
+            raise interruption
+
+        monkeypatch.setattr(workspace_owner, "abort_owner", observed_abort)
+        monkeypatch.setattr(
+            workspace_owner,
+            "commit_owner_receipt",
+            observed_commit,
+        )
+        monkeypatch.setattr(
+            PublishedWorkspaceReceiptOwner,
+            "_install",
+            interrupted_install,
+        )
+
+        with pytest.raises(KeyboardInterrupt) as caught:
+            workspace.publish_replacement_into(
+                prepared.output_owner,
+                deadline_ns=_replacement_deadline_ns(),
+            )
+        assert caught.value is interruption
+
+        if install_point == "before-store":
+            assert abort_calls == [prepared.native_owner]
+            assert commit_calls == []
+            assert prepared.output_owner.state == "cleanup"
+            with pytest.raises(RuntimeError, match="expected active"):
+                _ = prepared.output_owner.receipt
+            assert workspace_owner.owner_closed(prepared.native_owner)
+            assert prepared.destination.joinpath("payload").read_bytes() == b"old"
+            prepared.output_owner.close()
+            assert prepared.output_owner.closed
+            assert workspace.state == "closed"
+        else:
+            assert abort_calls == []
+            assert len(commit_calls) == 1
+            assert prepared.output_owner.active
+            assert (
+                workspace_owner.owner_state(prepared.native_owner)
+                == "replacement-receipted"
+            )
+            assert prepared.destination.joinpath("payload").read_bytes() == b"new"
+
+
+def test_replacement_commit_failure_retries_same_token_without_abort(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _bound_native_replacement(tmp_path) as prepared:
+        workspace = prepared.workspace
+        workspace.provision_bound_replacement(deadline_ns=_replacement_deadline_ns())
+        workspace.write_file("payload", (b"new",))
+        workspace.seal()
+        real_commit = workspace_owner.commit_owner_receipt
+        real_abort = workspace_owner.abort_owner
+        commit_calls: list[object] = []
+        abort_calls: list[object] = []
+        first_error = OSError(errno.EIO, "injected receipt commit failure")
+
+        def retrying_commit(token: object) -> None:
+            commit_calls.append(token)
+            if len(commit_calls) == 1:
+                raise first_error
+            real_commit(token)
+
+        def observed_abort(owner: object) -> None:
+            abort_calls.append(owner)
+            real_abort(owner)
+
+        monkeypatch.setattr(
+            workspace_owner,
+            "commit_owner_receipt",
+            retrying_commit,
+        )
+        monkeypatch.setattr(workspace_owner, "abort_owner", observed_abort)
+
+        with pytest.raises(OSError, match="receipt commit failure") as caught:
+            workspace.publish_replacement_into(
+                prepared.output_owner,
+                deadline_ns=_replacement_deadline_ns(),
+            )
+
+        assert caught.value is first_error
+        assert len(commit_calls) == 2
+        assert commit_calls[0] is commit_calls[1]
+        assert abort_calls == []
+        assert prepared.output_owner.active
+        assert (
+            workspace_owner.owner_state(prepared.native_owner)
+            == "replacement-receipted"
+        )
+        assert (
+            prepared.output_owner.consume(
+                lambda _receipt, reader: reader.read_bytes(
+                    "payload",
+                    max_bytes=3,
+                )
+            )
+            == b"new"
+        )

--- a/test/test_local_workspace_provider.py
+++ b/test/test_local_workspace_provider.py
@@ -423,6 +423,10 @@ def test_local_provider_rejects_receipt_bound_exact_before_mutation(
         mutation_calls.append("provision")
         raise AssertionError("exact rejection reached native provisioning")
 
+    def forbid_replacement_seam(*_args: object, **_kwargs: object) -> None:
+        mutation_calls.append("replacement-seam")
+        raise AssertionError("Local exact rejection reached replacement authority")
+
     monkeypatch.setattr(
         LocalWorkspaceProvider,
         "require_support",
@@ -434,6 +438,16 @@ def test_local_provider_rejects_receipt_bound_exact_before_mutation(
         "provision_owner",
         forbid_native_provision,
     )
+    for method in (
+        "bind_replacement_source",
+        "provision_bound_replacement",
+        "publish_replacement_into",
+    ):
+        monkeypatch.setattr(
+            local_provider_module.OwnedWorkspaceAuthority,
+            method,
+            forbid_replacement_seam,
+        )
 
     try:
         with pytest.raises(UnsupportedWorkspaceCreation, match="missing destination"):

--- a/test/test_workspace_provider.py
+++ b/test/test_workspace_provider.py
@@ -370,6 +370,57 @@ def test_provider_runs_one_callback_scoped_validated_publication(
         owner.close()
 
 
+def test_missing_destination_request_never_selects_the_replacement_seam(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = StrictWorkspaceRequest("missing", tmp_path / "published", _plan())
+    provider = _TestProvider()
+    owner = PublishedWorkspaceReceiptOwner()
+    replacement_calls: list[str] = []
+
+    def forbidden_replacement(
+        _workspace: OwnedWorkspaceAuthority,
+        *_args: object,
+        **_kwargs: object,
+    ) -> None:
+        replacement_calls.append("replacement")
+        raise AssertionError("missing destination selected replacement authority")
+
+    for method in (
+        "bind_replacement_source",
+        "provision_bound_replacement",
+        "publish_replacement_into",
+    ):
+        monkeypatch.setattr(
+            OwnedWorkspaceAuthority,
+            method,
+            forbidden_replacement,
+        )
+
+    def publish(session: StrictWorkspaceSession) -> bytes:
+        session.write_file("payload.bin", (b"missing",))
+        return session.publish_validated(
+            lambda reader: reader.read_bytes("payload.bin", max_bytes=32)
+        )
+
+    try:
+        assert (
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=owner,
+                operation=publish,
+            )
+            == b"missing"
+        )
+        assert replacement_calls == []
+        assert owner.active
+        assert request.destination.joinpath("payload.bin").read_bytes() == b"missing"
+    finally:
+        owner.close()
+
+
 def test_provider_cannot_substitute_the_callback_result(tmp_path: Path) -> None:
     request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
     delegate = _TestProvider()


### PR DESCRIPTION
## Summary

Add the Python dual-root publication seam for the leased protocol-v5 native
workspace-replacement owner. Bind an active incumbent receipt before candidate
provisioning, adopt the candidate and incumbent through distinct retained
descriptors, publish through the dedicated `RENAME_EXCHANGE` authority, and
settle the replacement receipt plus displaced-incumbent orphan at the
caller-owned receipt slot.

This completes only the dual-root authority seam left open by #667.
`LocalWorkspaceProvider` remains missing-only, and Local exact replacement
remains disabled because no production provider/session path supplies the
separately active source receipt owner needed to select this flow. Gate C and
M1 remain open. No default compiler or runtime route changes.

Related to #199. This PR does not close the RFC.

## Changes

- Add a dedicated dual-root publication authority with separate candidate and
  incumbent descriptor readers, exact authority-pair sealing, and
  candidate-only post-receipt verification.
- Bind an active exact source receipt to the already-leased native owner,
  authenticate the complete incumbent tree, and retain the one-shot replacement
  permit privately before provisioning.
- Provision and adopt the candidate only through the same native owner, hidden
  slot, and frozen workspace plan.
- Publish sealed replacements through the dedicated exchange path while
  rejecting the generic isolate-and-rename publication route.
- Keep the receipt-owner slot as the linearization point: abort and authenticate
  reversal before its store, and commit the same native receipt token after it.
- Return the displaced incumbent as a reopenable `DirectoryOrphan` using the
  ordinary `linux-renameat2` locator.
- Cover authority substitution, binding changes, fork behavior, cancellation,
  `BaseException`, receipt-commit retry, live-name rebinding, and missing-only
  provider paths.
- Document the new seam while keeping Local exact replacement, Gate C, and M1
  open.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- Combined dual-root, workspace-owner/provider, and complete release-artifact
  suite: `611 passed, 10 skipped in 10.75s` on the final rebased tree.
- Full unit marker in a from-scratch read-only bwrap namespace:
  `7067 passed, 71 skipped, 190 deselected in 162.32s`.
- The two unit-tier warnings were expected attempts to write pytest cache files
  in the deliberately read-only checkout.
- The direct host run reached `3656 passed, 49 skipped, 190 deselected` and
  stopped solely at the known absent `/usr/bin/docker` infrastructure check;
  Docker was not installed or modified.
- The newly merged wiki test surface passed: `15 passed`.
- Black, isort, flake8, Python compilation, and `git diff --check` passed on all
  six changed Python files.
- Strict MkDocs build and the public-documentation checker passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
