### PR TITLE
fix(core): enforce vendored igraph header layout

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -154,6 +154,79 @@ jobs:
           echo "run-slow=$RUN_SLOW ($REASON)"
 
   # =============================================================
+  # Hosted vendored-core proof — clean build without system igraph headers
+  # =============================================================
+  vendored-core-build:
+    needs: preflight
+    if: needs.preflight.outputs.should-run == 'true' && needs.preflight.outputs.run-serial == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Install vendored-core build deps
+        run: |
+          sudo apt-get update -y
+          sudo apt-get remove -y libigraph-dev
+          sudo apt-get install -y --no-install-recommends \
+            bison \
+            build-essential \
+            cmake \
+            flex \
+            libre2-dev \
+            pkg-config \
+            zlib1g-dev
+
+      - name: Verify vendored-only igraph preconditions
+        run: |
+          set -euo pipefail
+          if test -e /usr/include/igraph.h || \
+             test -e /usr/local/include/igraph.h || \
+             test -e /usr/include/igraph/igraph.h || \
+             test -e /usr/local/include/igraph/igraph.h || \
+             pkg-config --exists igraph; then
+            echo "::error::hosted proof requires no system igraph development files"
+            exit 1
+          fi
+          if printf '#include <igraph/igraph.h>\n' | \
+               c++ -E -x c++ - >/dev/null 2>&1; then
+            echo "::error::compiler unexpectedly resolved the installed igraph header layout"
+            exit 1
+          fi
+          if printf '#include <igraph.h>\n' | \
+               c++ -E -x c++ - >/dev/null 2>&1; then
+            echo "::error::compiler unexpectedly resolved a flat system igraph header"
+            exit 1
+          fi
+          if grep -R -n -F \
+               --include='*.cpp' \
+               --include='*.h' \
+               '#include <igraph/igraph.h>' core; then
+            echo "::error::core sources must not use the installed igraph header layout"
+            exit 1
+          fi
+          grep -Fqx '#include <igraph.h>' core/code_graph.h
+
+      - name: Build vendored core from a cold tree
+        run: |
+          set -euo pipefail
+          test ! -e build/vendored-core
+          cmake -S core -B build/vendored-core \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCODENIB_BUILD_PYBIND=OFF
+          cmake --build build/vendored-core \
+            --target codenib_core \
+            --parallel 2
+          test -f build/vendored-core/_deps/igraph-build/src/libigraph.a
+          test -f build/vendored-core/libcodenib_core.a
+          grep -F '_deps/igraph-src/include' \
+            build/vendored-core/compile_commands.json
+          grep -F '_deps/igraph-build/include' \
+            build/vendored-core/compile_commands.json
+
+  # =============================================================
   # Job 1 — Unit tests  (pure logic, mocks only, ~1 min)
   # =============================================================
   unit:
@@ -357,7 +430,7 @@ jobs:
   # $CODENIB_SCIP_CACHE with graph_ref.pkl per language.)
   # =============================================================
   scip-core:
-    needs: [preflight, integration-serial]
+    needs: [preflight, integration-serial, vendored-core-build]
     if: needs.preflight.outputs.should-run == 'true' && needs.preflight.outputs.run-serial == 'true'
     runs-on: self-hosted
     timeout-minutes: 30
@@ -517,8 +590,8 @@ jobs:
   # Job 4 — Slow tests  (LLM API, GPU embeddings, ~15 min)
   # =============================================================
   slow:
-    needs: [preflight, unit, integration, integration-serial, scip-core, graph-consumer]
-    if: always() && needs.preflight.outputs.should-run == 'true' && needs.preflight.outputs.run-slow == 'true' && needs.unit.result == 'success' && needs.integration.result == 'success' && (needs.integration-serial.result == 'success' || needs.integration-serial.result == 'skipped') && (needs.scip-core.result == 'success' || needs.scip-core.result == 'skipped') && (needs.graph-consumer.result == 'success' || needs.graph-consumer.result == 'skipped')
+    needs: [preflight, unit, integration, integration-serial, vendored-core-build, scip-core, graph-consumer]
+    if: always() && needs.preflight.outputs.should-run == 'true' && needs.preflight.outputs.run-slow == 'true' && needs.unit.result == 'success' && needs.integration.result == 'success' && (needs.integration-serial.result == 'success' || needs.integration-serial.result == 'skipped') && (needs.vendored-core-build.result == 'success' || needs.vendored-core-build.result == 'skipped') && (needs.scip-core.result == 'success' || needs.scip-core.result == 'skipped') && (needs.graph-consumer.result == 'success' || needs.graph-consumer.result == 'skipped')
     runs-on: self-hosted
     timeout-minutes: 60
     env:

--- a/core/code_graph.h
+++ b/core/code_graph.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <igraph/igraph.h>
+#include <igraph.h>
 
 #include <optional>
 #include <string>

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -87,15 +87,15 @@ integration, slow, or serial graph jobs for prose-only edits.
 ## Jobs
 
 Pull requests run one hosted `unit` job from `ci.yml`. The trusted
-`ci-full.yml` workflow has **7 jobs** wired into a dependency chain rooted at a
-hosted `preflight` decision job; its six test jobs use the persistent
-self-hosted runner for toolchain and graph-cache reuse. Documentation,
-labeling, packaging, release, and publication workflows use ephemeral
-GitHub-hosted runners.
+`ci-full.yml` workflow has **8 jobs** wired into a dependency chain rooted at a
+hosted `preflight` decision job. A second hosted job performs a clean vendored
+C++ core build, while the other six test jobs use the persistent self-hosted
+runner for toolchain and graph-cache reuse. Documentation, labeling, packaging,
+release, and publication workflows use ephemeral GitHub-hosted runners.
 
-```
-preflight ─ unit ─ integration ─ integration-serial ─┬─ scip-core ──────┐
-                                                     └─ graph-consumer ─┴─ slow
+```text
+preflight ┬─ vendored-core-build ─────────────────────┐
+          └─ unit ─ integration ─ integration-serial ─┴─ scip-core ─ graph-consumer ─ slow
 ```
 
 `slow` lists the **entire chain** in `needs` and runs last; its `if` tolerates
@@ -104,12 +104,13 @@ preflight ─ unit ─ integration ─ integration-serial ─┬─ scip-core �
 | Job | `needs` | Runner | Marker / command | Timeout |
 |-----|---------|--------|------------------|---------|
 | **preflight** | — | ubuntu-latest | Decision job; no tests | — |
+| **vendored-core-build** | `preflight` | ubuntu-latest | Cold CMake build of `codenib_core` without system igraph headers | 20 min |
 | **unit** | `preflight` | self-hosted | `not slow and not integration and not integration_serial and not integration_serial_consumer` | 20 min |
 | **integration** | `preflight`, `unit` | self-hosted | `integration and not slow` | 30 min |
 | **integration-serial** | `preflight`, `integration` | self-hosted | `integration_serial` | 45 min |
-| **scip-core** | `preflight`, `integration-serial` | self-hosted | `make core-test` (C++ executables plus SCIP/Fact/clangd parity) | 30 min |
-| **graph-consumer** | `preflight`, `integration-serial` | self-hosted | `integration_serial_consumer` | 15 min |
-| **slow** | `preflight`, `unit`, `integration`, `integration-serial`, `scip-core`, `graph-consumer` | self-hosted | `slow` | 60 min |
+| **scip-core** | `preflight`, `integration-serial`, `vendored-core-build` | self-hosted | `make core-test` (C++ executables plus SCIP/Fact/clangd parity) | 30 min |
+| **graph-consumer** | `preflight`, `integration-serial`, `scip-core` | self-hosted | `integration_serial_consumer` | 15 min |
+| **slow** | all preceding jobs | self-hosted | `slow` | 60 min |
 
 ### preflight — the decision job
 
@@ -119,8 +120,9 @@ other job gates on:
 - **`should-run`** — `true` unless the run was explicitly skipped (see
   [Skip mechanisms](#skip-mechanisms)). Every test job is guarded by
   `if: needs.preflight.outputs.should-run == 'true'`.
-- **`run-serial`** — whether the heavy serial chain
-  (`integration-serial` → `scip-core` / `graph-consumer`) should run.
+- **`run-serial`** — whether the hosted `vendored-core-build` proof and the
+  self-hosted serial chain (`integration-serial` → `scip-core` →
+  `graph-consumer`) should run.
 - **`run-slow`** — whether the opt-in `slow` tier should run (see
   [Skip mechanisms](#skip-mechanisms)).
 
@@ -180,11 +182,26 @@ still run for a release-only version change.
 
 Changes outside this list — agent, runtime, model, retrieval, eval — use the
 faster unit + integration tier on the post-merge push. When `run-serial` stays
-`false`, the serial chain (`integration-serial`, `scip-core`, `graph-consumer`)
-is skipped while `unit` and `integration` still run. Maintainers can run the
-entire chain before merge locally or through a reviewed manual dispatch; the
-checked-in PR workflow does not route pull-request code to the persistent
-runner.
+`false`, the serial gates (`vendored-core-build`, `integration-serial`,
+`scip-core`, `graph-consumer`) are skipped while `unit` and `integration` still
+run. Maintainers can run the entire chain before merge locally or through a
+reviewed manual dispatch; the checked-in PR workflow does not route
+pull-request code to the persistent runner.
+
+### vendored-core-build
+
+This hosted job proves that the native core builds against the c-igraph target
+exported by `FetchContent`, without an installed system igraph development
+package masking header-layout mistakes. It starts from an uncached checkout,
+installs only the non-igraph compiler dependencies, rejects both
+`<igraph/igraph.h>` in the core sources and system igraph headers or pkg-config
+metadata, and confirms with compiler probes that neither the installed-layout
+`<igraph/igraph.h>` nor the flat `<igraph.h>` header resolves before CMake
+configures the vendored dependency. It then configures with
+`CODENIB_BUILD_PYBIND=OFF`, builds the `codenib_core` target, and verifies that
+the vendored c-igraph archive, CodeNib archive, and vendored source/build include
+paths are all present. The job is gated by `run-serial`, so core and CI changes,
+scheduled runs, and manual full runs exercise it; light runs skip it.
 
 ### unit
 
@@ -294,12 +311,12 @@ pytest -m "integration_serial_consumer" -v --tb=short
 
 LLM API calls, HuggingFace downloads, and GPU embeddings. Runs
 **last**: its `needs` lists the entire chain (`preflight`, `unit`,
-`integration`, `integration-serial`, `scip-core`, `graph-consumer`) under an
-`if: always() && ...` guard that requires `unit` and `integration` to have
-**succeeded** and each serial-chain job to be **success or skipped**. A light
-run (serial chain gated off) can therefore still reach `slow`, but any
-serial-chain failure blocks it. The job itself only runs when `preflight` set
-`run-slow=true` (see [Skip mechanisms](#skip-mechanisms)). This tier is
+`integration`, `integration-serial`, `vendored-core-build`, `scip-core`,
+`graph-consumer`) under an `if: always() && ...` guard that requires `unit` and
+`integration` to have **succeeded** and each serial-chain job to be **success or
+skipped**. A light run (serial chain gated off) can therefore still reach
+`slow`, but any serial-chain failure blocks it. The job itself only runs when
+`preflight` sets `run-slow=true` (see [Skip mechanisms](#skip-mechanisms)). This tier is
 intentionally not xdist-parallelized because embedding model loads can exhaust
 shared GPU memory when started by multiple workers. Sets up GCP credentials and
 `VERTEXAI_PROJECT`, selects `VERTEXAI_LOCATION` from the repository variable
@@ -384,9 +401,9 @@ fires, or the serial chain is gated off) and **explicit** (`should-run=false`).
   *every* changed file matches one of: `**.md`, `docs/**`, `LICENSE`,
   `.gitignore`.
 - **Serial-chain path gating** — on a default-branch push, the serial chain
-  (`integration-serial`, `scip-core`, `graph-consumer`) is skipped unless the
-  change touches the serial-chain path allowlist. Scheduled runs and
-  `workflow_dispatch` with `test_tier=full` always run it. See
+  (`vendored-core-build`, `integration-serial`, `scip-core`, `graph-consumer`)
+  is skipped unless the change touches the serial-chain path allowlist.
+  Scheduled runs and `workflow_dispatch` with `test_tier=full` always run it. See
   [preflight](#preflight-the-decision-job).
 - **Slow tier gating** — `slow` is skipped on default-branch pushes. It runs
   for scheduled full CI or `workflow_dispatch` with `test_tier=full`.

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -595,6 +595,9 @@ containment `ref=8 cand=8 missing=0 extra=0`, and references `ref=1 cand=0`.
 - [x] Keep a manifest-driven large-repository profiling harness for active
   SCIP languages whose C++ acceleration status is still serial-only or needs
   revalidation.
+- [x] Gate the maintained C++ parity tier behind a clean hosted
+  `vendored-core-build` that rejects system igraph headers and pkg-config
+  metadata before building `codenib_core` from the FetchContent dependency.
 - [x] Retire the [#558](https://github.com/sysevol-ai/CodeNib/issues/558)
   native Python chunk-span POC after exact parity passed but the 20%
   end-to-end promotion gate failed; retain its measurements here rather than
@@ -628,6 +631,14 @@ end-to-end Kotlin cold-start graph time, so Kotlin does not cross the 20% C++
 acceleration gate yet. Kotlin, PHP, and Scala should get C++ acceleration only
 after larger real-repo profiles show local decode/build is a material
 bottleneck.
+
+Native core build-integrity status: trusted full CI now runs the hosted
+`vendored-core-build` before `scip-core`. The job removes the system c-igraph
+development package, rejects both flat and installed-layout system igraph
+headers or pkg-config metadata, and cold-builds `codenib_core` against the
+FetchContent source and build include trees. This protects the maintained C++
+parity gate from host packages masking the vendored header contract; it does
+not promote a new accelerated language route.
 
 C/C++ clangd artifact status: the provider-level LSP acceleration benchmark now
 requires an index-quality report before latency measurement. The shared gate

--- a/test/test_ci_policy.py
+++ b/test/test_ci_policy.py
@@ -272,7 +272,18 @@ def test_trusted_full_ci_is_separate_from_pull_request_ci() -> None:
     assert "pull_request" not in _workflow_triggers(full_ci)
     assert set(pull_request_ci["jobs"]) == {"unit"}
     assert pull_request_ci["jobs"]["unit"]["runs-on"] == "ubuntu-latest"
-    assert full_ci["jobs"]["preflight"]["runs-on"] == "ubuntu-latest"
+    assert set(full_ci["jobs"]) == {
+        "preflight",
+        "vendored-core-build",
+        "unit",
+        "integration",
+        "integration-serial",
+        "scip-core",
+        "graph-consumer",
+        "slow",
+    }
+    for name in ("preflight", "vendored-core-build"):
+        assert full_ci["jobs"][name]["runs-on"] == "ubuntu-latest"
     for name in (
         "unit",
         "integration",
@@ -314,6 +325,80 @@ def test_native_core_uses_vendored_igraph_header_contract() -> None:
     assert "libigraph-dev" not in core_packages
 
 
+def test_full_ci_cleanly_builds_vendored_core_without_system_igraph() -> None:
+    workflow = _workflow(".github/workflows/ci-full.yml")
+    job = workflow["jobs"]["vendored-core-build"]
+    dependency_step = next(
+        step
+        for step in job["steps"]
+        if step.get("name") == "Install vendored-core build deps"
+    )
+    precondition_step = next(
+        step
+        for step in job["steps"]
+        if step.get("name") == "Verify vendored-only igraph preconditions"
+    )
+    build_step = next(
+        step
+        for step in job["steps"]
+        if step.get("name") == "Build vendored core from a cold tree"
+    )
+    dependency_run = str(dependency_step["run"])
+    precondition_run = str(precondition_step["run"])
+    build_run = str(build_step["run"])
+    step_names = [step.get("name") for step in job["steps"]]
+
+    assert job["needs"] == "preflight"
+    assert "needs.preflight.outputs.run-serial == 'true'" in job["if"]
+    assert job["runs-on"] == "ubuntu-latest"
+    assert step_names.index("Verify vendored-only igraph preconditions") < (
+        step_names.index("Build vendored core from a cold tree")
+    )
+    assert all(
+        "actions/cache" not in str(step.get("uses", "")) for step in job["steps"]
+    )
+    assert "libre2-dev" in dependency_run
+    assert "zlib1g-dev" in dependency_run
+    assert "sudo apt-get remove -y libigraph-dev" in dependency_run
+    assert dependency_run.count("libigraph-dev") == 1
+    assert "/usr/include/igraph.h" in precondition_run
+    assert "/usr/local/include/igraph.h" in precondition_run
+    assert "/usr/include/igraph/igraph.h" in precondition_run
+    assert "/usr/local/include/igraph/igraph.h" in precondition_run
+    assert "pkg-config --exists igraph" in precondition_run
+    assert "printf '#include <igraph/igraph.h>\\n'" in precondition_run
+    assert "printf '#include <igraph.h>\\n'" in precondition_run
+    assert precondition_run.count("c++ -E -x c++ -") == 2
+    assert "#include <igraph/igraph.h>" in precondition_run
+    assert "#include <igraph.h>" in precondition_run
+    assert "test ! -e build/vendored-core" in build_run
+    assert "-DCODENIB_BUILD_PYBIND=OFF" in build_run
+    assert "--target codenib_core" in build_run
+    assert "_deps/igraph-build/src/libigraph.a" in build_run
+    assert "build/vendored-core/libcodenib_core.a" in build_run
+    assert "_deps/igraph-src/include" in build_run
+    assert "_deps/igraph-build/include" in build_run
+    assert "vendored-core-build" in workflow["jobs"]["scip-core"]["needs"]
+    assert "vendored-core-build" in workflow["jobs"]["slow"]["needs"]
+    assert "needs.vendored-core-build.result" in workflow["jobs"]["slow"]["if"]
+    assert workflow["jobs"]["graph-consumer"]["needs"] == [
+        "preflight",
+        "integration-serial",
+        "scip-core",
+    ]
+
+    roadmap = (ROOT / "docs/scip_multilanguage_roadmap.md").read_text(encoding="utf-8")
+    assert "`vendored-core-build`" in roadmap
+    assert re.search(
+        r"system igraph\s+headers or pkg-config metadata",
+        roadmap,
+    )
+    assert re.search(
+        r"does\s+not promote a new accelerated language route",
+        roadmap,
+    )
+
+
 def test_full_ci_enforces_the_maintained_native_core_gate() -> None:
     workflow = _workflow(".github/workflows/ci-full.yml")
     steps = workflow["jobs"]["scip-core"]["steps"]
@@ -330,6 +415,7 @@ def test_full_ci_enforces_the_maintained_native_core_gate() -> None:
 
     assert "pkg-config --exists zlib" in dependency_run
     assert "zlib1g-dev" in dependency_run
+    assert "libigraph-dev" not in dependency_run
     core_packages = next(
         line
         for line in makefile.splitlines()

--- a/test/test_ci_policy.py
+++ b/test/test_ci_policy.py
@@ -284,6 +284,36 @@ def test_trusted_full_ci_is_separate_from_pull_request_ci() -> None:
         assert full_ci["jobs"][name]["runs-on"] == "self-hosted"
 
 
+def test_native_core_uses_vendored_igraph_header_contract() -> None:
+    core_sources = sorted(
+        path for suffix in ("*.cpp", "*.h") for path in (ROOT / "core").rglob(suffix)
+    )
+    installed_layout_users = [
+        str(path.relative_to(ROOT))
+        for path in core_sources
+        if "#include <igraph/igraph.h>" in path.read_text(encoding="utf-8")
+    ]
+    code_graph_header = (ROOT / "core/code_graph.h").read_text(encoding="utf-8")
+    core_cmake = (ROOT / "core/CMakeLists.txt").read_text(encoding="utf-8")
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    core_packages = next(
+        line
+        for line in makefile.splitlines()
+        if line.startswith("CORE_SYSTEM_PACKAGES")
+    )
+
+    assert installed_layout_users == []
+    assert "#include <igraph.h>" in code_graph_header
+    assert "FetchContent_Declare(\n    igraph" in core_cmake
+    assert "FetchContent_MakeAvailable(igraph)" in core_cmake
+    assert re.search(r"find_package\s*\(\s*igraph\b", core_cmake, re.IGNORECASE) is None
+    assert (
+        re.search(r"pkg_check_modules\s*\([^)]*\bigraph\b", core_cmake, re.IGNORECASE)
+        is None
+    )
+    assert "libigraph-dev" not in core_packages
+
+
 def test_full_ci_enforces_the_maintained_native_core_gate() -> None:
     workflow = _workflow(".github/workflows/ci-full.yml")
     steps = workflow["jobs"]["scip-core"]["steps"]


### PR DESCRIPTION
## Summary

Make the native core compile against the flat c-igraph header layout exported
by the vendored FetchContent target, and add a clean hosted build proof so a
system `libigraph-dev` installation cannot mask this contract.

This removes the clean-host build blocker for the retained storage benchmark.
Related to #199.

## Changes

- Replace the installed-layout `<igraph/igraph.h>` include with the vendored
  target's `<igraph.h>` contract.
- Lock the source, CMake, and package boundaries against reintroducing system
  igraph discovery or headers.
- Add an uncached hosted `vendored-core-build` job that proves system igraph is
  absent, builds `codenib_core`, and verifies both vendored include roots and
  archives.
- Gate the maintained self-hosted native parity job on that proof and document
  the resulting eight-job topology.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `python -m pytest -q test/test_ci_policy.py`: `23 passed`.
- Maintained core executable and pybind contract checks: pass.
- Maintained core Python test batch: `219 passed, 4 skipped`.
- Clean `CODENIB_BUILD_PYBIND=OFF` vendored build: pass; `libigraph.a` and
  `libcodenib_core.a` were produced and the compile database contains both
  vendored include roots.
- `python -m mkdocs build --strict`: pass.
- Public-document boundary check, actionlint, Black, isort, flake8, and
  `git diff --check`: pass.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
