### PR TITLE
refactor(web): centralize graph freshness checks

### DIFF
--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -222,8 +222,8 @@ class RepoBundle:
 
     def info(self) -> RepoInfo:
         capabilities = dict(self.manifest.capabilities)
-        # The prebuilt indexes ship a symbol graph that the manifest doesn't
-        # declare; surface a "codemap" capability so the UI can offer the mode.
+        # Advertise codemap only when the manifest declares a current, readable
+        # symbol graph that this runtime can decode.
         graph_path = self._graph_path()
         graph_load_failed = getattr(self, "_code_graph_loaded", False) and (
             getattr(self, "_code_graph", None) is None
@@ -293,50 +293,26 @@ class RepoBundle:
         )
 
     def _graph_path(self) -> Optional[str]:
-        """Locate this repo's prebuilt symbol-graph pickle, if any.
-
-        The manifest only declares bm25/vector, but the prebuilt tree ships a
-        ``graph.pkl`` alongside the vector store (and, when present, via a
-        ``symbol_graph`` entry), so probe the legacy vector location only when
-        there is no explicit graph entry. Result is cached.
-        """
+        """Locate the current manifest-bound symbol-graph pickle, if any."""
         cached = getattr(self, "_graph_path_cache", "?")
         if cached != "?":
             return cached
-        candidates: List[str] = []
-        sg = self.manifest.indexes.get("symbol_graph")
-        if sg is not None:
-            if self._view_is_current(sg) and getattr(sg, "path", None):
-                candidates.append(
-                    sg.path
-                    if sg.path.endswith(".pkl")
-                    else os.path.join(sg.path, "graph.pkl")
-                )
-        else:
-            vec = self.manifest.indexes.get("vector")
-            if (
-                vec is not None
-                and self._view_is_current(vec)
-                and getattr(vec, "path", None)
-            ):
-                candidates.append(os.path.join(vec.path, "graph.pkl"))
-        found = next((p for p in candidates if p and os.path.isfile(p)), None)
+        found = None
+        entry = self.manifest.indexes.get("symbol_graph")
+        if (
+            entry is not None
+            and self.manifest.index_is_current("symbol_graph")
+            and getattr(entry, "path", None)
+        ):
+            candidate = (
+                entry.path
+                if entry.path.endswith(".pkl")
+                else os.path.join(entry.path, "graph.pkl")
+            )
+            if os.path.isfile(candidate):
+                found = candidate
         self._graph_path_cache = found
         return found
-
-    def _view_is_current(self, entry: Any) -> bool:
-        """Whether a persisted view is eligible for the manifest's snapshot."""
-
-        if getattr(entry, "status", None) != "fresh":
-            return False
-        view_commit = str(getattr(entry, "commit", "") or "")
-        manifest_commit = str(getattr(self.manifest, "commit", "") or "")
-        if view_commit and manifest_commit and view_commit != manifest_commit:
-            return False
-        manifest_source = str(getattr(self.manifest, "source_fingerprint", "") or "")
-        if not manifest_source:
-            return True
-        return str(getattr(entry, "source_fingerprint", "") or "") == manifest_source
 
     def _graph_schema_version(self) -> Optional[int]:
         """Return the persisted graph schema using a bounded, safe prefix read."""
@@ -377,7 +353,7 @@ class RepoBundle:
         if path is None:
             return None
         graph_entry = self.manifest.indexes.get("symbol_graph")
-        if graph_entry is None or not self._view_is_current(graph_entry):
+        if graph_entry is None or not self.manifest.index_is_current("symbol_graph"):
             self._code_graph_error = (
                 "symbol graph has no current manifest-bound artifact entry"
             )

--- a/docs/cognitive_debt_roadmap.md
+++ b/docs/cognitive_debt_roadmap.md
@@ -135,8 +135,14 @@ commands or speculative model serving.
 
 ### S2: One repository runtime
 
-Status: pending.
+Status: in progress.
 
+- [x] Make Web graph eligibility use canonical `RepoManifest` freshness and
+      remove its weaker local implementation and the unusable legacy vector
+      sidecar discovery path.
+- Define the supported `RepositoryContextExplorer` context protocol, migrate
+  duck-typed consumers to canonical manifests, and only then remove its
+  status-only freshness compatibility fallback.
 - Extract one neutral manifest/source/view loader from MCP `ServerContext`, Web
   `RepoRegistry`, and `compiler.skill_context`.
 - Make MCP, Web, Wiki, and `RepositoryContextExplorer` adapters over that
@@ -187,6 +193,7 @@ Status: pending.
 | 2026-08-24 | Begin the cognitive-debt program with pure subtraction | This baseline and the SCIP acceleration receipts | First subtraction iteration opened |
 | 2026-08-24 | Treat failed Python chunk acceleration candidates as closed experiments | Exact revisions, parity, timings, RSS, and gate decisions remain in `scip_multilanguage_roadmap.md` | Remove POC/gate code, ABIs, commands, tests, and active instructions |
 | 2026-08-24 | Retire three unowned retrieval evaluation scripts | RFC #133 remains closed and canonical retrieval metrics remain covered in `codenib.eval.retrieval_eval` | Remove the transitional comparator, manual smoke, and duplicate metric recomputation |
+| 2026-08-24 | Start runtime convergence at manifest freshness | `RepoManifest.index_is_current` already owns commit, fingerprint, and source-selection identity; authenticated graph loading requires a `symbol_graph` entry | Delete the weaker Web-only freshness rule and the unusable vector-sidecar discovery path; add rejection regressions |
 
 ## Completion Gate
 

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -67,6 +67,37 @@ def _repo_entry(repo, manifest_path, *, instance_id="owner__repo-1"):
     )
 
 
+def _legacy_view_manifest(
+    index_type,
+    path,
+    *,
+    status="fresh",
+    view_commit="",
+    manifest_commit="",
+    source_fingerprint="",
+    config=None,
+    metadata=None,
+):
+    entry = IndexEntry(
+        index_type=index_type,
+        path=path,
+        built_at="2026-08-24T00:00:00Z",
+        built_at_epoch=0.0,
+        status=status,
+        config=dict(config or {}),
+        metadata=dict(metadata or {}),
+        commit=view_commit,
+        source_fingerprint=source_fingerprint,
+    )
+    return RepoManifest(
+        version="1.1",
+        source_selection=None,
+        commit=manifest_commit,
+        source_fingerprint=source_fingerprint,
+        indexes={index_type: entry},
+    )
+
+
 @pytest.fixture
 def native_authorization(monkeypatch):
     token = object()
@@ -374,22 +405,16 @@ def test_bundle_rejects_graph_paths_outside_authenticated_selection(tmp_path):
     )
     bundle = RepoBundle(
         entry=SimpleNamespace(instance_id="owner__repo-1"),
-        manifest=SimpleNamespace(
-            commit="abc123",
-            source_fingerprint="",
-            indexes={
-                "symbol_graph": SimpleNamespace(
-                    status="fresh",
-                    commit="abc123",
-                    source_fingerprint="",
-                    path=str(graph_dir),
-                    config={
-                        "graph_artifact": {
-                            "relative_path": "graph.pkl",
-                            **regular_file_fingerprint(graph_path),
-                        }
-                    },
-                )
+        manifest=_legacy_view_manifest(
+            "symbol_graph",
+            str(graph_dir),
+            view_commit="abc123",
+            manifest_commit="abc123",
+            config={
+                "graph_artifact": {
+                    "relative_path": "graph.pkl",
+                    **regular_file_fingerprint(graph_path),
+                }
             },
         ),
         source_reader=binding.borrow_reader(),
@@ -568,15 +593,12 @@ def test_bundle_rejects_graphs_outside_the_manifest_snapshot(
     (graph_dir / "graph.pkl").write_bytes(b"stale graph")
     bundle = RepoBundle(
         entry=SimpleNamespace(),
-        manifest=SimpleNamespace(
-            commit="new-commit",
-            indexes={
-                "symbol_graph": SimpleNamespace(
-                    status=status,
-                    commit=view_commit,
-                    path=str(graph_dir),
-                )
-            },
+        manifest=_legacy_view_manifest(
+            "symbol_graph",
+            str(graph_dir),
+            status=status,
+            view_commit=view_commit,
+            manifest_commit="new-commit",
         ),
     )
 
@@ -590,41 +612,69 @@ def test_bundle_accepts_fresh_graph_for_manifest_snapshot(tmp_path):
     graph_path.write_bytes(b"current graph")
     bundle = RepoBundle(
         entry=SimpleNamespace(),
-        manifest=SimpleNamespace(
-            commit="new-commit",
-            indexes={
-                "symbol_graph": SimpleNamespace(
-                    status="fresh",
-                    commit="new-commit",
-                    path=str(graph_dir),
-                )
-            },
+        manifest=_legacy_view_manifest(
+            "symbol_graph",
+            str(graph_dir),
+            view_commit="new-commit",
+            manifest_commit="new-commit",
         ),
     )
 
     assert bundle._graph_path() == str(graph_path)
 
 
-def test_bundle_accepts_legacy_graph_beside_current_vector_view(tmp_path):
+def test_bundle_rejects_graph_from_a_different_source_selection(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "private").mkdir()
+    (repo / "src" / "runtime.py").write_text("def runtime():\n    return 1\n")
+    (repo / "private" / "secret.py").write_text("SECRET = True\n")
+    selection = RepositorySourceSelection(("private",))
+    source = fingerprint_repository(repo, selection=selection)
+
+    graph_dir = tmp_path / "symbol_graph"
+    graph_dir.mkdir()
+    graph_path = graph_dir / "graph.pkl"
+    graph_path.write_bytes(b"graph built for another source selection")
+    entry = IndexEntry(
+        index_type="symbol_graph",
+        path=str(graph_dir),
+        built_at="2026-08-24T00:00:00Z",
+        built_at_epoch=0.0,
+        status="fresh",
+        commit="abc123",
+        source_fingerprint=source.value,
+        source_selection_digest=RepositorySourceSelection().digest,
+    )
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        commit="abc123",
+        source_fingerprint=source.value,
+        source_selection=selection,
+        indexes={"symbol_graph": entry},
+    )
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=manifest)
+
+    assert manifest.index_is_current("symbol_graph") is False
+    assert bundle._graph_path() is None
+
+
+def test_bundle_rejects_legacy_graph_without_a_symbol_graph_entry(tmp_path):
     vector_dir = tmp_path / "vector"
     vector_dir.mkdir()
     graph_path = vector_dir / "graph.pkl"
     graph_path.write_bytes(b"legacy current graph")
     bundle = RepoBundle(
         entry=SimpleNamespace(),
-        manifest=SimpleNamespace(
-            commit="new-commit",
-            indexes={
-                "vector": SimpleNamespace(
-                    status="fresh",
-                    commit="new-commit",
-                    path=str(vector_dir),
-                )
-            },
+        manifest=_legacy_view_manifest(
+            "vector",
+            str(vector_dir),
+            view_commit="new-commit",
+            manifest_commit="new-commit",
         ),
     )
 
-    assert bundle._graph_path() == str(graph_path)
+    assert bundle._graph_path() is None
 
 
 def test_bundle_explains_schema_mismatch_without_advertising_codemap(
@@ -634,6 +684,15 @@ def test_bundle_explains_schema_mismatch_without_advertising_codemap(
     graph_dir.mkdir()
     with (graph_dir / "graph.pkl").open("wb") as handle:
         pickle.dump({"schema_version": 4}, handle)
+    manifest = _legacy_view_manifest(
+        "symbol_graph",
+        str(graph_dir),
+        view_commit="abc123456789",
+        manifest_commit="abc123456789",
+    )
+    manifest.capabilities = {"symbol_navigation": True}
+    manifest.languages = ["python"]
+    manifest.file_count = 1
     bundle = RepoBundle(
         entry=SimpleNamespace(
             instance_id="org__repo",
@@ -644,21 +703,7 @@ def test_bundle_explains_schema_mismatch_without_advertising_codemap(
             problem_statement="",
             repo_dir=str(tmp_path),
         ),
-        manifest=SimpleNamespace(
-            capabilities={"symbol_navigation": True},
-            languages=["python"],
-            file_count=1,
-            source_fingerprint="",
-            indexes={
-                "symbol_graph": SimpleNamespace(
-                    status="fresh",
-                    commit="abc123456789",
-                    path=str(graph_dir),
-                    metadata={},
-                )
-            },
-            commit="abc123456789",
-        ),
+        manifest=manifest,
     )
 
     def reject_old_graph(_path):


### PR DESCRIPTION
## Summary

Make Web symbol-graph eligibility use the canonical manifest freshness contract. Remove a weaker duplicate predicate and a legacy vector-sidecar discovery path that could advertise codemap but could never pass the authenticated graph loader.

## Changes

- replace Web-only commit/fingerprint freshness logic with `RepoManifest.index_is_current("symbol_graph")`
- stop guessing `graph.pkl` beside a vector view when the manifest has no `symbol_graph` entry
- add real-manifest regressions for source-selection drift, stale views, missing graph entries, and current legacy manifests
- record the first S2 runtime-convergence step and preserve the explicit compatibility boundary for `RepositoryContextExplorer`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/web/test_repo_registry.py test/compiler/test_manifest.py --tb=short` — 108 passed
- `python -m compileall -q codenib test/web/test_repo_registry.py`
- `python -m mkdocs build --strict`, public-doc boundary check, and namespace check
- fixed-version pre-commit hooks across the complete PR diff
- synthetic final-tree gate covering CodeGraph, chunking, manifest, Web, skill context, eval metrics, and import boundaries — 236 passed

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published