### PR TITLE
feat(wiki): add multimodal evaluation helpers

### DIFF
--- a/codenib/wiki/__init__.py
+++ b/codenib/wiki/__init__.py
@@ -13,6 +13,11 @@ to a real symbol span pulled from the indexes (no fabricated lines).
 from .builder import WikiBuilder
 from .media_artifacts import discover_media_manifest
 from .media_evidence import build_media_evidence_pack
+from .media_eval import (
+    evaluate_mmwiki_predictions,
+    evaluate_visual_code_grounding,
+    evaluate_visual_fact_extraction,
+)
 from .media_facts import build_visual_facts_manifest, deterministic_visual_facts
 from .media_grounding import (
     VisualGroundingScorer,
@@ -47,6 +52,9 @@ __all__ = [
     "diff_media_manifests",
     "discover_media_manifest",
     "discover_source_symbol_candidates",
+    "evaluate_mmwiki_predictions",
+    "evaluate_visual_code_grounding",
+    "evaluate_visual_fact_extraction",
     "find_visual_code_links",
     "get_visual_evidence",
     "ground_visual_facts_to_sources",

--- a/codenib/wiki/media_eval.py
+++ b/codenib/wiki/media_eval.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Evaluation helpers for multimodal repository knowledge views."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+
+def evaluate_visual_fact_extraction(
+    visual_facts_manifest: Mapping[str, Any],
+    gold: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Evaluate extracted visual entities against an MMWiki-style gold file."""
+
+    predicted_by_artifact = {
+        str(fact.get("artifact_path") or ""): fact
+        for fact in visual_facts_manifest.get("facts") or ()
+        if isinstance(fact, Mapping)
+    }
+    true_positive = 0
+    predicted_total = 0
+    gold_total = 0
+    per_artifact = []
+    for instance in _gold_instances(gold):
+        artifact_path = str(instance.get("artifact_path") or "")
+        predicted = {
+            _entity_key(entity)
+            for entity in (predicted_by_artifact.get(artifact_path) or {}).get(
+                "entities"
+            )
+            or ()
+            if isinstance(entity, Mapping) and _entity_key(entity)
+        }
+        expected = {
+            _entity_key(entity)
+            for entity in instance.get("gold_entities") or ()
+            if isinstance(entity, Mapping) and _entity_key(entity)
+        }
+        hits = predicted & expected
+        true_positive += len(hits)
+        predicted_total += len(predicted)
+        gold_total += len(expected)
+        per_artifact.append(
+            {
+                "artifact_path": artifact_path,
+                "entity_precision": _safe_div(len(hits), len(predicted)),
+                "entity_recall": _safe_div(len(hits), len(expected)),
+                "matched_entities": sorted(hits),
+            }
+        )
+    precision = _safe_div(true_positive, predicted_total)
+    recall = _safe_div(true_positive, gold_total)
+    return {
+        "entity_precision": precision,
+        "entity_recall": recall,
+        "entity_f1": _f1(precision, recall),
+        "entity_true_positive": true_positive,
+        "entity_predicted": predicted_total,
+        "entity_gold": gold_total,
+        "per_artifact": per_artifact,
+    }
+
+
+def evaluate_visual_code_grounding(
+    grounding_manifest: Mapping[str, Any],
+    gold: Mapping[str, Any],
+    *,
+    k: int = 5,
+) -> dict[str, Any]:
+    """Evaluate visual entity to source binding accuracy."""
+
+    predicted_by_key: dict[tuple[str, str], list[Mapping[str, Any]]] = {}
+    for binding in grounding_manifest.get("bindings") or ():
+        if not isinstance(binding, Mapping):
+            continue
+        key = (
+            str(binding.get("artifact_path") or ""),
+            _normalize(str(binding.get("entity_name") or "")),
+        )
+        predicted_by_key.setdefault(key, []).append(binding)
+    for values in predicted_by_key.values():
+        values.sort(
+            key=lambda item: (
+                -float(item.get("score") or 0.0),
+                str(item.get("source_path") or ""),
+                str(item.get("symbol") or ""),
+            )
+        )
+
+    total = 0
+    path_hits = 0
+    symbol_hits = 0
+    per_binding = []
+    for instance in _gold_instances(gold):
+        artifact_path = str(instance.get("artifact_path") or "")
+        for expected in instance.get("gold_bindings") or ():
+            if not isinstance(expected, Mapping):
+                continue
+            total += 1
+            entity_name = _normalize(str(expected.get("entity_name") or ""))
+            predictions = predicted_by_key.get((artifact_path, entity_name), [])[
+                : max(0, k)
+            ]
+            expected_path = str(expected.get("source_path") or "")
+            expected_symbol = str(expected.get("symbol") or "")
+            path_hit = any(
+                prediction.get("source_path") == expected_path
+                for prediction in predictions
+            )
+            symbol_hit = any(
+                prediction.get("source_path") == expected_path
+                and (not expected_symbol or prediction.get("symbol") == expected_symbol)
+                for prediction in predictions
+            )
+            path_hits += int(path_hit)
+            symbol_hits += int(symbol_hit)
+            per_binding.append(
+                {
+                    "artifact_path": artifact_path,
+                    "entity_name": expected.get("entity_name") or "",
+                    "path_hit_at_k": path_hit,
+                    "symbol_hit_at_k": symbol_hit,
+                    "predicted": [dict(prediction) for prediction in predictions],
+                }
+            )
+    return {
+        "k": k,
+        "binding_count": total,
+        "path_hit_at_k": _safe_div(path_hits, total),
+        "symbol_hit_at_k": _safe_div(symbol_hits, total),
+        "path_hits": path_hits,
+        "symbol_hits": symbol_hits,
+        "per_binding": per_binding,
+    }
+
+
+def evaluate_mmwiki_predictions(
+    visual_facts_manifest: Mapping[str, Any],
+    grounding_manifest: Mapping[str, Any],
+    gold: Mapping[str, Any],
+    *,
+    k: int = 5,
+) -> dict[str, Any]:
+    """Evaluate visual fact extraction and visual-code grounding together."""
+
+    facts = evaluate_visual_fact_extraction(visual_facts_manifest, gold)
+    grounding = evaluate_visual_code_grounding(grounding_manifest, gold, k=k)
+    return {
+        "task": "mmwiki",
+        "artifact_count": len(list(_gold_instances(gold))),
+        "visual_fact_extraction": facts,
+        "visual_code_grounding": grounding,
+    }
+
+
+def _gold_instances(gold: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    instances = gold.get("instances") or ()
+    return [instance for instance in instances if isinstance(instance, Mapping)]
+
+
+def _entity_key(entity: Mapping[str, Any]) -> str:
+    name = _normalize(str(entity.get("name") or ""))
+    kind = _normalize(str(entity.get("type") or "unknown"))
+    return f"{name}:{kind}" if name else ""
+
+
+def _normalize(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", str(value or "").lower())
+
+
+def _safe_div(numerator: int | float, denominator: int | float) -> float:
+    return float(numerator) / float(denominator) if denominator else 0.0
+
+
+def _f1(precision: float, recall: float) -> float:
+    return 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+
+
+__all__ = [
+    "evaluate_mmwiki_predictions",
+    "evaluate_visual_code_grounding",
+    "evaluate_visual_fact_extraction",
+]

--- a/codenib/wiki/media_eval.py
+++ b/codenib/wiki/media_eval.py
@@ -6,8 +6,18 @@
 
 from __future__ import annotations
 
+import math
 import re
-from typing import Any, Mapping
+from itertools import islice
+from pathlib import PurePosixPath
+from typing import Any, Iterable, Mapping
+
+_MAX_INSTANCES = 4096
+_MAX_ENTITIES_PER_ARTIFACT = 32
+_MAX_GOLD_BINDINGS_PER_ARTIFACT = 32
+_MAX_PREDICTED_BINDINGS = 20480
+_MAX_K = 20
+_MAX_TEXT_BYTES = 4096
 
 
 def evaluate_visual_fact_extraction(
@@ -16,29 +26,39 @@ def evaluate_visual_fact_extraction(
 ) -> dict[str, Any]:
     """Evaluate extracted visual entities against an MMWiki-style gold file."""
 
-    predicted_by_artifact = {
-        str(fact.get("artifact_path") or ""): fact
-        for fact in visual_facts_manifest.get("facts") or ()
-        if isinstance(fact, Mapping)
-    }
+    visual_facts_manifest = _require_mapping(
+        visual_facts_manifest,
+        label="visual facts manifest",
+    )
+    predicted_by_artifact: dict[str, Mapping[str, Any]] = {}
+    for fact in _mapping_items(
+        visual_facts_manifest.get("facts"),
+        limit=_MAX_INSTANCES,
+    ):
+        path = _safe_relative_path(fact.get("artifact_path"))
+        if path:
+            predicted_by_artifact.setdefault(path, fact)
+
     true_positive = 0
     predicted_total = 0
     gold_total = 0
     per_artifact = []
     for instance in _gold_instances(gold):
-        artifact_path = str(instance.get("artifact_path") or "")
+        artifact_path = _gold_artifact_path(instance)
         predicted = {
-            _entity_key(entity)
-            for entity in (predicted_by_artifact.get(artifact_path) or {}).get(
-                "entities"
+            key
+            for entity in _mapping_items(
+                (predicted_by_artifact.get(artifact_path) or {}).get("entities"),
+                limit=_MAX_ENTITIES_PER_ARTIFACT,
             )
-            or ()
-            if isinstance(entity, Mapping) and _entity_key(entity)
+            if (key := _entity_key(entity))
         }
         expected = {
-            _entity_key(entity)
-            for entity in instance.get("gold_entities") or ()
-            if isinstance(entity, Mapping) and _entity_key(entity)
+            _gold_entity_key(entity)
+            for entity in _mapping_items(
+                instance.get("gold_entities"),
+                limit=_MAX_ENTITIES_PER_ARTIFACT,
+            )
         }
         hits = predicted & expected
         true_positive += len(hits)
@@ -73,21 +93,32 @@ def evaluate_visual_code_grounding(
 ) -> dict[str, Any]:
     """Evaluate visual entity to source binding accuracy."""
 
-    predicted_by_key: dict[tuple[str, str], list[Mapping[str, Any]]] = {}
-    for binding in grounding_manifest.get("bindings") or ():
-        if not isinstance(binding, Mapping):
+    grounding_manifest = _require_mapping(
+        grounding_manifest,
+        label="grounding manifest",
+    )
+    result_limit = _validated_k(k)
+    predicted_by_key: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for binding in _mapping_items(
+        grounding_manifest.get("bindings"),
+        limit=_MAX_PREDICTED_BINDINGS,
+    ):
+        prediction = _prediction(binding)
+        if prediction is None:
             continue
         key = (
-            str(binding.get("artifact_path") or ""),
-            _normalize(str(binding.get("entity_name") or "")),
+            prediction["artifact_path"],
+            _normalize(prediction["entity_name"]),
         )
-        predicted_by_key.setdefault(key, []).append(binding)
+        if not key[1]:
+            continue
+        predicted_by_key.setdefault(key, []).append(prediction)
     for values in predicted_by_key.values():
         values.sort(
             key=lambda item: (
-                -float(item.get("score") or 0.0),
-                str(item.get("source_path") or ""),
-                str(item.get("symbol") or ""),
+                -item["score"],
+                item["source_path"],
+                item["symbol"],
             )
         )
 
@@ -96,24 +127,32 @@ def evaluate_visual_code_grounding(
     symbol_hits = 0
     per_binding = []
     for instance in _gold_instances(gold):
-        artifact_path = str(instance.get("artifact_path") or "")
-        for expected in instance.get("gold_bindings") or ():
-            if not isinstance(expected, Mapping):
-                continue
+        artifact_path = _gold_artifact_path(instance)
+        for expected in _mapping_items(
+            instance.get("gold_bindings"),
+            limit=_MAX_GOLD_BINDINGS_PER_ARTIFACT,
+        ):
             total += 1
-            entity_name = _normalize(str(expected.get("entity_name") or ""))
-            predictions = predicted_by_key.get((artifact_path, entity_name), [])[
-                : max(0, k)
-            ]
-            expected_path = str(expected.get("source_path") or "")
-            expected_symbol = str(expected.get("symbol") or "")
+            expected_entity = _required_text(
+                expected.get("entity_name"),
+                label="gold entity name",
+            )
+            entity_name = _normalize(expected_entity)
+            expected_path = _required_relative_path(
+                expected.get("source_path"),
+                label="gold source path",
+            )
+            expected_symbol = _safe_text(expected.get("symbol"))
+            predictions = predicted_by_key.get(
+                (artifact_path, entity_name),
+                [],
+            )[:result_limit]
             path_hit = any(
-                prediction.get("source_path") == expected_path
-                for prediction in predictions
+                prediction["source_path"] == expected_path for prediction in predictions
             )
             symbol_hit = any(
-                prediction.get("source_path") == expected_path
-                and (not expected_symbol or prediction.get("symbol") == expected_symbol)
+                prediction["source_path"] == expected_path
+                and (not expected_symbol or prediction["symbol"] == expected_symbol)
                 for prediction in predictions
             )
             path_hits += int(path_hit)
@@ -121,14 +160,14 @@ def evaluate_visual_code_grounding(
             per_binding.append(
                 {
                     "artifact_path": artifact_path,
-                    "entity_name": expected.get("entity_name") or "",
+                    "entity_name": expected_entity,
                     "path_hit_at_k": path_hit,
                     "symbol_hit_at_k": symbol_hit,
-                    "predicted": [dict(prediction) for prediction in predictions],
+                    "predicted": predictions,
                 }
             )
     return {
-        "k": k,
+        "k": result_limit,
         "binding_count": total,
         "path_hit_at_k": _safe_div(path_hits, total),
         "symbol_hit_at_k": _safe_div(symbol_hits, total),
@@ -147,29 +186,146 @@ def evaluate_mmwiki_predictions(
 ) -> dict[str, Any]:
     """Evaluate visual fact extraction and visual-code grounding together."""
 
-    facts = evaluate_visual_fact_extraction(visual_facts_manifest, gold)
-    grounding = evaluate_visual_code_grounding(grounding_manifest, gold, k=k)
+    instances = _gold_instances(gold)
+    stable_gold = {"instances": instances}
+    facts = evaluate_visual_fact_extraction(visual_facts_manifest, stable_gold)
+    grounding = evaluate_visual_code_grounding(
+        grounding_manifest,
+        stable_gold,
+        k=k,
+    )
     return {
         "task": "mmwiki",
-        "artifact_count": len(list(_gold_instances(gold))),
+        "artifact_count": len(instances),
         "visual_fact_extraction": facts,
         "visual_code_grounding": grounding,
     }
 
 
 def _gold_instances(gold: Mapping[str, Any]) -> list[Mapping[str, Any]]:
-    instances = gold.get("instances") or ()
-    return [instance for instance in instances if isinstance(instance, Mapping)]
+    gold = _require_mapping(gold, label="gold manifest")
+    return list(_mapping_items(gold.get("instances"), limit=_MAX_INSTANCES))
+
+
+def _gold_artifact_path(instance: Mapping[str, Any]) -> str:
+    return _required_relative_path(
+        instance.get("artifact_path"),
+        label="gold artifact path",
+    )
+
+
+def _prediction(binding: Mapping[str, Any]) -> dict[str, Any] | None:
+    artifact_path = _safe_relative_path(binding.get("artifact_path"))
+    source_path = _safe_relative_path(binding.get("source_path"))
+    entity_name = _safe_text(binding.get("entity_name"))
+    if not artifact_path or not source_path or not entity_name:
+        return None
+    return {
+        "artifact_path": artifact_path,
+        "entity_name": entity_name,
+        "source_path": source_path,
+        "symbol": _safe_text(binding.get("symbol")),
+        "kind": _safe_text(binding.get("kind") or "source"),
+        "line": _positive_int(binding.get("line")),
+        "score": _finite_score(binding.get("score")),
+        "evidence": _safe_text(binding.get("evidence")),
+    }
 
 
 def _entity_key(entity: Mapping[str, Any]) -> str:
-    name = _normalize(str(entity.get("name") or ""))
-    kind = _normalize(str(entity.get("type") or "unknown"))
+    name = _normalize(_safe_text(entity.get("name")))
+    kind = _normalize(_safe_text(entity.get("type") or "unknown"))
     return f"{name}:{kind}" if name else ""
 
 
+def _gold_entity_key(entity: Mapping[str, Any]) -> str:
+    name = _normalize(
+        _required_text(
+            entity.get("name"),
+            label="gold entity name",
+        )
+    )
+    kind = _normalize(_safe_text(entity.get("type") or "unknown"))
+    return f"{name}:{kind}"
+
+
+def _mapping_items(value: Any, *, limit: int) -> Iterable[Mapping[str, Any]]:
+    if isinstance(value, (str, bytes, bytearray, Mapping)):
+        return ()
+    try:
+        values = iter(value or ())
+    except TypeError:
+        return ()
+    return (item for item in islice(values, limit) if isinstance(item, Mapping))
+
+
+def _require_mapping(value: Any, *, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def _required_relative_path(value: Any, *, label: str) -> str:
+    path = _safe_relative_path(value)
+    if not path:
+        raise ValueError(f"{label} must be a repository-relative path")
+    return path
+
+
+def _required_text(value: Any, *, label: str) -> str:
+    text = _safe_text(value)
+    if not text:
+        raise ValueError(f"{label} is required")
+    return text
+
+
+def _safe_relative_path(value: Any) -> str:
+    text = _safe_text(value)
+    if not text or "\\" in text:
+        return ""
+    path = PurePosixPath(text)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        return ""
+    return path.as_posix()
+
+
+def _safe_text(value: Any) -> str:
+    text = str(value or "").strip()
+    text = "".join(
+        character
+        for character in text
+        if ord(character) >= 0x20 and ord(character) != 0x7F
+    )
+    raw = text.encode("utf-8")
+    if len(raw) <= _MAX_TEXT_BYTES:
+        return text
+    return raw[:_MAX_TEXT_BYTES].decode("utf-8", errors="ignore").rstrip()
+
+
 def _normalize(value: str) -> str:
-    return re.sub(r"[^a-z0-9]+", "", str(value or "").lower())
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def _finite_score(value: Any) -> float:
+    if isinstance(value, bool):
+        return 0.0
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return score if math.isfinite(score) and score > 0 else 0.0
+
+
+def _positive_int(value: Any) -> int:
+    if type(value) is not int:
+        return 0
+    return max(0, value)
+
+
+def _validated_k(value: Any) -> int:
+    if type(value) is not int or not 1 <= value <= _MAX_K:
+        raise ValueError(f"k must be an integer between 1 and {_MAX_K}")
+    return value
 
 
 def _safe_div(numerator: int | float, denominator: int | float) -> float:

--- a/docs/experiments/multimodal_repository_knowledge.md
+++ b/docs/experiments/multimodal_repository_knowledge.md
@@ -107,6 +107,39 @@ media changed   -> rerun VLM/extractor for that artifact
 media removed   -> drop stale visual facts and bindings
 ```
 
+### MMWiki-style evaluation
+
+`codenib.wiki.media_eval` defines a small evaluation protocol for the first
+benchmark seed. It does not try to replace SWE-bench Multimodal or MM-IssueLoc.
+Instead, it measures whether repository visuals can be compiled into persistent
+wiki knowledge:
+
+- visual entity extraction precision / recall / F1;
+- visual-code grounding path hit@k;
+- visual-code grounding symbol hit@k.
+
+Gold instances use this shape:
+
+```json
+{
+  "instances": [
+    {
+      "artifact_path": "docs/architecture.svg",
+      "gold_entities": [
+        {"name": "IndexCompiler", "type": "component"}
+      ],
+      "gold_bindings": [
+        {
+          "entity_name": "IndexCompiler",
+          "source_path": "codenib/compiler/index_compiler.py",
+          "symbol": "IndexCompiler"
+        }
+      ]
+    }
+  ]
+}
+```
+
 ## Why evidence stays server-side
 
 Media generation may use bounded source snippets inside provider prompts. Those

--- a/docs/experiments/multimodal_repository_knowledge.md
+++ b/docs/experiments/multimodal_repository_knowledge.md
@@ -118,6 +118,10 @@ wiki knowledge:
 - visual-code grounding path hit@k;
 - visual-code grounding symbol hit@k.
 
+Inputs and report payloads are bounded and normalized. Grounding `k` is limited
+to 1-20, non-finite ranking scores cannot destabilize ordering, and reports
+emit only canonical binding fields rather than arbitrary prediction metadata.
+
 Gold instances use this shape:
 
 ```json

--- a/test/wiki/test_media_eval.py
+++ b/test/wiki/test_media_eval.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from codenib.wiki.media_eval import (
     evaluate_mmwiki_predictions,
     evaluate_visual_code_grounding,
@@ -109,3 +111,58 @@ def test_evaluate_visual_code_grounding_handles_missing_predictions():
     assert metrics["path_hit_at_k"] == 0.0
     assert metrics["symbol_hit_at_k"] == 0.0
     assert metrics["binding_count"] == 2
+
+
+@pytest.mark.parametrize("k", [0, -1, 21, True, 1.5, "1"])
+def test_evaluate_visual_code_grounding_rejects_invalid_k(k):
+    with pytest.raises(ValueError, match="k must be"):
+        evaluate_visual_code_grounding(_grounding(), _gold(), k=k)
+
+
+def test_grounding_evaluation_handles_nonfinite_scores_and_bounds_output():
+    grounding = _grounding()
+    grounding["bindings"][0]["score"] = float("nan")
+    grounding["bindings"][0]["private_prompt"] = "must not leak"
+
+    metrics = evaluate_visual_code_grounding(grounding, _gold(), k=1)
+
+    predicted = metrics["per_binding"][0]["predicted"][0]
+    assert predicted["score"] == 0.0
+    assert "private_prompt" not in predicted
+
+
+def test_combined_evaluation_materializes_generator_gold_once():
+    gold = {"instances": (instance for instance in _gold()["instances"])}
+
+    metrics = evaluate_mmwiki_predictions(_facts(), _grounding(), gold, k=1)
+
+    assert metrics["artifact_count"] == 1
+    assert metrics["visual_fact_extraction"]["entity_gold"] == 2
+    assert metrics["visual_code_grounding"]["binding_count"] == 2
+
+
+def test_evaluation_rejects_unsafe_gold_paths():
+    gold = _gold()
+    gold["instances"][0]["artifact_path"] = "../secret.svg"
+
+    with pytest.raises(ValueError, match="repository-relative"):
+        evaluate_visual_fact_extraction(_facts(), gold)
+
+
+def test_evaluation_rejects_non_object_inputs():
+    with pytest.raises(ValueError, match="visual facts manifest"):
+        evaluate_visual_fact_extraction([], _gold())
+    with pytest.raises(ValueError, match="gold manifest"):
+        evaluate_visual_fact_extraction(_facts(), [])
+
+
+def test_evaluation_rejects_incomplete_gold_entities_and_bindings():
+    entity_gold = _gold()
+    entity_gold["instances"][0]["gold_entities"][0]["name"] = ""
+    with pytest.raises(ValueError, match="gold entity name"):
+        evaluate_visual_fact_extraction(_facts(), entity_gold)
+
+    binding_gold = _gold()
+    binding_gold["instances"][0]["gold_bindings"][0]["entity_name"] = ""
+    with pytest.raises(ValueError, match="gold entity name"):
+        evaluate_visual_code_grounding(_grounding(), binding_gold)

--- a/test/wiki/test_media_eval.py
+++ b/test/wiki/test_media_eval.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from codenib.wiki.media_eval import (
+    evaluate_mmwiki_predictions,
+    evaluate_visual_code_grounding,
+    evaluate_visual_fact_extraction,
+)
+
+
+def _facts():
+    return {
+        "facts": [
+            {
+                "artifact_path": "docs/architecture.svg",
+                "entities": [
+                    {"name": "IndexCompiler", "type": "component"},
+                    {"name": "VectorStore", "type": "component"},
+                    {"name": "Noise", "type": "component"},
+                ],
+            }
+        ]
+    }
+
+
+def _grounding():
+    return {
+        "bindings": [
+            {
+                "artifact_path": "docs/architecture.svg",
+                "entity_name": "IndexCompiler",
+                "source_path": "codenib/compiler/index_compiler.py",
+                "symbol": "IndexCompiler",
+                "score": 1.0,
+            },
+            {
+                "artifact_path": "docs/architecture.svg",
+                "entity_name": "VectorStore",
+                "source_path": "codenib/index/embedding/vector_store.py",
+                "symbol": "VectorStore",
+                "score": 0.9,
+            },
+        ]
+    }
+
+
+def _gold():
+    return {
+        "instances": [
+            {
+                "artifact_path": "docs/architecture.svg",
+                "gold_entities": [
+                    {"name": "IndexCompiler", "type": "component"},
+                    {"name": "VectorStore", "type": "component"},
+                ],
+                "gold_bindings": [
+                    {
+                        "entity_name": "IndexCompiler",
+                        "source_path": "codenib/compiler/index_compiler.py",
+                        "symbol": "IndexCompiler",
+                    },
+                    {
+                        "entity_name": "VectorStore",
+                        "source_path": "codenib/index/embedding/vector_store.py",
+                        "symbol": "VectorStore",
+                    },
+                ],
+            }
+        ]
+    }
+
+
+def test_evaluate_visual_fact_extraction_reports_precision_recall_f1():
+    metrics = evaluate_visual_fact_extraction(_facts(), _gold())
+
+    assert metrics["entity_true_positive"] == 2
+    assert metrics["entity_predicted"] == 3
+    assert metrics["entity_gold"] == 2
+    assert round(metrics["entity_precision"], 3) == 0.667
+    assert metrics["entity_recall"] == 1.0
+    assert round(metrics["entity_f1"], 3) == 0.8
+
+
+def test_evaluate_visual_code_grounding_reports_hits_at_k():
+    metrics = evaluate_visual_code_grounding(_grounding(), _gold(), k=1)
+
+    assert metrics["binding_count"] == 2
+    assert metrics["path_hit_at_k"] == 1.0
+    assert metrics["symbol_hit_at_k"] == 1.0
+    assert metrics["path_hits"] == 2
+    assert metrics["symbol_hits"] == 2
+
+
+def test_evaluate_mmwiki_predictions_combines_tasks():
+    metrics = evaluate_mmwiki_predictions(_facts(), _grounding(), _gold(), k=1)
+
+    assert metrics["task"] == "mmwiki"
+    assert metrics["artifact_count"] == 1
+    assert metrics["visual_fact_extraction"]["entity_true_positive"] == 2
+    assert metrics["visual_code_grounding"]["symbol_hit_at_k"] == 1.0
+
+
+def test_evaluate_visual_code_grounding_handles_missing_predictions():
+    metrics = evaluate_visual_code_grounding({"bindings": []}, _gold(), k=5)
+
+    assert metrics["path_hit_at_k"] == 0.0
+    assert metrics["symbol_hit_at_k"] == 0.0
+    assert metrics["binding_count"] == 2


### PR DESCRIPTION
## Summary

Restacks the MMWiki evaluation half of [MarinaMackay/CodeNib#8](https://github.com/MarinaMackay/CodeNib/pull/8) as the next independent slice of #655 after #673. The original feature commit retains Marina Mackay as its author, followed by a focused maintainer hardening commit.

Adds deterministic evaluation helpers for visual entity extraction and visual-to-code grounding without introducing model calls or benchmark infrastructure.

## Changes

- Measure visual entity precision, recall, F1, and per-artifact matches.
- Measure source-path and symbol hit@k for visual-code bindings.
- Combine both tasks into one bounded MMWiki-style report.
- Bound gold instances, entities, bindings, predictions, text, and `k`.
- Materialize one-shot gold iterables once for combined evaluation.
- Normalize safe repository-relative paths and reject malformed required gold fields.
- Stabilize ranking by mapping invalid, negative, and non-finite scores to zero.
- Emit only canonical prediction fields so arbitrary provider metadata cannot leak into reports.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] `pytest test/wiki/test_media_eval.py -q` (15 passed)
- [x] `pytest test/wiki test/scripts/test_build_multimodal_knowledge.py -q` (471 passed)
- [x] `python -m flake8 codenib/wiki/media_eval.py test/wiki/test_media_eval.py`
- [x] `git diff --check origin/main...HEAD`
- [x] Clean merge-tree against current `main`

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published