### PR TITLE
fix(storage): stream aggregate BM25 document budgets

### DIFF
--- a/codenib/artifacts/strict_bm25.py
+++ b/codenib/artifacts/strict_bm25.py
@@ -678,8 +678,11 @@ def _payloads(
     environ: Mapping[str, str],
     authenticated_source_files: frozenset[str],
 ) -> tuple[bytes, Iterable[bytes]]:
-    # Apply the whole-file lexical budgets, including string and atom limits,
-    # before the element iterator allocates any decoded document object.
+    # Apply whole-file lexical framing before any decoded document allocation.
+    # Aggregate counts are bounded by authenticated bytes; the iterator below
+    # independently preserves the stricter per-document complexity budgets.
+    documents_record = reader.record("documents.json")
+    lexical_budget = max(1, documents_record.size)
     with reader.open_file(
         "documents.json",
         max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
@@ -688,6 +691,8 @@ def _payloads(
             source,
             label="portable BM25 documents",
             max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+            max_nodes=lexical_budget,
+            max_lexical_tokens=lexical_budget,
         )
     metadata = _load_json_object(
         reader,

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -883,6 +883,15 @@ that collecting a fast result cannot silently approve a production route:
 | B2 source-bound | Promote a specifically scoped source-bound BM25 retained cold start. | Pending A2 source-bound BM25 runtime; it cannot satisfy the full manifest-compatibility gate. |
 | C | Supply the `provider-bound-exact` strict BM25 native provider. | Complete. The request still carries only its immutable receipt-derived binding. `run_strict_workspace(...)` accepts the separately active exact source owner and gives Local only a PID-bound, callback-scoped one-shot gate tied by object identity to that request, binding, operation, native owner, and workspace. Local captures and leases before the gate synchronously binds the source, provisions only through the handed-off workspace, and publishes only through the protocol-v5 dual-root seam. The displaced incumbent remains a reopenable `linux-renameat2` orphan. Automatic GC, a crash journal, hostile same-UID defense, and default-route promotion remain outside Gate C. |
 
+An initial v3 1x0 readiness smoke stopped before completion because strict BM25
+applied per-document node and token defaults to its whole-file lexical prepass.
+That prepass now derives only its aggregate node and token budgets from the
+authenticated `documents.json` record size; whole-file byte, depth, key,
+string, and atom limits and the per-document complexity caps remain unchanged.
+This is a readiness correction, not A2 evidence. A2 remains pending a fresh
+60/60 readiness smoke and canonical 20x4 measurements, and no compiler or
+runtime route or default is promoted.
+
 The A1 harness fixes the BM25 `fast` compiler/runtime comparison rather than
 accepting arbitrary route substitutions. For compiler cold start, arm A runs
 `codenib index --preset fast` from an empty cache and arm B runs the same build

--- a/test/artifacts/test_strict_bm25_publication.py
+++ b/test/artifacts/test_strict_bm25_publication.py
@@ -18,7 +18,11 @@ import pytest
 import codenib.artifacts.strict_bm25 as strict_bm25_module
 from codenib import LocalWorkspaceProvider
 from codenib._atomic_directory import TreeFileRecord
-from codenib._bounded_json import canonical_json_value_chunks
+from codenib._bounded_json import (
+    DEFAULT_MAX_LEXICAL_TOKENS,
+    DEFAULT_MAX_NODES_PER_ELEMENT,
+    canonical_json_value_chunks,
+)
 from codenib._captured_directory import (
     OwnedWorkspaceAuthority,
     PublishedWorkspaceReceiptOwner,
@@ -1555,6 +1559,174 @@ def test_strict_bm25_documents_are_bounded_before_element_dom(tmp_path: Path) ->
                 environ={},
             )
     finally:
+        source_owner.close()
+        repository_source.close()
+
+
+def test_strict_bm25_streams_aggregate_nodes_through_exact_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository(tmp_path)
+    document = {"page_content": "safe", "metadata": {}}
+    # Each document has three value nodes and five lexical tokens. The complete
+    # array exceeds both aggregate defaults while every document remains tiny.
+    document_count = DEFAULT_MAX_LEXICAL_TOKENS // 5
+    assert 1 + (3 * document_count) > DEFAULT_MAX_NODES_PER_ELEMENT
+    assert 1 + (5 * document_count) > DEFAULT_MAX_LEXICAL_TOKENS
+    documents = _canonical_bytes([document] * document_count)
+    destination, source_owner = _publish_source(
+        tmp_path,
+        repository,
+        documents=documents,
+    )
+    repository_source = capture_repository_source(repository)
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider()
+    real_validate = strict_bm25_module.validate_bounded_json_stream
+    observed_document_limits: list[dict[str, Any]] = []
+
+    def observe_document_limits(source, **limits):
+        if limits.get("label") == "portable BM25 documents":
+            observed_document_limits.append(dict(limits))
+        return real_validate(source, **limits)
+
+    monkeypatch.setattr(
+        strict_bm25_module,
+        "validate_bounded_json_stream",
+        observe_document_limits,
+    )
+    try:
+        normalize_owned_query_view_strict(
+            destination,
+            source_generation=source_owner,
+            repository_source=repository_source,
+            workspace_provider=provider,
+            output_receipt_owner=output_owner,
+            view_type="bm25",
+            view_config={},
+            environ={},
+        )
+
+        assert provider.support_count == 1
+        assert provider.run_count == 1
+        assert provider.requests[0].destination_expectation == "provider-bound-exact"
+        assert (
+            provider.requests[0].destination_binding is source_owner.destination_binding
+        )
+        assert source_owner.active
+        assert output_owner.active
+        assert (destination / "documents.json").read_bytes() == documents
+        expected_limits = {
+            "label": "portable BM25 documents",
+            "max_bytes": strict_bm25_module._MAX_DOCUMENTS_JSON_BYTES,
+            "max_nodes": len(documents),
+            "max_lexical_tokens": len(documents),
+        }
+        assert observed_document_limits
+        assert all(limits == expected_limits for limits in observed_document_limits)
+    finally:
+        output_owner.close()
+        source_owner.close()
+        repository_source.close()
+
+
+def test_strict_bm25_record_budget_still_rejects_source_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository(tmp_path)
+    documents = _canonical_bytes([{"page_content": "safe", "metadata": {}}])
+    mutated_documents = documents.replace(b"safe", b"evil", 1)
+    assert len(mutated_documents) == len(documents)
+    destination, source_owner = _publish_source(
+        tmp_path,
+        repository,
+        documents=documents,
+    )
+    repository_source = capture_repository_source(repository)
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider()
+    real_record = strict_bm25_module._PublicationBm25Reader.record
+    mutated = False
+
+    def mutate_after_record(self, path):
+        nonlocal mutated
+        record = real_record(self, path)
+        if not mutated and record.path == "documents.json":
+            mutated = True
+            (destination / "documents.json").write_bytes(mutated_documents)
+        return record
+
+    monkeypatch.setattr(
+        strict_bm25_module._PublicationBm25Reader,
+        "record",
+        mutate_after_record,
+    )
+    try:
+        with pytest.raises(RuntimeError, match="changed|differs"):
+            normalize_owned_query_view_strict(
+                destination,
+                source_generation=source_owner,
+                repository_source=repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_type="bm25",
+                view_config={},
+                environ={},
+            )
+
+        assert mutated
+        assert provider.support_count == 0
+        assert provider.run_count == 0
+        assert source_owner.active
+        assert output_owner.state == "empty"
+    finally:
+        output_owner.close()
+        source_owner.close()
+        repository_source.close()
+
+
+def test_strict_bm25_rejects_one_oversized_document_before_provider(
+    tmp_path: Path,
+) -> None:
+    repository = _repository(tmp_path)
+    document = {
+        "page_content": "safe",
+        "metadata": {"nodes": [None] * DEFAULT_MAX_NODES_PER_ELEMENT},
+    }
+    documents = _canonical_bytes([document])
+    destination, source_owner = _publish_source(
+        tmp_path,
+        repository,
+        documents=documents,
+    )
+    repository_source = capture_repository_source(repository)
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider()
+    try:
+        with pytest.raises(
+            ValueError,
+            match=rf"{DEFAULT_MAX_NODES_PER_ELEMENT}-node limit",
+        ):
+            normalize_owned_query_view_strict(
+                destination,
+                source_generation=source_owner,
+                repository_source=repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_type="bm25",
+                view_config={},
+                environ={},
+            )
+
+        assert provider.support_count == 0
+        assert provider.run_count == 0
+        assert source_owner.active
+        assert output_owner.state == "empty"
+        assert (destination / "documents.json").read_bytes() == documents
+    finally:
+        output_owner.close()
         source_owner.close()
         repository_source.close()
 


### PR DESCRIPTION
## Summary

Fix strict portable BM25 normalization so large authenticated multi-document streams are not rejected by per-document lexical defaults during the whole-file framing pass.

Related to #199.

## Changes

- Derive aggregate whole-file node and lexical-token budgets from the authenticated `documents.json` record size.
- Preserve the existing whole-file byte, depth, key, string, and atom limits and the stricter per-document complexity limits.
- Add regression coverage for aggregate document streams, same-size source mutation after record lookup, and oversized individual documents.
- Record the A2 readiness correction without claiming benchmark evidence or promoting compiler/runtime routes or defaults.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short`: 7,039 passed, 35 skipped, 190 deselected in 181.18s.
- `test/artifacts/test_strict_bm25_publication.py`: 45 passed.
- `test/test_bounded_json.py`: 42 passed.
- `test/artifacts`: 357 passed.
- `test/test_release_artifacts.py`: 31 passed.
- Independent adversarial selector matrix: 52 passed.
- MkDocs strict build, public-doc boundary, namespace checks, compileall, diff-check, Black 24.8, isort 5.13.2, and flake8 7.1.1 with bugbear passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
