### PR TITLE
feat(storage): enable receipt-bound exact replacement

### DIFF
--- a/codenib/_local_workspace_provider.py
+++ b/codenib/_local_workspace_provider.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Linux missing-destination provider for strict local workspaces.
+"""Linux provider for missing and receipt-bound exact local workspaces.
 
 The configured root is an authority boundary, not a sandbox.  It must be a
 private, quiescent directory controlled by the current process owner.  The
@@ -34,12 +34,14 @@ from ._captured_directory import (
     OwnedWorkspaceAuthority,
     PublishedWorkspaceReceiptOwner,
     UnsupportedWorkspaceCreation,
+    WorkspacePlan,
     _snapshot_workspace_plan,
     require_owned_workspace_publication_support,
 )
 from ._workspace_provider import (
     StrictWorkspaceRequest,
     StrictWorkspaceSession,
+    _ReplacementSourceGate,
     run_adopted_workspace_operation,
 )
 
@@ -47,6 +49,7 @@ _OperationResult = TypeVar("_OperationResult")
 _DEFAULT_PROVISION_TIMEOUT_NS = 30_000_000_000
 _MAX_PROVISION_TIMEOUT_NS = 300_000_000_000
 _STAGE_PREFIX = ".codenib-workspace-stage-"
+_PROVISION_BOUND_REPLACEMENT_EXACT = OwnedWorkspaceAuthority.provision_bound_replacement
 
 
 @dataclass(slots=True)
@@ -137,15 +140,22 @@ class LocalWorkspaceProvider:
         receipt_owner: PublishedWorkspaceReceiptOwner,
         operation: Callable[[StrictWorkspaceSession], _OperationResult],
         _expected_parent_identity: tuple[int, ...] | None = None,
+        _replacement_source: _ReplacementSourceGate | None = None,
     ) -> _OperationResult:
         self._require_owner_pid()
         if type(request) is not StrictWorkspaceRequest:
             raise TypeError("strict workspace request has an invalid type")
         if type(receipt_owner) is not PublishedWorkspaceReceiptOwner:
             raise TypeError("strict workspace receipt owner has an invalid type")
-        if request.destination_binding is not None:
-            raise UnsupportedWorkspaceCreation(
-                "local workspace provider currently requires a missing destination"
+        replacement = request.destination_binding is not None
+        if replacement:
+            if type(_replacement_source) is not _ReplacementSourceGate:
+                raise TypeError(
+                    "exact local workspace requires replacement source provenance"
+                )
+        elif _replacement_source is not None:
+            raise ValueError(
+                "missing local workspace cannot receive replacement source provenance"
             )
         if _expected_parent_identity is not None and (
             type(_expected_parent_identity) is not tuple
@@ -158,6 +168,20 @@ class LocalWorkspaceProvider:
         self.require_support()
         stage_name = _STAGE_PREFIX + secrets.token_hex(16)
         deadline_ns = time.monotonic_ns() + self.provision_timeout_ns
+        if replacement:
+            assert _replacement_source is not None
+            return self._run_replacement_workspace(
+                request,
+                receipt_owner=receipt_owner,
+                operation=operation,
+                replacement_source=_replacement_source,
+                detached_plan=detached_plan,
+                relative_destination=relative_destination,
+                stage_name=stage_name,
+                deadline_ns=deadline_ns,
+                expected_parent_identity=_expected_parent_identity,
+            )
+
         workspace = OwnedWorkspaceAuthority()
         native_owner = _workspace_owner.create_owner()
         publication_permit = _workspace_owner.claim_owner_publish_permit(native_owner)
@@ -212,6 +236,83 @@ class LocalWorkspaceProvider:
                 workspace=workspace,
                 receipt_owner=receipt_owner,
                 operation=operation,
+            )
+
+    def _run_replacement_workspace(
+        self,
+        request: StrictWorkspaceRequest,
+        *,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        operation: Callable[[StrictWorkspaceSession], _OperationResult],
+        replacement_source: _ReplacementSourceGate,
+        detached_plan: WorkspacePlan,
+        relative_destination: bytes,
+        stage_name: str,
+        deadline_ns: int,
+        expected_parent_identity: tuple[int, ...] | None,
+    ) -> _OperationResult:
+        """Bind before candidate mutation and delegate the handed-off owner."""
+
+        workspace = OwnedWorkspaceAuthority()
+        native_owner = _workspace_owner.create_owner()
+        cleanup_owner = _ProviderWorkspaceCleanupOwner(workspace, native_owner)
+        cleanup_actions = (
+            _OrderedAction(
+                label="local workspace replacement cleanup also failed",
+                action=cleanup_owner.close,
+                complete=lambda: cleanup_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=cleanup_owner,
+            ),
+        )
+        with _run_context_with_cleanup_actions(cleanup_actions):
+            # Capture and lease are pre-handoff native reads/coordination. The
+            # cleanup owner is already reachable if either transition becomes
+            # uncertain or retains the cooperative lease for retry.
+            self._require_private_root()
+            _workspace_owner.capture_owner_destination(
+                native_owner,
+                os.fsencode(self.allowed_root),
+                relative_destination,
+                deadline_ns,
+            )
+            _workspace_owner.acquire_owner_replacement_lease(
+                native_owner,
+                deadline_ns,
+            )
+            if expected_parent_identity is not None:
+                parent_descriptor = _workspace_owner.borrow_owner_parent_descriptor(
+                    native_owner
+                )
+                if (
+                    publication_parent_identity(parent_descriptor)
+                    != expected_parent_identity
+                ):
+                    raise RuntimeError(
+                        "native workspace parent differs from retained authority"
+                    )
+
+            # This call synchronously consumes the active source owner and is
+            # the sole native-owner handoff. Candidate mutation is impossible
+            # before it returns successfully.
+            replacement_source.bind(
+                workspace,
+                native_owner,
+                stage_name,
+                detached_plan,
+            )
+            self._require_private_root()
+            provision_deadline_ns = time.monotonic_ns() + self.provision_timeout_ns
+            _PROVISION_BOUND_REPLACEMENT_EXACT(
+                workspace,
+                deadline_ns=provision_deadline_ns,
+            )
+            return run_adopted_workspace_operation(
+                request,
+                workspace=workspace,
+                receipt_owner=receipt_owner,
+                operation=operation,
+                _replacement_timeout_ns=self.provision_timeout_ns,
             )
 
 

--- a/codenib/_workspace_provider.py
+++ b/codenib/_workspace_provider.py
@@ -14,6 +14,7 @@ by ``open`` is not a provider implementation.
 from __future__ import annotations
 
 import os
+import time
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
@@ -38,6 +39,15 @@ _OperationResult = TypeVar("_OperationResult")
 _ValidationResult = TypeVar("_ValidationResult")
 DestinationExpectation = Literal["missing", "provider-bound-exact"]
 _PUBLISHED_WORKSPACE_DESTINATION_BINDING_TYPE = PublishedWorkspaceDestinationBinding
+_PUBLISHED_WORKSPACE_RECEIPT_OWNER_TYPE = PublishedWorkspaceReceiptOwner
+_OWNED_WORKSPACE_AUTHORITY_TYPE = OwnedWorkspaceAuthority
+_BIND_REPLACEMENT_SOURCE_EXACT = OwnedWorkspaceAuthority.bind_replacement_source
+_PUBLISH_REPLACEMENT_EXACT = OwnedWorkspaceAuthority.publish_replacement_into
+_SOURCE_DESTINATION_BINDING_EXACT = (
+    PublishedWorkspaceReceiptOwner.destination_binding.fget
+)
+_MONOTONIC_NS_EXACT = time.monotonic_ns
+_MAX_REPLACEMENT_TIMEOUT_NS = 300_000_000_000
 _SESSION_RECOVERY_LIMIT = 64
 _UNSET_RESULT = object()
 _CONSUMED_SESSION_PROVENANCE = object()
@@ -93,6 +103,7 @@ def _create_session_provenance_registry() -> tuple[
         workspace: OwnedWorkspaceAuthority,
         receipt_owner: PublishedWorkspaceReceiptOwner,
         operation: Callable[[StrictWorkspaceSession], _OperationResult],
+        _replacement_timeout_ns: int | None = None,
     ) -> _OperationResult:
         """Run one bound operation against an already-adopted authority."""
 
@@ -102,6 +113,7 @@ def _create_session_provenance_registry() -> tuple[
             workspace=workspace,
             receipt_owner=receipt_owner,
             operation=operation,
+            replacement_timeout_ns=_replacement_timeout_ns,
         )
 
     return run_adopted_workspace_operation, consume, discard
@@ -201,17 +213,240 @@ class StrictWorkspaceProvider(Protocol):
         *,
         receipt_owner: PublishedWorkspaceReceiptOwner,
         operation: Callable[[StrictWorkspaceSession], _OperationResult],
+        _replacement_source: _ReplacementSourceGate | None = None,
     ) -> _OperationResult: ...
+
+
+class _ReplacementSourceGate:
+    """One-shot active-source handoff for one exact replacement operation."""
+
+    __slots__ = (
+        "_bind_replacement_source",
+        "_binding",
+        "_bound_native_owner",
+        "_bound_workspace",
+        "_lifecycle",
+        "_lock",
+        "_owner_pid",
+        "_request",
+        "_snapshot_plan",
+        "_source_destination_binding",
+        "_source_owner",
+    )
+
+    def __init__(
+        self,
+        request: StrictWorkspaceRequest,
+        source_owner: PublishedWorkspaceReceiptOwner,
+        *,
+        lifecycle: list[bool],
+    ) -> None:
+        if type(lifecycle) is not list or lifecycle != [False, False, False, True]:
+            raise TypeError("strict workspace replacement lifecycle is invalid")
+        # The enclosing strict call owns this mutable lifecycle before invoking
+        # the constructor.  Keep it inactive here: even an interruption at the
+        # constructor return boundary can then retain no usable bind authority.
+        self._lifecycle = lifecycle
+        self._owner_pid = os.getpid()
+        self._lock = _CancellationSafeRLock()
+        self._bound_workspace: OwnedWorkspaceAuthority | None = None
+        self._bound_native_owner: object | None = None
+        try:
+            if type(request) is not StrictWorkspaceRequest:
+                raise TypeError("strict workspace request has an invalid type")
+            if type(source_owner) is not _PUBLISHED_WORKSPACE_RECEIPT_OWNER_TYPE:
+                raise TypeError(
+                    "strict workspace replacement source must be an exact "
+                    "receipt owner"
+                )
+            binding = request.destination_binding
+            if binding is None:
+                raise ValueError(
+                    "strict workspace replacement source requires an exact binding"
+                )
+            source_destination_binding = _SOURCE_DESTINATION_BINDING_EXACT
+            assert source_destination_binding is not None
+            if source_destination_binding(source_owner) is not binding:
+                raise ValueError(
+                    "strict workspace replacement source differs from its request"
+                )
+            self._request = request
+            self._source_owner = source_owner
+            self._binding = binding
+            # Freeze exact binding callbacks before provider code can run.
+            self._bind_replacement_source = _BIND_REPLACEMENT_SOURCE_EXACT
+            self._snapshot_plan = _snapshot_workspace_plan
+            self._source_destination_binding = source_destination_binding
+        except BaseException:  # noqa: B036 - partial gates stay fail-closed
+            self._lifecycle[0] = False
+            self._lifecycle[2] = False
+            self._lifecycle[3] = False
+            raise
+
+    def _require_owner_pid(self) -> None:
+        if os.getpid() != self._owner_pid:
+            raise RuntimeError(
+                "strict workspace replacement source cannot cross a PID boundary"
+            )
+
+    def bind(
+        self,
+        workspace: OwnedWorkspaceAuthority,
+        native_owner: object,
+        stage_name: str,
+        plan: WorkspacePlan,
+    ) -> None:
+        """Consume and bind the active source without returning its authority."""
+
+        self._require_owner_pid()
+        if self._lock.held_by_current_thread():
+            raise RuntimeError("strict workspace replacement source bind is reentrant")
+
+        def bind_once() -> None:
+            if not self._lifecycle[0] or not self._lifecycle[2]:
+                raise RuntimeError(
+                    "strict workspace replacement source is no longer active"
+                )
+            if self._lifecycle[1]:
+                raise RuntimeError("strict workspace replacement source is one-shot")
+            self._lifecycle[1] = True
+            if type(workspace) is not _OWNED_WORKSPACE_AUTHORITY_TYPE:
+                raise TypeError("strict workspace replacement authority is invalid")
+            if self._request.destination_binding is not self._binding:
+                raise RuntimeError(
+                    "strict workspace replacement request binding changed"
+                )
+            if self._request.plan != self._snapshot_plan(plan):
+                raise ValueError(
+                    "strict workspace replacement plan differs from request"
+                )
+            if (
+                self._source_destination_binding(self._source_owner)
+                is not self._binding
+            ):
+                raise RuntimeError(
+                    "strict workspace replacement source binding changed"
+                )
+            try:
+                result = self._bind_replacement_source(
+                    workspace,
+                    self._source_owner,
+                    destination_binding=self._binding,
+                    native_owner=native_owner,
+                    stage_name=stage_name,
+                    plan=plan,
+                )
+                if result is not None:
+                    raise RuntimeError(
+                        "strict workspace replacement source bind result changed"
+                    )
+                self._bound_workspace = workspace
+                self._bound_native_owner = native_owner
+            finally:
+                # An attempted handoff is never replayable, including when the
+                # native/workspace settlement path raises or is interrupted.
+                self._lifecycle[0] = False
+
+        self._lock.run(bind_once)
+
+    def _require_bound_workspace(
+        self,
+        request: StrictWorkspaceRequest,
+        workspace: OwnedWorkspaceAuthority,
+    ) -> None:
+        self._require_owner_pid()
+
+        def require() -> None:
+            if not self._lifecycle[2]:
+                raise RuntimeError(
+                    "strict workspace replacement source is no longer active"
+                )
+            if request is not self._request:
+                raise ValueError(
+                    "strict workspace replacement source belongs to another request"
+                )
+            if request.destination_binding is not self._binding:
+                raise RuntimeError(
+                    "strict workspace replacement request binding changed"
+                )
+            if not self._lifecycle[1] or self._bound_workspace is not workspace:
+                raise RuntimeError(
+                    "strict workspace replacement source was not bound to "
+                    "this authority"
+                )
+            if (
+                self._bound_native_owner is None
+                or workspace._native_owner is not self._bound_native_owner
+            ):
+                raise RuntimeError("strict workspace replacement native owner changed")
+
+        self._lock.run(require)
+
+    def revoke(self) -> None:
+        self._require_owner_pid()
+        deferred: BaseException | None = None
+
+        def deactivate() -> None:
+            self._lifecycle[0] = False
+            self._lifecycle[2] = False
+            self._lifecycle[3] = False
+
+        for _attempt in range(_SESSION_RECOVERY_LIMIT):
+            try:
+                self._lock.run(deactivate)
+            except BaseException as interruption:  # noqa: B036
+                if deferred is None:
+                    deferred = interruption
+                else:
+                    _annotate_secondary_error(
+                        deferred,
+                        "strict workspace replacement source revocation "
+                        "was interrupted again",
+                        interruption,
+                    )
+                continue
+            try:
+                inactive = self._lock.run(
+                    lambda: (
+                        not self._lifecycle[0]
+                        and not self._lifecycle[2]
+                        and not self._lifecycle[3]
+                    )
+                )
+            except BaseException as interruption:  # noqa: B036
+                if deferred is None:
+                    deferred = interruption
+                else:
+                    _annotate_secondary_error(
+                        deferred,
+                        "strict workspace replacement source revocation "
+                        "check also failed",
+                        interruption,
+                    )
+                continue
+            if inactive:
+                if deferred is not None:
+                    raise deferred.with_traceback(deferred.__traceback__)
+                return
+        recovery_error = RuntimeError(
+            "strict workspace replacement source revocation did not converge"
+        )
+        if deferred is not None:
+            raise recovery_error from deferred
+        raise recovery_error
 
 
 class _AdoptedWorkspaceSession:
     __slots__ = (
         "_active",
         "_gate",
+        "_monotonic_ns",
         "_operation_provenance",
         "_owner_pid",
         "_published",
+        "_publish_replacement",
         "_receipt_owner",
+        "_replacement_timeout_ns",
         "_request",
         "_workspace",
     )
@@ -223,15 +458,21 @@ class _AdoptedWorkspaceSession:
         receipt_owner: PublishedWorkspaceReceiptOwner,
         *,
         operation_provenance: object,
+        monotonic_ns: Callable[[], int] = _MONOTONIC_NS_EXACT,
+        publish_replacement: Callable[..., None] = _PUBLISH_REPLACEMENT_EXACT,
+        replacement_timeout_ns: int | None = None,
     ) -> None:
         self._request = request
         self._workspace = workspace
         self._receipt_owner = receipt_owner
         self._active = True
+        self._monotonic_ns = monotonic_ns
         self._operation_provenance = operation_provenance
+        self._replacement_timeout_ns = replacement_timeout_ns
         self._owner_pid = os.getpid()
         self._gate = _CancellationSafeRLock()
         self._published = False
+        self._publish_replacement = publish_replacement
 
     def _require_owner_pid(self) -> None:
         if os.getpid() != self._owner_pid:
@@ -347,11 +588,30 @@ class _AdoptedWorkspaceSession:
             # Sealing is a separate authority transition. Recheck again
             # immediately before entering the authority's rename operation.
             self._require_request_binding()
-            self._workspace.publish_into(
-                self._receipt_owner,
-                validate_staged_directory=validate_staged,
-                validate_published_destination=validate_published,
-            )
+            if self._request.destination_binding is None:
+                if self._replacement_timeout_ns is not None:
+                    raise RuntimeError(
+                        "missing workspace received a replacement timeout"
+                    )
+                self._workspace.publish_into(
+                    self._receipt_owner,
+                    validate_staged_directory=validate_staged,
+                    validate_published_destination=validate_published,
+                )
+            else:
+                timeout_ns = self._replacement_timeout_ns
+                if type(timeout_ns) is not int or not (
+                    0 < timeout_ns <= _MAX_REPLACEMENT_TIMEOUT_NS
+                ):
+                    raise RuntimeError("exact workspace replacement timeout is missing")
+                deadline_ns = self._monotonic_ns() + timeout_ns
+                self._publish_replacement(
+                    self._workspace,
+                    self._receipt_owner,
+                    deadline_ns=deadline_ns,
+                    validate_staged_directory=validate_staged,
+                    validate_published_destination=validate_published,
+                )
             if len(published) != 1 or not self._receipt_owner.active:
                 raise RuntimeError(
                     "strict workspace publication did not install one active receipt"
@@ -415,12 +675,14 @@ class _ProviderOperationGate:
     """One-shot callback lease revoked before a provider call can escape."""
 
     __slots__ = (
-        "_active",
-        "_called",
+        "_lifecycle",
         "_lock",
+        "_monotonic_ns",
         "_operation",
         "_operation_outcome",
         "_owner_pid",
+        "_publish_replacement",
+        "_replacement_source",
         "_request",
     )
 
@@ -428,15 +690,27 @@ class _ProviderOperationGate:
         self,
         request: StrictWorkspaceRequest,
         operation: Callable[[StrictWorkspaceSession], _OperationResult],
+        *,
+        lifecycle: list[bool],
+        replacement_source: _ReplacementSourceGate | None = None,
     ) -> None:
-        self._active = True
-        self._called = False
+        if type(lifecycle) is not list or lifecycle != [False, False, True]:
+            raise TypeError("strict workspace operation lifecycle is invalid")
+        # As for the source gate, the enclosing strict call owns this inactive
+        # cell before construction and is the only code that may activate it.
+        self._lifecycle = lifecycle
         self._lock = _CancellationSafeRLock()
+        # Exact callers construct this gate before provider support; missing
+        # callers construct it before provisioning. Freeze the publication
+        # callback and clock once for either lifecycle.
+        self._monotonic_ns = _MONOTONIC_NS_EXACT
+        self._publish_replacement = _PUBLISH_REPLACEMENT_EXACT
         self._operation = operation
         self._operation_outcome: tuple[object, BaseException | None] | object = (
             _UNSET_RESULT
         )
         self._owner_pid = os.getpid()
+        self._replacement_source = replacement_source
         self._request = request
 
     def _require_owner_pid(self) -> None:
@@ -449,13 +723,24 @@ class _ProviderOperationGate:
         self._require_owner_pid()
 
         def invoke() -> _OperationResult:
-            if not self._active:
+            if not self._lifecycle[0]:
                 raise RuntimeError("strict workspace operation is no longer active")
-            if self._called:
+            if self._lifecycle[1]:
                 raise RuntimeError("strict workspace operation is one-shot")
             if type(session) is not _AdoptedWorkspaceSession:
                 raise TypeError(
                     "strict workspace provider must supply an adopted session"
+                )
+            replacement_source = self._replacement_source
+            if replacement_source is None:
+                if self._request.destination_binding is not None:
+                    raise RuntimeError(
+                        "exact workspace operation lacks replacement source provenance"
+                    )
+            else:
+                replacement_source._require_bound_workspace(
+                    self._request,
+                    session._workspace,
                 )
             provenance = _CONSUME_SESSION_PROVENANCE(
                 self,
@@ -468,7 +753,7 @@ class _ProviderOperationGate:
                 provenance,
                 consume=True,
             )
-            self._called = True
+            self._lifecycle[1] = True
             try:
                 result = self._operation(session)
                 self._record_operation_outcome(result, None)
@@ -489,9 +774,9 @@ class _ProviderOperationGate:
         self._require_owner_pid()
 
         def bind() -> None:
-            if not self._active:
+            if not self._lifecycle[0]:
                 raise RuntimeError("strict workspace operation is no longer active")
-            if self._called:
+            if self._lifecycle[1]:
                 raise RuntimeError("strict workspace operation is one-shot")
             if request is not self._request:
                 raise ValueError("strict workspace session belongs to another request")
@@ -516,7 +801,7 @@ class _ProviderOperationGate:
     @property
     def called(self) -> bool:
         self._require_owner_pid()
-        return self._lock.run(lambda: self._called)
+        return self._lock.run(lambda: self._lifecycle[1])
 
     def _record_operation_outcome(
         self,
@@ -584,7 +869,8 @@ class _ProviderOperationGate:
 
     def _deactivate(self) -> None:
         self._require_owner_pid()
-        self._active = False
+        self._lifecycle[0] = False
+        self._lifecycle[2] = False
         _DISCARD_SESSION_PROVENANCE(self)
 
     def revoke(self) -> None:
@@ -604,7 +890,9 @@ class _ProviderOperationGate:
                     )
                 continue
             try:
-                inactive = self._lock.run(lambda: not self._active)
+                inactive = self._lock.run(
+                    lambda: not self._lifecycle[0] and not self._lifecycle[2]
+                )
             except BaseException as interruption:  # noqa: B036
                 if deferred is None:
                     deferred = interruption
@@ -627,6 +915,268 @@ class _ProviderOperationGate:
         raise recovery_error
 
 
+def _settle_replacement_source_gate(
+    gate: _ReplacementSourceGate | None,
+    lifecycle: list[bool] | None,
+) -> BaseException | None:
+    """Deactivate even when cancellation lands before the first gate call."""
+
+    deferred: BaseException | None = None
+    for _attempt in range(_SESSION_RECOVERY_LIMIT):
+        try:
+            if gate is None:
+                if lifecycle is not None:
+                    lifecycle[0] = False
+                    lifecycle[2] = False
+                    lifecycle[3] = False
+            else:
+                gate.revoke()
+        except BaseException as interruption:  # noqa: B036
+            if deferred is None:
+                deferred = interruption
+            else:
+                try:
+                    _annotate_secondary_error(
+                        deferred,
+                        "strict workspace replacement source outer settlement "
+                        "was interrupted again",
+                        interruption,
+                    )
+                except BaseException:  # noqa: B036 - diagnostic is best-effort
+                    pass
+            continue
+        try:
+            if gate is None:
+                inactive = lifecycle is None or (
+                    not lifecycle[0] and not lifecycle[2] and not lifecycle[3]
+                )
+            else:
+                inactive = gate._lock.run(
+                    lambda: (
+                        not gate._lifecycle[0]
+                        and not gate._lifecycle[2]
+                        and not gate._lifecycle[3]
+                    )
+                )
+        except BaseException as interruption:  # noqa: B036
+            if deferred is None:
+                deferred = interruption
+            else:
+                try:
+                    _annotate_secondary_error(
+                        deferred,
+                        "strict workspace replacement source outer settlement "
+                        "check also failed",
+                        interruption,
+                    )
+                except BaseException:  # noqa: B036 - diagnostic is best-effort
+                    pass
+            continue
+        if inactive:
+            return deferred
+    recovery_error = RuntimeError(
+        "strict workspace replacement source outer settlement did not converge"
+    )
+    if deferred is not None:
+        try:
+            _annotate_secondary_error(
+                recovery_error,
+                "strict workspace replacement source outer settlement failed",
+                deferred,
+            )
+        except BaseException:  # noqa: B036 - diagnostic is best-effort
+            pass
+    return recovery_error
+
+
+def _settle_provider_operation_gate(
+    gate: _ProviderOperationGate | None,
+    lifecycle: list[bool] | None,
+) -> BaseException | None:
+    """Deactivate a callback cell across constructor and call boundaries."""
+
+    deferred: BaseException | None = None
+    for _attempt in range(_SESSION_RECOVERY_LIMIT):
+        try:
+            if gate is None:
+                if lifecycle is not None:
+                    lifecycle[0] = False
+                    lifecycle[2] = False
+            else:
+                gate.revoke()
+        except BaseException as interruption:  # noqa: B036
+            if deferred is None:
+                deferred = interruption
+            else:
+                try:
+                    _annotate_secondary_error(
+                        deferred,
+                        "strict workspace provider callback outer settlement "
+                        "was interrupted again",
+                        interruption,
+                    )
+                except BaseException:  # noqa: B036 - diagnostic is best-effort
+                    pass
+            continue
+        try:
+            if gate is None:
+                inactive = lifecycle is None or (not lifecycle[0] and not lifecycle[2])
+            else:
+                inactive = gate._lock.run(
+                    lambda: not gate._lifecycle[0] and not gate._lifecycle[2]
+                )
+        except BaseException as interruption:  # noqa: B036
+            if deferred is None:
+                deferred = interruption
+            else:
+                try:
+                    _annotate_secondary_error(
+                        deferred,
+                        "strict workspace provider callback outer settlement "
+                        "check also failed",
+                        interruption,
+                    )
+                except BaseException:  # noqa: B036 - diagnostic is best-effort
+                    pass
+            continue
+        if inactive:
+            return deferred
+    recovery_error = RuntimeError(
+        "strict workspace provider callback outer settlement did not converge"
+    )
+    if deferred is not None:
+        try:
+            _annotate_secondary_error(
+                recovery_error,
+                "strict workspace provider callback outer settlement failed",
+                deferred,
+            )
+        except BaseException:  # noqa: B036 - diagnostic is best-effort
+            pass
+    return recovery_error
+
+
+def _commit_provider_primary(
+    primary_cell: list[BaseException | None],
+    primary_error: BaseException,
+) -> None:
+    """Commit the provider primary before child-frame settlement can run."""
+
+    for _attempt in range(_SESSION_RECOVERY_LIMIT):
+        try:
+            primary_cell[0] = primary_error
+            if primary_cell[0] is not primary_error:
+                raise RuntimeError("strict workspace provider primary changed")
+        except BaseException as transition_error:  # noqa: B036
+            if transition_error is not primary_error:
+                try:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "strict workspace provider primary commit also failed",
+                        transition_error,
+                    )
+                except BaseException:  # noqa: B036 - diagnostic is best-effort
+                    pass
+            continue
+        return
+    recovery_error = RuntimeError(
+        "strict workspace provider primary commit did not converge"
+    )
+    try:
+        _annotate_secondary_error(
+            primary_error,
+            "strict workspace provider primary commit recovery also failed",
+            recovery_error,
+        )
+    except BaseException:  # noqa: B036 - diagnostic is best-effort
+        pass
+    raise primary_error.with_traceback(primary_error.__traceback__)
+
+
+def _invoke_strict_workspace_provider(
+    run_workspace: Callable[..., object],
+    request: StrictWorkspaceRequest,
+    receipt_owner: PublishedWorkspaceReceiptOwner,
+    operation_gate: _ProviderOperationGate,
+    replacement_source: _ReplacementSourceGate | None,
+    replacement_lifecycle: list[bool] | None,
+    operation_lifecycle: list[bool],
+    provider_primary: list[BaseException | None],
+    provider_started: list[bool],
+    provider_returned: list[bool],
+    commit_provider_primary: Callable[
+        [list[BaseException | None], BaseException],
+        None,
+    ],
+    settle_replacement_source: Callable[
+        [_ReplacementSourceGate | None, list[bool] | None],
+        BaseException | None,
+    ],
+    settle_provider_operation: Callable[
+        [_ProviderOperationGate | None, list[bool] | None],
+        BaseException | None,
+    ],
+) -> object:
+    """Invoke once, with a first settlement pass owned by a child frame."""
+
+    primary_error: BaseException | None = None
+    result: object = _UNSET_RESULT
+    try:
+        try:
+            provider_started[0] = True
+            if replacement_source is None:
+                result = run_workspace(
+                    request,
+                    receipt_owner=receipt_owner,
+                    operation=operation_gate,
+                )
+            else:
+                result = run_workspace(
+                    request,
+                    receipt_owner=receipt_owner,
+                    operation=operation_gate,
+                    _replacement_source=replacement_source,
+                )
+            provider_returned[0] = True
+        except BaseException as exc:  # noqa: B036 - settle before propagation
+            commit_provider_primary(provider_primary, exc)
+            primary_error = exc
+    finally:
+        try:
+            replacement_cleanup_error = settle_replacement_source(
+                replacement_source,
+                replacement_lifecycle,
+            )
+            if replacement_cleanup_error is not None:
+                if primary_error is None:
+                    primary_error = replacement_cleanup_error
+                else:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "strict workspace replacement source revocation also failed",
+                        replacement_cleanup_error,
+                    )
+        finally:
+            operation_cleanup_error = settle_provider_operation(
+                operation_gate,
+                operation_lifecycle,
+            )
+            if operation_cleanup_error is not None:
+                if primary_error is None:
+                    primary_error = operation_cleanup_error
+                else:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "strict workspace provider callback revocation also failed",
+                        operation_cleanup_error,
+                    )
+    if primary_error is not None:
+        raise primary_error.with_traceback(primary_error.__traceback__)
+    if result is _UNSET_RESULT:
+        raise RuntimeError("strict workspace provider returned no result")
+    return result
+
+
 def _run_adopted_workspace_operation(
     bind_provenance: Callable[[object, object, object, object], None],
     request: StrictWorkspaceRequest,
@@ -634,6 +1184,7 @@ def _run_adopted_workspace_operation(
     workspace: OwnedWorkspaceAuthority,
     receipt_owner: PublishedWorkspaceReceiptOwner,
     operation: Callable[[StrictWorkspaceSession], _OperationResult],
+    replacement_timeout_ns: int | None,
 ) -> _OperationResult:
     """Run one operation against an already-adopted borrowed authority.
 
@@ -654,6 +1205,13 @@ def _run_adopted_workspace_operation(
         raise RuntimeError("strict workspace receipt owner must be empty")
     if workspace.state != "adopted":
         raise RuntimeError("strict workspace authority must be freshly adopted")
+    if request.destination_binding is None:
+        if replacement_timeout_ns is not None:
+            raise ValueError("missing workspace cannot use a replacement timeout")
+    elif type(replacement_timeout_ns) is not int or not (
+        0 < replacement_timeout_ns <= _MAX_REPLACEMENT_TIMEOUT_NS
+    ):
+        raise ValueError("exact workspace requires a bounded replacement timeout")
 
     operation_provenance = object()
     session = _AdoptedWorkspaceSession(
@@ -661,6 +1219,9 @@ def _run_adopted_workspace_operation(
         workspace,
         receipt_owner,
         operation_provenance=operation_provenance,
+        monotonic_ns=operation._monotonic_ns,
+        publish_replacement=operation._publish_replacement,
+        replacement_timeout_ns=replacement_timeout_ns,
     )
     session._require_operation_request(request)
     operation._bind_adopted_session(
@@ -704,6 +1265,7 @@ def run_strict_workspace(
     *,
     receipt_owner: PublishedWorkspaceReceiptOwner,
     operation: Callable[[StrictWorkspaceSession], _OperationResult],
+    source_owner: PublishedWorkspaceReceiptOwner | None = None,
 ) -> _OperationResult:
     """Preflight and invoke one trusted provider without an ambient fallback."""
 
@@ -715,38 +1277,312 @@ def run_strict_workspace(
         raise TypeError("strict workspace operation must be callable")
     if receipt_owner.state != "empty":
         raise RuntimeError("strict workspace receipt owner must be empty")
-
-    # The shared platform gate precedes even provider attribute lookup: a
-    # descriptor/property proxy is not allowed to run on an unsupported host.
-    require_owned_workspace_publication_support()
-    require_support = getattr(provider, "require_support", None)
-    run_workspace = getattr(provider, "run_workspace", None)
-    if not callable(require_support) or not callable(run_workspace):
-        raise TypeError("strict workspace provider has an invalid contract")
-    # The provider-specific gate also precedes its provisioning entry point.
-    require_support()
-    operation_gate = _ProviderOperationGate(request, operation)
+    binding = request.destination_binding
+    replacement_lifecycle: list[bool] | None = None
+    operation_lifecycle: list[bool] | None = None
+    replacement_source: _ReplacementSourceGate | None = None
+    operation_gate: _ProviderOperationGate | None = None
+    run_workspace: Callable[..., object] | None = None
     primary_error: BaseException | None = None
     result: object = _UNSET_RESULT
-    try:
-        result = run_workspace(
-            request,
-            receipt_owner=receipt_owner,
-            operation=operation_gate,
+    provider_primary: list[BaseException | None] = [None]
+    provider_started = [False]
+    provider_returned = [False]
+    invoke_strict_provider = _invoke_strict_workspace_provider
+    commit_provider_primary = _commit_provider_primary
+    settle_replacement_source = _settle_replacement_source_gate
+    settle_provider_operation = _settle_provider_operation_gate
+    if binding is None and source_owner is not None:
+        raise ValueError("missing strict workspace cannot receive a replacement source")
+    if binding is not None and source_owner is receipt_owner:
+        raise ValueError(
+            "strict workspace source and output receipt owners must differ"
         )
-    except BaseException as exc:  # noqa: B036 - revoke before propagation
-        primary_error = exc
+
     try:
-        operation_gate.revoke()
-    except BaseException as revoke_error:  # noqa: B036
-        if primary_error is None:
-            primary_error = revoke_error
-        else:
-            _annotate_secondary_error(
-                primary_error,
-                "strict workspace provider callback revocation also failed",
-                revoke_error,
+        try:
+            if binding is None:
+                # Preserve the missing-destination ordering exactly: shared
+                # support and provider support precede callback-gate construction.
+                require_owned_workspace_publication_support()
+                require_support = getattr(provider, "require_support", None)
+                provider_run_workspace = getattr(provider, "run_workspace", None)
+                if not callable(require_support) or not callable(
+                    provider_run_workspace
+                ):
+                    raise TypeError("strict workspace provider has an invalid contract")
+                require_support()
+                operation_lifecycle = [False, False, True]
+                operation_gate = _ProviderOperationGate(
+                    request,
+                    operation,
+                    lifecycle=operation_lifecycle,
+                )
+                run_workspace = provider_run_workspace
+                # Spend the outer-only activation authority before making the
+                # callback live. Both stores and provider entry remain inside
+                # the same settlement boundary.
+                operation_lifecycle[2] = False
+                operation_lifecycle[0] = True
+                result = invoke_strict_provider(
+                    run_workspace,
+                    request,
+                    receipt_owner,
+                    operation_gate,
+                    None,
+                    None,
+                    operation_lifecycle,
+                    provider_primary,
+                    provider_started,
+                    provider_returned,
+                    commit_provider_primary,
+                    settle_replacement_source,
+                    settle_provider_operation,
+                )
+            else:
+                replacement_lifecycle = [False, False, False, True]
+                replacement_source = _ReplacementSourceGate(
+                    request,
+                    source_owner,  # type: ignore[arg-type]
+                    lifecycle=replacement_lifecycle,
+                )
+                operation_lifecycle = [False, False, True]
+                operation_gate = _ProviderOperationGate(
+                    request,
+                    operation,
+                    lifecycle=operation_lifecycle,
+                    replacement_source=replacement_source,
+                )
+                # Exact gates must be revoked on every later exit, including
+                # shared support, hostile provider descriptors, and provider
+                # support. Both gates remain inactive during those callbacks.
+                require_owned_workspace_publication_support()
+                require_support = getattr(provider, "require_support", None)
+                provider_run_workspace = getattr(provider, "run_workspace", None)
+                if not callable(require_support) or not callable(
+                    provider_run_workspace
+                ):
+                    raise TypeError("strict workspace provider has an invalid contract")
+                require_support()
+                run_workspace = provider_run_workspace
+                # No activation callable is retained by either gate. Spend both
+                # outer-only activation bits before enabling either capability,
+                # then enter the provider without leaving this guarded region.
+                replacement_lifecycle[3] = False
+                operation_lifecycle[2] = False
+                replacement_lifecycle[0] = True
+                replacement_lifecycle[2] = True
+                operation_lifecycle[0] = True
+                result = invoke_strict_provider(
+                    run_workspace,
+                    request,
+                    receipt_owner,
+                    operation_gate,
+                    replacement_source,
+                    replacement_lifecycle,
+                    operation_lifecycle,
+                    provider_primary,
+                    provider_started,
+                    provider_returned,
+                    commit_provider_primary,
+                    settle_replacement_source,
+                    settle_provider_operation,
+                )
+        except BaseException as exc:  # noqa: B036 - settle before propagation
+            if (
+                provider_primary[0] is None
+                and provider_started[0]
+                and not provider_returned[0]
+                and exc.__context__ is not None
+            ):
+                commit_provider_primary(provider_primary, exc.__context__)
+            primary_error = exc
+        # Settle once while still inside the protected outer try. If
+        # cancellation lands on the first cleanup line, control transfers to
+        # the outer handler/finally and the second pass still owns every cell.
+        try:
+            replacement_cleanup_error = settle_replacement_source(
+                replacement_source,
+                replacement_lifecycle,
             )
+            if replacement_cleanup_error is not None:
+                if primary_error is None:
+                    primary_error = replacement_cleanup_error
+                else:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "strict workspace replacement source revocation also failed",
+                        replacement_cleanup_error,
+                    )
+        finally:
+            operation_cleanup_error = settle_provider_operation(
+                operation_gate,
+                operation_lifecycle,
+            )
+            if operation_cleanup_error is not None:
+                if primary_error is None:
+                    primary_error = operation_cleanup_error
+                else:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "strict workspace provider callback revocation also failed",
+                        operation_cleanup_error,
+                    )
+    except BaseException as settlement_boundary_error:  # noqa: B036
+        if primary_error is None:
+            primary_error = settlement_boundary_error
+        elif settlement_boundary_error is not primary_error:
+            try:
+                _annotate_secondary_error(
+                    primary_error,
+                    "strict workspace gate settlement boundary also failed",
+                    settlement_boundary_error,
+                )
+            except BaseException:  # noqa: B036 - diagnostic is best-effort
+                pass
+    finally:
+        try:
+            try:
+                replacement_cleanup_error = settle_replacement_source(
+                    replacement_source,
+                    replacement_lifecycle,
+                )
+            except BaseException as interruption:  # noqa: B036
+                # Cancellation can land on the helper-call boundary before its
+                # own retry loop begins. Retain that exact interruption and
+                # retry the whole settlement until inactivity is observed.
+                replacement_cleanup_error = interruption
+                for _attempt in range(_SESSION_RECOVERY_LIMIT):
+                    try:
+                        retry_error = settle_replacement_source(
+                            replacement_source,
+                            replacement_lifecycle,
+                        )
+                    except BaseException as retry_interruption:  # noqa: B036
+                        try:
+                            _annotate_secondary_error(
+                                replacement_cleanup_error,
+                                "strict workspace replacement source settlement "
+                                "boundary was interrupted again",
+                                retry_interruption,
+                            )
+                        except BaseException:  # noqa: B036 - best-effort note
+                            pass
+                        continue
+                    if retry_error is not None:
+                        try:
+                            _annotate_secondary_error(
+                                replacement_cleanup_error,
+                                "strict workspace replacement source settlement "
+                                "also failed",
+                                retry_error,
+                            )
+                        except BaseException:  # noqa: B036 - best-effort note
+                            pass
+                    break
+                else:
+                    recovery_error = RuntimeError(
+                        "strict workspace replacement source settlement boundary "
+                        "did not converge"
+                    )
+                    try:
+                        _annotate_secondary_error(
+                            replacement_cleanup_error,
+                            "strict workspace replacement source settlement "
+                            "recovery also failed",
+                            recovery_error,
+                        )
+                    except BaseException:  # noqa: B036 - best-effort note
+                        pass
+            if replacement_cleanup_error is not None:
+                if primary_error is None:
+                    primary_error = replacement_cleanup_error
+                else:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "strict workspace replacement source revocation also failed",
+                        replacement_cleanup_error,
+                    )
+        finally:
+            try:
+                operation_cleanup_error = settle_provider_operation(
+                    operation_gate,
+                    operation_lifecycle,
+                )
+            except BaseException as interruption:  # noqa: B036
+                operation_cleanup_error = interruption
+                for _attempt in range(_SESSION_RECOVERY_LIMIT):
+                    try:
+                        retry_error = settle_provider_operation(
+                            operation_gate,
+                            operation_lifecycle,
+                        )
+                    except BaseException as retry_interruption:  # noqa: B036
+                        try:
+                            _annotate_secondary_error(
+                                operation_cleanup_error,
+                                "strict workspace provider callback settlement "
+                                "boundary was interrupted again",
+                                retry_interruption,
+                            )
+                        except BaseException:  # noqa: B036 - best-effort note
+                            pass
+                        continue
+                    if retry_error is not None:
+                        try:
+                            _annotate_secondary_error(
+                                operation_cleanup_error,
+                                "strict workspace provider callback settlement "
+                                "also failed",
+                                retry_error,
+                            )
+                        except BaseException:  # noqa: B036 - best-effort note
+                            pass
+                    break
+                else:
+                    recovery_error = RuntimeError(
+                        "strict workspace provider callback settlement boundary "
+                        "did not converge"
+                    )
+                    try:
+                        _annotate_secondary_error(
+                            operation_cleanup_error,
+                            "strict workspace provider callback settlement "
+                            "recovery also failed",
+                            recovery_error,
+                        )
+                    except BaseException:  # noqa: B036 - best-effort note
+                        pass
+            if operation_cleanup_error is not None:
+                if primary_error is None:
+                    primary_error = operation_cleanup_error
+                else:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "strict workspace provider callback revocation also failed",
+                        operation_cleanup_error,
+                    )
+
+    committed_provider_primary = provider_primary[0]
+    if (
+        committed_provider_primary is not None
+        and primary_error is not committed_provider_primary
+    ):
+        if primary_error is not None:
+            try:
+                _annotate_secondary_error(
+                    committed_provider_primary,
+                    "strict workspace provider cleanup boundary also failed",
+                    primary_error,
+                )
+            except BaseException:  # noqa: B036 - diagnostic is best-effort
+                pass
+        primary_error = committed_provider_primary
+
+    if operation_gate is None:
+        if primary_error is None:
+            raise RuntimeError("strict workspace operation gate was not constructed")
+        raise primary_error.with_traceback(primary_error.__traceback__)
     outcome_read_error: BaseException | None = None
     for _attempt in range(_SESSION_RECOVERY_LIMIT):
         try:

--- a/codenib/artifacts/strict_bm25.py
+++ b/codenib/artifacts/strict_bm25.py
@@ -1261,6 +1261,7 @@ def _publish_planned_bm25_view_with_identity(
         request,
         receipt_owner=output_receipt_owner,
         operation=operation,
+        source_owner=source_generation,
     )
     if not output_receipt_owner.active:
         raise RuntimeError("strict BM25 publication returned without a receipt")

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -12,7 +12,8 @@ SPDX-License-Identifier: Apache-2.0
 
 `LocalWorkspaceProvider` is CodeNib's production Linux implementation of the
 strict workspace contract. It publishes one fully validated directory into a
-missing destination and transfers the generation to a caller-owned
+missing destination or replaces the exact generation named by an active
+receipt, then transfers the new generation to a caller-owned
 `PublishedWorkspaceReceiptOwner`.
 
 The provider is not enabled by CodeNib's default compiler or runtime path. Four
@@ -32,9 +33,9 @@ incumbent, and candidate descriptors throughout; every descriptor borrowed by
 trusted internal code remains owner-owned and must never be closed by the
 borrower.
 
-The Python authority now exposes the fail-closed half needed to use that
-primitive, but this does not change `LocalWorkspaceProvider`: the provider
-remains missing-only. Exact replacement has three explicit authority phases:
+The Python authority and `LocalWorkspaceProvider` now select that primitive for
+receipt-bound exact requests. Exact replacement has three explicit authority
+phases:
 
 1. `bind_replacement_source(...)` synchronously consumes an active source
    receipt while a separately supplied protocol-v5 owner already holds the
@@ -54,6 +55,18 @@ remains missing-only. Exact replacement has three explicit authority phases:
    separate retained descriptors. It never enters the generic
    isolate-and-rename helper and never performs a generic post-exchange parent
    sync; the native exchange and receipt settlement own durability ordering.
+
+In exact mode, `provision_timeout_ns` supplies three independent absolute
+deadline budgets. The provider mints one before destination capture and lease,
+a fresh one after the complete active-source scan and handoff immediately
+before candidate provisioning, and the operation mints a third immediately
+before the pre-exchange candidate/incumbent scans and staged validation. A valid
+long source scan or user build therefore cannot inherit an already expired
+provision or publication deadline. Those pre-exchange checks consume the third
+budget, and native exchange observes expiry before mutating the namespace. The
+post-exchange published validator and receipt/abort settlement retain their
+normal reconciliation guarantees but are not governed by that absolute
+deadline.
 
 The caller-owned receipt slot remains the linearization point. Before its store,
 failure reconciliation invokes native abort, which authenticates and reverses
@@ -79,14 +92,18 @@ the callback session compares the complete adopted binding with the request.
 The `destination_expectation` label remains only a derived diagnostic property,
 so a string or raw ownership token cannot select replacement. Strict BM25 now
 derives this binding from `source_generation` and cross-checks the borrowed
-receipt. The standard shared and provider-specific support probes still run
-first; `LocalWorkspaceProvider` then rejects every non-`None` binding before
-provisioning or namespace mutation. Gate C must still add a private, one-shot
-provider/session provenance path carrying the active source receipt owner
-separately from the frozen request binding, select the three-phase authority
-flow, and settle the old receipt/orphan handoff. Automatic orphan GC, a crash
-journal, and protection from hostile same-UID mutation are not part of this
-seam. Gate C and M1 therefore remain open.
+receipt. It passes that still-active owner separately from the request. A
+private PID-bound, one-shot replacement-source gate proves exact binding and
+operation identity, synchronously invokes `bind_replacement_source(...)`, and
+spends its one-shot bind authority before candidate provisioning. The provider
+receives the gate, never the source owner or a replayable capability. An exact
+callback cannot enter unless that same gate bound the same adopted workspace;
+the full callback lifetime is revoked before the provider call escapes.
+`LocalWorkspaceProvider` then provisions only through the handed-off workspace
+and the session publishes only through `publish_replacement_into(...)`. This
+completes Gate C. Automatic orphan GC, a crash journal, protection from hostile
+same-UID mutation, default route promotion, and the remaining M1 evidence gates
+are outside this seam.
 
 ## Publish a normal index build
 
@@ -409,11 +426,9 @@ required before either policy track can advance.
 
 These retained-read routes and the explicit BM25/vector ingress above do not
 complete the hybrid-storage M1 milestone. Benchmark-backed promotion of the
-opt-in compiler and runtime routes is still missing, as is a production
-provider for the strict BM25 replacement producer's `provider-bound-exact`
-destination contract. Protocol v4 supplies the lower-level exact exchange
-primitive, but no production provider selects it and the local provider still
-rejects replacement requests. Graph and Zoekt ingress remain M2 or later work;
+opt-in compiler and runtime routes is still missing. The production
+`provider-bound-exact` strict BM25 seam is now complete, but it does not select
+or promote a default route. Graph and Zoekt ingress remain M2 or later work;
 fenced jobs and runtime hot switching remain separate milestones.
 
 ## Measure the retained storage gate
@@ -554,13 +569,12 @@ path remains blocked on equal public behavior, artifact provenance, native
 capability policy, and required view coverage. A future source-bound BM25
 default requires its own A2 decision and does not satisfy that full
 compatibility gate. The independent gate C
-`provider-bound-exact` native provider is still required before M1 closes.
-Protocol v4 supplies a primitive-only exact exchange; it does not wire that
-primitive into `LocalWorkspaceProvider`. The strict BM25 route now carries its
-receipt-derived destination binding to the provider boundary, but the local
-provider still rejects that binding and cannot execute the exchange. This
-harness does not add M2 generic generation publication or fenced jobs, M3 hot
-switching or request pins, or M5 retention and garbage collection.
+`provider-bound-exact` native provider is now complete, independently of this
+measurement protocol. The strict BM25 route carries both its receipt-derived
+immutable binding and the separately active source owner to the one-shot Local
+provider seam. This harness does not promote that producer or add M2 generic
+generation publication or fenced jobs, M3 hot switching or request pins, or M5
+retention and garbage collection.
 
 ## Lifecycle
 
@@ -606,8 +620,9 @@ native handles. Closing the receipt owner does not delete the published output.
 The provider deliberately has a narrow first release:
 
 - Linux only, with `cp310-abi3-manylinux_2_28` wheels for x86-64 and AArch64.
-- Missing destinations only; it never replaces an existing file, directory, or
-  symlink.
+- Missing destinations, or one exact existing directory generation bound by
+  the separately active source receipt. It never replaces an unbound existing
+  file, directory, or symlink.
 - One absolute authority root owned by the current effective UID, with exact
   mode `0700`. The root must be a private, quiescent namespace rather than a
   directory another same-UID process actively mutates.
@@ -781,6 +796,7 @@ All borrowed incumbent, candidate-root, parent, and planned-directory
 descriptors remain owned by the aggregate and are valid only for its lifetime;
 borrowers must never close them. The primitive remains an authority boundary
 for trusted internal code, not a Python sandbox or full `_TreeOwnership`.
-`LocalWorkspaceProvider` does not yet integrate it, continues to reject
-the non-`None` binding whose derived expectation is `provider-bound-exact`.
-Gate C and M1 remain open.
+`LocalWorkspaceProvider` now integrates it for the non-`None` binding whose
+derived expectation is `provider-bound-exact`, using the separately active
+source owner only through the private one-shot gate. Gate C is complete; M1
+remains open on canonical A2 evidence and configured-default decisions.

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -280,8 +280,9 @@ return the authenticated file record, and staged and published validators run
 inside the same atomic publication boundary. The caller-owned receipt keeps its
 authenticated reader pinned through synchronous consumption. The contract
 remains provider-neutral, and a concrete `LocalWorkspaceProvider` now supplies
-it on Linux for missing destinations below one private, quiescent root owned by
-the current effective UID with exact mode `0700`. Native workspace-owner
+it on Linux for missing or active-receipt-bound exact destinations below one
+private, quiescent root owned by the current effective UID with exact mode
+`0700`. Native workspace-owner
 protocol v5 preserves the v2 publication contract: it pins the namespace and
 owns every file descriptor, acquires and writes files without exposing raw file
 descriptors to Python, and gates the only forward rename with a one-shot publish
@@ -481,22 +482,29 @@ It then replays and validates the same bytes through that contract before and
 after replacement without consulting mutable public source projections. Its
 `PlannedBm25View` is a short-lived in-process replay subject, not a catalog
 profile or durable job payload. Strict whole-context and retained
-materialization APIs are now available as injectable library producers. The
-Linux local provider deliberately accepts only missing destinations, so
-whole-context retained materialization can use it explicitly, while strict BM25
-replacement now sends the active source generation's exact destination binding
-and still lacks a concrete production provider. Protocol v5 and the
-three-phase Python dual-root seam now supply the lower-level exact exchange and
-receipt settlement, but `LocalWorkspaceProvider` rejects the non-`None`
-binding before mutation and does not select that seam. Gate C must carry the
-active source receipt owner through a private one-shot provider/session
-provenance gate, separately from the frozen request binding, and settle the old
-receipt/orphan handoff. The
-explicit retained workflows can now construct the whole-context producer for one
-existing catalog selection, publish normal compiler output, and load one
-selected generation at MCP cold start, but no default compiler/runtime route
-constructs them. M1 remains in progress and the M2 BM25 profile adapter is still
-outstanding.
+materialization APIs are now available as injectable library producers.
+`LocalWorkspaceProvider` preserves the missing-destination flow and now also
+selects the protocol-v5 replacement seam for strict BM25. The immutable request
+still contains only its receipt-derived destination binding. The top-level
+operation receives the separately active exact source owner and creates a
+private PID-bound, callback-scoped one-shot gate. That gate is tied by object
+identity to the request binding and operation, consumes the active source into
+`bind_replacement_source(...)`, and returns no owner or replayable capability.
+The exact callback cannot enter unless the same gate bound the same workspace;
+the Local provider then provisions only through the handed-off authority and
+the session publishes only through `publish_replacement_into(...)`. Gate C is
+complete. Exact mode treats `provision_timeout_ns` as three fresh budgets: one
+for capture and lease, one minted after source binding for provisioning, and
+one minted after the user build for the pre-exchange publication transaction.
+Candidate and incumbent scans, staged validation, and the binding rechecks
+consume the last absolute deadline; if they overrun it, native exchange observes
+expiry before namespace mutation. Published validation and post-exchange
+settlement retain their reconciliation contracts but are not controlled by
+that deadline. The explicit retained workflows can now construct the
+whole-context producer for one existing catalog selection, publish normal
+compiler output, and load one selected generation at MCP cold start, but no
+default compiler/runtime route constructs them. M1 remains in progress and the
+M2 BM25 profile adapter is still outstanding.
 
 Strict whole-context publication can now aggregate already-normalized BM25 and
 vector generations retained by active workspace receipt owners. The plan binds
@@ -843,14 +851,14 @@ initialize or populate the control plane, import a legacy cache, build views,
 advance refs, or make retained storage the default. Benchmark-backed promotion
 of the explicit compiler and runtime routes remains outstanding M1 work; graph
 and Zoekt cache ingress and fenced job publication remain M2 or later work.
-Strict BM25 replacement also still lacks the `provider-bound-exact` production
-provider. Protocol v5 and the dual-root publication authority implement exact
-preprovision binding, same-owner candidate adoption, exchange, receipt
-settlement, and displaced-incumbent handoff, but `LocalWorkspaceProvider`
-continues to reject the receipt-derived binding. The strict producer is wired
-to the authenticated request seam, but no provider supplies the separately
-active source-owner provenance needed to select the new operation. Provider
-integration remains separate.
+Strict BM25 replacement now has its `provider-bound-exact` production provider.
+The strict producer passes its separately active source owner outside the
+immutable request; a private one-shot gate binds it to the same request,
+destination-binding object, operation, native owner, and workspace before Local
+candidate mutation. Local then selects the protocol-v5 dual-root provision and
+publication seam. This completes Gate C without changing any compiler/runtime
+default, automatic orphan reclamation, crash recovery, or the remaining M1
+evidence requirements.
 
 #### Retained storage promotion protocol
 
@@ -867,7 +875,7 @@ that collecting a fast result cannot silently approve a production route:
 | B1 | Promote BM25 compiler publication to a configured default. | Pending A2 compiler. |
 | B2 | Promote query-only BM25 retained cold start to a configured default. | Pending A2 query-only runtime; this does not replace source-bound manifest MCP. |
 | B2 source-bound | Promote a specifically scoped source-bound BM25 retained cold start. | Pending A2 source-bound BM25 runtime; it cannot satisfy the full manifest-compatibility gate. |
-| C | Supply the `provider-bound-exact` strict BM25 native provider. | Protocol v5 provides the leased Linux-only `RENAME_EXCHANGE` primitive, and the Python authority now implements active-receipt preprovision binding, same-owner/slot/plan candidate adoption, separate dual-root validation, receipt-slot settlement, candidate-only postreceipt authority, and a reopenable displaced-incumbent orphan. The request still carries only its immutable destination binding: no provider/session path supplies the separately active source receipt owner required by `bind_replacement_source(...)`. `LocalWorkspaceProvider` therefore continues to reject every exact binding and cannot select this seam. Gate C remains pending and required before M1 closes; automatic GC, a crash journal, and hostile same-UID defense are outside this gate. |
+| C | Supply the `provider-bound-exact` strict BM25 native provider. | Complete. The request still carries only its immutable receipt-derived binding. `run_strict_workspace(...)` accepts the separately active exact source owner and gives Local only a PID-bound, callback-scoped one-shot gate tied by object identity to that request, binding, operation, native owner, and workspace. Local captures and leases before the gate synchronously binds the source, provisions only through the handed-off workspace, and publishes only through the protocol-v5 dual-root seam. The displaced incumbent remains a reopenable `linux-renameat2` orphan. Automatic GC, a crash journal, hostile same-UID defense, and default-route promotion remain outside Gate C. |
 
 The A1 harness fixes the BM25 `fast` compiler/runtime comparison rather than
 accepting arbitrary route substitutions. For compiler cold start, arm A runs

--- a/test/artifacts/test_strict_bm25_publication.py
+++ b/test/artifacts/test_strict_bm25_publication.py
@@ -101,12 +101,21 @@ class _TestWorkspaceProvider:
         *,
         receipt_owner: PublishedWorkspaceReceiptOwner,
         operation: Callable[[StrictWorkspaceSession], _Result],
+        _replacement_source: object | None = None,
     ) -> _Result:
         self.run_count += 1
         self.requests.append(request)
         plan = request.plan if self.workspace_plan is None else self.workspace_plan
         parent = request.destination.parent
         parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if request.destination_binding is not None and self.workspace_plan is None:
+            parent.chmod(0o700)
+            return LocalWorkspaceProvider(parent).run_workspace(
+                request,
+                receipt_owner=receipt_owner,
+                operation=operation,
+                _replacement_source=_replacement_source,  # type: ignore[arg-type]
+            )
         stage = parent / (
             f".{request.destination.name}.strict-{id(self):x}-{self.run_count}"
         )
@@ -142,6 +151,11 @@ class _TestWorkspaceProvider:
                     workspace=workspace,
                     receipt_owner=receipt_owner,
                     operation=operation,
+                    _replacement_timeout_ns=(
+                        1_000_000_000
+                        if request.destination_binding is not None
+                        else None
+                    ),
                 )
             except BaseException:
                 if receipt_owner.state == "empty":
@@ -356,6 +370,115 @@ def test_strict_bm25_plans_replays_and_serves_same_query_semantics(
         assert [doc.page_content for doc in before.retriever.invoke("VALUE")] == [
             doc.page_content for doc in after.retriever.invoke("VALUE")
         ]
+    finally:
+        output_owner.close()
+
+
+def test_strict_bm25_passes_source_owner_outside_the_immutable_request(
+    strict_generation,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = strict_generation
+    planned = plan_bm25_view_strict(
+        fixture.source_owner,
+        repository_source=fixture.repository_source,
+        view_config={},
+        environ={},
+    )
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider()
+    calls: list[tuple[StrictWorkspaceRequest, object]] = []
+    real_run = strict_bm25_module.run_strict_workspace
+
+    def inspect_run(
+        workspace_provider,
+        request,
+        *,
+        receipt_owner,
+        operation,
+        source_owner=None,
+    ):
+        calls.append((request, source_owner))
+        return real_run(
+            workspace_provider,
+            request,
+            receipt_owner=receipt_owner,
+            operation=operation,
+            source_owner=source_owner,
+        )
+
+    monkeypatch.setattr(strict_bm25_module, "run_strict_workspace", inspect_run)
+    try:
+        publish_planned_bm25_view_strict(
+            fixture.destination,
+            planned=planned,
+            source_generation=fixture.source_owner,
+            repository_source=fixture.repository_source,
+            workspace_provider=provider,
+            output_receipt_owner=output_owner,
+            view_config={},
+            environ={},
+        )
+        assert calls == [(provider.requests[0], fixture.source_owner)]
+        assert (
+            calls[0][0].destination_binding is fixture.source_owner.destination_binding
+        )
+        assert not hasattr(calls[0][0], "source_owner")
+        assert output_owner.active
+    finally:
+        output_owner.close()
+
+
+def test_strict_bm25_provider_cannot_drop_source_gate_and_launder_binding(
+    strict_generation,
+) -> None:
+    fixture = strict_generation
+    planned = plan_bm25_view_strict(
+        fixture.source_owner,
+        repository_source=fixture.repository_source,
+        view_config={},
+        environ={},
+    )
+    original_documents = fixture.destination.joinpath("documents.json").read_bytes()
+    output_owner = PublishedWorkspaceReceiptOwner()
+    delegate = _TestWorkspaceProvider(workspace_plan=planned.plan)
+
+    class DroppingProvider:
+        def require_support(self) -> None:
+            return None
+
+        def run_workspace(
+            self,
+            request,
+            *,
+            receipt_owner,
+            operation,
+            _replacement_source,
+        ):
+            del _replacement_source
+            return delegate.run_workspace(
+                request,
+                receipt_owner=receipt_owner,
+                operation=operation,
+            )
+
+    try:
+        with pytest.raises(RuntimeError, match="was not bound to this authority"):
+            publish_planned_bm25_view_strict(
+                fixture.destination,
+                planned=planned,
+                source_generation=fixture.source_owner,
+                repository_source=fixture.repository_source,
+                workspace_provider=DroppingProvider(),
+                output_receipt_owner=output_owner,
+                view_config={},
+                environ={},
+            )
+        assert output_owner.state == "empty"
+        assert fixture.source_owner.active
+        assert fixture.destination.joinpath("documents.json").read_bytes() == (
+            original_documents
+        )
     finally:
         output_owner.close()
 
@@ -890,7 +1013,7 @@ def test_strict_bm25_recapture_rejects_forbidden_policy_postflight(
         repository_source.close()
 
 
-def test_strict_bm25_rejects_missing_only_local_provider_before_mutation(
+def test_strict_bm25_uses_local_provider_for_exact_replacement(
     strict_generation,
     tmp_path: Path,
 ) -> None:
@@ -910,11 +1033,8 @@ def test_strict_bm25_rejects_missing_only_local_provider_before_mutation(
         pytest.skip(f"native local workspace provider is unavailable: {error}")
     output_owner = PublishedWorkspaceReceiptOwner()
 
-    with pytest.raises(
-        UnsupportedWorkspaceCreation,
-        match="requires a missing destination",
-    ):
-        publish_planned_bm25_view_strict(
+    try:
+        adjustments = publish_planned_bm25_view_strict(
             fixture.destination,
             planned=planned,
             source_generation=fixture.source_owner,
@@ -924,11 +1044,17 @@ def test_strict_bm25_rejects_missing_only_local_provider_before_mutation(
             view_config=view_config,
             environ={},
         )
-
-    assert output_owner.state == "empty"
-    assert fixture.source_owner.active
-    assert not tuple(tmp_path.glob(".codenib-workspace-stage-*"))
-    assert not tuple(tmp_path.glob(".codenib-workspace-orphan-*"))
+        assert output_owner.active
+        assert fixture.source_owner.active
+        assert output_owner.receipt.path == fixture.destination
+        assert output_owner.receipt.plan == planned.plan
+        assert output_owner.receipt.orphan is not None
+        assert set(adjustments["artifact_file_fingerprints"]) == {
+            "bm25_metadata.json",
+            "documents.json",
+        }
+    finally:
+        output_owner.close()
 
 
 def test_strict_bm25_high_level_freezes_caller_mappings_once(

--- a/test/test_local_workspace_provider.py
+++ b/test/test_local_workspace_provider.py
@@ -8,6 +8,7 @@ import errno
 import hashlib
 import os
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -16,6 +17,7 @@ import pytest
 import codenib
 import codenib._local_workspace_provider as local_provider_module
 import codenib._workspace_owner as workspace_owner
+import codenib._workspace_provider as workspace_provider_module
 from codenib._atomic_directory import publication_parent_identity
 from codenib._captured_directory import (
     PublishedWorkspaceDestinationBinding,
@@ -388,7 +390,7 @@ def test_local_provider_preserves_an_existing_destination(tmp_path: Path) -> Non
     assert receipt_owner.state == "empty"
 
 
-def test_local_provider_rejects_receipt_bound_exact_before_mutation(
+def test_local_provider_replaces_receipt_bound_exact_via_two_phase_seam(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -405,72 +407,553 @@ def test_local_provider_rejects_receipt_bound_exact_before_mutation(
     binding = source_owner.destination_binding
     request = _request(root, destination_binding=binding)
     receipt_owner = PublishedWorkspaceReceiptOwner()
-    before = tuple(sorted(path.name for path in root.iterdir()))
-    support_calls = 0
-    mutation_calls: list[str] = []
-    real_require_support = LocalWorkspaceProvider.require_support
+    events: list[str] = []
+    real_capture = workspace_owner.capture_owner_destination
+    real_lease = workspace_owner.acquire_owner_replacement_lease
+    real_bind = local_provider_module._ReplacementSourceGate.bind
+    real_provision = local_provider_module._PROVISION_BOUND_REPLACEMENT_EXACT
+    replay_errors: list[BaseException] = []
+    bound_gates: list[object] = []
 
-    def counted_require_support(self: LocalWorkspaceProvider) -> None:
-        nonlocal support_calls
-        support_calls += 1
-        real_require_support(self)
+    def capture(*args: object, **kwargs: object) -> None:
+        events.append("capture")
+        real_capture(*args, **kwargs)
 
-    def forbid_native_owner() -> object:
-        mutation_calls.append("create")
-        raise AssertionError("exact rejection reached native owner creation")
+    def lease(*args: object, **kwargs: object) -> None:
+        events.append("lease")
+        real_lease(*args, **kwargs)
 
-    def forbid_native_provision(*_args: object, **_kwargs: object) -> None:
-        mutation_calls.append("provision")
-        raise AssertionError("exact rejection reached native provisioning")
+    def bind(*args: object, **kwargs: object) -> None:
+        events.append("bind")
+        bound_gates.append(args[0])
+        real_bind(*args, **kwargs)
+        try:
+            real_bind(*args, **kwargs)
+        except BaseException as error:  # noqa: B036 - assert exact replay denial
+            replay_errors.append(error)
+        else:
+            raise AssertionError("replacement source gate allowed a second bind")
 
-    def forbid_replacement_seam(*_args: object, **_kwargs: object) -> None:
-        mutation_calls.append("replacement-seam")
-        raise AssertionError("Local exact rejection reached replacement authority")
+    def provision(*args: object, **kwargs: object) -> None:
+        events.append("provision")
+        real_provision(*args, **kwargs)
 
+    def forbid_missing_provision(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("exact replacement reached missing-only provisioning")
+
+    monkeypatch.setattr(workspace_owner, "capture_owner_destination", capture)
+    monkeypatch.setattr(workspace_owner, "acquire_owner_replacement_lease", lease)
+    monkeypatch.setattr(local_provider_module._ReplacementSourceGate, "bind", bind)
     monkeypatch.setattr(
-        LocalWorkspaceProvider,
-        "require_support",
-        counted_require_support,
+        local_provider_module,
+        "_PROVISION_BOUND_REPLACEMENT_EXACT",
+        provision,
     )
-    monkeypatch.setattr(workspace_owner, "create_owner", forbid_native_owner)
-    monkeypatch.setattr(
-        workspace_owner,
-        "provision_owner",
-        forbid_native_provision,
-    )
-    for method in (
-        "bind_replacement_source",
-        "provision_bound_replacement",
-        "publish_replacement_into",
-    ):
-        monkeypatch.setattr(
-            local_provider_module.OwnedWorkspaceAuthority,
-            method,
-            forbid_replacement_seam,
-        )
+    monkeypatch.setattr(workspace_owner, "provision_owner", forbid_missing_provision)
 
     try:
-        with pytest.raises(UnsupportedWorkspaceCreation, match="missing destination"):
+        record, _ownership = run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=receipt_owner,
+            operation=lambda session: _write_and_publish(session, b"new"),
+            source_owner=source_owner,
+        )
+
+        assert events == ["capture", "lease", "bind", "provision"]
+        assert len(bound_gates) == 1
+        assert len(replay_errors) == 1
+        assert isinstance(replay_errors[0], RuntimeError)
+        assert "no longer active" in str(replay_errors[0])
+        assert record.sha256 == hashlib.sha256(b"new").hexdigest()
+        assert request.destination.joinpath("data/result.json").read_bytes() == b"new"
+        assert source_owner.active
+        assert receipt_owner.active
+        bound_gate = bound_gates[0]
+        bound_workspace = bound_gate._bound_workspace  # type: ignore[attr-defined]
+        assert bound_workspace is not None
+        with pytest.raises(RuntimeError, match="no longer active"):
+            bound_gate._require_bound_workspace(  # type: ignore[attr-defined]
+                request,
+                bound_workspace,
+            )
+        orphan = receipt_owner.receipt.orphan
+        assert orphan is not None
+        assert orphan.locator.backend_tag == "linux-renameat2"
+        assert (
+            orphan.reopen(
+                lambda reader: reader.read_bytes(
+                    "data/result.json",
+                    max_bytes=16,
+                )
+            )
+            == b"old"
+        )
+    finally:
+        receipt_owner.close()
+        source_owner.close()
+
+
+def test_local_exact_mints_fresh_provision_and_publication_deadlines(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "authority"
+    source_provider = _require_native_provider(root)
+    source_owner = PublishedWorkspaceReceiptOwner()
+    source_request = _request(root)
+    run_strict_workspace(
+        source_provider,
+        source_request,
+        receipt_owner=source_owner,
+        operation=lambda session: _write_and_publish(session, b"old"),
+    )
+    timeout_ns = 10_000_000_000
+    provider = LocalWorkspaceProvider(root, provision_timeout_ns=timeout_ns)
+    request = _request(root, destination_binding=source_owner.destination_binding)
+    output_owner = PublishedWorkspaceReceiptOwner()
+    base_ns = local_provider_module.time.monotonic_ns()
+    capture_deadlines: list[int] = []
+    provision_deadlines: list[int] = []
+    publication_deadlines: list[int] = []
+    real_capture = workspace_owner.capture_owner_destination
+    real_bind = local_provider_module._ReplacementSourceGate.bind
+    real_provision = local_provider_module._PROVISION_BOUND_REPLACEMENT_EXACT
+    real_publish = workspace_provider_module._PUBLISH_REPLACEMENT_EXACT
+
+    def capture(
+        owner: object,
+        allowed_root: bytes,
+        destination: bytes,
+        deadline_ns: int,
+    ) -> None:
+        capture_deadlines.append(deadline_ns)
+        real_capture(owner, allowed_root, destination, deadline_ns)
+
+    def bind(*args: object, **kwargs: object) -> None:
+        real_bind(*args, **kwargs)
+        monkeypatch.setattr(
+            local_provider_module.time,
+            "monotonic_ns",
+            lambda: base_ns + 2 * timeout_ns,
+        )
+
+    def provision(workspace, *, deadline_ns: int) -> None:
+        provision_deadlines.append(deadline_ns)
+        real_provision(workspace, deadline_ns=deadline_ns)
+
+    def publish(workspace, receipt_owner, *, deadline_ns: int, **kwargs) -> None:
+        publication_deadlines.append(deadline_ns)
+        real_publish(
+            workspace,
+            receipt_owner,
+            deadline_ns=deadline_ns,
+            **kwargs,
+        )
+
+    monkeypatch.setattr(workspace_owner, "capture_owner_destination", capture)
+    monkeypatch.setattr(local_provider_module._ReplacementSourceGate, "bind", bind)
+    monkeypatch.setattr(
+        local_provider_module,
+        "_PROVISION_BOUND_REPLACEMENT_EXACT",
+        provision,
+    )
+    monkeypatch.setattr(
+        workspace_provider_module,
+        "_MONOTONIC_NS_EXACT",
+        lambda: base_ns + 4 * timeout_ns,
+    )
+    monkeypatch.setattr(
+        workspace_provider_module,
+        "_PUBLISH_REPLACEMENT_EXACT",
+        publish,
+    )
+
+    def operation(session: StrictWorkspaceSession) -> object:
+        # The operation gate already froze its clock. This later replacement
+        # must not collapse the publication deadline back to one timeout.
+        monkeypatch.setattr(
+            workspace_provider_module,
+            "_MONOTONIC_NS_EXACT",
+            lambda: 1,
+        )
+        return _write_and_publish(session, b"new")
+
+    try:
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=output_owner,
+            operation=operation,
+            source_owner=source_owner,
+        )
+        assert len(capture_deadlines) == 1
+        assert capture_deadlines[0] < base_ns + 2 * timeout_ns
+        assert provision_deadlines == [base_ns + 3 * timeout_ns]
+        assert publication_deadlines == [base_ns + 5 * timeout_ns]
+        assert output_owner.active
+    finally:
+        output_owner.close()
+        source_owner.close()
+
+
+def test_local_exact_never_uses_generic_workspace_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    source_owner = PublishedWorkspaceReceiptOwner()
+    source_request = _request(root)
+    run_strict_workspace(
+        provider,
+        source_request,
+        receipt_owner=source_owner,
+        operation=lambda session: _write_and_publish(session, b"old"),
+    )
+    request = _request(root, destination_binding=source_owner.destination_binding)
+    output_owner = PublishedWorkspaceReceiptOwner()
+
+    def forbid_generic(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("exact Local publication reached the generic helper")
+
+    monkeypatch.setattr(
+        local_provider_module.OwnedWorkspaceAuthority,
+        "publish_into",
+        forbid_generic,
+    )
+    try:
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=output_owner,
+            operation=lambda session: _write_and_publish(session, b"new"),
+            source_owner=source_owner,
+        )
+        assert output_owner.active
+        assert request.destination.joinpath("data/result.json").read_bytes() == b"new"
+    finally:
+        output_owner.close()
+        source_owner.close()
+
+
+def test_local_exact_freezes_gate_callbacks_before_provider_support(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "authority"
+    delegate = _require_native_provider(root)
+    source_owner = PublishedWorkspaceReceiptOwner()
+    source_request = _request(root)
+    run_strict_workspace(
+        delegate,
+        source_request,
+        receipt_owner=source_owner,
+        operation=lambda session: _write_and_publish(session, b"old"),
+    )
+    request = _request(root, destination_binding=source_owner.destination_binding)
+    output_owner = PublishedWorkspaceReceiptOwner()
+    intercepted: list[str] = []
+
+    def forbid_frozen_callback(*_args: object, **_kwargs: object) -> None:
+        intercepted.append("intercepted")
+        raise AssertionError("provider intercepted an exact callback")
+
+    class MutatingProvider:
+        def require_support(self) -> None:
+            for name in (
+                "_BIND_REPLACEMENT_SOURCE_EXACT",
+                "_MONOTONIC_NS_EXACT",
+                "_PUBLISH_REPLACEMENT_EXACT",
+                "_SOURCE_DESTINATION_BINDING_EXACT",
+                "_commit_provider_primary",
+                "_invoke_strict_workspace_provider",
+                "_settle_provider_operation_gate",
+                "_settle_replacement_source_gate",
+                "_snapshot_workspace_plan",
+            ):
+                monkeypatch.setattr(
+                    workspace_provider_module,
+                    name,
+                    forbid_frozen_callback,
+                )
+            delegate.require_support()
+
+        def run_workspace(
+            self,
+            bound_request: StrictWorkspaceRequest,
+            *,
+            receipt_owner: PublishedWorkspaceReceiptOwner,
+            operation,
+            _replacement_source,
+        ) -> object:
+            return delegate.run_workspace(
+                bound_request,
+                receipt_owner=receipt_owner,
+                operation=operation,
+                _replacement_source=_replacement_source,
+            )
+
+    try:
+        run_strict_workspace(
+            MutatingProvider(),
+            request,
+            receipt_owner=output_owner,
+            operation=lambda session: _write_and_publish(session, b"new"),
+            source_owner=source_owner,
+        )
+        assert intercepted == []
+        assert output_owner.active
+        assert request.destination.joinpath("data/result.json").read_bytes() == b"new"
+    finally:
+        output_owner.close()
+        source_owner.close()
+
+
+def test_local_exact_posthandoff_failure_delegates_cleanup_to_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    source_owner = PublishedWorkspaceReceiptOwner()
+    source_request = _request(root)
+    run_strict_workspace(
+        provider,
+        source_request,
+        receipt_owner=source_owner,
+        operation=lambda session: _write_and_publish(session, b"old"),
+    )
+    request = _request(root, destination_binding=source_owner.destination_binding)
+    output_owner = PublishedWorkspaceReceiptOwner()
+    failure = RuntimeError("injected posthandoff failure")
+
+    def fail_provision(*_args: object, **_kwargs: object) -> None:
+        raise failure
+
+    monkeypatch.setattr(
+        local_provider_module,
+        "_PROVISION_BOUND_REPLACEMENT_EXACT",
+        fail_provision,
+    )
+    try:
+        with pytest.raises(RuntimeError) as caught:
             run_strict_workspace(
                 provider,
                 request,
-                receipt_owner=receipt_owner,
-                operation=lambda session: _write_and_publish(
-                    session,
-                    b"forbidden",
-                ),
+                receipt_owner=output_owner,
+                operation=lambda session: _write_and_publish(session, b"new"),
+                source_owner=source_owner,
+            )
+        assert caught.value is failure
+        assert output_owner.state == "empty"
+        assert source_owner.active
+        assert request.destination.joinpath("data/result.json").read_bytes() == b"old"
+        assert not tuple(root.glob(".codenib-workspace-stage-*"))
+    finally:
+        output_owner.close()
+        source_owner.close()
+
+
+def test_local_exact_gate_bind_failure_releases_lease_before_handoff(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    source_owner = PublishedWorkspaceReceiptOwner()
+    source_request = _request(root)
+    run_strict_workspace(
+        provider,
+        source_request,
+        receipt_owner=source_owner,
+        operation=lambda session: _write_and_publish(session, b"old"),
+    )
+    request = _request(root, destination_binding=source_owner.destination_binding)
+    failed_output_owner = PublishedWorkspaceReceiptOwner()
+    successful_output_owner = PublishedWorkspaceReceiptOwner()
+    failure = KeyboardInterrupt("injected gate bind failure")
+    real_bind = local_provider_module._ReplacementSourceGate.bind
+
+    def fail_bind(*_args: object, **_kwargs: object) -> None:
+        raise failure
+
+    monkeypatch.setattr(
+        local_provider_module._ReplacementSourceGate,
+        "bind",
+        fail_bind,
+    )
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=failed_output_owner,
+                operation=lambda session: _write_and_publish(session, b"forbidden"),
+                source_owner=source_owner,
             )
 
-        assert tuple(sorted(path.name for path in root.iterdir())) == before
-        assert not tuple(root.glob(".codenib-workspace-stage-*"))
-        assert not tuple(root.glob(".codenib-workspace-orphan-*"))
-        assert request.destination.joinpath("data/result.json").read_bytes() == b"old"
+        assert caught.value is failure
+        assert failed_output_owner.state == "empty"
         assert source_owner.active
-        assert receipt_owner.state == "empty"
-        assert support_calls == 1
-        assert mutation_calls == []
+        assert (
+            source_owner.consume(
+                lambda _receipt, reader: reader.read_bytes(
+                    "data/result.json",
+                    max_bytes=16,
+                )
+            )
+            == b"old"
+        )
+        assert not tuple(root.glob(".codenib-workspace-stage-*"))
+
+        # A second exact replacement must acquire the released native lease.
+        monkeypatch.setattr(
+            local_provider_module._ReplacementSourceGate,
+            "bind",
+            real_bind,
+        )
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=successful_output_owner,
+            operation=lambda session: _write_and_publish(session, b"new"),
+            source_owner=source_owner,
+        )
+        assert successful_output_owner.active
+        assert request.destination.joinpath("data/result.json").read_bytes() == b"new"
     finally:
-        receipt_owner.close()
+        failed_output_owner.close()
+        successful_output_owner.close()
+        source_owner.close()
+
+
+def test_local_exact_user_cancellation_quarantines_provisioned_candidate(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    source_owner = PublishedWorkspaceReceiptOwner()
+    source_request = _request(root)
+    run_strict_workspace(
+        provider,
+        source_request,
+        receipt_owner=source_owner,
+        operation=lambda session: _write_and_publish(session, b"old"),
+    )
+    request = _request(root, destination_binding=source_owner.destination_binding)
+    output_owner = PublishedWorkspaceReceiptOwner()
+    cancellation = KeyboardInterrupt("injected prepublication cancellation")
+
+    def cancel_before_publication(session: StrictWorkspaceSession) -> None:
+        session.write_file("data/result.json", (b"new",))
+        raise cancellation
+
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=output_owner,
+                operation=cancel_before_publication,
+                source_owner=source_owner,
+            )
+
+        assert caught.value is cancellation
+        trace_names: list[str] = []
+        traceback = caught.value.__traceback__
+        while traceback is not None:
+            trace_names.append(traceback.tb_frame.f_code.co_name)
+            traceback = traceback.tb_next
+        assert "cancel_before_publication" in trace_names
+        assert output_owner.state == "empty"
+        assert source_owner.active
+        assert (
+            source_owner.consume(
+                lambda _receipt, reader: reader.read_bytes(
+                    "data/result.json",
+                    max_bytes=16,
+                )
+            )
+            == b"old"
+        )
+        quarantined = tuple(root.glob(".codenib-workspace-stage-*"))
+        assert len(quarantined) == 1
+        assert quarantined[0].joinpath("data/result.json").read_bytes() == b"new"
+    finally:
+        output_owner.close()
+        source_owner.close()
+
+
+def test_local_exact_staged_validation_expiry_restores_incumbent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "authority"
+    source_provider = _require_native_provider(root)
+    source_owner = PublishedWorkspaceReceiptOwner()
+    source_request = _request(root)
+    run_strict_workspace(
+        source_provider,
+        source_request,
+        receipt_owner=source_owner,
+        operation=lambda session: _write_and_publish(session, b"old"),
+    )
+    timeout_ns = 1_000_000_000
+    provider = LocalWorkspaceProvider(root, provision_timeout_ns=timeout_ns)
+    request = _request(root, destination_binding=source_owner.destination_binding)
+    output_owner = PublishedWorkspaceReceiptOwner()
+    real_monotonic_ns = time.monotonic_ns
+    staged_calls = 0
+    monkeypatch.setattr(
+        workspace_provider_module,
+        "_MONOTONIC_NS_EXACT",
+        lambda: real_monotonic_ns() - timeout_ns + 20_000_000,
+    )
+
+    def operation(session: StrictWorkspaceSession) -> None:
+        session.write_file("data/result.json", (b"new",))
+
+        def expire_before_exchange(_reader) -> None:
+            nonlocal staged_calls
+            staged_calls += 1
+            time.sleep(0.05)
+
+        session.publish_validated(expire_before_exchange)
+
+    try:
+        with pytest.raises(TimeoutError, match="deadline expired"):
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=output_owner,
+                operation=operation,
+                source_owner=source_owner,
+            )
+        assert staged_calls == 1
+        # Publication reserved the caller slot before validation, so the slot
+        # retains cleanup authority but never exposes an active receipt.
+        assert output_owner.state == "cleanup"
+        assert not output_owner.active
+        assert source_owner.active
+        assert request.destination.joinpath("data/result.json").read_bytes() == b"old"
+        assert (
+            source_owner.consume(
+                lambda _receipt, reader: reader.read_bytes(
+                    "data/result.json",
+                    max_bytes=16,
+                )
+            )
+            == b"old"
+        )
+        quarantined = tuple(root.glob(".codenib-workspace-stage-*"))
+        assert len(quarantined) == 1
+        assert quarantined[0].joinpath("data/result.json").read_bytes() == b"new"
+        output_owner.close()
+        assert output_owner.closed
+        assert tuple(root.glob(".codenib-workspace-stage-*")) == quarantined
+    finally:
+        output_owner.close()
         source_owner.close()
 
 

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -958,6 +958,11 @@ def test_protocol_v5_workspace_replacement_limits_are_documented() -> None:
         "WorkspaceReceiptToken",
     ):
         assert symbol in provider
-    assert "the provider remains missing-only" in provider_prose
-    assert "Gate C and M1 remain open" in provider_prose
-    assert "Gate C remains pending and required before M1 closes" in roadmap
+    assert "This completes Gate C" in provider_prose
+    assert "Gate C is complete; M1 remains open" in provider_prose
+    assert "default route promotion" in provider_prose
+    assert (
+        "| C | Supply the `provider-bound-exact` strict BM25 native "
+        "provider. | Complete." in roadmap
+    )
+    assert "M1 remains in progress" in roadmap

--- a/test/test_workspace_provider.py
+++ b/test/test_workspace_provider.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import hashlib
 import os
 import signal
+import sys
 import threading
 from pathlib import Path
 from typing import Callable
@@ -38,6 +39,37 @@ def _plan() -> WorkspacePlan:
         subject_digest=hashlib.sha256(b"workspace-provider-test").hexdigest(),
         files=(WorkspaceFile(Path("payload.bin"), max_bytes=32),),
     )
+
+
+def _active_replacement_source_gate(
+    request: StrictWorkspaceRequest,
+    source_owner: PublishedWorkspaceReceiptOwner,
+) -> workspace_provider._ReplacementSourceGate:
+    lifecycle = [False, False, False, True]
+    gate = workspace_provider._ReplacementSourceGate(
+        request,
+        source_owner,
+        lifecycle=lifecycle,
+    )
+    lifecycle[3] = False
+    lifecycle[0] = True
+    lifecycle[2] = True
+    return gate
+
+
+def _active_provider_operation_gate(
+    request: StrictWorkspaceRequest,
+    operation: Callable[[StrictWorkspaceSession], object],
+) -> workspace_provider._ProviderOperationGate:
+    lifecycle = [False, False, True]
+    gate = workspace_provider._ProviderOperationGate(
+        request,
+        operation,
+        lifecycle=lifecycle,
+    )
+    lifecycle[2] = False
+    lifecycle[0] = True
+    return gate
 
 
 def _interrupt_before_store_attr(
@@ -81,6 +113,7 @@ class _TestProvider:
         self.support_checks = 0
         self.runs = 0
         self.last_workspace: OwnedWorkspaceAuthority | None = None
+        self.last_replacement_source: object | None = None
         self.adopted_destination = adopted_destination
         self.destination_binding = destination_binding
 
@@ -93,8 +126,10 @@ class _TestProvider:
         *,
         receipt_owner: PublishedWorkspaceReceiptOwner,
         operation: Callable[[StrictWorkspaceSession], object],
+        _replacement_source: object | None = None,
     ) -> object:
         self.runs += 1
+        self.last_replacement_source = _replacement_source
         destination = self.adopted_destination or request.destination
         parent = destination.parent
         parent.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -124,6 +159,9 @@ class _TestProvider:
                 workspace=workspace,
                 receipt_owner=receipt_owner,
                 operation=operation,
+                _replacement_timeout_ns=(
+                    1_000_000_000 if request.destination_binding is not None else None
+                ),
             )
         finally:
             os.close(root_descriptor)
@@ -308,6 +346,837 @@ def test_request_accepts_only_exact_binding_for_its_lexical_destination(
                 destination_binding=forged,
             )
     finally:
+        source_owner.close()
+
+
+def test_exact_request_requires_its_separate_active_source_before_provider(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    source_owner = _publish_generation(destination)
+    request = StrictWorkspaceRequest(
+        "replace",
+        destination,
+        _plan(),
+        destination_binding=source_owner.destination_binding,
+    )
+    provider = _TestProvider()
+    output_owner = PublishedWorkspaceReceiptOwner()
+    try:
+        with pytest.raises(TypeError, match="exact receipt owner"):
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=output_owner,
+                operation=lambda _session: None,
+            )
+        assert provider.support_checks == provider.runs == 0
+        assert source_owner.active
+        assert output_owner.state == "empty"
+        assert destination.joinpath("payload.bin").read_bytes() == b"same bytes"
+    finally:
+        output_owner.close()
+        source_owner.close()
+
+
+def test_exact_request_rejects_another_active_source_by_binding_identity(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    source_owner = _publish_generation(destination)
+    other_owner = _publish_generation(tmp_path / "other")
+    request = StrictWorkspaceRequest(
+        "replace",
+        destination,
+        _plan(),
+        destination_binding=source_owner.destination_binding,
+    )
+    provider = _TestProvider()
+    output_owner = PublishedWorkspaceReceiptOwner()
+    try:
+        with pytest.raises(ValueError, match="differs from its request"):
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=output_owner,
+                operation=lambda _session: None,
+                source_owner=other_owner,
+            )
+        assert provider.support_checks == provider.runs == 0
+        assert source_owner.active and other_owner.active
+        assert output_owner.state == "empty"
+    finally:
+        output_owner.close()
+        other_owner.close()
+        source_owner.close()
+
+
+def test_missing_request_rejects_replacement_source_before_provider(
+    tmp_path: Path,
+) -> None:
+    source_owner = _publish_generation(tmp_path / "source")
+    request = StrictWorkspaceRequest("missing", tmp_path / "output", _plan())
+    provider = _TestProvider()
+    output_owner = PublishedWorkspaceReceiptOwner()
+    try:
+        with pytest.raises(ValueError, match="missing strict workspace"):
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=output_owner,
+                operation=lambda _session: None,
+                source_owner=source_owner,
+            )
+        assert provider.support_checks == provider.runs == 0
+        assert output_owner.state == "empty"
+        assert not request.destination.exists()
+    finally:
+        output_owner.close()
+        source_owner.close()
+
+
+def test_exact_source_constructor_return_interruption_retains_inactive_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    source_owner = _publish_generation(destination)
+    request = StrictWorkspaceRequest(
+        "replace",
+        destination,
+        _plan(),
+        destination_binding=source_owner.destination_binding,
+    )
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestProvider()
+    failure = KeyboardInterrupt("replacement constructor return interruption")
+    retained: list[workspace_provider._ReplacementSourceGate] = []
+    gate_type = workspace_provider._ReplacementSourceGate
+    initialize = gate_type.__init__
+
+    def interrupted_init(self, *args, **kwargs) -> None:
+        initialize(self, *args, **kwargs)
+        retained.append(self)
+        raise failure
+
+    monkeypatch.setattr(gate_type, "__init__", interrupted_init)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=output_owner,
+                operation=lambda _session: None,
+                source_owner=source_owner,
+            )
+
+        assert caught.value is failure
+        assert len(retained) == 1
+        gate = retained[0]
+        assert gate._lifecycle == [False, False, False, False]
+        with pytest.raises(RuntimeError, match="no longer active"):
+            gate.bind(  # type: ignore[arg-type]
+                object(),
+                object(),
+                ".late-constructor-stage",
+                request.plan,
+            )
+        assert provider.support_checks == provider.runs == 0
+        assert output_owner.state == "empty"
+        assert (
+            source_owner.consume(
+                lambda _receipt, reader: reader.read_bytes(
+                    "payload.bin",
+                    max_bytes=32,
+                )
+            )
+            == b"same bytes"
+        )
+    finally:
+        output_owner.close()
+        source_owner.close()
+
+
+@pytest.mark.parametrize("exact", [False, True], ids=["missing", "exact"])
+def test_operation_constructor_return_interruption_retains_inactive_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exact: bool,
+) -> None:
+    destination = tmp_path / "published"
+    source_owner = _publish_generation(destination) if exact else None
+    request = StrictWorkspaceRequest(
+        "replace" if exact else "missing",
+        destination,
+        _plan(),
+        destination_binding=(
+            source_owner.destination_binding if source_owner is not None else None
+        ),
+    )
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestProvider()
+    failure = KeyboardInterrupt("operation constructor return interruption")
+    retained: list[workspace_provider._ProviderOperationGate] = []
+    gate_type = workspace_provider._ProviderOperationGate
+    initialize = gate_type.__init__
+
+    def interrupted_init(self, *args, **kwargs) -> None:
+        initialize(self, *args, **kwargs)
+        retained.append(self)
+        raise failure
+
+    monkeypatch.setattr(gate_type, "__init__", interrupted_init)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=output_owner,
+                operation=lambda _session: None,
+                source_owner=source_owner,
+            )
+
+        assert caught.value is failure
+        assert len(retained) == 1
+        gate = retained[0]
+        assert gate._lifecycle == [False, False, False]
+        with pytest.raises(RuntimeError, match="no longer active"):
+            gate(object())  # type: ignore[arg-type]
+        if exact:
+            replacement_source = gate._replacement_source
+            assert replacement_source is not None
+            assert replacement_source._lifecycle == [False, False, False, False]
+            with pytest.raises(RuntimeError, match="no longer active"):
+                replacement_source.bind(  # type: ignore[arg-type]
+                    object(),
+                    object(),
+                    ".late-operation-constructor-stage",
+                    request.plan,
+                )
+            assert provider.support_checks == 0
+        else:
+            assert provider.support_checks == 1
+        assert provider.runs == 0
+        assert output_owner.state == "empty"
+        if source_owner is None:
+            assert not destination.exists()
+        else:
+            assert (
+                source_owner.consume(
+                    lambda _receipt, reader: reader.read_bytes(
+                        "payload.bin",
+                        max_bytes=32,
+                    )
+                )
+                == b"same bytes"
+            )
+    finally:
+        output_owner.close()
+        if source_owner is not None:
+            source_owner.close()
+
+
+@pytest.mark.parametrize("exact", [False, True], ids=["missing", "exact"])
+def test_activation_interruption_revokes_outer_owned_gate_cells(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exact: bool,
+) -> None:
+    destination = tmp_path / "published"
+    source_owner = _publish_generation(destination) if exact else None
+    request = StrictWorkspaceRequest(
+        "replace" if exact else "missing",
+        destination,
+        _plan(),
+        destination_binding=(
+            source_owner.destination_binding if source_owner is not None else None
+        ),
+    )
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestProvider()
+    failure = KeyboardInterrupt("gate activation interruption")
+    operation_gates: list[workspace_provider._ProviderOperationGate] = []
+    source_gates: list[workspace_provider._ReplacementSourceGate] = []
+    operation_init = workspace_provider._ProviderOperationGate.__init__
+    source_init = workspace_provider._ReplacementSourceGate.__init__
+
+    def capture_operation_gate(self, *args, **kwargs) -> None:
+        operation_init(self, *args, **kwargs)
+        operation_gates.append(self)
+
+    def capture_source_gate(self, *args, **kwargs) -> None:
+        source_init(self, *args, **kwargs)
+        source_gates.append(self)
+
+    monkeypatch.setattr(
+        workspace_provider._ProviderOperationGate,
+        "__init__",
+        capture_operation_gate,
+    )
+    monkeypatch.setattr(
+        workspace_provider._ReplacementSourceGate,
+        "__init__",
+        capture_source_gate,
+    )
+    injected: list[bool] = []
+    target_code = run_strict_workspace.__code__
+    previous_trace = sys.gettrace()
+
+    def interrupt_active_cells(frame, event, _argument):
+        if not injected and event == "line" and frame.f_code is target_code:
+            operation_lifecycle = frame.f_locals.get("operation_lifecycle")
+            replacement_lifecycle = frame.f_locals.get("replacement_lifecycle")
+            operation_active = (
+                type(operation_lifecycle) is list and operation_lifecycle[0]
+            )
+            replacement_active = (
+                type(replacement_lifecycle) is list
+                and replacement_lifecycle[0]
+                and replacement_lifecycle[2]
+            )
+            if operation_active and (not exact or replacement_active):
+                injected.append(True)
+                raise failure
+        return interrupt_active_cells
+
+    try:
+        sys.settrace(interrupt_active_cells)
+        with pytest.raises(KeyboardInterrupt) as caught:
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=output_owner,
+                operation=lambda _session: None,
+                source_owner=source_owner,
+            )
+    finally:
+        sys.settrace(previous_trace)
+
+    try:
+        assert caught.value is failure
+        assert injected == [True]
+        assert len(operation_gates) == 1
+        operation_gate = operation_gates[0]
+        assert operation_gate._lifecycle == [False, False, False]
+        with pytest.raises(RuntimeError, match="no longer active"):
+            operation_gate(object())  # type: ignore[arg-type]
+        if exact:
+            assert len(source_gates) == 1
+            source_gate = source_gates[0]
+            assert source_gate._lifecycle == [False, False, False, False]
+            with pytest.raises(RuntimeError, match="no longer active"):
+                source_gate.bind(  # type: ignore[arg-type]
+                    object(),
+                    object(),
+                    ".late-activation-stage",
+                    request.plan,
+                )
+        else:
+            assert source_gates == []
+        assert provider.support_checks == 1
+        assert provider.runs == 0
+        assert output_owner.state == "empty"
+        if source_owner is None:
+            assert not destination.exists()
+        else:
+            assert (
+                source_owner.consume(
+                    lambda _receipt, reader: reader.read_bytes(
+                        "payload.bin",
+                        max_bytes=32,
+                    )
+                )
+                == b"same bytes"
+            )
+    finally:
+        output_owner.close()
+        if source_owner is not None:
+            source_owner.close()
+
+
+@pytest.mark.parametrize("exact", [False, True], ids=["missing", "exact"])
+def test_cleanup_entry_interruption_retries_both_gate_settlements(
+    tmp_path: Path,
+    exact: bool,
+) -> None:
+    destination = tmp_path / "published"
+    source_owner = _publish_generation(destination) if exact else None
+    request = StrictWorkspaceRequest(
+        "replace" if exact else "missing",
+        destination,
+        _plan(),
+        destination_binding=(
+            source_owner.destination_binding if source_owner is not None else None
+        ),
+    )
+    output_owner = PublishedWorkspaceReceiptOwner()
+    returned = object()
+    failure = KeyboardInterrupt("cleanup entry interruption")
+
+    class ReturningProvider:
+        def __init__(self) -> None:
+            self.support_checks = 0
+            self.runs = 0
+            self.operation_gate = None
+            self.source_gate = None
+
+        def require_support(self) -> None:
+            self.support_checks += 1
+
+        def run_workspace(
+            self,
+            _request,
+            *,
+            receipt_owner,
+            operation,
+            _replacement_source=None,
+        ) -> object:
+            del receipt_owner
+            self.runs += 1
+            self.operation_gate = operation
+            self.source_gate = _replacement_source
+            return returned
+
+    provider = ReturningProvider()
+    injected: list[int] = []
+    target_code = workspace_provider._invoke_strict_workspace_provider.__code__
+    previous_trace = sys.gettrace()
+
+    def interrupt_first_cleanup_line(frame, event, _argument):
+        if (
+            not injected
+            and event == "line"
+            and frame.f_code is target_code
+            and frame.f_locals.get("result") is returned
+        ):
+            operation_lifecycle = frame.f_locals.get("operation_lifecycle")
+            replacement_lifecycle = frame.f_locals.get("replacement_lifecycle")
+            operation_active = (
+                type(operation_lifecycle) is list and operation_lifecycle[0]
+            )
+            replacement_active = (
+                type(replacement_lifecycle) is list
+                and replacement_lifecycle[0]
+                and replacement_lifecycle[2]
+            )
+            if operation_active and (not exact or replacement_active):
+                injected.append(frame.f_lineno)
+                raise failure
+        return interrupt_first_cleanup_line
+
+    try:
+        sys.settrace(interrupt_first_cleanup_line)
+        with pytest.raises(KeyboardInterrupt) as caught:
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=output_owner,
+                operation=lambda _session: None,
+                source_owner=source_owner,
+            )
+    finally:
+        sys.settrace(previous_trace)
+
+    try:
+        assert caught.value is failure
+        assert len(injected) == 1
+        assert provider.support_checks == provider.runs == 1
+        operation_gate = provider.operation_gate
+        assert type(operation_gate) is workspace_provider._ProviderOperationGate
+        assert operation_gate._lifecycle == [False, False, False], injected
+        with pytest.raises(RuntimeError, match="no longer active"):
+            operation_gate(object())
+        if exact:
+            source_gate = provider.source_gate
+            assert type(source_gate) is workspace_provider._ReplacementSourceGate
+            assert source_gate._lifecycle == [False, False, False, False]
+            with pytest.raises(RuntimeError, match="no longer active"):
+                source_gate.bind(  # type: ignore[arg-type]
+                    object(),
+                    object(),
+                    ".late-cleanup-stage",
+                    request.plan,
+                )
+        else:
+            assert provider.source_gate is None
+        assert output_owner.state == "empty"
+        if source_owner is None:
+            assert not destination.exists()
+        else:
+            assert (
+                source_owner.consume(
+                    lambda _receipt, reader: reader.read_bytes(
+                        "payload.bin",
+                        max_bytes=32,
+                    )
+                )
+                == b"same bytes"
+            )
+    finally:
+        output_owner.close()
+        if source_owner is not None:
+            source_owner.close()
+
+
+@pytest.mark.parametrize("exact", [False, True], ids=["missing", "exact"])
+@pytest.mark.parametrize("seam", ["commit-entry", "cleanup-entry"])
+def test_cleanup_entry_interruption_preserves_provider_primary(
+    tmp_path: Path,
+    exact: bool,
+    seam: str,
+) -> None:
+    destination = tmp_path / "published"
+    source_owner = _publish_generation(destination) if exact else None
+    request = StrictWorkspaceRequest(
+        "replace" if exact else "missing",
+        destination,
+        _plan(),
+        destination_binding=(
+            source_owner.destination_binding if source_owner is not None else None
+        ),
+    )
+    output_owner = PublishedWorkspaceReceiptOwner()
+    primary = RuntimeError("provider-primary")
+    secondary = KeyboardInterrupt("cleanup-entry-secondary")
+
+    class FailingProvider:
+        def __init__(self) -> None:
+            self.support_checks = 0
+            self.runs = 0
+            self.operation_gate = None
+            self.source_gate = None
+
+        def require_support(self) -> None:
+            self.support_checks += 1
+
+        def run_workspace(
+            self,
+            _request,
+            *,
+            receipt_owner,
+            operation,
+            _replacement_source=None,
+        ) -> object:
+            del receipt_owner
+            self.runs += 1
+            self.operation_gate = operation
+            self.source_gate = _replacement_source
+            raise primary
+
+    provider = FailingProvider()
+    injected: list[int] = []
+    target_code = workspace_provider._invoke_strict_workspace_provider.__code__
+    previous_trace = sys.gettrace()
+
+    def interrupt_first_cleanup_line(frame, event, _argument):
+        provider_primary = frame.f_locals.get("provider_primary")
+        at_commit_entry = (
+            seam == "commit-entry"
+            and frame.f_locals.get("exc") is primary
+            and type(provider_primary) is list
+            and provider_primary[0] is None
+        )
+        at_cleanup_entry = (
+            seam == "cleanup-entry" and frame.f_locals.get("primary_error") is primary
+        )
+        if (
+            not injected
+            and event == "line"
+            and frame.f_code is target_code
+            and (at_commit_entry or at_cleanup_entry)
+        ):
+            operation_lifecycle = frame.f_locals.get("operation_lifecycle")
+            replacement_lifecycle = frame.f_locals.get("replacement_lifecycle")
+            operation_active = (
+                type(operation_lifecycle) is list and operation_lifecycle[0]
+            )
+            replacement_active = (
+                type(replacement_lifecycle) is list
+                and replacement_lifecycle[0]
+                and replacement_lifecycle[2]
+            )
+            if operation_active and (not exact or replacement_active):
+                injected.append(frame.f_lineno)
+                raise secondary
+        return interrupt_first_cleanup_line
+
+    try:
+        sys.settrace(interrupt_first_cleanup_line)
+        with pytest.raises(RuntimeError) as caught:
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=output_owner,
+                operation=lambda _session: None,
+                source_owner=source_owner,
+            )
+    finally:
+        sys.settrace(previous_trace)
+
+    try:
+        assert caught.value is primary
+        assert len(injected) == 1
+        trace_names: list[str] = []
+        traceback = caught.value.__traceback__
+        while traceback is not None:
+            trace_names.append(traceback.tb_frame.f_code.co_name)
+            traceback = traceback.tb_next
+        assert "run_workspace" in trace_names
+        assert any(
+            "provider cleanup boundary also failed" in note
+            and "cleanup-entry-secondary" in note
+            for note in _notes(primary)
+        )
+        assert provider.support_checks == provider.runs == 1
+        operation_gate = provider.operation_gate
+        assert type(operation_gate) is workspace_provider._ProviderOperationGate
+        assert operation_gate._lifecycle == [False, False, False]
+        with pytest.raises(RuntimeError, match="no longer active"):
+            operation_gate(object())
+        if exact:
+            source_gate = provider.source_gate
+            assert type(source_gate) is workspace_provider._ReplacementSourceGate
+            assert source_gate._lifecycle == [False, False, False, False]
+            with pytest.raises(RuntimeError, match="no longer active"):
+                source_gate.bind(  # type: ignore[arg-type]
+                    object(),
+                    object(),
+                    ".late-primary-cleanup-stage",
+                    request.plan,
+                )
+        else:
+            assert provider.source_gate is None
+        assert output_owner.state == "empty"
+        if source_owner is None:
+            assert not destination.exists()
+        else:
+            assert (
+                source_owner.consume(
+                    lambda _receipt, reader: reader.read_bytes(
+                        "payload.bin",
+                        max_bytes=32,
+                    )
+                )
+                == b"same bytes"
+            )
+    finally:
+        output_owner.close()
+        if source_owner is not None:
+            source_owner.close()
+
+
+def test_stashed_replacement_source_gate_is_revoked_without_instance_store(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    source_owner = _publish_generation(destination)
+    request = StrictWorkspaceRequest(
+        "replace",
+        destination,
+        _plan(),
+        destination_binding=source_owner.destination_binding,
+    )
+    output_owner = PublishedWorkspaceReceiptOwner()
+    stashed: list[object] = []
+    attempted_stores: list[str] = []
+    gate_type = workspace_provider._ReplacementSourceGate
+    inherited_setattr = gate_type.__setattr__
+
+    def forbid_instance_store(instance, name, value) -> None:
+        attempted_stores.append(name)
+        raise KeyboardInterrupt("permanent replacement-gate store interruption")
+
+    class StashingProvider:
+        def require_support(self) -> None:
+            return None
+
+        def run_workspace(
+            self,
+            _request,
+            *,
+            receipt_owner,
+            operation,
+            _replacement_source,
+        ) -> object:
+            del receipt_owner, operation
+            stashed.append(_replacement_source)
+            gate_type.__setattr__ = forbid_instance_store
+            return object()
+
+    try:
+        with pytest.raises(RuntimeError, match="did not invoke its operation"):
+            run_strict_workspace(
+                StashingProvider(),
+                request,
+                receipt_owner=output_owner,
+                operation=lambda _session: None,
+                source_owner=source_owner,
+            )
+    finally:
+        gate_type.__setattr__ = inherited_setattr
+
+    assert attempted_stores == []
+    assert len(stashed) == 1
+    gate = stashed[0]
+    workspace = OwnedWorkspaceAuthority()
+    try:
+        with pytest.raises(RuntimeError, match="no longer active"):
+            gate.bind(  # type: ignore[attr-defined]
+                workspace,
+                object(),
+                ".late-stage",
+                request.plan,
+            )
+    finally:
+        workspace.close()
+        output_owner.close()
+        source_owner.close()
+
+
+def test_exact_support_baseexception_revokes_gate_retained_by_traceback(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    source_owner = _publish_generation(destination)
+    request = StrictWorkspaceRequest(
+        "replace",
+        destination,
+        _plan(),
+        destination_binding=source_owner.destination_binding,
+    )
+    output_owner = PublishedWorkspaceReceiptOwner()
+    failure = KeyboardInterrupt("injected exact support failure")
+    support_calls = 0
+    run_called = False
+
+    class FailingSupportProvider:
+        def require_support(self) -> None:
+            nonlocal support_calls
+            support_calls += 1
+            raise failure
+
+        def run_workspace(self, *_args: object, **_kwargs: object) -> object:
+            nonlocal run_called
+            run_called = True
+            raise AssertionError("exact support failure reached provider execution")
+
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            run_strict_workspace(
+                FailingSupportProvider(),
+                request,
+                receipt_owner=output_owner,
+                operation=lambda _session: None,
+                source_owner=source_owner,
+            )
+
+        assert caught.value is failure
+        retained_gates: list[object] = []
+        traceback = caught.value.__traceback__
+        while traceback is not None:
+            candidate = traceback.tb_frame.f_locals.get("replacement_source")
+            if type(candidate) is workspace_provider._ReplacementSourceGate:
+                retained_gates.append(candidate)
+            traceback = traceback.tb_next
+        assert retained_gates
+        gate = retained_gates[0]
+        assert all(candidate is gate for candidate in retained_gates)
+        assert gate._lifecycle == [  # type: ignore[attr-defined]
+            False,
+            False,
+            False,
+            False,
+        ]
+        workspace = OwnedWorkspaceAuthority()
+        try:
+            with pytest.raises(RuntimeError, match="no longer active"):
+                gate.bind(  # type: ignore[attr-defined]
+                    workspace,
+                    object(),
+                    ".late-support-stage",
+                    request.plan,
+                )
+        finally:
+            workspace.close()
+        assert support_calls == 1
+        assert not run_called
+        assert output_owner.state == "empty"
+        assert source_owner.active
+        assert destination.joinpath("payload.bin").read_bytes() == b"same bytes"
+        assert (
+            source_owner.consume(
+                lambda _receipt, reader: reader.read_bytes(
+                    "payload.bin",
+                    max_bytes=32,
+                )
+            )
+            == b"same bytes"
+        )
+    finally:
+        output_owner.close()
+        source_owner.close()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_replacement_source_gate_pid_boundary_precedes_argument_inspection(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    source_owner = _publish_generation(destination)
+    request = StrictWorkspaceRequest(
+        "replace",
+        destination,
+        _plan(),
+        destination_binding=source_owner.destination_binding,
+    )
+    gate = _active_replacement_source_gate(request, source_owner)
+    try:
+        exit_code, payload = _fork_expect_pid_boundary(
+            lambda: gate.bind(  # type: ignore[arg-type]
+                object(),
+                object(),
+                ".child-stage",
+                request.plan,
+            ),
+            expected_message=(
+                "strict workspace replacement source cannot cross a PID boundary"
+            ),
+        )
+        assert exit_code == 0, payload
+        assert payload == "expected PID boundary"
+        assert gate._lifecycle == [True, False, True, False]
+        assert source_owner.active
+    finally:
+        gate.revoke()
+        source_owner.close()
+
+
+def test_replacement_source_gate_reentrant_bind_preserves_parent_lifecycle(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    source_owner = _publish_generation(destination)
+    request = StrictWorkspaceRequest(
+        "replace",
+        destination,
+        _plan(),
+        destination_binding=source_owner.destination_binding,
+    )
+    gate = _active_replacement_source_gate(request, source_owner)
+    try:
+        with pytest.raises(RuntimeError, match="bind is reentrant"):
+            gate._lock.run(
+                lambda: gate.bind(  # type: ignore[arg-type]
+                    object(),
+                    object(),
+                    ".reentrant-stage",
+                    request.plan,
+                )
+            )
+        assert gate._lifecycle == [True, False, True, False]
+        assert source_owner.active
+    finally:
+        gate.revoke()
         source_owner.close()
 
 
@@ -794,6 +1663,7 @@ def test_adopted_workspace_rejects_missing_binding_for_exact_request(
                 request,
                 receipt_owner=owner,
                 operation=operation,
+                source_owner=source_owner,
             )
 
         assert called is False
@@ -826,20 +1696,17 @@ def test_provider_bound_exact_request_replaces_only_captured_destination(
         )
 
     try:
-        assert (
+        with pytest.raises(RuntimeError, match="was not bound to this authority"):
             run_strict_workspace(
                 provider,
                 request,
                 receipt_owner=owner,
                 operation=operation,
+                source_owner=source_owner,
             )
-            == b"owned"
-        )
-        assert owner.active
-        assert owner.receipt.orphan is not None
-        assert provider.last_workspace is not None
-        assert provider.last_workspace.expected_destination_binding is binding
-        assert destination.joinpath("payload.bin").read_bytes() == b"owned"
+        assert owner.state == "empty"
+        assert source_owner.active
+        assert destination.joinpath("payload.bin").read_bytes() == b"old"
     finally:
         owner.close()
         source_owner.close()
@@ -879,6 +1746,7 @@ def test_session_compares_entire_genuine_destination_binding(
                 request,
                 receipt_owner=output_owner,
                 operation=operation,
+                source_owner=first_owner,
             )
         assert called is False
         assert output_owner.state == "empty"
@@ -917,6 +1785,7 @@ def test_provider_cannot_launder_independently_captured_tree_token(
                 request,
                 receipt_owner=output_owner,
                 operation=operation,
+                source_owner=source_owner,
             )
         assert called is False
         assert output_owner.state == "empty"
@@ -1168,6 +2037,7 @@ def test_operation_primary_survives_session_revocation_failure(
 def test_provider_primary_survives_callback_revocation_failure(
     tmp_path: Path,
     primary_type: type[BaseException],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     primary = primary_type("provider-primary")
 
@@ -1187,14 +2057,21 @@ def test_provider_primary_survives_callback_revocation_failure(
         )
 
     injected: list[bool] = []
+    deactivate = workspace_provider._ProviderOperationGate._deactivate
+
+    def interrupt_deactivate(self) -> None:
+        if not injected:
+            injected.append(True)
+            raise RuntimeError("provider-revocation-secondary")
+        deactivate(self)
+
+    monkeypatch.setattr(
+        workspace_provider._ProviderOperationGate,
+        "_deactivate",
+        interrupt_deactivate,
+    )
     with pytest.raises(primary_type, match="provider-primary") as caught:
-        _interrupt_before_store_attr(
-            run,
-            target_type=workspace_provider._ProviderOperationGate,
-            attribute="_active",
-            error=RuntimeError("provider-revocation-secondary"),
-            injected=injected,
-        )
+        run()
 
     assert caught.value is primary
     assert injected == [True]
@@ -1308,7 +2185,7 @@ def test_provider_operation_pid_boundary_precedes_inherited_gate(
         worker_values: list[object] = []
         worker_errors: list[BaseException] = []
 
-        operation_gate = workspace_provider._ProviderOperationGate(
+        operation_gate = _active_provider_operation_gate(
             request,
             lambda _session: None,
         )


### PR DESCRIPTION
## Summary

Enable receipt-bound exact replacement in `LocalWorkspaceProvider` by carrying active source ownership through a private PID-bound, one-shot gate into protocol-v5 dual-root publication.

This completes Gate C only. M1 evidence and default promotion, crash journaling, and automatic orphan GC remain open.

Related to #199.

## Changes

- Bind exact replacement to the same request, destination binding, operation, native owner, and adopted workspace before candidate mutation.
- Give destination capture and lease, post-source-scan provisioning, and pre-exchange publication independent exact-mode deadline budgets.
- Route Local provisioning and publication through the bound protocol-v5 workspace APIs while preserving missing-destination behavior.
- Pass strict BM25 source ownership separately from the immutable request and fail closed across cancellation, constructor-return, cleanup, fork, PID, reentrancy, and replay boundaries.
- Document Gate C completion without promoting compiler or runtime defaults or claiming crash recovery or automatic orphan reclamation.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Workspace provider, Local provider, and captured-directory batch: `200 passed`.
- Strict BM25 and strict context publication batch: `59 passed`.
- Release-artifact and documentation-contract batch: `30 passed`.
- Strict vector publication and manifest materialization batch: `39 passed, 2 skipped`.
- Full unit marker tier in a read-only `bwrap` environment: `7160 passed, 71 skipped, 190 deselected`.
- The host run with the rebuilt protocol-v5 extension reached `3658 passed, 49 skipped` before stopping solely because `/usr/bin/docker` is not installed; no code failure occurred.
- Black, isort, flake8, Python compilation, and `git diff --check`: pass.
- MkDocs strict build and public-documentation boundary checks: pass.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
