### PR TITLE
feat(wiki): add multimodal knowledge tool router

### DIFF
--- a/codenib/wiki/__init__.py
+++ b/codenib/wiki/__init__.py
@@ -26,9 +26,12 @@ from .media_knowledge import (
     search_visual_context,
 )
 from .media_pipeline import build_multimodal_repository_knowledge
+from .media_tools import MULTIMODAL_TOOL_SCHEMAS, MultimodalKnowledgeToolRouter
 from .media_vlm import OpenAICompatibleVisualFactExtractor
 
 __all__ = [
+    "MULTIMODAL_TOOL_SCHEMAS",
+    "MultimodalKnowledgeToolRouter",
     "WikiBuilder",
     "OpenAICompatibleVisualFactExtractor",
     "VisualGroundingScorer",

--- a/codenib/wiki/__init__.py
+++ b/codenib/wiki/__init__.py
@@ -26,11 +26,10 @@ from .media_knowledge import (
     search_visual_context,
 )
 from .media_pipeline import build_multimodal_repository_knowledge
-from .media_tools import MULTIMODAL_TOOL_SCHEMAS, MultimodalKnowledgeToolRouter
+from .media_tools import MultimodalKnowledgeToolRouter, multimodal_tool_schemas
 from .media_vlm import OpenAICompatibleVisualFactExtractor
 
 __all__ = [
-    "MULTIMODAL_TOOL_SCHEMAS",
     "MultimodalKnowledgeToolRouter",
     "WikiBuilder",
     "OpenAICompatibleVisualFactExtractor",
@@ -45,5 +44,6 @@ __all__ = [
     "find_visual_code_links",
     "get_visual_evidence",
     "ground_visual_facts_to_sources",
+    "multimodal_tool_schemas",
     "search_visual_context",
 ]

--- a/codenib/wiki/media_tools.py
+++ b/codenib/wiki/media_tools.py
@@ -6,7 +6,9 @@
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass
+from pathlib import PurePosixPath
 from typing import Any, Mapping
 
 from .media_knowledge import (
@@ -51,6 +53,7 @@ MULTIMODAL_TOOL_SCHEMAS: tuple[dict[str, Any], ...] = (
             "properties": {
                 "source_path": {"type": "string"},
                 "symbol": {"type": "string"},
+                "limit": {"type": "integer", "minimum": 1, "maximum": _MAX_LIMIT},
             },
             "required": ["source_path"],
             "additionalProperties": False,
@@ -66,29 +69,33 @@ class MultimodalKnowledgeToolRouter:
     view: Mapping[str, Any]
 
     def tool_schemas(self) -> list[dict[str, Any]]:
-        return [dict(schema) for schema in MULTIMODAL_TOOL_SCHEMAS]
+        return list(copy.deepcopy(MULTIMODAL_TOOL_SCHEMAS))
 
     def call_tool(self, name: str, arguments: Mapping[str, Any]) -> dict[str, Any]:
-        if not isinstance(arguments, Mapping):
-            raise ValueError("multimodal tool arguments must be an object")
+        if type(name) is not str:
+            raise ValueError("unknown multimodal knowledge tool")
         if name == "search_visual_context":
+            arguments = _arguments(arguments, allowed={"query", "limit"})
             query = _bounded_text(arguments.get("query"), label="query")
             limit = _limit(arguments.get("limit", 5))
             return {
                 "results": search_visual_context(self.view, query, limit=limit),
             }
         if name == "get_visual_evidence":
-            artifact_path = _bounded_text(
+            arguments = _arguments(arguments, allowed={"artifact_path"})
+            artifact_path = _relative_path(
                 arguments.get("artifact_path"),
                 label="artifact_path",
-                max_bytes=_MAX_PATH_BYTES,
             )
             return {"evidence": get_visual_evidence(self.view, artifact_path)}
         if name == "find_visual_code_links":
-            source_path = _bounded_text(
+            arguments = _arguments(
+                arguments,
+                allowed={"source_path", "symbol", "limit"},
+            )
+            source_path = _relative_path(
                 arguments.get("source_path"),
                 label="source_path",
-                max_bytes=_MAX_PATH_BYTES,
             )
             symbol = _bounded_text(
                 arguments.get("symbol", ""),
@@ -96,14 +103,29 @@ class MultimodalKnowledgeToolRouter:
                 max_bytes=_MAX_PATH_BYTES,
                 allow_empty=True,
             )
+            limit = _limit(arguments.get("limit", _MAX_LIMIT))
             return {
                 "links": find_visual_code_links(
                     self.view,
                     source_path,
                     symbol=symbol,
-                )
+                )[:limit]
             }
-        raise ValueError(f"unknown multimodal knowledge tool: {name}")
+        raise ValueError("unknown multimodal knowledge tool")
+
+
+def _arguments(
+    value: Any,
+    *,
+    allowed: set[str],
+) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError("multimodal tool arguments must be an object")
+    if len(value) > len(allowed) or any(
+        type(key) is not str or key not in allowed for key in value
+    ):
+        raise ValueError("multimodal tool arguments contain unexpected properties")
+    return value
 
 
 def _bounded_text(
@@ -113,26 +135,38 @@ def _bounded_text(
     max_bytes: int = _MAX_QUERY_BYTES,
     allow_empty: bool = False,
 ) -> str:
-    text = str(value or "").strip()
+    if type(value) is not str:
+        raise ValueError(f"{label} must be a string")
+    text = value.strip()
     if not text and not allow_empty:
         raise ValueError(f"{label} is required")
     if len(text.encode("utf-8")) > max_bytes:
         raise ValueError(f"{label} exceeds the byte limit")
-    if any(ord(character) < 0x20 for character in text):
+    if any(ord(character) < 0x20 or ord(character) == 0x7F for character in text):
         raise ValueError(f"{label} contains control characters")
     return text
 
 
+def _relative_path(value: Any, *, label: str) -> str:
+    text = _bounded_text(value, label=label, max_bytes=_MAX_PATH_BYTES)
+    if "\\" in text:
+        raise ValueError(f"{label} must be a repository-relative path")
+    path = PurePosixPath(text)
+    if (
+        path.is_absolute()
+        or any(part in {"", ".", ".."} for part in path.parts)
+        or path.as_posix() != text
+    ):
+        raise ValueError(f"{label} must be a repository-relative path")
+    return path.as_posix()
+
+
 def _limit(value: Any) -> int:
-    if isinstance(value, bool):
+    if type(value) is not int:
         raise ValueError("limit must be an integer")
-    try:
-        limit = int(value)
-    except (TypeError, ValueError) as exc:
-        raise ValueError("limit must be an integer") from exc
-    if not 1 <= limit <= _MAX_LIMIT:
+    if not 1 <= value <= _MAX_LIMIT:
         raise ValueError(f"limit must be between 1 and {_MAX_LIMIT}")
-    return limit
+    return value
 
 
 __all__ = ["MULTIMODAL_TOOL_SCHEMAS", "MultimodalKnowledgeToolRouter"]

--- a/codenib/wiki/media_tools.py
+++ b/codenib/wiki/media_tools.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""MCP-compatible query surface for multimodal repository knowledge."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from .media_knowledge import (
+    find_visual_code_links,
+    get_visual_evidence,
+    search_visual_context,
+)
+
+_MAX_QUERY_BYTES = 4096
+_MAX_PATH_BYTES = 4096
+_MAX_LIMIT = 20
+
+MULTIMODAL_TOOL_SCHEMAS: tuple[dict[str, Any], ...] = (
+    {
+        "name": "search_visual_context",
+        "description": "Search repository visual artifacts, facts, and source bindings.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "limit": {"type": "integer", "minimum": 1, "maximum": _MAX_LIMIT},
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "get_visual_evidence",
+        "description": "Return one visual evidence entry by repository-relative artifact path.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"artifact_path": {"type": "string"}},
+            "required": ["artifact_path"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "find_visual_code_links",
+        "description": "Find visual artifacts grounded to a source file and optional symbol.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "source_path": {"type": "string"},
+                "symbol": {"type": "string"},
+            },
+            "required": ["source_path"],
+            "additionalProperties": False,
+        },
+    },
+)
+
+
+@dataclass(frozen=True)
+class MultimodalKnowledgeToolRouter:
+    """Small tool router that mirrors the future MCP surface."""
+
+    view: Mapping[str, Any]
+
+    def tool_schemas(self) -> list[dict[str, Any]]:
+        return [dict(schema) for schema in MULTIMODAL_TOOL_SCHEMAS]
+
+    def call_tool(self, name: str, arguments: Mapping[str, Any]) -> dict[str, Any]:
+        if not isinstance(arguments, Mapping):
+            raise ValueError("multimodal tool arguments must be an object")
+        if name == "search_visual_context":
+            query = _bounded_text(arguments.get("query"), label="query")
+            limit = _limit(arguments.get("limit", 5))
+            return {
+                "results": search_visual_context(self.view, query, limit=limit),
+            }
+        if name == "get_visual_evidence":
+            artifact_path = _bounded_text(
+                arguments.get("artifact_path"),
+                label="artifact_path",
+                max_bytes=_MAX_PATH_BYTES,
+            )
+            return {"evidence": get_visual_evidence(self.view, artifact_path)}
+        if name == "find_visual_code_links":
+            source_path = _bounded_text(
+                arguments.get("source_path"),
+                label="source_path",
+                max_bytes=_MAX_PATH_BYTES,
+            )
+            symbol = _bounded_text(
+                arguments.get("symbol", ""),
+                label="symbol",
+                max_bytes=_MAX_PATH_BYTES,
+                allow_empty=True,
+            )
+            return {
+                "links": find_visual_code_links(
+                    self.view,
+                    source_path,
+                    symbol=symbol,
+                )
+            }
+        raise ValueError(f"unknown multimodal knowledge tool: {name}")
+
+
+def _bounded_text(
+    value: Any,
+    *,
+    label: str,
+    max_bytes: int = _MAX_QUERY_BYTES,
+    allow_empty: bool = False,
+) -> str:
+    text = str(value or "").strip()
+    if not text and not allow_empty:
+        raise ValueError(f"{label} is required")
+    if len(text.encode("utf-8")) > max_bytes:
+        raise ValueError(f"{label} exceeds the byte limit")
+    if any(ord(character) < 0x20 for character in text):
+        raise ValueError(f"{label} contains control characters")
+    return text
+
+
+def _limit(value: Any) -> int:
+    if isinstance(value, bool):
+        raise ValueError("limit must be an integer")
+    try:
+        limit = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("limit must be an integer") from exc
+    if not 1 <= limit <= _MAX_LIMIT:
+        raise ValueError(f"limit must be between 1 and {_MAX_LIMIT}")
+    return limit
+
+
+__all__ = ["MULTIMODAL_TOOL_SCHEMAS", "MultimodalKnowledgeToolRouter"]

--- a/codenib/wiki/media_tools.py
+++ b/codenib/wiki/media_tools.py
@@ -20,15 +20,30 @@ from .media_knowledge import (
 _MAX_QUERY_BYTES = 4096
 _MAX_PATH_BYTES = 4096
 _MAX_LIMIT = 20
+_NONEMPTY_TEXT_PATTERN = r"^(?=.*\S)[^\u0000-\u001F\u007F]*$"
+_OPTIONAL_TEXT_PATTERN = r"^[^\u0000-\u001F\u007F]*$"
+_RELATIVE_PATH_PATTERN = (
+    r"^(?=.*\S)(?!/)(?!.*//)(?!.*(?:^|/)\.\.?(?:/|$))(?!.*\/$)"
+    r"[^\\\u0000-\u001F\u007F]+$"
+)
 
-MULTIMODAL_TOOL_SCHEMAS: tuple[dict[str, Any], ...] = (
+_MULTIMODAL_TOOL_SCHEMAS: tuple[dict[str, Any], ...] = (
     {
         "name": "search_visual_context",
         "description": "Search repository visual artifacts, facts, and source bindings.",
         "input_schema": {
             "type": "object",
             "properties": {
-                "query": {"type": "string"},
+                "query": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": _MAX_QUERY_BYTES,
+                    "pattern": _NONEMPTY_TEXT_PATTERN,
+                    "description": (
+                        "Nonempty query without control characters; the UTF-8 "
+                        f"payload is limited to {_MAX_QUERY_BYTES} bytes."
+                    ),
+                },
                 "limit": {"type": "integer", "minimum": 1, "maximum": _MAX_LIMIT},
             },
             "required": ["query"],
@@ -40,7 +55,18 @@ MULTIMODAL_TOOL_SCHEMAS: tuple[dict[str, Any], ...] = (
         "description": "Return one visual evidence entry by repository-relative artifact path.",
         "input_schema": {
             "type": "object",
-            "properties": {"artifact_path": {"type": "string"}},
+            "properties": {
+                "artifact_path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": _MAX_PATH_BYTES,
+                    "pattern": _RELATIVE_PATH_PATTERN,
+                    "description": (
+                        "Canonical repository-relative POSIX path without control "
+                        f"characters; limited to {_MAX_PATH_BYTES} UTF-8 bytes."
+                    ),
+                }
+            },
             "required": ["artifact_path"],
             "additionalProperties": False,
         },
@@ -51,8 +77,25 @@ MULTIMODAL_TOOL_SCHEMAS: tuple[dict[str, Any], ...] = (
         "input_schema": {
             "type": "object",
             "properties": {
-                "source_path": {"type": "string"},
-                "symbol": {"type": "string"},
+                "source_path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": _MAX_PATH_BYTES,
+                    "pattern": _RELATIVE_PATH_PATTERN,
+                    "description": (
+                        "Canonical repository-relative POSIX path without control "
+                        f"characters; limited to {_MAX_PATH_BYTES} UTF-8 bytes."
+                    ),
+                },
+                "symbol": {
+                    "type": "string",
+                    "maxLength": _MAX_PATH_BYTES,
+                    "pattern": _OPTIONAL_TEXT_PATTERN,
+                    "description": (
+                        "Optional symbol without control characters; limited to "
+                        f"{_MAX_PATH_BYTES} UTF-8 bytes."
+                    ),
+                },
                 "limit": {"type": "integer", "minimum": 1, "maximum": _MAX_LIMIT},
             },
             "required": ["source_path"],
@@ -62,6 +105,12 @@ MULTIMODAL_TOOL_SCHEMAS: tuple[dict[str, Any], ...] = (
 )
 
 
+def multimodal_tool_schemas() -> list[dict[str, Any]]:
+    """Return independent mutable copies of the stable tool schemas."""
+
+    return list(copy.deepcopy(_MULTIMODAL_TOOL_SCHEMAS))
+
+
 @dataclass(frozen=True)
 class MultimodalKnowledgeToolRouter:
     """Small tool router that mirrors the future MCP surface."""
@@ -69,7 +118,7 @@ class MultimodalKnowledgeToolRouter:
     view: Mapping[str, Any]
 
     def tool_schemas(self) -> list[dict[str, Any]]:
-        return list(copy.deepcopy(MULTIMODAL_TOOL_SCHEMAS))
+        return multimodal_tool_schemas()
 
     def call_tool(self, name: str, arguments: Mapping[str, Any]) -> dict[str, Any]:
         if type(name) is not str:
@@ -169,4 +218,4 @@ def _limit(value: Any) -> int:
     return value
 
 
-__all__ = ["MULTIMODAL_TOOL_SCHEMAS", "MultimodalKnowledgeToolRouter"]
+__all__ = ["MultimodalKnowledgeToolRouter", "multimodal_tool_schemas"]

--- a/docs/experiments/multimodal_repository_knowledge.md
+++ b/docs/experiments/multimodal_repository_knowledge.md
@@ -78,6 +78,10 @@ a queryable view. It exposes three functions that future MCP tools can wrap:
 - `get_visual_evidence`
 - `find_visual_code_links`
 
+`codenib.wiki.media_tools.MultimodalKnowledgeToolRouter` exposes the same
+surface as an MCP-compatible tool router with stable tool schemas and bounded
+input validation. This keeps the query surface testable before wiring it into a
+server-specific MCP registration path.
 ## Why evidence stays server-side
 
 Media generation may use bounded source snippets inside provider prompts. Those

--- a/docs/experiments/multimodal_repository_knowledge.md
+++ b/docs/experiments/multimodal_repository_knowledge.md
@@ -82,6 +82,7 @@ a queryable view. It exposes three functions that future MCP tools can wrap:
 surface as an MCP-compatible tool router with stable tool schemas and bounded
 input validation. This keeps the query surface testable before wiring it into a
 server-specific MCP registration path.
+
 ## Why evidence stays server-side
 
 Media generation may use bounded source snippets inside provider prompts. Those

--- a/test/wiki/test_media_tools.py
+++ b/test/wiki/test_media_tools.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from codenib.wiki.media_tools import (
+    MULTIMODAL_TOOL_SCHEMAS,
+    MultimodalKnowledgeToolRouter,
+)
+
+
+def _view():
+    return {
+        "entries": [
+            {
+                "artifact": {
+                    "path": "docs/architecture.svg",
+                    "caption": "IndexCompiler architecture",
+                    "role_hint": "architecture_diagram",
+                },
+                "facts": {
+                    "entities": [{"name": "IndexCompiler", "type": "component"}],
+                    "claims": [{"text": "IndexCompiler writes to VectorStore."}],
+                },
+                "bindings": [
+                    {
+                        "artifact_path": "docs/architecture.svg",
+                        "entity_name": "IndexCompiler",
+                        "source_path": "codenib/compiler/index_compiler.py",
+                        "symbol": "IndexCompiler",
+                        "kind": "symbol",
+                        "line": 42,
+                        "score": 1.0,
+                        "evidence": "exact symbol match",
+                    }
+                ],
+                "search_text": (
+                    "docs/architecture.svg IndexCompiler architecture "
+                    "codenib/compiler/index_compiler.py"
+                ),
+            }
+        ]
+    }
+
+
+def test_multimodal_tool_schemas_are_exposed():
+    names = {schema["name"] for schema in MULTIMODAL_TOOL_SCHEMAS}
+
+    assert names == {
+        "search_visual_context",
+        "get_visual_evidence",
+        "find_visual_code_links",
+    }
+
+
+def test_tool_router_searches_visual_context():
+    router = MultimodalKnowledgeToolRouter(_view())
+
+    result = router.call_tool(
+        "search_visual_context",
+        {"query": "IndexCompiler", "limit": 1},
+    )
+
+    assert result["results"][0]["artifact_path"] == "docs/architecture.svg"
+
+
+def test_tool_router_gets_visual_evidence():
+    router = MultimodalKnowledgeToolRouter(_view())
+
+    result = router.call_tool(
+        "get_visual_evidence",
+        {"artifact_path": "docs/architecture.svg"},
+    )
+
+    assert result["evidence"]["artifact"]["caption"] == "IndexCompiler architecture"
+
+
+def test_tool_router_finds_visual_code_links():
+    router = MultimodalKnowledgeToolRouter(_view())
+
+    result = router.call_tool(
+        "find_visual_code_links",
+        {
+            "source_path": "codenib/compiler/index_compiler.py",
+            "symbol": "IndexCompiler",
+        },
+    )
+
+    assert result["links"][0]["binding"]["line"] == 42
+
+
+@pytest.mark.parametrize(
+    ("name", "arguments", "message"),
+    [
+        ("unknown", {}, "unknown"),
+        ("search_visual_context", {"query": ""}, "query"),
+        ("search_visual_context", {"query": "x", "limit": 100}, "limit"),
+        ("get_visual_evidence", {"artifact_path": "bad\npath"}, "control"),
+        ("find_visual_code_links", {"source_path": ""}, "source_path"),
+    ],
+)
+def test_tool_router_validates_inputs(name, arguments, message):
+    router = MultimodalKnowledgeToolRouter(_view())
+
+    with pytest.raises(ValueError, match=message):
+        router.call_tool(name, arguments)

--- a/test/wiki/test_media_tools.py
+++ b/test/wiki/test_media_tools.py
@@ -56,6 +56,19 @@ def test_multimodal_tool_schemas_are_exposed():
     }
 
 
+def test_tool_schema_copies_do_not_mutate_the_public_contract():
+    router = MultimodalKnowledgeToolRouter(_view())
+    schemas = router.tool_schemas()
+
+    assert isinstance(schemas, list)
+    schemas[0]["input_schema"]["properties"]["query"]["type"] = "integer"
+
+    assert (
+        MULTIMODAL_TOOL_SCHEMAS[0]["input_schema"]["properties"]["query"]["type"]
+        == "string"
+    )
+
+
 def test_tool_router_searches_visual_context():
     router = MultimodalKnowledgeToolRouter(_view())
 
@@ -86,10 +99,32 @@ def test_tool_router_finds_visual_code_links():
         {
             "source_path": "codenib/compiler/index_compiler.py",
             "symbol": "IndexCompiler",
+            "limit": 1,
         },
     )
 
     assert result["links"][0]["binding"]["line"] == 42
+
+
+def test_tool_router_limits_visual_code_links():
+    view = _view()
+    second = dict(view["entries"][0])
+    second["artifact"] = {
+        **second["artifact"],
+        "path": "docs/second-architecture.svg",
+    }
+    view["entries"].append(second)
+    router = MultimodalKnowledgeToolRouter(view)
+
+    result = router.call_tool(
+        "find_visual_code_links",
+        {
+            "source_path": "codenib/compiler/index_compiler.py",
+            "limit": 1,
+        },
+    )
+
+    assert len(result["links"]) == 1
 
 
 @pytest.mark.parametrize(
@@ -98,8 +133,19 @@ def test_tool_router_finds_visual_code_links():
         ("unknown", {}, "unknown"),
         ("search_visual_context", {"query": ""}, "query"),
         ("search_visual_context", {"query": "x", "limit": 100}, "limit"),
+        ("search_visual_context", {"query": 1}, "string"),
+        ("search_visual_context", {"query": "x", "limit": "1"}, "integer"),
+        (
+            "search_visual_context",
+            {"query": "x", "unexpected": True},
+            "unexpected",
+        ),
         ("get_visual_evidence", {"artifact_path": "bad\npath"}, "control"),
+        ("get_visual_evidence", {"artifact_path": "../secret.svg"}, "relative"),
+        ("get_visual_evidence", {"artifact_path": "/tmp/secret.svg"}, "relative"),
+        ("get_visual_evidence", {"artifact_path": "docs\\secret.svg"}, "relative"),
         ("find_visual_code_links", {"source_path": ""}, "source_path"),
+        ("find_visual_code_links", {"source_path": None}, "string"),
     ],
 )
 def test_tool_router_validates_inputs(name, arguments, message):
@@ -107,3 +153,10 @@ def test_tool_router_validates_inputs(name, arguments, message):
 
     with pytest.raises(ValueError, match=message):
         router.call_tool(name, arguments)
+
+
+def test_tool_router_requires_an_argument_object():
+    router = MultimodalKnowledgeToolRouter(_view())
+
+    with pytest.raises(ValueError, match="object"):
+        router.call_tool("search_visual_context", [])

--- a/test/wiki/test_media_tools.py
+++ b/test/wiki/test_media_tools.py
@@ -4,11 +4,13 @@
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from codenib.wiki.media_tools import (
-    MULTIMODAL_TOOL_SCHEMAS,
     MultimodalKnowledgeToolRouter,
+    multimodal_tool_schemas,
 )
 
 
@@ -47,13 +49,34 @@ def _view():
 
 
 def test_multimodal_tool_schemas_are_exposed():
-    names = {schema["name"] for schema in MULTIMODAL_TOOL_SCHEMAS}
+    schemas = multimodal_tool_schemas()
+    names = {schema["name"] for schema in schemas}
 
     assert names == {
         "search_visual_context",
         "get_visual_evidence",
         "find_visual_code_links",
     }
+    search = next(
+        schema for schema in schemas if schema["name"] == "search_visual_context"
+    )
+    query = search["input_schema"]["properties"]["query"]
+    assert query["minLength"] == 1
+    assert query["maxLength"] == 4096
+    assert "pattern" in query
+
+    evidence = next(
+        schema for schema in schemas if schema["name"] == "get_visual_evidence"
+    )
+    artifact_path = evidence["input_schema"]["properties"]["artifact_path"]
+    assert artifact_path["minLength"] == 1
+    assert "repository-relative" in artifact_path["description"]
+
+    assert re.search(query["pattern"], "IndexCompiler")
+    assert not re.search(query["pattern"], "   ")
+    assert re.search(artifact_path["pattern"], "docs/architecture.svg")
+    for invalid in ("", "   ", "/tmp/x", "../x", "docs//x", "docs/x/"):
+        assert not re.search(artifact_path["pattern"], invalid)
 
 
 def test_tool_schema_copies_do_not_mutate_the_public_contract():
@@ -63,10 +86,8 @@ def test_tool_schema_copies_do_not_mutate_the_public_contract():
     assert isinstance(schemas, list)
     schemas[0]["input_schema"]["properties"]["query"]["type"] = "integer"
 
-    assert (
-        MULTIMODAL_TOOL_SCHEMAS[0]["input_schema"]["properties"]["query"]["type"]
-        == "string"
-    )
+    fresh = multimodal_tool_schemas()
+    assert fresh[0]["input_schema"]["properties"]["query"]["type"] == "string"
 
 
 def test_tool_router_searches_visual_context():


### PR DESCRIPTION
## Summary

Restacks and integrates [MarinaMackay/CodeNib#7](https://github.com/MarinaMackay/CodeNib/pull/7) as the next independent slice of #655.

Adds an MCP-compatible multimodal knowledge query router with stable schemas and strict bounded runtime validation. Production MCP server registration remains a later slice.

## Changes

- Expose schemas and routing for visual search, artifact evidence, and visual-code links.
- Make runtime argument validation match each published JSON schema, including strict types and rejection of extra properties.
- Require canonical repository-relative artifact/source paths and bounded positive integer limits.
- Deep-copy returned tool schemas so callers cannot mutate the public contract.
- Bound visual-code link responses and avoid echoing untrusted tool names in errors.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] `pytest test/wiki/test_media_tools.py -q` (19 passed)
- [x] `PYTHONPATH=/tmp/codenib-pr665.wWzYRC pytest test/wiki test/scripts/test_build_multimodal_knowledge.py -q` (430 passed)
- [x] `python -m flake8 codenib/wiki/__init__.py codenib/wiki/media_tools.py test/wiki/test_media_tools.py`
- [x] `git diff --check origin/main...HEAD`
- [x] Clean merge-tree against current `main`

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published