### PR TITLE
feat(wiki): add multimodal knowledge pipeline

### DIFF
--- a/codenib/wiki/__init__.py
+++ b/codenib/wiki/__init__.py
@@ -25,6 +25,7 @@ from .media_knowledge import (
     get_visual_evidence,
     search_visual_context,
 )
+from .media_pipeline import build_multimodal_repository_knowledge
 from .media_vlm import OpenAICompatibleVisualFactExtractor
 
 __all__ = [
@@ -33,6 +34,7 @@ __all__ = [
     "VisualGroundingScorer",
     "build_media_evidence_pack",
     "build_multimodal_knowledge_view",
+    "build_multimodal_repository_knowledge",
     "build_visual_facts_manifest",
     "deterministic_visual_facts",
     "discover_media_manifest",

--- a/codenib/wiki/media_pipeline.py
+++ b/codenib/wiki/media_pipeline.py
@@ -36,9 +36,10 @@ def build_multimodal_repository_knowledge(
 ) -> dict[str, Any]:
     """Build the deterministic multimodal repository knowledge bundle."""
 
+    root = _repository_root(repo_path)
     excluded = tuple(exclude_roots)
     media_manifest = discover_media_manifest(
-        repo_path,
+        root,
         commit=commit,
         exclude_roots=excluded,
         selection=selection,
@@ -49,7 +50,7 @@ def build_multimodal_repository_knowledge(
         facts_kwargs["extractor"] = extractor
     visual_facts_manifest = build_visual_facts_manifest(media_manifest, **facts_kwargs)
     source_candidates = discover_source_symbol_candidates(
-        repo_path,
+        root,
         exclude_roots=excluded,
         selection=selection,
         max_candidates=max_source_candidates,
@@ -71,6 +72,13 @@ def build_multimodal_repository_knowledge(
         "grounding_manifest": grounding_manifest,
         "knowledge_view": knowledge_view,
     }
+
+
+def _repository_root(repo_path: str | Path) -> Path:
+    root = Path(repo_path).expanduser().resolve(strict=True)
+    if not root.is_dir():
+        raise NotADirectoryError(f"repository root is not a directory: {root}")
+    return root
 
 
 __all__ = ["build_multimodal_repository_knowledge"]

--- a/codenib/wiki/media_pipeline.py
+++ b/codenib/wiki/media_pipeline.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Iterable
 
 from ..repository_source_selection import (
     DEFAULT_REPOSITORY_SOURCE_SELECTION,
@@ -16,6 +16,7 @@ from ..repository_source_selection import (
 from .media_artifacts import discover_media_manifest
 from .media_facts import VisualFactExtractor, build_visual_facts_manifest
 from .media_grounding import (
+    VisualGroundingScorer,
     discover_source_symbol_candidates,
     ground_visual_facts_to_sources,
 )
@@ -26,18 +27,20 @@ def build_multimodal_repository_knowledge(
     repo_path: str | Path,
     *,
     commit: str | None = None,
-    exclude_roots: tuple[str | Path, ...] = (),
+    exclude_roots: Iterable[str | Path] = (),
     selection: RepositorySourceSelection = DEFAULT_REPOSITORY_SOURCE_SELECTION,
     extractor: VisualFactExtractor | None = None,
+    scorer: VisualGroundingScorer | None = None,
     max_artifacts: int = 4096,
     max_source_candidates: int = 8192,
 ) -> dict[str, Any]:
     """Build the deterministic multimodal repository knowledge bundle."""
 
+    excluded = tuple(exclude_roots)
     media_manifest = discover_media_manifest(
         repo_path,
         commit=commit,
-        exclude_roots=exclude_roots,
+        exclude_roots=excluded,
         selection=selection,
         max_artifacts=max_artifacts,
     )
@@ -47,13 +50,14 @@ def build_multimodal_repository_knowledge(
     visual_facts_manifest = build_visual_facts_manifest(media_manifest, **facts_kwargs)
     source_candidates = discover_source_symbol_candidates(
         repo_path,
-        exclude_roots=exclude_roots,
+        exclude_roots=excluded,
         selection=selection,
         max_candidates=max_source_candidates,
     )
     grounding_manifest = ground_visual_facts_to_sources(
         visual_facts_manifest,
         source_candidates,
+        scorer=scorer,
     )
     knowledge_view = build_multimodal_knowledge_view(
         media_manifest,

--- a/codenib/wiki/media_pipeline.py
+++ b/codenib/wiki/media_pipeline.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end construction for multimodal repository knowledge."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from ..repository_source_selection import (
+    DEFAULT_REPOSITORY_SOURCE_SELECTION,
+    RepositorySourceSelection,
+)
+from .media_artifacts import discover_media_manifest
+from .media_facts import VisualFactExtractor, build_visual_facts_manifest
+from .media_grounding import (
+    discover_source_symbol_candidates,
+    ground_visual_facts_to_sources,
+)
+from .media_knowledge import build_multimodal_knowledge_view
+
+
+def build_multimodal_repository_knowledge(
+    repo_path: str | Path,
+    *,
+    commit: str | None = None,
+    exclude_roots: tuple[str | Path, ...] = (),
+    selection: RepositorySourceSelection = DEFAULT_REPOSITORY_SOURCE_SELECTION,
+    extractor: VisualFactExtractor | None = None,
+    max_artifacts: int = 4096,
+    max_source_candidates: int = 8192,
+) -> dict[str, Any]:
+    """Build the deterministic multimodal repository knowledge bundle."""
+
+    media_manifest = discover_media_manifest(
+        repo_path,
+        commit=commit,
+        exclude_roots=exclude_roots,
+        selection=selection,
+        max_artifacts=max_artifacts,
+    )
+    facts_kwargs: dict[str, Any] = {}
+    if extractor is not None:
+        facts_kwargs["extractor"] = extractor
+    visual_facts_manifest = build_visual_facts_manifest(media_manifest, **facts_kwargs)
+    source_candidates = discover_source_symbol_candidates(
+        repo_path,
+        exclude_roots=exclude_roots,
+        selection=selection,
+        max_candidates=max_source_candidates,
+    )
+    grounding_manifest = ground_visual_facts_to_sources(
+        visual_facts_manifest,
+        source_candidates,
+    )
+    knowledge_view = build_multimodal_knowledge_view(
+        media_manifest,
+        visual_facts_manifest,
+        grounding_manifest,
+    )
+    return {
+        "media_manifest": media_manifest,
+        "visual_facts_manifest": visual_facts_manifest,
+        "source_candidate_count": len(source_candidates),
+        "grounding_manifest": grounding_manifest,
+        "knowledge_view": knowledge_view,
+    }
+
+
+__all__ = ["build_multimodal_repository_knowledge"]

--- a/docs/experiments/multimodal_repository_knowledge.md
+++ b/docs/experiments/multimodal_repository_knowledge.md
@@ -123,7 +123,8 @@ The same deterministic bundle can be written from the command line:
 
 ```text
 python scripts/build_multimodal_knowledge.py /path/to/repository \
-  --output /tmp/multimodal-knowledge.json
+  --output /tmp/multimodal-knowledge.json \
+  --exclude-root /path/to/repository/generated
 ```
 
 ```python

--- a/docs/experiments/multimodal_repository_knowledge.md
+++ b/docs/experiments/multimodal_repository_knowledge.md
@@ -110,6 +110,15 @@ print(view["entry_count"])
 This creates a deterministic local view. A VLM extractor can be added later by
 passing a custom extractor into `build_visual_facts_manifest()`.
 
+For callers that want the full deterministic pipeline in one step:
+
+```python
+from codenib.wiki import build_multimodal_repository_knowledge
+
+bundle = build_multimodal_repository_knowledge(repo)
+view = bundle["knowledge_view"]
+```
+
 ```python
 from codenib.wiki import OpenAICompatibleVisualFactExtractor
 

--- a/docs/experiments/multimodal_repository_knowledge.md
+++ b/docs/experiments/multimodal_repository_knowledge.md
@@ -119,6 +119,13 @@ bundle = build_multimodal_repository_knowledge(repo)
 view = bundle["knowledge_view"]
 ```
 
+The same deterministic bundle can be written from the command line:
+
+```text
+python scripts/build_multimodal_knowledge.py /path/to/repository \
+  --output /tmp/multimodal-knowledge.json
+```
+
 ```python
 from codenib.wiki import OpenAICompatibleVisualFactExtractor
 

--- a/scripts/build_multimodal_knowledge.py
+++ b/scripts/build_multimodal_knowledge.py
@@ -9,9 +9,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
-from codenib.wiki import build_multimodal_repository_knowledge
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from codenib.wiki import build_multimodal_repository_knowledge  # noqa: E402
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -50,9 +55,15 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    repo = Path(args.repo).expanduser()
+    if not repo.exists():
+        parser.error(f"repository root does not exist: {repo}")
+    if not repo.is_dir():
+        parser.error(f"repository root is not a directory: {repo}")
     bundle = build_multimodal_repository_knowledge(
-        args.repo,
+        repo,
         commit=args.commit,
         exclude_roots=tuple(args.exclude_root),
         max_artifacts=args.max_artifacts,

--- a/scripts/build_multimodal_knowledge.py
+++ b/scripts/build_multimodal_knowledge.py
@@ -29,6 +29,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional commit identity to record in the media manifest",
     )
     parser.add_argument(
+        "--exclude-root",
+        action="append",
+        default=[],
+        help="Path to exclude from repository discovery; may be repeated",
+    )
+    parser.add_argument(
         "--max-artifacts",
         type=int,
         default=4096,
@@ -48,6 +54,7 @@ def main(argv: list[str] | None = None) -> int:
     bundle = build_multimodal_repository_knowledge(
         args.repo,
         commit=args.commit,
+        exclude_roots=tuple(args.exclude_root),
         max_artifacts=args.max_artifacts,
         max_source_candidates=args.max_source_candidates,
     )

--- a/scripts/build_multimodal_knowledge.py
+++ b/scripts/build_multimodal_knowledge.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build a deterministic multimodal repository knowledge bundle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from codenib.wiki import build_multimodal_repository_knowledge
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("repo", help="Repository root to scan")
+    parser.add_argument(
+        "--output",
+        "-o",
+        required=True,
+        help="Path to write the multimodal knowledge bundle JSON",
+    )
+    parser.add_argument(
+        "--commit",
+        default=None,
+        help="Optional commit identity to record in the media manifest",
+    )
+    parser.add_argument(
+        "--max-artifacts",
+        type=int,
+        default=4096,
+        help="Maximum media artifacts to include",
+    )
+    parser.add_argument(
+        "--max-source-candidates",
+        type=int,
+        default=8192,
+        help="Maximum source-symbol candidates to consider for grounding",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    bundle = build_multimodal_repository_knowledge(
+        args.repo,
+        commit=args.commit,
+        max_artifacts=args.max_artifacts,
+        max_source_candidates=args.max_source_candidates,
+    )
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(bundle, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    counts = {
+        "media_artifacts": bundle["media_manifest"]["artifact_count"],
+        "visual_fact_packs": bundle["visual_facts_manifest"]["fact_count"],
+        "source_candidates": bundle["source_candidate_count"],
+        "visual_code_bindings": bundle["grounding_manifest"]["binding_count"],
+        "knowledge_entries": bundle["knowledge_view"]["entry_count"],
+    }
+    print(json.dumps(counts, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/scripts/test_build_multimodal_knowledge.py
+++ b/test/scripts/test_build_multimodal_knowledge.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+
+def test_build_multimodal_knowledge_script_writes_bundle(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "docs").mkdir()
+    (repo / "src").mkdir()
+    (repo / "docs" / "architecture.svg").write_text(
+        "<svg>WikiService</svg>",
+        encoding="utf-8",
+    )
+    (repo / "README.md").write_text(
+        "![WikiService architecture](docs/architecture.svg)",
+        encoding="utf-8",
+    )
+    (repo / "src" / "wiki.py").write_text(
+        "class WikiService: pass",
+        encoding="utf-8",
+    )
+    output = tmp_path / "bundle.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/build_multimodal_knowledge.py",
+            str(repo),
+            "--output",
+            str(output),
+            "--commit",
+            "abc123",
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+    counts = json.loads(completed.stdout)
+    bundle = json.loads(output.read_text(encoding="utf-8"))
+    assert counts["media_artifacts"] == 1
+    assert counts["knowledge_entries"] == 1
+    assert bundle["media_manifest"]["commit"] == "abc123"
+    assert bundle["knowledge_view"]["entry_count"] == 1

--- a/test/scripts/test_build_multimodal_knowledge.py
+++ b/test/scripts/test_build_multimodal_knowledge.py
@@ -26,6 +26,9 @@ def test_build_multimodal_knowledge_script_writes_bundle(tmp_path):
         "class WikiService: pass",
         encoding="utf-8",
     )
+    generated = repo / "generated"
+    generated.mkdir()
+    (generated / "ignored.png").write_bytes(b"png")
     output = tmp_path / "bundle.json"
 
     completed = subprocess.run(
@@ -37,6 +40,8 @@ def test_build_multimodal_knowledge_script_writes_bundle(tmp_path):
             str(output),
             "--commit",
             "abc123",
+            "--exclude-root",
+            str(generated),
         ],
         check=True,
         stdout=subprocess.PIPE,

--- a/test/scripts/test_build_multimodal_knowledge.py
+++ b/test/scripts/test_build_multimodal_knowledge.py
@@ -34,6 +34,7 @@ def test_build_multimodal_knowledge_script_writes_bundle(tmp_path):
     completed = subprocess.run(
         [
             sys.executable,
+            "-I",
             "scripts/build_multimodal_knowledge.py",
             str(repo),
             "--output",
@@ -54,3 +55,26 @@ def test_build_multimodal_knowledge_script_writes_bundle(tmp_path):
     assert counts["knowledge_entries"] == 1
     assert bundle["media_manifest"]["commit"] == "abc123"
     assert bundle["knowledge_view"]["entry_count"] == 1
+
+
+def test_build_multimodal_knowledge_script_rejects_missing_repository(tmp_path):
+    output = tmp_path / "bundle.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "scripts/build_multimodal_knowledge.py",
+            str(tmp_path / "missing"),
+            "--output",
+            str(output),
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "repository root does not exist" in completed.stderr
+    assert not output.exists()

--- a/test/wiki/test_media_pipeline.py
+++ b/test/wiki/test_media_pipeline.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from codenib.wiki import (
     build_multimodal_knowledge_view,
+    build_multimodal_repository_knowledge,
     build_visual_facts_manifest,
     discover_media_manifest,
     discover_source_symbol_candidates,
@@ -57,3 +58,24 @@ def test_multimodal_repository_knowledge_pipeline(tmp_path):
     assert view["entry_count"] == 1
     assert search_visual_context(view, "IndexCompiler architecture")
     assert find_visual_code_links(view, "src/compiler.py", symbol="IndexCompiler")
+
+
+def test_build_multimodal_repository_knowledge_wraps_pipeline(tmp_path):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "src").mkdir()
+    (tmp_path / "docs" / "diagram.png").write_bytes(b"png")
+    (tmp_path / "README.md").write_text(
+        "![WikiService diagram](docs/diagram.png)",
+        encoding="utf-8",
+    )
+    (tmp_path / "src" / "wiki.py").write_text(
+        "class WikiService: pass",
+        encoding="utf-8",
+    )
+
+    bundle = build_multimodal_repository_knowledge(tmp_path, commit="abc123")
+
+    assert bundle["media_manifest"]["artifact_count"] == 1
+    assert bundle["visual_facts_manifest"]["fact_count"] == 1
+    assert bundle["source_candidate_count"] >= 1
+    assert bundle["knowledge_view"]["entry_count"] == 1

--- a/test/wiki/test_media_pipeline.py
+++ b/test/wiki/test_media_pipeline.py
@@ -79,3 +79,61 @@ def test_build_multimodal_repository_knowledge_wraps_pipeline(tmp_path):
     assert bundle["visual_facts_manifest"]["fact_count"] == 1
     assert bundle["source_candidate_count"] >= 1
     assert bundle["knowledge_view"]["entry_count"] == 1
+
+
+def test_pipeline_forwards_custom_grounding_scorer(tmp_path):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "src").mkdir()
+    (tmp_path / "docs" / "diagram.svg").write_text(
+        "<svg>DiagramBox</svg>",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "![DiagramBox](docs/diagram.svg)",
+        encoding="utf-8",
+    )
+    (tmp_path / "src" / "wiki.py").write_text(
+        "class WikiService: pass",
+        encoding="utf-8",
+    )
+
+    def scorer(entity, candidate):
+        if entity["name"] == "DiagramBox" and candidate["symbol"] == "WikiService":
+            return {"score": 0.91, "evidence": "pipeline scorer"}
+        return None
+
+    bundle = build_multimodal_repository_knowledge(tmp_path, scorer=scorer)
+
+    assert any(
+        binding["symbol"] == "WikiService"
+        and binding["score"] == 0.91
+        and binding["evidence"] == "pipeline scorer"
+        for binding in bundle["grounding_manifest"]["bindings"]
+    )
+
+
+def test_pipeline_materializes_exclude_roots_for_each_stage(tmp_path):
+    (tmp_path / "docs").mkdir()
+    excluded = tmp_path / "generated"
+    excluded.mkdir()
+    (tmp_path / "docs" / "diagram.svg").write_text(
+        "<svg>HiddenService</svg>",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "![HiddenService](docs/diagram.svg)",
+        encoding="utf-8",
+    )
+    (excluded / "ignored.png").write_bytes(b"png")
+    (excluded / "hidden.py").write_text(
+        "class HiddenService: pass",
+        encoding="utf-8",
+    )
+
+    bundle = build_multimodal_repository_knowledge(
+        tmp_path,
+        exclude_roots=(path for path in [excluded]),
+    )
+
+    assert bundle["media_manifest"]["artifact_count"] == 1
+    assert bundle["grounding_manifest"]["binding_count"] == 0

--- a/test/wiki/test_media_pipeline.py
+++ b/test/wiki/test_media_pipeline.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from codenib.wiki import (
     build_multimodal_knowledge_view,
     build_multimodal_repository_knowledge,
@@ -137,3 +139,14 @@ def test_pipeline_materializes_exclude_roots_for_each_stage(tmp_path):
 
     assert bundle["media_manifest"]["artifact_count"] == 1
     assert bundle["grounding_manifest"]["binding_count"] == 0
+
+
+def test_pipeline_rejects_invalid_repository_roots(tmp_path):
+    missing = tmp_path / "missing"
+    with pytest.raises(FileNotFoundError):
+        build_multimodal_repository_knowledge(missing)
+
+    file_path = tmp_path / "repository.txt"
+    file_path.write_text("not a directory", encoding="utf-8")
+    with pytest.raises(NotADirectoryError, match="not a directory"):
+        build_multimodal_repository_knowledge(file_path)


### PR DESCRIPTION
## Summary

Restacks and integrates [MarinaMackay/CodeNib#6](https://github.com/MarinaMackay/CodeNib/pull/6) as the next independent slice of #655.

Adds a one-step deterministic multimodal repository-knowledge builder and a local JSON build script on top of the merged artifact, fact, grounding, and knowledge-view contracts.

## Changes

- Add public `build_multimodal_repository_knowledge()` pipeline composition.
- Add a clean-checkout-compatible `scripts/build_multimodal_knowledge.py` with bounded artifact/source limits and compact counts.
- Forward optional visual extractors and custom grounding scorers through the one-step API.
- Materialize caller-provided exclusion iterables before both repository scans.
- Add repeatable CLI `--exclude-root` handling and document the local workflow.
- Reject missing and non-directory repository roots before publishing an empty-looking bundle.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] `pytest test/wiki -q` (409 passed)
- [x] `pytest test/wiki/test_media_pipeline.py test/scripts/test_build_multimodal_knowledge.py -q` (7 passed)
- [x] Direct script subprocess coverage under isolated Python (`python -I`)
- [x] `python -m flake8 codenib/wiki/__init__.py codenib/wiki/media_pipeline.py scripts/build_multimodal_knowledge.py test/wiki/test_media_pipeline.py test/scripts/test_build_multimodal_knowledge.py`
- [x] `git diff --check origin/main...HEAD`

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published