### PR TITLE
docs(site): name reference deployment landing page

### DIFF
--- a/docs/guides/reference-deployments/index.md
+++ b/docs/guides/reference-deployments/index.md
@@ -1,3 +1,9 @@
+---
+title: Reference Deployments
+hide:
+  - toc
+---
+
 <!--
 SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
 

--- a/test/scripts/test_check_public_docs.py
+++ b/test/scripts/test_check_public_docs.py
@@ -60,6 +60,14 @@ def test_mkdocs_navigation_tabs_contract():
         "guides/reference-deployments/index.md",
         {"NVIDIA DGX Spark": "guides/reference-deployments/dgx-spark.md"},
     ]
+    reference_source = (
+        REPO_ROOT / "docs" / "guides" / "reference-deployments" / "index.md"
+    ).read_text(encoding="utf-8")
+    reference_metadata = yaml.safe_load(reference_source.split("---", 2)[1])
+    assert reference_metadata == {
+        "title": "Reference Deployments",
+        "hide": ["toc"],
+    }
 
     retrieval_planning = next(
         item["Retrieval Planning"]


### PR DESCRIPTION
## Summary

Fix the published Reference Deployments landing-page title so it uses the section name instead of the source filename.

## Changes

- Add explicit `Reference Deployments` page metadata.
- Hide the redundant landing-page table of contents.
- Lock the metadata contract in the public navigation test.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `python -m pytest -q test/scripts/test_check_public_docs.py --tb=short` (15 passed)
- `uv run --group docs --frozen mkdocs build --strict`
- `uv run --group docs --frozen python scripts/check_public_docs.py`
- Generated HTML title verified as `Reference Deployments - CodeNib`.
- Direct Black, isort, flake8, and `git diff --check` validation passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
