### PR TITLE
fix(codegraph): isolate runtime readiness probe

### DIFF
--- a/codenib/codegraph_onboarding.py
+++ b/codenib/codegraph_onboarding.py
@@ -446,7 +446,7 @@ def inspect_server_command(
             f"expected {expected!r}, observed {observed[:240]!r}",
         )
     probe = _invoke_client(
-        (server.command, *server.args, "--runtime-probe"),
+        (server.command, *prefix, "mcp", "--runtime-probe"),
         repository=Path(repository).expanduser().resolve(),
         runner=runner,
     )

--- a/test/test_codegraph_onboarding.py
+++ b/test/test_codegraph_onboarding.py
@@ -381,9 +381,6 @@ def test_server_command_must_report_the_active_codenib_version(tmp_path: Path) -
             "-m",
             "codenib",
             "mcp",
-            str(repo.resolve()),
-            "--tool-surface",
-            "full",
             "--runtime-probe",
         ),
     ]
@@ -409,6 +406,32 @@ def test_server_command_must_report_the_active_codenib_version(tmp_path: Path) -
     )
     assert failed_probe.ready is False
     assert "runtime probe failed" in failed_probe.detail
+
+
+def test_server_runtime_probe_uses_the_context_free_mcp_mode(tmp_path: Path) -> None:
+    from codenib._version import package_version
+
+    repo = _repository(tmp_path)
+    server = _server(repo)
+
+    def runner(command, **_kwargs):
+        if command[-1] == "--version":
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                f"codenib {package_version()}\n",
+                "",
+            )
+        probe_args = cli.build_parser().parse_args(list(command[1:]))
+        assert cli._mcp_context_mode(probe_args) == "probe"
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            "codenib codegraph mcp runtime ready\n",
+            "",
+        )
+
+    assert inspect_server_command(server, repo, runner=runner).ready is True
 
 
 def _ready_plan(repo: Path) -> SimpleNamespace:


### PR DESCRIPTION
## Summary

Restore the installed CodeGraph onboarding path by probing the configured CodeNib runtime without replaying MCP context arguments that are intentionally incompatible with `--runtime-probe`.

## Changes

- Build the readiness probe from the validated executable prefix plus `mcp --runtime-probe`.
- Keep manifest, repository, and tool-surface arguments on real MCP startup only.
- Add a cross-module regression proving the emitted probe selects the context-free MCP mode.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [ ] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/test_codegraph_onboarding.py --tb=short` (32 passed)
- `pytest -q test/test_cli.py -k 'mcp_context_mode or mcp_runtime_probe' --tb=short` (5 passed)
- Real subprocess `inspect_server_command` probe (ready)
- `scripts/smoke_release_graph.py` (installed CodeGraph, Codex/Claude onboarding, MCP, and Dependency Map passed)
- Pre-commit on both changed files (passed)
- Full `test/test_cli.py`: 166 passed; one existing local environment failure because this checkout lacks the workspace-owner extension.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
