### PR TITLE
feat(wiki): plan incremental multimodal updates

### DIFF
--- a/codenib/wiki/__init__.py
+++ b/codenib/wiki/__init__.py
@@ -19,6 +19,11 @@ from .media_grounding import (
     discover_source_symbol_candidates,
     ground_visual_facts_to_sources,
 )
+from .media_incremental import (
+    diff_media_manifests,
+    merge_incremental_visual_facts,
+    plan_incremental_visual_fact_update,
+)
 from .media_knowledge import (
     build_multimodal_knowledge_view,
     find_visual_code_links,
@@ -39,11 +44,14 @@ __all__ = [
     "build_multimodal_repository_knowledge",
     "build_visual_facts_manifest",
     "deterministic_visual_facts",
+    "diff_media_manifests",
     "discover_media_manifest",
     "discover_source_symbol_candidates",
     "find_visual_code_links",
     "get_visual_evidence",
     "ground_visual_facts_to_sources",
+    "merge_incremental_visual_facts",
     "multimodal_tool_schemas",
+    "plan_incremental_visual_fact_update",
     "search_visual_context",
 ]

--- a/codenib/wiki/media_facts.py
+++ b/codenib/wiki/media_facts.py
@@ -160,13 +160,31 @@ class VisualFactsManifest:
 
     @property
     def manifest_sha256(self) -> str:
-        payload = {
-            "schema": self.schema,
-            "version": self.version,
-            "media_manifest_sha256": self.media_manifest_sha256,
-            "facts": [fact.to_dict() for fact in self.facts],
+        return compute_visual_facts_manifest_sha256(
+            schema=self.schema,
+            version=self.version,
+            media_manifest_sha256=self.media_manifest_sha256,
+            facts=(fact.to_dict() for fact in self.facts),
+        )
+
+
+def compute_visual_facts_manifest_sha256(
+    *,
+    schema: str,
+    version: int,
+    media_manifest_sha256: str,
+    facts: Iterable[Mapping[str, Any]],
+) -> str:
+    """Return the canonical digest used by :class:`VisualFactsManifest`."""
+
+    return _sha256_json(
+        {
+            "schema": schema,
+            "version": version,
+            "media_manifest_sha256": media_manifest_sha256,
+            "facts": list(facts),
         }
-        return _sha256_json(payload)
+    )
 
 
 def build_visual_fact_extraction_prompt(artifact: Mapping[str, Any]) -> str:
@@ -577,6 +595,7 @@ __all__ = [
     "VisualRelation",
     "build_visual_fact_extraction_prompt",
     "build_visual_facts_manifest",
+    "compute_visual_facts_manifest_sha256",
     "deterministic_visual_facts",
     "normalize_visual_fact_pack",
 ]

--- a/codenib/wiki/media_incremental.py
+++ b/codenib/wiki/media_incremental.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+from itertools import chain, islice
+from pathlib import PurePosixPath
 from typing import Any, Iterable, Mapping
 
 from .media_facts import (
@@ -18,6 +20,11 @@ from .media_facts import (
 
 MEDIA_INCREMENTAL_SCHEMA = "codenib.media-incremental-plan.v1"
 MEDIA_INCREMENTAL_VERSION = 1
+MEDIA_MANIFEST_DIFF_SCHEMA = "codenib.media-manifest-diff.v1"
+MEDIA_MANIFEST_DIFF_VERSION = 1
+_MAX_ARTIFACTS = 4096
+_MAX_FACT_PACKS = 4096
+_MAX_TEXT_BYTES = 4096
 
 
 def diff_media_manifests(
@@ -32,11 +39,13 @@ def diff_media_manifests(
     for path in sorted(set(previous_artifacts) | set(current_artifacts)):
         before = previous_artifacts.get(path)
         after = current_artifacts.get(path)
+        previous_sha256 = _safe_text((before or {}).get("sha256"))
+        current_sha256 = _safe_text((after or {}).get("sha256"))
         if before is None:
             status = "added"
         elif after is None:
             status = "removed"
-        elif before.get("sha256") == after.get("sha256"):
+        elif previous_sha256 == current_sha256:
             status = "unchanged"
         else:
             status = "changed"
@@ -44,15 +53,15 @@ def diff_media_manifests(
             {
                 "path": path,
                 "status": status,
-                "previous_sha256": str((before or {}).get("sha256") or ""),
-                "current_sha256": str((after or {}).get("sha256") or ""),
+                "previous_sha256": previous_sha256,
+                "current_sha256": current_sha256,
             }
         )
-    return {
-        "schema": MEDIA_INCREMENTAL_SCHEMA,
-        "version": MEDIA_INCREMENTAL_VERSION,
-        "previous_media_manifest_sha256": str(previous.get("manifest_sha256") or ""),
-        "current_media_manifest_sha256": str(current.get("manifest_sha256") or ""),
+    payload = {
+        "schema": MEDIA_MANIFEST_DIFF_SCHEMA,
+        "version": MEDIA_MANIFEST_DIFF_VERSION,
+        "previous_media_manifest_sha256": _safe_text(previous.get("manifest_sha256")),
+        "current_media_manifest_sha256": _safe_text(current.get("manifest_sha256")),
         "counts": {
             "added": sum(1 for change in changes if change["status"] == "added"),
             "removed": sum(1 for change in changes if change["status"] == "removed"),
@@ -63,6 +72,8 @@ def diff_media_manifests(
         },
         "changes": changes,
     }
+    payload["diff_sha256"] = _sha256_json(payload)
+    return payload
 
 
 def plan_incremental_visual_fact_update(
@@ -74,40 +85,57 @@ def plan_incremental_visual_fact_update(
 
     diff = diff_media_manifests(previous_media_manifest, current_media_manifest)
     current_artifacts = _artifacts_by_path(current_media_manifest)
-    previous_facts = {
-        str(fact.get("artifact_path") or ""): dict(fact)
-        for fact in previous_visual_facts_manifest.get("facts") or ()
-        if isinstance(fact, Mapping) and fact.get("artifact_path")
-    }
+    previous_visual_facts_manifest = _require_mapping(
+        previous_visual_facts_manifest,
+        label="previous visual facts manifest",
+    )
+    previous_facts: dict[str, Mapping[str, Any]] = {}
+    for fact in _mapping_items(
+        previous_visual_facts_manifest.get("facts"),
+        limit=_MAX_FACT_PACKS,
+    ):
+        path = _safe_relative_path(fact.get("artifact_path"))
+        if path:
+            previous_facts.setdefault(path, fact)
     reusable_fact_packs = []
     extract_artifact_paths = []
     removed_artifact_paths = []
     for change in diff["changes"]:
         path = change["path"]
-        if change["status"] == "unchanged" and path in previous_facts:
-            fact = previous_facts[path]
-            if fact.get("artifact_sha256") == current_artifacts[path].get("sha256"):
-                reusable_fact_packs.append(fact)
-            else:
+        if change["status"] == "unchanged":
+            artifact = current_artifacts[path]
+            fact = previous_facts.get(path)
+            if fact is None or _safe_text(fact.get("artifact_sha256")) != _safe_text(
+                artifact.get("sha256")
+            ):
+                extract_artifact_paths.append(path)
+                continue
+            try:
+                reusable_fact_packs.append(
+                    normalize_visual_fact_pack(fact, artifact=artifact)
+                )
+            except ValueError:
                 extract_artifact_paths.append(path)
         elif change["status"] in {"added", "changed"}:
             extract_artifact_paths.append(path)
         elif change["status"] == "removed":
             removed_artifact_paths.append(path)
-    return {
+    payload = {
         "schema": MEDIA_INCREMENTAL_SCHEMA,
         "version": MEDIA_INCREMENTAL_VERSION,
         "media_diff": diff,
-        "current_media_manifest_sha256": str(
+        "current_media_manifest_sha256": _safe_text(
             current_media_manifest.get("manifest_sha256") or ""
         ),
-        "previous_visual_facts_manifest_sha256": str(
+        "previous_visual_facts_manifest_sha256": _safe_text(
             previous_visual_facts_manifest.get("manifest_sha256") or ""
         ),
         "reusable_fact_packs": reusable_fact_packs,
         "extract_artifact_paths": sorted(extract_artifact_paths),
         "removed_artifact_paths": sorted(removed_artifact_paths),
     }
+    payload["plan_sha256"] = _sha256_json(payload)
+    return payload
 
 
 def merge_incremental_visual_facts(
@@ -119,22 +147,24 @@ def merge_incremental_visual_facts(
 
     current_artifacts = _artifacts_by_path(current_media_manifest)
     by_path: dict[str, dict[str, Any]] = {}
-    for pack in list(reusable_fact_packs or ()) + list(new_fact_packs or ()):
-        if not isinstance(pack, Mapping):
-            continue
-        normalized = normalize_visual_fact_pack(pack)
-        path = normalized.get("artifact_path")
+    packs = chain(
+        _mapping_items(reusable_fact_packs, limit=_MAX_FACT_PACKS),
+        _mapping_items(new_fact_packs, limit=_MAX_FACT_PACKS),
+    )
+    for pack in packs:
+        path = _safe_relative_path(pack.get("artifact_path"))
         artifact = current_artifacts.get(path)
-        if artifact is None or normalized.get("artifact_sha256") != artifact.get(
-            "sha256"
+        if artifact is None or _safe_text(pack.get("artifact_sha256")) != _safe_text(
+            artifact.get("sha256")
         ):
             continue
+        normalized = normalize_visual_fact_pack(pack, artifact=artifact)
         by_path[path] = normalized
     facts = [by_path[path] for path in sorted(by_path)]
     payload = {
         "schema": MEDIA_FACTS_SCHEMA,
         "version": MEDIA_FACTS_VERSION,
-        "media_manifest_sha256": str(
+        "media_manifest_sha256": _safe_text(
             current_media_manifest.get("manifest_sha256") or ""
         ),
         "fact_count": len(facts),
@@ -147,11 +177,61 @@ def merge_incremental_visual_facts(
 
 
 def _artifacts_by_path(manifest: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
-    return {
-        str(artifact.get("path") or ""): dict(artifact)
-        for artifact in manifest.get("artifacts") or ()
-        if isinstance(artifact, Mapping) and artifact.get("path")
-    }
+    manifest = _require_mapping(manifest, label="media manifest")
+    artifacts: dict[str, dict[str, Any]] = {}
+    for artifact in _mapping_items(
+        manifest.get("artifacts"),
+        limit=_MAX_ARTIFACTS,
+    ):
+        path = _safe_relative_path(artifact.get("path"))
+        if not path:
+            raise ValueError("media artifact path must be repository-relative")
+        if path in artifacts:
+            raise ValueError(f"duplicate media artifact path: {path}")
+        sha256 = _safe_text(artifact.get("sha256"))
+        if not sha256:
+            raise ValueError(f"media artifact sha256 is required: {path}")
+        artifacts[path] = {**artifact, "path": path, "sha256": sha256}
+    return artifacts
+
+
+def _require_mapping(value: Any, *, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def _mapping_items(value: Any, *, limit: int) -> Iterable[Mapping[str, Any]]:
+    if isinstance(value, (str, bytes, bytearray, Mapping)):
+        return ()
+    try:
+        values = iter(value or ())
+    except TypeError:
+        return ()
+    return (item for item in islice(values, limit) if isinstance(item, Mapping))
+
+
+def _safe_relative_path(value: Any) -> str:
+    text = _safe_text(value)
+    if not text or "\\" in text:
+        return ""
+    path = PurePosixPath(text)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        return ""
+    return path.as_posix()
+
+
+def _safe_text(value: Any) -> str:
+    text = str(value or "").strip()
+    text = "".join(
+        character
+        for character in text
+        if ord(character) >= 0x20 and ord(character) != 0x7F
+    )
+    raw = text.encode("utf-8")
+    if len(raw) <= _MAX_TEXT_BYTES:
+        return text
+    return raw[:_MAX_TEXT_BYTES].decode("utf-8", errors="ignore").rstrip()
 
 
 def _sha256_json(payload: Mapping[str, Any]) -> str:
@@ -168,6 +248,8 @@ def _sha256_json(payload: Mapping[str, Any]) -> str:
 __all__ = [
     "MEDIA_INCREMENTAL_SCHEMA",
     "MEDIA_INCREMENTAL_VERSION",
+    "MEDIA_MANIFEST_DIFF_SCHEMA",
+    "MEDIA_MANIFEST_DIFF_VERSION",
     "diff_media_manifests",
     "merge_incremental_visual_facts",
     "plan_incremental_visual_fact_update",

--- a/codenib/wiki/media_incremental.py
+++ b/codenib/wiki/media_incremental.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Incremental update planning for multimodal repository knowledge."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Iterable, Mapping
+
+from .media_facts import (
+    MEDIA_FACTS_SCHEMA,
+    MEDIA_FACTS_VERSION,
+    normalize_visual_fact_pack,
+)
+
+MEDIA_INCREMENTAL_SCHEMA = "codenib.media-incremental-plan.v1"
+MEDIA_INCREMENTAL_VERSION = 1
+
+
+def diff_media_manifests(
+    previous: Mapping[str, Any],
+    current: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return a stable path/hash diff between two media manifests."""
+
+    previous_artifacts = _artifacts_by_path(previous)
+    current_artifacts = _artifacts_by_path(current)
+    changes = []
+    for path in sorted(set(previous_artifacts) | set(current_artifacts)):
+        before = previous_artifacts.get(path)
+        after = current_artifacts.get(path)
+        if before is None:
+            status = "added"
+        elif after is None:
+            status = "removed"
+        elif before.get("sha256") == after.get("sha256"):
+            status = "unchanged"
+        else:
+            status = "changed"
+        changes.append(
+            {
+                "path": path,
+                "status": status,
+                "previous_sha256": str((before or {}).get("sha256") or ""),
+                "current_sha256": str((after or {}).get("sha256") or ""),
+            }
+        )
+    return {
+        "schema": MEDIA_INCREMENTAL_SCHEMA,
+        "version": MEDIA_INCREMENTAL_VERSION,
+        "previous_media_manifest_sha256": str(previous.get("manifest_sha256") or ""),
+        "current_media_manifest_sha256": str(current.get("manifest_sha256") or ""),
+        "counts": {
+            "added": sum(1 for change in changes if change["status"] == "added"),
+            "removed": sum(1 for change in changes if change["status"] == "removed"),
+            "changed": sum(1 for change in changes if change["status"] == "changed"),
+            "unchanged": sum(
+                1 for change in changes if change["status"] == "unchanged"
+            ),
+        },
+        "changes": changes,
+    }
+
+
+def plan_incremental_visual_fact_update(
+    previous_media_manifest: Mapping[str, Any],
+    current_media_manifest: Mapping[str, Any],
+    previous_visual_facts_manifest: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Plan which visual facts can be reused and which artifacts need VLM work."""
+
+    diff = diff_media_manifests(previous_media_manifest, current_media_manifest)
+    current_artifacts = _artifacts_by_path(current_media_manifest)
+    previous_facts = {
+        str(fact.get("artifact_path") or ""): dict(fact)
+        for fact in previous_visual_facts_manifest.get("facts") or ()
+        if isinstance(fact, Mapping) and fact.get("artifact_path")
+    }
+    reusable_fact_packs = []
+    extract_artifact_paths = []
+    removed_artifact_paths = []
+    for change in diff["changes"]:
+        path = change["path"]
+        if change["status"] == "unchanged" and path in previous_facts:
+            fact = previous_facts[path]
+            if fact.get("artifact_sha256") == current_artifacts[path].get("sha256"):
+                reusable_fact_packs.append(fact)
+            else:
+                extract_artifact_paths.append(path)
+        elif change["status"] in {"added", "changed"}:
+            extract_artifact_paths.append(path)
+        elif change["status"] == "removed":
+            removed_artifact_paths.append(path)
+    return {
+        "schema": MEDIA_INCREMENTAL_SCHEMA,
+        "version": MEDIA_INCREMENTAL_VERSION,
+        "media_diff": diff,
+        "current_media_manifest_sha256": str(
+            current_media_manifest.get("manifest_sha256") or ""
+        ),
+        "previous_visual_facts_manifest_sha256": str(
+            previous_visual_facts_manifest.get("manifest_sha256") or ""
+        ),
+        "reusable_fact_packs": reusable_fact_packs,
+        "extract_artifact_paths": sorted(extract_artifact_paths),
+        "removed_artifact_paths": sorted(removed_artifact_paths),
+    }
+
+
+def merge_incremental_visual_facts(
+    current_media_manifest: Mapping[str, Any],
+    reusable_fact_packs: Iterable[Mapping[str, Any]],
+    new_fact_packs: Iterable[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Merge reused and newly extracted fact packs for the current media manifest."""
+
+    current_artifacts = _artifacts_by_path(current_media_manifest)
+    by_path: dict[str, dict[str, Any]] = {}
+    for pack in list(reusable_fact_packs or ()) + list(new_fact_packs or ()):
+        if not isinstance(pack, Mapping):
+            continue
+        normalized = normalize_visual_fact_pack(pack)
+        path = normalized.get("artifact_path")
+        artifact = current_artifacts.get(path)
+        if artifact is None or normalized.get("artifact_sha256") != artifact.get(
+            "sha256"
+        ):
+            continue
+        by_path[path] = normalized
+    facts = [by_path[path] for path in sorted(by_path)]
+    payload = {
+        "schema": MEDIA_FACTS_SCHEMA,
+        "version": MEDIA_FACTS_VERSION,
+        "media_manifest_sha256": str(
+            current_media_manifest.get("manifest_sha256") or ""
+        ),
+        "fact_count": len(facts),
+        "facts": facts,
+    }
+    payload["manifest_sha256"] = _sha256_json(
+        {key: value for key, value in payload.items() if key != "manifest_sha256"}
+    )
+    return payload
+
+
+def _artifacts_by_path(manifest: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    return {
+        str(artifact.get("path") or ""): dict(artifact)
+        for artifact in manifest.get("artifacts") or ()
+        if isinstance(artifact, Mapping) and artifact.get("path")
+    }
+
+
+def _sha256_json(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        payload,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+__all__ = [
+    "MEDIA_INCREMENTAL_SCHEMA",
+    "MEDIA_INCREMENTAL_VERSION",
+    "diff_media_manifests",
+    "merge_incremental_visual_facts",
+    "plan_incremental_visual_fact_update",
+]

--- a/codenib/wiki/media_incremental.py
+++ b/codenib/wiki/media_incremental.py
@@ -15,6 +15,7 @@ from typing import Any, Iterable, Mapping
 from .media_facts import (
     MEDIA_FACTS_SCHEMA,
     MEDIA_FACTS_VERSION,
+    compute_visual_facts_manifest_sha256,
     normalize_visual_fact_pack,
 )
 
@@ -24,6 +25,7 @@ MEDIA_MANIFEST_DIFF_SCHEMA = "codenib.media-manifest-diff.v1"
 MEDIA_MANIFEST_DIFF_VERSION = 1
 _MAX_ARTIFACTS = 4096
 _MAX_FACT_PACKS = 4096
+_MAX_REFERENCES_PER_ARTIFACT = 64
 _MAX_TEXT_BYTES = 4096
 
 
@@ -56,11 +58,17 @@ def _diff_artifact_maps(
         after = current_artifacts.get(path)
         previous_sha256 = _safe_text((before or {}).get("sha256"))
         current_sha256 = _safe_text((after or {}).get("sha256"))
+        previous_extraction_sha256 = (
+            _artifact_extraction_sha256(before) if before is not None else ""
+        )
+        current_extraction_sha256 = (
+            _artifact_extraction_sha256(after) if after is not None else ""
+        )
         if before is None:
             status = "added"
         elif after is None:
             status = "removed"
-        elif previous_sha256 == current_sha256:
+        elif previous_extraction_sha256 == current_extraction_sha256:
             status = "unchanged"
         else:
             status = "changed"
@@ -70,6 +78,8 @@ def _diff_artifact_maps(
                 "status": status,
                 "previous_sha256": previous_sha256,
                 "current_sha256": current_sha256,
+                "previous_extraction_sha256": previous_extraction_sha256,
+                "current_extraction_sha256": current_extraction_sha256,
             }
         )
     payload = {
@@ -95,8 +105,15 @@ def plan_incremental_visual_fact_update(
     previous_media_manifest: Mapping[str, Any],
     current_media_manifest: Mapping[str, Any],
     previous_visual_facts_manifest: Mapping[str, Any],
+    *,
+    expected_extractor: str | None = None,
 ) -> dict[str, Any]:
-    """Plan which visual facts can be reused and which artifacts need VLM work."""
+    """Plan reusable facts for the explicitly selected extraction policy.
+
+    Reuse is disabled unless ``expected_extractor`` names the extractor that
+    will be used for new work. Callers should change that identifier whenever
+    their model or extraction policy changes.
+    """
 
     previous_artifacts = _artifacts_by_path(previous_media_manifest)
     current_artifacts = _artifacts_by_path(current_media_manifest)
@@ -110,14 +127,26 @@ def plan_incremental_visual_fact_update(
         previous_visual_facts_manifest,
         label="previous visual facts manifest",
     )
-    previous_facts: dict[str, Mapping[str, Any]] = {}
-    for fact in _mapping_items(
-        previous_visual_facts_manifest.get("facts"),
-        limit=_MAX_FACT_PACKS,
-    ):
-        path = _safe_relative_path(fact.get("artifact_path"))
-        if path:
-            previous_facts.setdefault(path, fact)
+    if expected_extractor is not None and not isinstance(expected_extractor, str):
+        raise ValueError("expected_extractor must be a non-empty string")
+    extractor = _safe_text(expected_extractor)
+    if expected_extractor is not None and not extractor:
+        raise ValueError("expected_extractor must be a non-empty string")
+    previous_fact_items = _bounded_fact_items(
+        previous_visual_facts_manifest.get("facts")
+    )
+    previous_facts = (
+        _trusted_previous_facts(
+            previous_visual_facts_manifest,
+            previous_media_manifest_sha256=_safe_text(
+                previous_media_manifest.get("manifest_sha256")
+            ),
+            previous_artifacts=previous_artifacts,
+            facts=previous_fact_items,
+        )
+        if previous_fact_items is not None
+        else {}
+    )
     reusable_fact_packs = []
     extract_artifact_paths = []
     removed_artifact_paths = []
@@ -126,8 +155,12 @@ def plan_incremental_visual_fact_update(
         if change["status"] == "unchanged":
             artifact = current_artifacts[path]
             fact = previous_facts.get(path)
-            if fact is None or _safe_text(fact.get("artifact_sha256")) != _safe_text(
-                artifact.get("sha256")
+            if (
+                not extractor
+                or fact is None
+                or _safe_text(fact.get("extractor")) != extractor
+                or _safe_text(fact.get("artifact_sha256"))
+                != _safe_text(artifact.get("sha256"))
             ):
                 extract_artifact_paths.append(path)
                 continue
@@ -151,6 +184,7 @@ def plan_incremental_visual_fact_update(
         "previous_visual_facts_manifest_sha256": _safe_text(
             previous_visual_facts_manifest.get("manifest_sha256") or ""
         ),
+        "expected_extractor": extractor,
         "reusable_fact_packs": reusable_fact_packs,
         "extract_artifact_paths": sorted(extract_artifact_paths),
         "removed_artifact_paths": sorted(removed_artifact_paths),
@@ -191,10 +225,73 @@ def merge_incremental_visual_facts(
         "fact_count": len(facts),
         "facts": facts,
     }
-    payload["manifest_sha256"] = _sha256_json(
-        {key: value for key, value in payload.items() if key != "manifest_sha256"}
+    payload["manifest_sha256"] = compute_visual_facts_manifest_sha256(
+        schema=MEDIA_FACTS_SCHEMA,
+        version=MEDIA_FACTS_VERSION,
+        media_manifest_sha256=payload["media_manifest_sha256"],
+        facts=facts,
     )
     return payload
+
+
+def _trusted_previous_facts(
+    manifest: Mapping[str, Any],
+    *,
+    previous_media_manifest_sha256: str,
+    previous_artifacts: Mapping[str, Mapping[str, Any]],
+    facts: list[Mapping[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    if (
+        not previous_media_manifest_sha256
+        or manifest.get("schema") != MEDIA_FACTS_SCHEMA
+        or type(manifest.get("version")) is not int
+        or manifest.get("version") != MEDIA_FACTS_VERSION
+        or _safe_text(manifest.get("media_manifest_sha256"))
+        != previous_media_manifest_sha256
+    ):
+        return {}
+    try:
+        expected_manifest_sha256 = compute_visual_facts_manifest_sha256(
+            schema=MEDIA_FACTS_SCHEMA,
+            version=MEDIA_FACTS_VERSION,
+            media_manifest_sha256=previous_media_manifest_sha256,
+            facts=facts,
+        )
+    except (TypeError, ValueError):
+        return {}
+    if _safe_text(manifest.get("manifest_sha256")) != expected_manifest_sha256:
+        return {}
+
+    trusted: dict[str, dict[str, Any]] = {}
+    for fact in facts:
+        path = _safe_relative_path(fact.get("artifact_path"))
+        artifact = previous_artifacts.get(path)
+        if not path or path in trusted or artifact is None:
+            return {}
+        try:
+            normalized = normalize_visual_fact_pack(fact, artifact=artifact)
+        except ValueError:
+            return {}
+        if _safe_text(fact.get("fact_pack_sha256")) != normalized.get(
+            "fact_pack_sha256"
+        ):
+            return {}
+        trusted[path] = normalized
+    return trusted
+
+
+def _bounded_fact_items(value: Any) -> list[Mapping[str, Any]] | None:
+    if isinstance(value, (str, bytes, bytearray, Mapping)):
+        return None
+    try:
+        items = list(islice(iter(value), _MAX_FACT_PACKS + 1))
+    except TypeError:
+        return None
+    if len(items) > _MAX_FACT_PACKS or any(
+        not isinstance(item, Mapping) for item in items
+    ):
+        return None
+    return items
 
 
 def _artifacts_by_path(manifest: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
@@ -214,6 +311,36 @@ def _artifacts_by_path(manifest: Mapping[str, Any]) -> dict[str, dict[str, Any]]
             raise ValueError(f"media artifact sha256 is required: {path}")
         artifacts[path] = {**artifact, "path": path, "sha256": sha256}
     return artifacts
+
+
+def _artifact_extraction_sha256(artifact: Mapping[str, Any]) -> str:
+    references = [
+        {
+            "markdown_path": _safe_text(reference.get("markdown_path")),
+            "line": (
+                reference.get("line") if type(reference.get("line")) is int else 0
+            ),
+            "alt_text": _safe_text(reference.get("alt_text")),
+            "title": _safe_text(reference.get("title")),
+            "surrounding_text": _safe_text(reference.get("surrounding_text")),
+        }
+        for reference in _mapping_items(
+            artifact.get("references"),
+            limit=_MAX_REFERENCES_PER_ARTIFACT,
+        )
+    ]
+    return _sha256_json(
+        {
+            "path": _safe_relative_path(artifact.get("path")),
+            "sha256": _safe_text(artifact.get("sha256")),
+            "media_type": _safe_text(artifact.get("media_type")),
+            "mime_type": _safe_text(artifact.get("mime_type")),
+            "role_hint": _safe_text(artifact.get("role_hint")),
+            "caption": _safe_text(artifact.get("caption")),
+            "surrounding_text": _safe_text(artifact.get("surrounding_text")),
+            "references": references,
+        }
+    )
 
 
 def _require_mapping(value: Any, *, label: str) -> Mapping[str, Any]:

--- a/codenib/wiki/media_incremental.py
+++ b/codenib/wiki/media_incremental.py
@@ -35,6 +35,21 @@ def diff_media_manifests(
 
     previous_artifacts = _artifacts_by_path(previous)
     current_artifacts = _artifacts_by_path(current)
+    return _diff_artifact_maps(
+        previous,
+        current,
+        previous_artifacts=previous_artifacts,
+        current_artifacts=current_artifacts,
+    )
+
+
+def _diff_artifact_maps(
+    previous: Mapping[str, Any],
+    current: Mapping[str, Any],
+    *,
+    previous_artifacts: Mapping[str, Mapping[str, Any]],
+    current_artifacts: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
     changes = []
     for path in sorted(set(previous_artifacts) | set(current_artifacts)):
         before = previous_artifacts.get(path)
@@ -83,8 +98,14 @@ def plan_incremental_visual_fact_update(
 ) -> dict[str, Any]:
     """Plan which visual facts can be reused and which artifacts need VLM work."""
 
-    diff = diff_media_manifests(previous_media_manifest, current_media_manifest)
+    previous_artifacts = _artifacts_by_path(previous_media_manifest)
     current_artifacts = _artifacts_by_path(current_media_manifest)
+    diff = _diff_artifact_maps(
+        previous_media_manifest,
+        current_media_manifest,
+        previous_artifacts=previous_artifacts,
+        current_artifacts=current_artifacts,
+    )
     previous_visual_facts_manifest = _require_mapping(
         previous_visual_facts_manifest,
         label="previous visual facts manifest",

--- a/docs/experiments/multimodal_repository_knowledge.md
+++ b/docs/experiments/multimodal_repository_knowledge.md
@@ -86,11 +86,18 @@ server-specific MCP registration path.
 ### Incremental updates
 
 `codenib.wiki.media_incremental` provides deterministic update planning for
-multimodal views. It compares two media manifests by path and content hash,
-marks artifacts as added, removed, changed, or unchanged, and identifies which
-visual fact packs can be reused without another VLM call. Reused packs are
-re-normalized against the current trusted artifact record; missing, stale, or
-invalid packs are scheduled for extraction instead.
+multimodal views. It compares two media manifests by path and by a stable
+fingerprint of every extraction input: media bytes, MIME/role metadata,
+captions, surrounding Markdown, and references. It marks artifacts as added,
+removed, changed, or unchanged and identifies which visual fact packs can be
+reused without another VLM call. Reused packs are re-normalized against the
+current trusted artifact record. Missing, stale, invalid, or digest-mismatched
+packs are scheduled for extraction instead.
+
+Reuse is opt-in through `expected_extractor`. Omitting it safely schedules all
+current artifacts for extraction. Callers should use a distinct extractor
+identifier whenever the model or extraction policy changes so an upgrade
+cannot silently retain facts produced by an older policy.
 
 This is the first step toward incremental multimodal maintenance:
 

--- a/docs/experiments/multimodal_repository_knowledge.md
+++ b/docs/experiments/multimodal_repository_knowledge.md
@@ -88,7 +88,9 @@ server-specific MCP registration path.
 `codenib.wiki.media_incremental` provides deterministic update planning for
 multimodal views. It compares two media manifests by path and content hash,
 marks artifacts as added, removed, changed, or unchanged, and identifies which
-visual fact packs can be reused without another VLM call.
+visual fact packs can be reused without another VLM call. Reused packs are
+re-normalized against the current trusted artifact record; missing, stale, or
+invalid packs are scheduled for extraction instead.
 
 This is the first step toward incremental multimodal maintenance:
 

--- a/docs/experiments/multimodal_repository_knowledge.md
+++ b/docs/experiments/multimodal_repository_knowledge.md
@@ -83,6 +83,21 @@ surface as an MCP-compatible tool router with stable tool schemas and bounded
 input validation. This keeps the query surface testable before wiring it into a
 server-specific MCP registration path.
 
+### Incremental updates
+
+`codenib.wiki.media_incremental` provides deterministic update planning for
+multimodal views. It compares two media manifests by path and content hash,
+marks artifacts as added, removed, changed, or unchanged, and identifies which
+visual fact packs can be reused without another VLM call.
+
+This is the first step toward incremental multimodal maintenance:
+
+```text
+media unchanged -> reuse existing VisualFactPack
+media changed   -> rerun VLM/extractor for that artifact
+media removed   -> drop stale visual facts and bindings
+```
+
 ## Why evidence stays server-side
 
 Media generation may use bounded source snippets inside provider prompts. Those

--- a/test/wiki/test_media_incremental.py
+++ b/test/wiki/test_media_incremental.py
@@ -6,6 +6,10 @@ from __future__ import annotations
 
 import pytest
 
+from codenib.wiki.media_facts import (
+    build_visual_facts_manifest,
+    compute_visual_facts_manifest_sha256,
+)
 from codenib.wiki.media_incremental import (
     diff_media_manifests,
     merge_incremental_visual_facts,
@@ -41,6 +45,14 @@ def _fact(path, sha, name="Component"):
         "claims": [],
         "metadata": {},
     }
+
+
+def _facts_manifest(media, facts):
+    return merge_incremental_visual_facts(
+        media,
+        reusable_fact_packs=(),
+        new_fact_packs=facts,
+    )
 
 
 def test_diff_media_manifests_reports_added_removed_changed_unchanged():
@@ -97,19 +109,20 @@ def test_plan_incremental_visual_fact_update_reuses_only_matching_facts():
             _artifact("added.png", "fresh"),
         ],
     }
-    previous_facts = {
-        "manifest_sha256": "previous-facts",
-        "facts": [
+    previous_facts = _facts_manifest(
+        previous_media,
+        [
             _fact("unchanged.png", "same"),
             _fact("changed.png", "old"),
             _fact("removed.png", "gone"),
         ],
-    }
+    )
 
     plan = plan_incremental_visual_fact_update(
         previous_media,
         current_media,
         previous_facts,
+        expected_extractor="local/metadata",
     )
 
     assert [fact["artifact_path"] for fact in plan["reusable_fact_packs"]] == [
@@ -130,7 +143,8 @@ def test_plan_extracts_unchanged_artifact_when_previous_fact_is_missing():
     plan = plan_incremental_visual_fact_update(
         media,
         media,
-        {"manifest_sha256": "facts", "facts": []},
+        _facts_manifest(media, []),
+        expected_extractor="local/metadata",
     )
 
     assert plan["reusable_fact_packs"] == []
@@ -138,29 +152,145 @@ def test_plan_extracts_unchanged_artifact_when_previous_fact_is_missing():
 
 
 def test_plan_materializes_generator_manifests_once():
+    artifact = _artifact("diagram.png", "same")
     previous_media = {
         "manifest_sha256": "previous-media",
-        "artifacts": (artifact for artifact in [_artifact("diagram.png", "same")]),
+        "artifacts": (item for item in [artifact]),
     }
     current_media = {
         "manifest_sha256": "current-media",
-        "artifacts": (artifact for artifact in [_artifact("diagram.png", "same")]),
+        "artifacts": (item for item in [artifact]),
     }
-    previous_facts = {
-        "manifest_sha256": "facts",
-        "facts": (fact for fact in [_fact("diagram.png", "same")]),
-    }
+    previous_facts = _facts_manifest(
+        {"manifest_sha256": "previous-media", "artifacts": [artifact]},
+        [_fact("diagram.png", "same")],
+    )
+    previous_facts["facts"] = (fact for fact in previous_facts["facts"])
 
     plan = plan_incremental_visual_fact_update(
         previous_media,
         current_media,
         previous_facts,
+        expected_extractor="local/metadata",
     )
 
     assert [fact["artifact_path"] for fact in plan["reusable_fact_packs"]] == [
         "diagram.png"
     ]
     assert plan["extract_artifact_paths"] == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("caption", "Updated caption"),
+        ("surrounding_text", "Updated Markdown context"),
+        ("mime_type", "image/svg+xml"),
+        ("role_hint", "architecture_diagram"),
+        (
+            "references",
+            [
+                {
+                    "markdown_path": "README.md",
+                    "line": 4,
+                    "alt_text": "Architecture",
+                    "title": "Overview",
+                }
+            ],
+        ),
+    ],
+)
+def test_plan_reextracts_when_artifact_context_changes(field, value):
+    previous_artifact = _artifact("diagram.png", "same")
+    current_artifact = {**previous_artifact, field: value}
+    previous_media = {
+        "manifest_sha256": "previous-media",
+        "artifacts": [previous_artifact],
+    }
+    current_media = {
+        "manifest_sha256": "current-media",
+        "artifacts": [current_artifact],
+    }
+
+    plan = plan_incremental_visual_fact_update(
+        previous_media,
+        current_media,
+        _facts_manifest(previous_media, [_fact("diagram.png", "same")]),
+        expected_extractor="local/metadata",
+    )
+
+    assert plan["media_diff"]["changes"][0]["status"] == "changed"
+    assert plan["extract_artifact_paths"] == ["diagram.png"]
+    assert plan["reusable_fact_packs"] == []
+
+
+@pytest.mark.parametrize("expected_extractor", [None, "openai-compatible"])
+def test_plan_requires_matching_extractor_for_reuse(expected_extractor):
+    media = {
+        "manifest_sha256": "media",
+        "artifacts": [_artifact("diagram.png", "same")],
+    }
+
+    plan = plan_incremental_visual_fact_update(
+        media,
+        media,
+        _facts_manifest(media, [_fact("diagram.png", "same")]),
+        expected_extractor=expected_extractor,
+    )
+
+    assert plan["expected_extractor"] == (expected_extractor or "")
+    assert plan["extract_artifact_paths"] == ["diagram.png"]
+    assert plan["reusable_fact_packs"] == []
+
+
+@pytest.mark.parametrize("expected_extractor", ["", "   ", 1])
+def test_plan_rejects_invalid_expected_extractors(expected_extractor):
+    media = {"manifest_sha256": "media", "artifacts": []}
+
+    with pytest.raises(ValueError, match="expected_extractor"):
+        plan_incremental_visual_fact_update(
+            media,
+            media,
+            _facts_manifest(media, []),
+            expected_extractor=expected_extractor,
+        )
+
+
+@pytest.mark.parametrize("corruption", ["manifest", "association", "fact_pack"])
+def test_plan_rejects_untrusted_previous_fact_manifests(corruption):
+    media = {
+        "manifest_sha256": "media",
+        "artifacts": [_artifact("diagram.png", "same")],
+    }
+    facts = _facts_manifest(media, [_fact("diagram.png", "same")])
+    if corruption == "manifest":
+        facts["manifest_sha256"] = "corrupted"
+    elif corruption == "association":
+        facts["media_manifest_sha256"] = "different-media"
+        facts["manifest_sha256"] = compute_visual_facts_manifest_sha256(
+            schema=facts["schema"],
+            version=facts["version"],
+            media_manifest_sha256=facts["media_manifest_sha256"],
+            facts=facts["facts"],
+        )
+    else:
+        facts["facts"][0]["entities"][0]["name"] = "Tampered"
+        facts["manifest_sha256"] = compute_visual_facts_manifest_sha256(
+            schema=facts["schema"],
+            version=facts["version"],
+            media_manifest_sha256=facts["media_manifest_sha256"],
+            facts=facts["facts"],
+        )
+
+    plan = plan_incremental_visual_fact_update(
+        media,
+        media,
+        facts,
+        expected_extractor="local/metadata",
+    )
+
+    assert plan["extract_artifact_paths"] == ["diagram.png"]
+    assert plan["reusable_fact_packs"] == []
 
 
 def test_merge_incremental_visual_facts_keeps_current_artifacts_only():
@@ -206,6 +336,22 @@ def test_merge_anchors_reused_facts_to_current_artifact_provenance():
     assert merged["facts"][0]["artifact_path"] == "diagram.png"
     assert merged["facts"][0]["artifact_sha256"] == "same"
     assert merged["facts"][0]["role_hint"] == "repository_image"
+
+
+def test_incremental_merge_uses_the_canonical_visual_facts_digest():
+    media = {
+        "manifest_sha256": "media",
+        "artifacts": [_artifact("diagram.png", "same")],
+    }
+    full = build_visual_facts_manifest(media)
+
+    incremental = merge_incremental_visual_facts(
+        media,
+        reusable_fact_packs=full["facts"],
+        new_fact_packs=(),
+    )
+
+    assert incremental == full
 
 
 @pytest.mark.parametrize("path", ["../secret.png", "/tmp/secret.png", "bad\\x.png"])

--- a/test/wiki/test_media_incremental.py
+++ b/test/wiki/test_media_incremental.py
@@ -137,6 +137,32 @@ def test_plan_extracts_unchanged_artifact_when_previous_fact_is_missing():
     assert plan["extract_artifact_paths"] == ["missing-fact.png"]
 
 
+def test_plan_materializes_generator_manifests_once():
+    previous_media = {
+        "manifest_sha256": "previous-media",
+        "artifacts": (artifact for artifact in [_artifact("diagram.png", "same")]),
+    }
+    current_media = {
+        "manifest_sha256": "current-media",
+        "artifacts": (artifact for artifact in [_artifact("diagram.png", "same")]),
+    }
+    previous_facts = {
+        "manifest_sha256": "facts",
+        "facts": (fact for fact in [_fact("diagram.png", "same")]),
+    }
+
+    plan = plan_incremental_visual_fact_update(
+        previous_media,
+        current_media,
+        previous_facts,
+    )
+
+    assert [fact["artifact_path"] for fact in plan["reusable_fact_packs"]] == [
+        "diagram.png"
+    ]
+    assert plan["extract_artifact_paths"] == []
+
+
 def test_merge_incremental_visual_facts_keeps_current_artifacts_only():
     current_media = {
         "manifest_sha256": "current-media",

--- a/test/wiki/test_media_incremental.py
+++ b/test/wiki/test_media_incremental.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from codenib.wiki.media_incremental import (
+    diff_media_manifests,
+    merge_incremental_visual_facts,
+    plan_incremental_visual_fact_update,
+)
+
+
+def _artifact(path, sha):
+    return {
+        "path": path,
+        "sha256": sha,
+        "role_hint": "repository_image",
+        "mime_type": "image/png",
+    }
+
+
+def _fact(path, sha, name="Component"):
+    return {
+        "artifact_path": path,
+        "artifact_sha256": sha,
+        "role_hint": "repository_image",
+        "extractor": "local/metadata",
+        "entities": [
+            {
+                "name": name,
+                "type": "component",
+                "evidence": path,
+                "confidence": 0.5,
+                "grounding_candidates": [name],
+            }
+        ],
+        "relations": [],
+        "claims": [],
+        "metadata": {},
+    }
+
+
+def test_diff_media_manifests_reports_added_removed_changed_unchanged():
+    previous = {
+        "manifest_sha256": "previous",
+        "artifacts": [
+            _artifact("unchanged.png", "same"),
+            _artifact("changed.png", "old"),
+            _artifact("removed.png", "gone"),
+        ],
+    }
+    current = {
+        "manifest_sha256": "current",
+        "artifacts": [
+            _artifact("unchanged.png", "same"),
+            _artifact("changed.png", "new"),
+            _artifact("added.png", "fresh"),
+        ],
+    }
+
+    diff = diff_media_manifests(previous, current)
+
+    assert diff["counts"] == {
+        "added": 1,
+        "removed": 1,
+        "changed": 1,
+        "unchanged": 1,
+    }
+    statuses = {change["path"]: change["status"] for change in diff["changes"]}
+    assert statuses == {
+        "added.png": "added",
+        "changed.png": "changed",
+        "removed.png": "removed",
+        "unchanged.png": "unchanged",
+    }
+
+
+def test_plan_incremental_visual_fact_update_reuses_only_matching_facts():
+    previous_media = {
+        "manifest_sha256": "previous-media",
+        "artifacts": [
+            _artifact("unchanged.png", "same"),
+            _artifact("changed.png", "old"),
+            _artifact("removed.png", "gone"),
+        ],
+    }
+    current_media = {
+        "manifest_sha256": "current-media",
+        "artifacts": [
+            _artifact("unchanged.png", "same"),
+            _artifact("changed.png", "new"),
+            _artifact("added.png", "fresh"),
+        ],
+    }
+    previous_facts = {
+        "manifest_sha256": "previous-facts",
+        "facts": [
+            _fact("unchanged.png", "same"),
+            _fact("changed.png", "old"),
+            _fact("removed.png", "gone"),
+        ],
+    }
+
+    plan = plan_incremental_visual_fact_update(
+        previous_media,
+        current_media,
+        previous_facts,
+    )
+
+    assert [fact["artifact_path"] for fact in plan["reusable_fact_packs"]] == [
+        "unchanged.png"
+    ]
+    assert plan["extract_artifact_paths"] == ["added.png", "changed.png"]
+    assert plan["removed_artifact_paths"] == ["removed.png"]
+
+
+def test_merge_incremental_visual_facts_keeps_current_artifacts_only():
+    current_media = {
+        "manifest_sha256": "current-media",
+        "artifacts": [
+            _artifact("unchanged.png", "same"),
+            _artifact("added.png", "fresh"),
+        ],
+    }
+
+    merged = merge_incremental_visual_facts(
+        current_media,
+        reusable_fact_packs=[
+            _fact("unchanged.png", "same", name="Reused"),
+            _fact("removed.png", "gone", name="Removed"),
+            _fact("changed.png", "old", name="Stale"),
+        ],
+        new_fact_packs=[_fact("added.png", "fresh", name="New")],
+    )
+
+    assert merged["schema"] == "codenib.media-facts.v1"
+    assert merged["media_manifest_sha256"] == "current-media"
+    assert merged["fact_count"] == 2
+    assert [fact["artifact_path"] for fact in merged["facts"]] == [
+        "added.png",
+        "unchanged.png",
+    ]
+    assert merged["manifest_sha256"]

--- a/test/wiki/test_media_incremental.py
+++ b/test/wiki/test_media_incremental.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from codenib.wiki.media_incremental import (
     diff_media_manifests,
     merge_incremental_visual_facts,
@@ -61,6 +63,8 @@ def test_diff_media_manifests_reports_added_removed_changed_unchanged():
 
     diff = diff_media_manifests(previous, current)
 
+    assert diff["schema"] == "codenib.media-manifest-diff.v1"
+    assert diff["diff_sha256"]
     assert diff["counts"] == {
         "added": 1,
         "removed": 1,
@@ -113,6 +117,24 @@ def test_plan_incremental_visual_fact_update_reuses_only_matching_facts():
     ]
     assert plan["extract_artifact_paths"] == ["added.png", "changed.png"]
     assert plan["removed_artifact_paths"] == ["removed.png"]
+    assert plan["schema"] == "codenib.media-incremental-plan.v1"
+    assert plan["plan_sha256"]
+
+
+def test_plan_extracts_unchanged_artifact_when_previous_fact_is_missing():
+    media = {
+        "manifest_sha256": "media",
+        "artifacts": [_artifact("missing-fact.png", "same")],
+    }
+
+    plan = plan_incremental_visual_fact_update(
+        media,
+        media,
+        {"manifest_sha256": "facts", "facts": []},
+    )
+
+    assert plan["reusable_fact_packs"] == []
+    assert plan["extract_artifact_paths"] == ["missing-fact.png"]
 
 
 def test_merge_incremental_visual_facts_keeps_current_artifacts_only():
@@ -142,3 +164,60 @@ def test_merge_incremental_visual_facts_keeps_current_artifacts_only():
         "unchanged.png",
     ]
     assert merged["manifest_sha256"]
+
+
+def test_merge_anchors_reused_facts_to_current_artifact_provenance():
+    artifact = _artifact("diagram.png", "same")
+    fact = _fact("diagram.png", "same", name="Reused")
+    fact["role_hint"] = "forged"
+
+    merged = merge_incremental_visual_facts(
+        {"manifest_sha256": "media", "artifacts": [artifact]},
+        reusable_fact_packs=(pack for pack in [fact]),
+        new_fact_packs=(),
+    )
+
+    assert merged["facts"][0]["artifact_path"] == "diagram.png"
+    assert merged["facts"][0]["artifact_sha256"] == "same"
+    assert merged["facts"][0]["role_hint"] == "repository_image"
+
+
+@pytest.mark.parametrize("path", ["../secret.png", "/tmp/secret.png", "bad\\x.png"])
+def test_incremental_helpers_reject_unsafe_artifact_paths(path):
+    manifest = {
+        "manifest_sha256": "media",
+        "artifacts": [_artifact(path, "same")],
+    }
+
+    with pytest.raises(ValueError, match="repository-relative"):
+        diff_media_manifests({}, manifest)
+
+
+def test_incremental_helpers_reject_duplicate_artifact_paths():
+    manifest = {
+        "manifest_sha256": "media",
+        "artifacts": [
+            _artifact("diagram.png", "first"),
+            _artifact("diagram.png", "second"),
+        ],
+    }
+
+    with pytest.raises(ValueError, match="duplicate"):
+        diff_media_manifests({}, manifest)
+
+
+def test_incremental_helpers_reject_artifacts_without_content_hashes():
+    manifest = {
+        "manifest_sha256": "media",
+        "artifacts": [_artifact("diagram.png", "")],
+    }
+
+    with pytest.raises(ValueError, match="sha256"):
+        diff_media_manifests({}, manifest)
+
+
+def test_incremental_helpers_reject_non_object_manifests():
+    with pytest.raises(ValueError, match="media manifest"):
+        diff_media_manifests([], {})
+    with pytest.raises(ValueError, match="visual facts manifest"):
+        plan_incremental_visual_fact_update({}, {}, [])


### PR DESCRIPTION
## Summary

Restacks the incremental-planning half of [MarinaMackay/CodeNib#8](https://github.com/MarinaMackay/CodeNib/pull/8) as the next independent slice of #655. The MMWiki evaluation helpers are intentionally kept for a separate follow-up PR.

Adds deterministic media-manifest diffs, integrity-checked visual-fact reuse planning, and trusted merging for incremental multimodal updates.

## Changes

- Diff bounded media manifests by canonical repository path and every visual extraction input, including media SHA, MIME/role metadata, captions, surrounding Markdown, and references.
- Give manifest diffs and update plans distinct versioned schemas and stable hashes.
- Require an explicit matching `expected_extractor` before reusing normalized fact packs.
- Verify the previous media association, visual-facts manifest digest, and every fact-pack digest before trusting persisted facts.
- Share a single bounded artifact snapshot between diffing and planning so one-shot iterables are consumed once.
- Schedule artifacts with missing, stale, invalid, context-changed, or policy-mismatched facts for extraction.
- Use the same canonical visual-facts digest for full and incremental builds.
- Reject unsafe/duplicate artifact paths, missing content hashes, malformed manifests, and invalid extractor selectors.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] `pytest test/wiki/test_media_incremental.py test/wiki/test_media_facts.py -q` (35 passed)
- [x] `pytest test/wiki test/scripts/test_build_multimodal_knowledge.py -q` (456 passed)
- [x] `python -m flake8 codenib/wiki/media_facts.py codenib/wiki/media_incremental.py test/wiki/test_media_incremental.py`
- [x] `git diff --check origin/main...HEAD`
- [x] Clean merge-tree against current `main`
- [ ] Local full unit tier stopped after 484 passed because this isolated clone lacks the workspace-owner native extension; GitHub CI builds and exercises that extension.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published