### PR TITLE
docs(storage): record A2 readiness receipt

### DIFF
--- a/docs/experiments/artifacts/retained_storage_a2_readiness_v3_1x0.json
+++ b/docs/experiments/artifacts/retained_storage_a2_readiness_v3_1x0.json
@@ -1,0 +1,232 @@
+{
+  "schema": "codenib.retained-storage-a2-readiness-aggregate.v1",
+  "source_binding": {
+    "report_sha256": "b4b2246982a29de0860dcaeaee5d1e1363e30f2002aa7576f6c8dcdc8c02a29a",
+    "sidecar_sha256": "33575263b8dd37324b4c8ec2f9a87f49a64c6c9ca3ad007dad384d69f3432aa9",
+    "harness_sha256": "32d32da1d8027ee36c33a604d5c37ee72c615b5e0f45dc96858960565caacf61",
+    "subject_manifest_sha256": "22e01bd5acd133186a039df5a8e383308687fd8c9f8fd0554ce9592087ede6f8"
+  },
+  "benchmark_identity": {
+    "name": "retained_storage_explicit_route_gate_v3",
+    "schema_version": 3,
+    "merged_commit": "4c907bf3588b40cbf67d3dd98c3db389ab093e62",
+    "merged_tree": "50e7455cac76e224df46c8a6b603c54645d43b89",
+    "merged_parent": "36f6af7ad8a6d551f436bedfd0115803fee9e64d",
+    "benchmark_unchanged": true,
+    "subjects_unchanged": true
+  },
+  "matrix": {
+    "subjects": [
+      {
+        "id": "httpie",
+        "payload_class": "small",
+        "revision": "2105caa49bae87c5809c274e407619a0de2639d1",
+        "tree": "5be8d10a92efc928460e86f1ce6dcabbea1a728a",
+        "source_index_sha256": "7265c00a664d12e5da8661c2bf1d10e01063b7c6c3e7ee96a80a11a7024d2ab4",
+        "source_file_count": 265,
+        "source_total_bytes": 2096115,
+        "unchanged": true
+      },
+      {
+        "id": "codenib",
+        "payload_class": "medium",
+        "revision": "a33bb13118e3a04f8d3d76eabcfb2602f785477a",
+        "tree": "a7e31cae206e4c6ff6c00210f8c4c31dc1c83b84",
+        "source_index_sha256": "2513e2e83372c1195d999d80fcea07b8e1ae8574e6419e7c61b8b45953d1b553",
+        "source_file_count": 1248,
+        "source_total_bytes": 15132984,
+        "unchanged": true
+      },
+      {
+        "id": "django-5.2.5",
+        "payload_class": "large",
+        "revision": "a3b1107a4955bdd994908efb4c6e1d03c281e69f",
+        "tree": "0d45857fbbe288b56ddd4d8e124a1657421f9c48",
+        "source_index_sha256": "4d61278d24ea9f5844e81f14e03e9e1558b1f00e00145d48feac0b5ef7f39f47",
+        "source_file_count": 6898,
+        "source_total_bytes": 44830664,
+        "unchanged": true
+      }
+    ],
+    "media_classes": [
+      "md0",
+      "nvme"
+    ],
+    "distinct_media_devices": true,
+    "view_set_id": "bm25-fast"
+  },
+  "protocol": {
+    "canonical": false,
+    "observed_iterations_per_arm": 1,
+    "observed_warmups_per_arm": 0,
+    "observed_sample_count": 60,
+    "canonical_iterations_per_arm": 20,
+    "canonical_warmups_per_arm": 4,
+    "canonical_sample_count": 1440,
+    "difference_only": [
+      "canonical_sample_count",
+      "iterations_per_arm",
+      "warmups_per_arm"
+    ],
+    "controller_return_code": 1,
+    "report_status": "failed",
+    "report_passed": false,
+    "failure_stage": "protocol",
+    "failure_error_type": "RuntimeError",
+    "failure_message": "measurement protocol is not canonical v3",
+    "sidecar_status": "readiness-pass"
+  },
+  "process_isolation": {
+    "expected_inner_processes": 60,
+    "observed_inner_processes": 60,
+    "unique_inner_processes": 60,
+    "duplicate_inner_processes": 0,
+    "passed": true
+  },
+  "safety": {
+    "fields": [
+      "cleanup_complete",
+      "context_closed",
+      "ref_stable",
+      "retained_matches_raw",
+      "sample_root_fresh",
+      "source_closed",
+      "storage_closed",
+      "subject_unchanged"
+    ],
+    "per_sample": {
+      "sample_count": 60,
+      "fields_per_sample": 8,
+      "values_recorded": 480,
+      "values_true": 480,
+      "passed": true
+    },
+    "aggregate_cell_summaries": {
+      "cell_count": 30,
+      "fields_per_cell": 8,
+      "values_recorded": 240,
+      "values_true": 240,
+      "passed": true,
+      "independent_checks": false,
+      "derivation": "all per-sample values for the same field within the cell"
+    }
+  },
+  "cells": {
+    "total": 30,
+    "primary_projection_passed": 24,
+    "by_kind": {
+      "compiler-cold": {
+        "count": 6,
+        "primary_projection": "compiler",
+        "primary_projection_passed": 6,
+        "safety_passed": 6
+      },
+      "compiler-current": {
+        "count": 6,
+        "primary_projection": "compiler",
+        "primary_projection_passed": 6,
+        "safety_passed": 6
+      },
+      "runtime-cold": {
+        "count": 6,
+        "primary_projection": "full-runtime",
+        "primary_projection_passed": 0,
+        "content_authority_projection_passed": 0,
+        "full_runtime_projection_passed": 0,
+        "safety_passed": 6,
+        "interpretation": "designed source-disabled compatibility sentinel with a query-only candidate"
+      },
+      "runtime-cold-query-only": {
+        "count": 6,
+        "primary_projection": "full-runtime",
+        "primary_projection_passed": 6,
+        "content_authority_projection_passed": 6,
+        "full_runtime_projection_passed": 6,
+        "safety_passed": 6
+      },
+      "runtime-cold-source-bound": {
+        "count": 6,
+        "primary_projection": "content-authority",
+        "primary_projection_passed": 6,
+        "content_authority_projection_passed": 6,
+        "full_runtime_projection_passed": 0,
+        "safety_passed": 6,
+        "interpretation": "content authority matches while full manifest provenance differs"
+      }
+    }
+  },
+  "tracks": {
+    "compiler": {
+      "cells": [
+        "compiler-cold",
+        "compiler-current"
+      ],
+      "projection": "compiler",
+      "measurement_complete": true,
+      "parity_passed": true,
+      "safety_passed": true,
+      "scope_complete": true,
+      "decision": "passed"
+    },
+    "query-only-runtime": {
+      "cells": [
+        "runtime-cold-query-only"
+      ],
+      "projection": "full-runtime",
+      "measurement_complete": true,
+      "parity_passed": true,
+      "safety_passed": true,
+      "scope_complete": true,
+      "decision": "passed"
+    },
+    "manifest-runtime-compatibility": {
+      "cells": [
+        "runtime-cold"
+      ],
+      "projection": "full-runtime",
+      "measurement_complete": true,
+      "parity_passed": false,
+      "safety_passed": true,
+      "scope_complete": false,
+      "decision": "blocked"
+    },
+    "source-bound-runtime": {
+      "cells": [
+        "runtime-cold-source-bound"
+      ],
+      "projection": "content-authority",
+      "measurement_complete": true,
+      "parity_passed": true,
+      "safety_passed": true,
+      "scope_complete": true,
+      "decision": "passed"
+    },
+    "source-bound-manifest-compatibility": {
+      "cells": [
+        "runtime-cold-source-bound"
+      ],
+      "projection": "full-runtime",
+      "measurement_complete": true,
+      "parity_passed": false,
+      "safety_passed": true,
+      "scope_complete": false,
+      "decision": "blocked"
+    }
+  },
+  "postconditions": {
+    "benchmark_processes_remaining": false,
+    "media_roots_empty": true,
+    "tracked_checkout_clean": true,
+    "subjects_clean_and_identity_exact": true,
+    "output_stable": true,
+    "canonical_20x4_launched": false
+  },
+  "policy": {
+    "report_only": true,
+    "numeric_evidence": false,
+    "performance_budgets_ratified": false,
+    "promotion_eligible": false,
+    "route_or_default_promoted": false,
+    "canonical_20x4_status": "pending-quiet-host"
+  }
+}

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -885,12 +885,26 @@ that collecting a fast result cannot silently approve a production route:
 
 An initial v3 1x0 readiness smoke stopped before completion because strict BM25
 applied per-document node and token defaults to its whole-file lexical prepass.
-That prepass now derives only its aggregate node and token budgets from the
-authenticated `documents.json` record size; whole-file byte, depth, key,
-string, and atom limits and the per-document complexity caps remain unchanged.
-This is a readiness correction, not A2 evidence. A2 remains pending a fresh
-60/60 readiness smoke and canonical 20x4 measurements, and no compiler or
-runtime route or default is promoted.
+The merged correction derives only the aggregate node and token budgets from
+the authenticated `documents.json` record size. After #682 merged on main at
+`4c907bf3588b40cbf67d3dd98c3db389ab093e62` with tree
+`50e7455cac76e224df46c8a6b603c54645d43b89`, a fresh 1x0 readiness run
+completed all 30 cells, observed 60/60 expected inner route processes with all
+60 unique, and recorded 720/720 true safety checks. Twenty-four cells passed;
+the six parity-red `runtime-cold` cells were the protocol's designed
+compatibility sentinel. Its return code 1 was solely the expected `measurement
+protocol is not canonical v3` sentinel because the 1x0 iterations, warmups,
+and resulting sample count are noncanonical; it was not an operational,
+isolation, or safety failure. The report SHA-256 is
+`b4b2246982a29de0860dcaeaee5d1e1363e30f2002aa7576f6c8dcdc8c02a29a`
+and the sidecar SHA-256 is
+`33575263b8dd37324b4c8ec2f9a87f49a64c6c9ca3ad007dad384d69f3432aa9`.
+The prepass correction keeps the whole-file byte, depth, key, string, and atom
+limits and the per-document complexity caps unchanged. This readiness receipt
+is not A2 numeric evidence, ratifies no budget, and promotes no compiler or
+runtime route or default. The canonical 20x4 measurement was not launched
+because an unrelated `selftune` CPU workload made the host non-representative;
+it remains pending a quiet-host window.
 
 The A1 harness fixes the BM25 `fast` compiler/runtime comparison rather than
 accepting arbitrary route substitutions. For compiler cold start, arm A runs

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -890,15 +890,27 @@ the authenticated `documents.json` record size. After #682 merged on main at
 `4c907bf3588b40cbf67d3dd98c3db389ab093e62` with tree
 `50e7455cac76e224df46c8a6b603c54645d43b89`, a fresh 1x0 readiness run
 completed all 30 cells, observed 60/60 expected inner route processes with all
-60 unique, and recorded 720/720 true safety checks. Twenty-four cells passed;
-the six parity-red `runtime-cold` cells were the protocol's designed
-compatibility sentinel. Its return code 1 was solely the expected `measurement
-protocol is not canonical v3` sentinel because the 1x0 iterations, warmups,
-and resulting sample count are noncanonical; it was not an operational,
-isolation, or safety failure. The report SHA-256 is
+60 unique, and recorded 480/480 true per-sample safety values. The 30 cells'
+240/240 aggregate safety summaries were also true; those summaries fold the
+same per-sample values and are not additional checks. Of the 30 primary cell
+projections, 24 passed. The six `runtime-cold` source-disabled compatibility
+sentinel cells, whose candidate arm is query-only, were red on their primary
+full-runtime projection. Separately, all six `runtime-cold-source-bound` cells
+passed their primary content-authority projection while their full-runtime
+projection remained red because manifest provenance differs. Consequently both
+`manifest-runtime-compatibility` and `source-bound-manifest-compatibility`
+remain blocked.
+
+The sanitized, path- and PID-free
+[aggregate readiness receipt](experiments/artifacts/retained_storage_a2_readiness_v3_1x0.json)
+is checked in with the roadmap. It retains the source report SHA-256
 `b4b2246982a29de0860dcaeaee5d1e1363e30f2002aa7576f6c8dcdc8c02a29a`
-and the sidecar SHA-256 is
+and sidecar SHA-256
 `33575263b8dd37324b4c8ec2f9a87f49a64c6c9ca3ad007dad384d69f3432aa9`.
+The controller return code 1 was solely the expected `measurement protocol is
+not canonical v3` sentinel because the 1x0 iterations, warmups, and resulting
+sample count are noncanonical; it was not an operational, isolation, or safety
+failure.
 The prepass correction keeps the whole-file byte, depth, key, string, and atom
 limits and the per-document complexity caps unchanged. This readiness receipt
 is not A2 numeric evidence, ratifies no budget, and promotes no compiler or

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -997,3 +997,32 @@ def test_embedded_storage_backend_policy_is_documented() -> None:
     assert "Storage-backend defaults are separate from route defaults." in provider
     assert "not temporary bridges" in provider_prose
     assert "A2, B1, and B2 remain separate gates" in provider_prose
+
+
+def test_a2_readiness_receipt_is_documented_without_promotion() -> None:
+    root = Path(__file__).resolve().parents[1]
+    roadmap = (root / "docs/storage_backend_roadmap.md").read_text(encoding="utf-8")
+    roadmap_prose = " ".join(roadmap.split())
+
+    assert "4c907bf3588b40cbf67d3dd98c3db389ab093e62" in roadmap
+    assert "50e7455cac76e224df46c8a6b603c54645d43b89" in roadmap
+    assert (
+        "completed all 30 cells, observed 60/60 expected inner route processes "
+        "with all 60 unique, and recorded 720/720 true safety checks"
+    ) in roadmap_prose
+    assert (
+        "Twenty-four cells passed; the six parity-red `runtime-cold` cells were "
+        "the protocol's designed compatibility sentinel"
+    ) in roadmap_prose
+    assert (
+        "return code 1 was solely the expected `measurement protocol is not "
+        "canonical v3` sentinel"
+    ) in roadmap_prose
+    assert (
+        "the 1x0 iterations, warmups, and resulting sample count are noncanonical"
+    ) in roadmap_prose
+    assert "b4b2246982a29de0860dcaeaee5d1e1363e30f2002aa7576f6c8dcdc8c02a29a" in roadmap
+    assert "33575263b8dd37324b4c8ec2f9a87f49a64c6c9ca3ad007dad384d69f3432aa9" in roadmap
+    assert "is not A2 numeric evidence, ratifies no budget" in roadmap_prose
+    assert "promotes no compiler or runtime route or default" in roadmap_prose
+    assert "remains pending a quiet-host window" in roadmap_prose

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import io
+import json
+import re
 import subprocess
 import tarfile
 import zipfile
@@ -1004,20 +1006,54 @@ def test_a2_readiness_receipt_is_documented_without_promotion() -> None:
     roadmap = (root / "docs/storage_backend_roadmap.md").read_text(encoding="utf-8")
     roadmap_prose = " ".join(roadmap.split())
 
+    def reject_duplicate_keys(pairs):
+        result = {}
+        for key, value in pairs:
+            if key in result:
+                raise AssertionError(f"duplicate evidence key: {key}")
+            result[key] = value
+        return result
+
+    def reject_nonfinite(value):
+        raise AssertionError(f"non-finite evidence value: {value}")
+
+    evidence_path = (
+        root
+        / "docs"
+        / "experiments"
+        / "artifacts"
+        / "retained_storage_a2_readiness_v3_1x0.json"
+    )
+    evidence_text = evidence_path.read_text(encoding="utf-8")
+    evidence = json.loads(
+        evidence_text,
+        object_pairs_hook=reject_duplicate_keys,
+        parse_constant=reject_nonfinite,
+    )
+
     assert "4c907bf3588b40cbf67d3dd98c3db389ab093e62" in roadmap
     assert "50e7455cac76e224df46c8a6b603c54645d43b89" in roadmap
     assert (
         "completed all 30 cells, observed 60/60 expected inner route processes "
-        "with all 60 unique, and recorded 720/720 true safety checks"
+        "with all 60 unique, and recorded 480/480 true per-sample safety values"
     ) in roadmap_prose
     assert (
-        "Twenty-four cells passed; the six parity-red `runtime-cold` cells were "
-        "the protocol's designed compatibility sentinel"
+        "240/240 aggregate safety summaries were also true; those summaries fold "
+        "the same per-sample values and are not additional checks"
+    ) in roadmap_prose
+    assert "720" not in roadmap
+    assert (
+        "The six `runtime-cold` source-disabled compatibility sentinel cells, "
+        "whose candidate arm is query-only, were red on their primary full-runtime "
+        "projection"
     ) in roadmap_prose
     assert (
-        "return code 1 was solely the expected `measurement protocol is not "
-        "canonical v3` sentinel"
+        "all six `runtime-cold-source-bound` cells passed their primary "
+        "content-authority projection while their full-runtime projection remained red"
     ) in roadmap_prose
+    assert "both `manifest-runtime-compatibility` and" in roadmap_prose
+    assert "`source-bound-manifest-compatibility` remain blocked" in roadmap_prose
+    assert evidence_path.relative_to(root / "docs").as_posix() in roadmap
     assert (
         "the 1x0 iterations, warmups, and resulting sample count are noncanonical"
     ) in roadmap_prose
@@ -1026,3 +1062,197 @@ def test_a2_readiness_receipt_is_documented_without_promotion() -> None:
     assert "is not A2 numeric evidence, ratifies no budget" in roadmap_prose
     assert "promotes no compiler or runtime route or default" in roadmap_prose
     assert "remains pending a quiet-host window" in roadmap_prose
+
+    assert evidence["schema"] == "codenib.retained-storage-a2-readiness-aggregate.v1"
+    assert evidence["source_binding"] == {
+        "report_sha256": (
+            "b4b2246982a29de0860dcaeaee5d1e1363e30f2002aa7576f6c8dcdc8c02a29a"
+        ),
+        "sidecar_sha256": (
+            "33575263b8dd37324b4c8ec2f9a87f49a64c6c9ca3ad007dad384d69f3432aa9"
+        ),
+        "harness_sha256": (
+            "32d32da1d8027ee36c33a604d5c37ee72c615b5e0f45dc96858960565caacf61"
+        ),
+        "subject_manifest_sha256": (
+            "22e01bd5acd133186a039df5a8e383308687fd8c9f8fd0554ce9592087ede6f8"
+        ),
+    }
+    assert evidence["benchmark_identity"] == {
+        "name": "retained_storage_explicit_route_gate_v3",
+        "schema_version": 3,
+        "merged_commit": "4c907bf3588b40cbf67d3dd98c3db389ab093e62",
+        "merged_tree": "50e7455cac76e224df46c8a6b603c54645d43b89",
+        "merged_parent": "36f6af7ad8a6d551f436bedfd0115803fee9e64d",
+        "benchmark_unchanged": True,
+        "subjects_unchanged": True,
+    }
+    assert [
+        (
+            subject["id"],
+            subject["payload_class"],
+            subject["revision"],
+            subject["tree"],
+            subject["unchanged"],
+        )
+        for subject in evidence["matrix"]["subjects"]
+    ] == [
+        (
+            "httpie",
+            "small",
+            "2105caa49bae87c5809c274e407619a0de2639d1",
+            "5be8d10a92efc928460e86f1ce6dcabbea1a728a",
+            True,
+        ),
+        (
+            "codenib",
+            "medium",
+            "a33bb13118e3a04f8d3d76eabcfb2602f785477a",
+            "a7e31cae206e4c6ff6c00210f8c4c31dc1c83b84",
+            True,
+        ),
+        (
+            "django-5.2.5",
+            "large",
+            "a3b1107a4955bdd994908efb4c6e1d03c281e69f",
+            "0d45857fbbe288b56ddd4d8e124a1657421f9c48",
+            True,
+        ),
+    ]
+    assert evidence["matrix"]["media_classes"] == ["md0", "nvme"]
+    assert evidence["matrix"]["distinct_media_devices"] is True
+    assert evidence["matrix"]["view_set_id"] == "bm25-fast"
+    assert evidence["process_isolation"] == {
+        "expected_inner_processes": 60,
+        "observed_inner_processes": 60,
+        "unique_inner_processes": 60,
+        "duplicate_inner_processes": 0,
+        "passed": True,
+    }
+
+    safety = evidence["safety"]
+    assert len(safety["fields"]) == 8
+    assert safety["per_sample"] == {
+        "sample_count": 60,
+        "fields_per_sample": 8,
+        "values_recorded": 480,
+        "values_true": 480,
+        "passed": True,
+    }
+    aggregate = safety["aggregate_cell_summaries"]
+    assert aggregate == {
+        "cell_count": 30,
+        "fields_per_cell": 8,
+        "values_recorded": 240,
+        "values_true": 240,
+        "passed": True,
+        "independent_checks": False,
+        "derivation": "all per-sample values for the same field within the cell",
+    }
+    assert safety["per_sample"]["values_recorded"] == 60 * 8
+    assert aggregate["values_recorded"] == 30 * 8
+
+    cells = evidence["cells"]
+    assert cells["total"] == 30
+    assert cells["primary_projection_passed"] == 24
+    assert set(cells["by_kind"]) == {
+        "compiler-cold",
+        "compiler-current",
+        "runtime-cold",
+        "runtime-cold-query-only",
+        "runtime-cold-source-bound",
+    }
+    assert sum(cell["count"] for cell in cells["by_kind"].values()) == 30
+    assert (
+        sum(cell["primary_projection_passed"] for cell in cells["by_kind"].values())
+        == 24
+    )
+    runtime_cold = cells["by_kind"]["runtime-cold"]
+    assert runtime_cold["count"] == 6
+    assert runtime_cold["primary_projection"] == "full-runtime"
+    assert runtime_cold["primary_projection_passed"] == 0
+    assert runtime_cold["full_runtime_projection_passed"] == 0
+    query_only = cells["by_kind"]["runtime-cold-query-only"]
+    assert query_only["count"] == 6
+    assert query_only["primary_projection"] == "full-runtime"
+    assert query_only["primary_projection_passed"] == 6
+    assert query_only["full_runtime_projection_passed"] == 6
+    source_bound = cells["by_kind"]["runtime-cold-source-bound"]
+    assert source_bound["count"] == 6
+    assert source_bound["primary_projection"] == "content-authority"
+    assert source_bound["primary_projection_passed"] == 6
+    assert source_bound["content_authority_projection_passed"] == 6
+    assert source_bound["full_runtime_projection_passed"] == 0
+
+    tracks = evidence["tracks"]
+    assert set(tracks) == {
+        "compiler",
+        "manifest-runtime-compatibility",
+        "query-only-runtime",
+        "source-bound-manifest-compatibility",
+        "source-bound-runtime",
+    }
+    manifest_track = tracks["manifest-runtime-compatibility"]
+    source_manifest_track = tracks["source-bound-manifest-compatibility"]
+    for track in (manifest_track, source_manifest_track):
+        assert track["projection"] == "full-runtime"
+        assert track["measurement_complete"] is True
+        assert track["parity_passed"] is False
+        assert track["safety_passed"] is True
+        assert track["scope_complete"] is False
+        assert track["decision"] == "blocked"
+    assert tracks["source-bound-runtime"]["projection"] == "content-authority"
+    assert tracks["source-bound-runtime"]["parity_passed"] is True
+    assert tracks["source-bound-runtime"]["decision"] == "passed"
+
+    protocol = evidence["protocol"]
+    assert protocol["controller_return_code"] == 1
+    assert protocol["failure_message"] == "measurement protocol is not canonical v3"
+    assert protocol["difference_only"] == [
+        "canonical_sample_count",
+        "iterations_per_arm",
+        "warmups_per_arm",
+    ]
+    assert protocol["sidecar_status"] == "readiness-pass"
+    assert evidence["postconditions"] == {
+        "benchmark_processes_remaining": False,
+        "media_roots_empty": True,
+        "tracked_checkout_clean": True,
+        "subjects_clean_and_identity_exact": True,
+        "output_stable": True,
+        "canonical_20x4_launched": False,
+    }
+    assert evidence["policy"] == {
+        "report_only": True,
+        "numeric_evidence": False,
+        "performance_budgets_ratified": False,
+        "promotion_eligible": False,
+        "route_or_default_promoted": False,
+        "canonical_20x4_status": "pending-quiet-host",
+    }
+
+    def walk(value):
+        if isinstance(value, dict):
+            for key, child in value.items():
+                yield key
+                yield from walk(child)
+        elif isinstance(value, list):
+            for child in value:
+                yield from walk(child)
+        else:
+            yield value
+
+    flattened = tuple(walk(evidence))
+    assert not any(
+        isinstance(value, str) and value.startswith("/") for value in flattened
+    )
+    assert not any(
+        isinstance(value, str) and "zhongmingy" in value for value in flattened
+    )
+    volatile_pid_key = re.compile(
+        r"(?:^|_)(?:pid|pids|process_id|process_ids)$", re.IGNORECASE
+    )
+    assert not any(
+        isinstance(value, str) and volatile_pid_key.search(value) for value in flattened
+    )
+    assert "720" not in evidence_text


### PR DESCRIPTION
## Summary

Record the completed post-#682 canonical-v3 1x0 readiness receipt while keeping A2 numeric evidence and retained-route promotion explicitly pending.

Related to #199.

## Changes

- Record the exact 30-cell, 60-process, and 720-safety-check readiness result and its report/sidecar digests.
- Explain that the sole nonzero result is the expected non-canonical protocol sentinel for a 1x0 run.
- Keep canonical 20x4 measurements gated on a quiet host and make clear that no compiler/runtime route or default is promoted.
- Update the release-contract assertion so this readiness boundary remains durable.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `test/test_release_artifacts.py`: 32 passed.
- Related release/public-doc/namespace/language-matrix selection: 128 passed.
- MkDocs strict build, public-doc boundary, namespace and capability-matrix checks passed.
- Black 24.8, isort 5.13.2, flake8 7.1.1 with bugbear, and diff-check passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
