### PR TITLE
docs(storage): make embedded backends canonical

### DIFF
--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -23,6 +23,13 @@ import-cache` recaptures an already existing selected cache, `codenib artifact
 materialize` publishes a retained catalog ref or immutable snapshot to a
 missing portable-artifact directory, and retained `codenib mcp` cold-start
 materializes and holds one such generation for a single stdio server lifetime.
+Storage-backend defaults are separate from route defaults. SQLite WAL and the
+local filesystem SHA-256 CAS are CodeNib's canonical supported production
+backends, not temporary bridges. PostgreSQL and S3-compatible adapters remain
+optional and demand-gated; they are not prerequisites for M1-M5 or retained
+route promotion. This backend choice does not enable any compiler or runtime
+route: A2, B1, and B2 remain separate gates.
+
 Protocol v4 introduced an internal existing-destination replacement primitive:
 it captures the incumbent, provisions and authenticates one hidden same-parent
 candidate, exchanges the two exact directory bindings with Linux

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -4,15 +4,20 @@
 
 CodeNib will publish repository context through a transactional catalog and
 immutable, content-addressed artifacts without replacing the query engines
-that make the artifacts useful.  The embedded deployment uses SQLite in WAL
-mode plus a local filesystem object store.  A server deployment may replace
-those two implementations with PostgreSQL and an S3-compatible object store
-without changing compiler or retrieval contracts.
+that make the artifacts useful. SQLite WAL and the local filesystem SHA-256
+CAS are CodeNib's canonical supported storage backends and production defaults,
+not temporary bridge implementations. PostgreSQL and S3-compatible object
+storage are optional adapters that may be activated independently only after
+documented deployment demand and representative benchmark or operational
+evidence justify them. Neither adapter is a prerequisite for M1-M5, embedded
+completion, or retained-route promotion.
 
-The program is complete only when repository updates, concurrent readers,
-multi-version queries, overlays, garbage collection, and server-backed
-storage all preserve the existing `RepoManifest`, MCP, BM25, FAISS, graph, and
-portable artifact behavior.
+The embedded program is complete only when repository updates, concurrent
+readers, multi-version queries, overlays, and garbage collection preserve the
+existing `RepoManifest`, MCP, BM25, FAISS, graph, and portable artifact
+behavior over those canonical backends. Choosing the canonical backends does
+not itself promote retained compiler or runtime routes; A2, B1, and B2 remain
+separate gates.
 
 ## Architectural Boundaries
 
@@ -20,12 +25,13 @@ The storage system has three independent layers:
 
 1. **Transactional catalog** — repositories, source revisions, profiles,
    immutable view generations, published snapshots, refs, jobs, leases, and
-   authorization metadata.  SQLite is the embedded implementation;
-   PostgreSQL is the future multi-worker implementation.
+   authorization metadata. SQLite WAL is the canonical supported production
+   default; PostgreSQL is an optional future multi-worker adapter.
 2. **Content-addressed object store** — large immutable payloads such as BM25
    documents, FAISS indexes and document mappings, graph payloads, and
-   portable context artifacts.  The embedded implementation uses regular
-   files; the server implementation uses object storage.
+   portable context artifacts. The local filesystem SHA-256 CAS is the
+   canonical supported production default; S3-compatible storage is an
+   optional future adapter.
 3. **Materialized query views** — BM25, FAISS, and igraph remain the execution
    formats used by a pinned snapshot.  They are read models, not the catalog
    or the source of versioning semantics.
@@ -1144,16 +1150,22 @@ isolation.
 - Generalize the clangd semantic-facts upsert/delete generation to the
   remaining adapters and enforce owner isolation.
 
-### M6: PostgreSQL and object-storage deployment
+### M6: Optional server storage adapters
 
-Status: pending and demand-gated.
+Status: deferred; demand gate not activated.
 
-- Implement the same catalog semantics with PostgreSQL transactions, row
-  locking/`SKIP LOCKED`, leases, and namespace-scoped authorization.
-- Implement S3/MinIO object publication, verification, materialization cache,
-  and deletion recovery.
-- Validate multi-worker contention, backup/restore, migration, quotas, audit,
-  and failure injection before making the server backend supported.
+- Activate the PostgreSQL catalog and S3-compatible object-store gates
+  independently. Neither adapter requires the other.
+- Before activating either gate, document a concrete deployment constraint
+  that the canonical SQLite WAL catalog or local filesystem CAS cannot meet,
+  and retain representative workload plus operational acceptance evidence.
+- Once activated, implement the same `IndexCatalog` or `ObjectStore` contract;
+  PostgreSQL retains transactions, row locking/`SKIP LOCKED`, leases, and
+  namespace-scoped authorization, while S3/MinIO retains publication,
+  verification, materialization-cache, and deletion-recovery semantics.
+- Validate contention, backup/restore, migration, quotas, audit, and failure
+  injection before declaring an activated adapter supported.
+- Keep M1-M5 and embedded completion independent of this deferred milestone.
 
 ### M7: Managed semantic and optional shared ANN
 
@@ -1168,7 +1180,9 @@ Status: pending and benchmark-gated.
 
 ## Completion Gate
 
-The program is complete when all milestones are implemented, locally and
-remotely verified at their required test tiers, documented, and reconciled
-with their issues and PRs.  Passing one backend test, landing the catalog
-schema, or publishing a single snapshot is not completion of the objective.
+The embedded storage program is complete when M0-M5 are implemented, locally
+and remotely verified at their required test tiers, documented, and reconciled
+with their issues and PRs. M6 and M7 are optional extensions and do not hold
+embedded completion open unless their demand or benchmark gates are explicitly
+activated. Passing one backend test, landing the catalog schema, or publishing
+a single snapshot is not completion of the embedded objective.

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -966,3 +966,34 @@ def test_protocol_v5_workspace_replacement_limits_are_documented() -> None:
         "provider. | Complete." in roadmap
     )
     assert "M1 remains in progress" in roadmap
+
+
+def test_embedded_storage_backend_policy_is_documented() -> None:
+    root = Path(__file__).resolve().parents[1]
+    provider = (root / "docs/development/local-workspace-provider.md").read_text(
+        encoding="utf-8"
+    )
+    roadmap = (root / "docs/storage_backend_roadmap.md").read_text(encoding="utf-8")
+    provider_prose = " ".join(provider.split())
+    roadmap_prose = " ".join(roadmap.split())
+
+    assert (
+        "SQLite WAL and the local filesystem SHA-256 CAS are CodeNib's "
+        "canonical supported storage backends and production defaults, not "
+        "temporary bridge implementations"
+    ) in roadmap_prose
+    assert (
+        "Neither adapter is a prerequisite for M1-M5, embedded completion, "
+        "or retained-route promotion"
+    ) in roadmap_prose
+    assert "### M6: Optional server storage adapters" in roadmap
+    assert "Status: deferred; demand gate not activated." in roadmap
+    assert "Activate the PostgreSQL catalog and S3-compatible" in roadmap
+    assert "Neither adapter requires the other." in roadmap_prose
+    assert (
+        "M6 and M7 are optional extensions and do not hold embedded completion "
+        "open unless their demand or benchmark gates are explicitly activated"
+    ) in roadmap_prose
+    assert "Storage-backend defaults are separate from route defaults." in provider
+    assert "not temporary bridges" in provider_prose
+    assert "A2, B1, and B2 remain separate gates" in provider_prose


### PR DESCRIPTION
## Summary

Make SQLite WAL and the local filesystem SHA-256 CAS CodeNib's canonical
supported production storage defaults. Keep PostgreSQL and S3-compatible
adapters optional, independent, and demand-gated without changing retained
compiler or runtime route defaults.

This reconciles the durable storage plan with the embedded deployment decision.
Related to #199.

## Changes

- Define SQLite WAL and the local filesystem SHA-256 CAS as supported production
  defaults, not temporary bridges.
- Separate storage-backend defaults from A2, B1, and B2 retained-route promotion.
- Defer PostgreSQL and S3-compatible adapters until concrete demand and evidence
  activate their independent M6 gates.
- Lock the policy boundary in release-artifact tests.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `python -m pytest -q test/test_release_artifacts.py`: 31 passed.
- Focused explicit retained-route boundary tests: 7 passed.
- `python -m mkdocs build --strict`: pass.
- Public-document boundary, Black, isort, flake8, and `git diff --check`: pass.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
