### PR TITLE
feat(storage): publish BM25 cache job outputs

### DIFF
--- a/codenib/compiler/__init__.py
+++ b/codenib/compiler/__init__.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
     from codenib.compiler.cache_import import (
         CompilerCacheBm25RecaptureResult,
         CompilerCacheImportResult,
+        CompilerCacheJobPublicationResult,
         CompilerCacheMultiViewImportResult,
         CompilerCacheTopologyGuard,
         CompilerCacheViewRecaptureResult,
@@ -36,6 +37,7 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
         compile_and_import_repo,
         import_compiler_cache,
         import_compiler_cache_bm25,
+        publish_compiler_cache_bm25_job,
     )
     from codenib.compiler.index_builders import IndexBuilderRegistry
     from codenib.compiler.index_compiler import IndexCompiler, IndexCompilerConfig
@@ -87,6 +89,10 @@ _EXPORTS = {
         "codenib.compiler.cache_import",
         "CompilerCacheImportResult",
     ),
+    "CompilerCacheJobPublicationResult": (
+        "codenib.compiler.cache_import",
+        "CompilerCacheJobPublicationResult",
+    ),
     "CompilerCacheMultiViewImportResult": (
         "codenib.compiler.cache_import",
         "CompilerCacheMultiViewImportResult",
@@ -114,6 +120,10 @@ _EXPORTS = {
     "import_compiler_cache_bm25": (
         "codenib.compiler.cache_import",
         "import_compiler_cache_bm25",
+    ),
+    "publish_compiler_cache_bm25_job": (
+        "codenib.compiler.cache_import",
+        "publish_compiler_cache_bm25_job",
     ),
     "IndexCompiler": ("codenib.compiler.index_compiler", "IndexCompiler"),
     "IndexCompilerConfig": (
@@ -216,6 +226,7 @@ __all__ = [
     # Index compilation
     "CompilerCacheBm25RecaptureResult",
     "CompilerCacheImportResult",
+    "CompilerCacheJobPublicationResult",
     "CompilerCacheMultiViewImportResult",
     "CompilerCacheTopologyGuard",
     "CompilerCacheViewRecaptureResult",
@@ -223,6 +234,7 @@ __all__ = [
     "compile_and_import_repo",
     "import_compiler_cache",
     "import_compiler_cache_bm25",
+    "publish_compiler_cache_bm25_job",
     "IndexCompiler",
     "IndexCompilerConfig",
     "IndexBuilderRegistry",

--- a/codenib/compiler/cache_import.py
+++ b/codenib/compiler/cache_import.py
@@ -62,15 +62,23 @@ from ..source_fingerprint import (
 )
 from ..storage.models import (
     DEFAULT_NAMESPACE_NAME,
+    IndexJobRecord,
+    IndexJobRequest,
+    IndexJobRequestedMode,
+    IndexJobStatus,
+    IndexJobViewRecord,
     RepositoryIdentity,
+    SourceRevision,
     StorageIntegrityError,
     StorageValidationError,
 )
 from ..storage.protocols import (
     RETAINED_IMPORT_CATALOG_CONTRACT,
+    JobPublicationCatalog,
     RetainedImportCatalog,
     RetainedImportObjectStore,
 )
+from ..storage.publication import publish_job_artifacts
 from ..storage.view_bundle import (
     DEFAULT_MAX_BUNDLE_BYTES,
     DEFAULT_MAX_BUNDLE_FILES,
@@ -91,6 +99,7 @@ from .manifest_import import (
     _expected_generation,
     _expected_namespace_id,
     _positive_limit,
+    _prepare_job_view_artifacts_inside_authority,
     _require_static_methods,
     _snapshot_environment,
     _snapshot_forbidden_paths,
@@ -109,6 +118,7 @@ from .snapshot_store import normalize_repo
 
 _COMMIT_RE = re.compile(r"[0-9a-f]{40}\Z", re.ASCII)
 _SUPPORTED_CACHE_VIEWS = ("bm25", "vector")
+_CATALOG_INT64_MAX = 9_223_372_036_854_775_807
 
 
 class CompilerCacheTopologyGuard(Protocol):
@@ -262,6 +272,64 @@ class CompilerCacheImportResult:
 
 
 @dataclass(frozen=True, slots=True)
+class CompilerCacheJobPublicationResult:
+    """Exact data returned after one fenced BM25 job publication."""
+
+    manifest: RepoManifest
+    import_plan: RepoManifestImportPlan
+    recapture: CompilerCacheBm25RecaptureResult
+    job: IndexJobRecord
+
+    def __post_init__(self) -> None:
+        if type(self) is not CompilerCacheJobPublicationResult:
+            raise TypeError(
+                "compiler cache job publication must use the exact result type"
+            )
+        if type(self.manifest) is not RepoManifest:
+            raise TypeError("compiler cache job manifest is invalid")
+        if type(self.import_plan) is not RepoManifestImportPlan:
+            raise TypeError("compiler cache job import plan is invalid")
+        if type(self.recapture) is not CompilerCacheBm25RecaptureResult:
+            raise TypeError("compiler cache job recapture is invalid")
+        if type(self.job) is not IndexJobRecord:
+            raise TypeError("compiler cache job record is invalid")
+        try:
+            manifest = RepoManifest.from_dict(copy.deepcopy(self.manifest.to_dict()))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise StorageIntegrityError(
+                "compiler cache job manifest cannot be detached"
+            ) from exc
+        plan_views = self.import_plan.views
+        request_views = _index_job_request(self.job).view_requests
+        expected_source = SourceRevision.dirty(
+            self.job.repository_id,
+            source_fingerprint=self.import_plan.source.fingerprint,
+            commit_sha=None,
+        )
+        if (
+            self.import_plan.selection.selected_views != ("bm25",)
+            or len(plan_views) != 1
+            or plan_views[0].view_type != "bm25"
+            or len(request_views) != 1
+            or request_views[0].view_type != "bm25"
+            or request_views[0].profile_id != plan_views[0].profile_id
+            or request_views[0].requested_mode is not IndexJobRequestedMode.FULL
+            or request_views[0].required is not True
+            or self.job.source_revision_id != expected_source.source_revision_id
+            or self.job.status is not IndexJobStatus.SUCCEEDED
+            or self.job.cancel_requested
+            or self.job.result_snapshot_id is None
+            or manifest.to_dict() != self.import_plan.manifest.to_dict()
+            or self.recapture.canonical_manifest_bytes
+            != _pretty_manifest_bytes(manifest)
+        ):
+            raise StorageIntegrityError(
+                "compiler cache job publication result identities are inconsistent"
+            )
+        object.__setattr__(self, "manifest", manifest)
+
+
+@dataclass(frozen=True, slots=True)
 class CompilerCacheMultiViewImportResult:
     """Pure-data result of one atomic compiler-cache view-set import."""
 
@@ -392,6 +460,14 @@ class _PreparedCompilerCacheImport:
     canonical_manifest_bytes: bytes
     import_plan: RepoManifestImportPlan
     context_artifact: ContextArtifactResult
+
+
+@dataclass(frozen=True, slots=True)
+class _CompilerCacheJobBinding:
+    job: IndexJobRecord
+    view: IndexJobViewRecord
+    source_snapshot: RepositorySourceIdentitySnapshot
+    source_identity: SourceRevision
 
 
 def _path_relation(path: Path, boundary: Path) -> str:
@@ -612,6 +688,323 @@ def _preflight_catalog_contract(catalog: RetainedImportCatalog) -> None:
     contract = catalog.retained_import_contract()
     if type(contract) is not str or contract != RETAINED_IMPORT_CATALOG_CONTRACT:
         raise TypeError("compiler cache import catalog contract is incompatible")
+
+
+def _index_job_request(job: IndexJobRecord) -> IndexJobRequest:
+    return IndexJobRequest(
+        repository_id=job.repository_id,
+        source_revision_id=job.source_revision_id,
+        ref_name=job.ref_name,
+        idempotency_key=job.idempotency_key,
+        expected_ref_generation=job.expected_ref_generation,
+        max_attempts=job.max_attempts,
+        request_json=job.request_json,
+    )
+
+
+def _detach_index_job_record(value: object) -> IndexJobRecord:
+    if type(value) is not IndexJobRecord:
+        raise StorageIntegrityError("catalog returned an invalid index job record")
+    text_fields = (
+        "job_id",
+        "repository_id",
+        "source_revision_id",
+        "ref_name",
+        "idempotency_key",
+        "request_json",
+        "request_digest",
+    )
+    optional_text_fields = (
+        "result_snapshot_id",
+        "error_code",
+        "error_message",
+    )
+    integer_fields = (
+        "expected_ref_generation",
+        "max_attempts",
+        "attempt_count",
+        "created_at_ms",
+        "updated_at_ms",
+    )
+    optional_integer_fields = ("started_at_ms", "finished_at_ms")
+    if (
+        any(type(getattr(value, field)) is not str for field in text_fields)
+        or any(
+            getattr(value, field) is not None and type(getattr(value, field)) is not str
+            for field in optional_text_fields
+        )
+        or any(type(getattr(value, field)) is not int for field in integer_fields)
+        or any(
+            getattr(value, field) is not None and type(getattr(value, field)) is not int
+            for field in optional_integer_fields
+        )
+        or type(value.status) is not IndexJobStatus
+        or type(value.cancel_requested) is not bool
+    ):
+        raise StorageIntegrityError("catalog index job fields are not exact")
+    detached = IndexJobRecord(
+        job_id=value.job_id,
+        repository_id=value.repository_id,
+        source_revision_id=value.source_revision_id,
+        ref_name=value.ref_name,
+        idempotency_key=value.idempotency_key,
+        expected_ref_generation=value.expected_ref_generation,
+        max_attempts=value.max_attempts,
+        request_json=value.request_json,
+        request_digest=value.request_digest,
+        status=value.status,
+        cancel_requested=value.cancel_requested,
+        attempt_count=value.attempt_count,
+        result_snapshot_id=value.result_snapshot_id,
+        error_code=value.error_code,
+        error_message=value.error_message,
+        created_at_ms=value.created_at_ms,
+        updated_at_ms=value.updated_at_ms,
+        started_at_ms=value.started_at_ms,
+        finished_at_ms=value.finished_at_ms,
+    )
+    if detached != value:
+        raise StorageIntegrityError("catalog index job record is not canonical")
+    return detached
+
+
+def _detach_index_job_views(value: object) -> tuple[IndexJobViewRecord, ...]:
+    if type(value) is not tuple or any(
+        type(item) is not IndexJobViewRecord for item in value
+    ):
+        raise StorageIntegrityError("catalog returned invalid index job view rows")
+    if any(
+        type(item.job_id) is not str
+        or type(item.view_type) is not str
+        or type(item.profile_id) is not str
+        or type(item.requested_mode) is not IndexJobRequestedMode
+        or type(item.required) is not bool
+        for item in value
+    ):
+        raise StorageIntegrityError("catalog index job view fields are not exact")
+    detached = tuple(
+        IndexJobViewRecord(
+            job_id=item.job_id,
+            view_type=item.view_type,
+            profile_id=item.profile_id,
+            requested_mode=item.requested_mode,
+            required=item.required,
+        )
+        for item in value
+    )
+    if detached != value:
+        raise StorageIntegrityError("catalog index job view rows are not canonical")
+    return detached
+
+
+def _read_compiler_cache_bm25_job_binding(
+    job_id: str,
+    *,
+    catalog: JobPublicationCatalog,
+    repository_source: RepositorySourceBinding,
+    repository_key: str,
+    namespace_name: str,
+) -> _CompilerCacheJobBinding:
+    source_snapshot = repository_source.authenticated_identity_snapshot()
+    if type(source_snapshot) is not RepositorySourceIdentitySnapshot:
+        raise TypeError("compiler cache repository identity has an invalid type")
+    repository_identity = RepositoryIdentity(
+        namespace_id=_expected_namespace_id(namespace_name),
+        repository_key=repository_key,
+    )
+    source_identity = SourceRevision.dirty(
+        repository_identity.repository_id,
+        source_fingerprint=source_snapshot.fingerprint,
+        commit_sha=None,
+    )
+    job = _detach_index_job_record(catalog.get_job(job_id))
+    if job.job_id != job_id:
+        raise StorageIntegrityError("catalog returned a different index job")
+    views = _detach_index_job_views(catalog.get_job_views(job_id))
+    expected_views = _index_job_request(job).view_requests
+    if views != expected_views:
+        raise StorageIntegrityError(
+            "catalog job view rows differ from the canonical request"
+        )
+    if (
+        job.repository_id != repository_identity.repository_id
+        or job.source_revision_id != source_identity.source_revision_id
+    ):
+        raise StorageValidationError(
+            "compiler cache job repository or source identity does not match"
+        )
+    if (
+        len(views) != 1
+        or views[0].job_id != job.job_id
+        or views[0].view_type != "bm25"
+        or views[0].requested_mode is not IndexJobRequestedMode.FULL
+        or views[0].required is not True
+    ):
+        raise StorageValidationError(
+            "compiler cache job must request exactly required FULL BM25"
+        )
+    if job.cancel_requested:
+        raise StorageValidationError("compiler cache job is cancelled")
+    if job.status not in {IndexJobStatus.RUNNING, IndexJobStatus.SUCCEEDED}:
+        raise StorageValidationError(
+            "compiler cache job must be active or an exact successful replay"
+        )
+    if job.attempt_count < 1 or job.started_at_ms is None:
+        raise StorageValidationError(
+            "compiler cache job has no acquired publication attempt"
+        )
+    return _CompilerCacheJobBinding(
+        job=job,
+        view=views[0],
+        source_snapshot=source_snapshot,
+        source_identity=source_identity,
+    )
+
+
+def _require_compiler_cache_bm25_job_profile(
+    binding: _CompilerCacheJobBinding,
+    plan: RepoManifestImportPlan,
+) -> None:
+    if (
+        type(plan) is not RepoManifestImportPlan
+        or plan.selection.selected_views != ("bm25",)
+        or len(plan.views) != 1
+        or plan.views[0].view_type != "bm25"
+    ):
+        raise StorageIntegrityError("compiler cache BM25 import plan is inconsistent")
+    if binding.view.profile_id != plan.views[0].profile_id:
+        raise StorageValidationError(
+            "compiler cache BM25 profile does not match the job request"
+        )
+
+
+def _preflight_cache_job_operation(
+    cache_dir: str | Path,
+    *,
+    job_id: str,
+    owner_id: str,
+    fencing_token: int,
+    repository_source: RepositorySourceBinding,
+    bm25_output_owner: PublishedWorkspaceReceiptOwner,
+    context_output_owner: PublishedWorkspaceReceiptOwner,
+    bm25_destination: Path,
+    context_destination: Path,
+    workspace_provider: StrictWorkspaceProvider,
+    repository_key: str,
+    catalog: JobPublicationCatalog,
+    object_store: RetainedImportObjectStore,
+    namespace_name: str,
+    max_manifest_bytes: int,
+    max_context_files: int,
+    max_context_bytes: int,
+    max_bundle_files: int,
+    max_bundle_bytes: int,
+    max_bundle_metadata_bytes: int,
+    forbidden_paths: Iterable[Path],
+    environ: Mapping[str, str] | None,
+) -> tuple[_ImportOperation, _CompilerCacheJobBinding, str, str, int]:
+    normalized_job_id = _exact_text(job_id, "job ID", max_length=80)
+    normalized_owner_id = _exact_text(owner_id, "lease owner ID", max_length=256)
+    if (
+        type(fencing_token) is not int
+        or fencing_token < 1
+        or fencing_token > _CATALOG_INT64_MAX
+    ):
+        raise StorageValidationError("fencing token must be a positive catalog int64")
+    _preflight_authorities(
+        views=("bm25",),
+        repository_source=repository_source,
+        view_output_owners={"bm25": bm25_output_owner},
+        view_destinations={"bm25": bm25_destination},
+        context_output_owner=context_output_owner,
+        context_destination=context_destination,
+    )
+    repository = _exact_text(repository_key, "repository key")
+    try:
+        normalized_repository = normalize_repo(repository)
+    except ValueError as exc:
+        raise StorageValidationError("repository key is not canonical") from exc
+    if normalized_repository != repository:
+        raise StorageValidationError("repository key is not canonical")
+    namespace = _exact_text(namespace_name, "namespace name")
+    manifest_limit = _manifest_limit(max_manifest_bytes)
+    context_files = _positive_limit(max_context_files, "context file limit")
+    context_bytes = _positive_limit(max_context_bytes, "context byte limit")
+    bundle_files = _positive_limit(max_bundle_files, "bundle file limit")
+    bundle_bytes = _positive_limit(max_bundle_bytes, "bundle byte limit")
+    bundle_metadata_bytes = _positive_limit(
+        max_bundle_metadata_bytes,
+        "bundle metadata byte limit",
+    )
+    environment = _snapshot_environment(environ)
+    forbidden = _snapshot_forbidden_paths(forbidden_paths)
+    if not isinstance(catalog, JobPublicationCatalog):
+        raise TypeError("compiler cache job catalog lacks publication capabilities")
+    _require_static_methods(
+        catalog,
+        label="compiler cache job catalog",
+        names=("get_job", "get_job_views", "publish_job_outputs"),
+    )
+    if not isinstance(object_store, RetainedImportObjectStore):
+        raise TypeError(
+            "compiler cache job object store lacks retained streaming capabilities"
+        )
+    _require_static_methods(
+        object_store,
+        label="compiler cache job object store",
+        names=_OBJECT_STORE_METHODS,
+    )
+    _preflight_workspace_provider(workspace_provider)
+    binding = _read_compiler_cache_bm25_job_binding(
+        normalized_job_id,
+        catalog=catalog,
+        repository_source=repository_source,
+        repository_key=repository,
+        namespace_name=namespace,
+    )
+    inputs = _ImportPreflight(
+        repository_key=repository,
+        namespace_name=namespace,
+        ref_name=binding.job.ref_name,
+        expected_generation=binding.job.expected_ref_generation,
+        max_manifest_bytes=manifest_limit,
+        max_context_files=context_files,
+        max_context_bytes=context_bytes,
+        max_bundle_files=bundle_files,
+        max_bundle_bytes=bundle_bytes,
+        max_bundle_metadata_bytes=bundle_metadata_bytes,
+        max_projection_bytes=DEFAULT_MAX_PROJECTION_BYTES,
+        forbidden_paths=forbidden,
+        environment=environment,
+    )
+    cache = lexical_directory_path(Path(cache_dir))
+    bm25_output = lexical_directory_path(bm25_destination)
+    context_output = lexical_directory_path(context_destination)
+    fixed_source_views = {"bm25": lexical_directory_path(cache / "bm25")}
+    policy_forbidden = _snapshot_forbidden_paths(
+        (
+            *inputs.forbidden_paths,
+            cache,
+            *fixed_source_views.values(),
+            bm25_output,
+            context_output,
+        )
+    )
+    return (
+        _ImportOperation(
+            cache=cache,
+            view_owners={"bm25": bm25_output_owner},
+            view_outputs={"bm25": bm25_output},
+            context_output=context_output,
+            inputs=inputs,
+            fixed_source_views=fixed_source_views,
+            policy_forbidden=policy_forbidden,
+        ),
+        binding,
+        normalized_job_id,
+        normalized_owner_id,
+        fencing_token,
+    )
 
 
 def _cache_topology(
@@ -1117,6 +1510,7 @@ def _prepare_compiler_cache_import_locked(
     context_output_owner: PublishedWorkspaceReceiptOwner,
     workspace_provider: StrictWorkspaceProvider,
     expected_manifest: RepoManifest | None = None,
+    job_binding: _CompilerCacheJobBinding | None = None,
 ) -> _PreparedCompilerCacheImport:
     """Recapture selected views while the caller holds the cache lease."""
 
@@ -1198,6 +1592,10 @@ def _prepare_compiler_cache_import_locked(
         raise StorageIntegrityError(
             "compiler cache portable manifest changed during import planning"
         )
+    if job_binding is not None:
+        if type(job_binding) is not _CompilerCacheJobBinding or views != ("bm25",):
+            raise TypeError("compiler cache job binding is invalid")
+        _require_compiler_cache_bm25_job_profile(job_binding, import_plan)
 
     recaptures: list[CompilerCacheViewRecaptureResult] = []
     for view in views:
@@ -1399,6 +1797,165 @@ def import_compiler_cache(
         context_output_owner=context_output_owner,
         catalog=catalog,
         object_store=object_store,
+    )
+
+
+def publish_compiler_cache_bm25_job(
+    cache_dir: str | Path,
+    *,
+    job_id: str,
+    owner_id: str,
+    fencing_token: int,
+    repository_source: RepositorySourceBinding,
+    bm25_output_owner: PublishedWorkspaceReceiptOwner,
+    context_output_owner: PublishedWorkspaceReceiptOwner,
+    bm25_destination: Path,
+    context_destination: Path,
+    workspace_provider: StrictWorkspaceProvider,
+    repository_key: str,
+    catalog: JobPublicationCatalog,
+    object_store: RetainedImportObjectStore,
+    namespace_name: str = DEFAULT_NAMESPACE_NAME,
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+    max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
+    max_context_bytes: int = DEFAULT_MAX_CONTEXT_BYTES,
+    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
+    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
+    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> CompilerCacheJobPublicationResult:
+    """Publish one exact current BM25 cache into a caller-owned fenced job.
+
+    The caller must already have registered the repository, source, and exact
+    BM25 profile, created the job, and acquired its active ref lease. This
+    adapter never creates, acquires, renews, or finishes a job independently.
+    Mutable cache reads and strict recapture share one existing-only compiler
+    cache lease. Only the retained context receipt crosses that boundary into
+    bundle/member CAS ingestion, and ``publish_job_artifacts`` is the sole
+    catalog mutation path.
+    """
+
+    operation, binding, normalized_job_id, normalized_owner_id, token = (
+        _preflight_cache_job_operation(
+            cache_dir,
+            job_id=job_id,
+            owner_id=owner_id,
+            fencing_token=fencing_token,
+            repository_source=repository_source,
+            bm25_output_owner=bm25_output_owner,
+            context_output_owner=context_output_owner,
+            bm25_destination=bm25_destination,
+            context_destination=context_destination,
+            workspace_provider=workspace_provider,
+            repository_key=repository_key,
+            catalog=catalog,
+            object_store=object_store,
+            namespace_name=namespace_name,
+            max_manifest_bytes=max_manifest_bytes,
+            max_context_files=max_context_files,
+            max_context_bytes=max_context_bytes,
+            max_bundle_files=max_bundle_files,
+            max_bundle_bytes=max_bundle_bytes,
+            max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+            forbidden_paths=forbidden_paths,
+            environ=environ,
+        )
+    )
+    with compiler_cache_lock(operation.cache, create=False):
+        preparation = _prepare_compiler_cache_import_locked(
+            operation,
+            views=("bm25",),
+            repository_source=repository_source,
+            context_output_owner=context_output_owner,
+            workspace_provider=workspace_provider,
+            job_binding=binding,
+        )
+
+    # Job reads are advisory fail-fast gates. The final publication transaction
+    # remains authoritative for the owner, fence, expiry, cancellation, and ref
+    # generation; a previously committed exact success remains replayable.
+    current = _read_compiler_cache_bm25_job_binding(
+        normalized_job_id,
+        catalog=catalog,
+        repository_source=repository_source,
+        repository_key=operation.inputs.repository_key,
+        namespace_name=operation.inputs.namespace_name,
+    )
+    _require_compiler_cache_bm25_job_profile(current, preparation.import_plan)
+    if (
+        current.source_snapshot != binding.source_snapshot
+        or current.source_identity != binding.source_identity
+        or current.job.request_digest != binding.job.request_digest
+    ):
+        raise StorageIntegrityError(
+            "compiler cache job or repository source changed before CAS ingestion"
+        )
+
+    artifacts = context_output_owner.consume(
+        lambda receipt, publication: _prepare_job_view_artifacts_inside_authority(
+            receipt,
+            publication,
+            plan=preparation.import_plan,
+            repository_source=repository_source,
+            repository_key=operation.inputs.repository_key,
+            source_identity=binding.source_identity,
+            object_store=object_store,
+            environment=operation.inputs.environment,
+            forbidden_paths=operation.policy_forbidden,
+            max_context_files=operation.inputs.max_context_files,
+            max_context_bytes=operation.inputs.max_context_bytes,
+            max_bundle_files=operation.inputs.max_bundle_files,
+            max_bundle_bytes=operation.inputs.max_bundle_bytes,
+            max_bundle_metadata_bytes=operation.inputs.max_bundle_metadata_bytes,
+        )
+    )
+    if type(artifacts) is not tuple or len(artifacts) != 1:
+        raise StorageIntegrityError(
+            "compiler cache BM25 ingestion returned invalid job artifacts"
+        )
+    if repository_source.authenticated_identity_snapshot() != binding.source_snapshot:
+        raise StorageIntegrityError(
+            "compiler cache repository source changed during CAS ingestion"
+        )
+    current = _read_compiler_cache_bm25_job_binding(
+        normalized_job_id,
+        catalog=catalog,
+        repository_source=repository_source,
+        repository_key=operation.inputs.repository_key,
+        namespace_name=operation.inputs.namespace_name,
+    )
+    _require_compiler_cache_bm25_job_profile(current, preparation.import_plan)
+    if (
+        current.source_snapshot != binding.source_snapshot
+        or current.source_identity != binding.source_identity
+        or current.job.request_digest != binding.job.request_digest
+    ):
+        raise StorageIntegrityError(
+            "compiler cache job or repository source changed before publication"
+        )
+    completed = publish_job_artifacts(
+        normalized_job_id,
+        catalog=catalog,
+        object_store=object_store,
+        owner_id=normalized_owner_id,
+        fencing_token=token,
+        outputs=artifacts,
+    )
+    recapture = preparation.recaptures[0]
+    if recapture.view_type != "bm25":  # pragma: no cover - adapter invariant
+        raise AssertionError("compiler cache BM25 job selected another view")
+    return CompilerCacheJobPublicationResult(
+        manifest=preparation.import_plan.manifest,
+        import_plan=preparation.import_plan,
+        recapture=CompilerCacheBm25RecaptureResult(
+            source_view=recapture.source_view,
+            output_view=recapture.output_view,
+            source_records=recapture.source_records,
+            output_records=recapture.output_records,
+            canonical_manifest_bytes=preparation.canonical_manifest_bytes,
+        ),
+        job=completed,
     )
 
 
@@ -1625,6 +2182,7 @@ def _fingerprints_adjustment(
 __all__ = [
     "CompilerCacheBm25RecaptureResult",
     "CompilerCacheImportResult",
+    "CompilerCacheJobPublicationResult",
     "CompilerCacheMultiViewImportResult",
     "CompilerCacheTopologyGuard",
     "CompilerCacheViewRecaptureResult",
@@ -1632,4 +2190,5 @@ __all__ = [
     "compile_and_import_repo",
     "import_compiler_cache",
     "import_compiler_cache_bm25",
+    "publish_compiler_cache_bm25_job",
 ]

--- a/codenib/compiler/manifest_import.py
+++ b/codenib/compiler/manifest_import.py
@@ -66,6 +66,7 @@ from ..storage.protocols import (
     RetainedImportObjectStore,
     snapshot_retained_import_response,
 )
+from ..storage.publication import IndexJobObjectArtifact, IndexJobViewArtifact
 from ..storage.view_bundle import (
     DEFAULT_MAX_BUNDLE_BYTES,
     DEFAULT_MAX_BUNDLE_FILES,
@@ -193,6 +194,12 @@ class _PreparedView:
     bundle: _StoredObject
     members: tuple[tuple[str, int, int, _StoredObject], ...]
     generation: ViewGeneration
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedManifestViews:
+    artifact_plan_digest: str
+    views: tuple[_PreparedView, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -712,7 +719,7 @@ def _drain(chunks: Iterable[bytes]) -> None:
         pass
 
 
-def _prepare_import_inside_authority(
+def _prepare_manifest_views_inside_authority(
     receipt: PublishedWorkspaceReceipt,
     publication: PublicationDirectoryReader,
     *,
@@ -728,8 +735,7 @@ def _prepare_import_inside_authority(
     max_bundle_files: int,
     max_bundle_bytes: int,
     max_bundle_metadata_bytes: int,
-    max_projection_bytes: int,
-) -> _PreparedImport:
+) -> _PreparedManifestViews:
     if type(receipt) is not PublishedWorkspaceReceipt:
         raise TypeError("retained context receipt has an invalid type")
     if type(publication) is not PublicationDirectoryReader:
@@ -854,13 +860,123 @@ def _prepare_import_inside_authority(
             )
         )
 
+    return _PreparedManifestViews(
+        artifact_plan_digest=artifact_plan_digest,
+        views=tuple(prepared_views),
+    )
+
+
+def _prepare_job_view_artifacts_inside_authority(
+    receipt: PublishedWorkspaceReceipt,
+    publication: PublicationDirectoryReader,
+    *,
+    plan: RepoManifestImportPlan,
+    repository_source: RepositorySourceBinding,
+    repository_key: str,
+    source_identity: SourceRevision,
+    object_store: RetainedImportObjectStore,
+    environment: Mapping[str, str],
+    forbidden_paths: tuple[Path, ...],
+    max_context_files: int,
+    max_context_bytes: int,
+    max_bundle_files: int,
+    max_bundle_bytes: int,
+    max_bundle_metadata_bytes: int,
+) -> tuple[IndexJobViewArtifact, ...]:
+    """Ingest exact selected-view receipts without a manifest projection."""
+
+    prepared = _prepare_manifest_views_inside_authority(
+        receipt,
+        publication,
+        plan=plan,
+        repository_source=repository_source,
+        repository_key=repository_key,
+        source_identity=source_identity,
+        object_store=object_store,
+        environment=environment,
+        forbidden_paths=forbidden_paths,
+        max_context_files=max_context_files,
+        max_context_bytes=max_context_bytes,
+        max_bundle_files=max_bundle_files,
+        max_bundle_bytes=max_bundle_bytes,
+        max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+    )
+    artifacts: list[IndexJobViewArtifact] = []
+    for view in prepared.views:
+        members = _unique_stored_objects(member[3] for member in view.members)
+        artifact = IndexJobViewArtifact.create(
+            view.intent.view_type,
+            view.intent.profile_id,
+            view.bundle.receipt,
+            schema_version=VIEW_BUNDLE_SCHEMA,
+            media_type=view.bundle.record.media_type,
+            metadata=_intent_generation_metadata(view.intent),
+            member_artifacts=tuple(
+                IndexJobObjectArtifact(member.receipt, member.record.media_type)
+                for member in members
+            ),
+        )
+        output = artifact._output()
+        if (
+            output.view_type != view.generation.view_type
+            or output.profile_id != view.generation.profile_id
+            or output.object_record != view.bundle.record
+            or output.schema_version != view.generation.schema_version
+            or canonical_json(output.generation_metadata)
+            != view.generation.metadata_json
+            or output.member_object_records
+            != tuple(member.record for member in members)
+        ):
+            raise StorageIntegrityError(
+                "retained job artifact differs from its prepared view generation"
+            )
+        artifacts.append(artifact)
+    repository_source.verify_snapshot()
+    return tuple(artifacts)
+
+
+def _prepare_import_inside_authority(
+    receipt: PublishedWorkspaceReceipt,
+    publication: PublicationDirectoryReader,
+    *,
+    plan: RepoManifestImportPlan,
+    repository_source: RepositorySourceBinding,
+    repository_key: str,
+    source_identity: SourceRevision,
+    object_store: RetainedImportObjectStore,
+    environment: Mapping[str, str],
+    forbidden_paths: tuple[Path, ...],
+    max_context_files: int,
+    max_context_bytes: int,
+    max_bundle_files: int,
+    max_bundle_bytes: int,
+    max_bundle_metadata_bytes: int,
+    max_projection_bytes: int,
+) -> _PreparedImport:
+    prepared = _prepare_manifest_views_inside_authority(
+        receipt,
+        publication,
+        plan=plan,
+        repository_source=repository_source,
+        repository_key=repository_key,
+        source_identity=source_identity,
+        object_store=object_store,
+        environment=environment,
+        forbidden_paths=forbidden_paths,
+        max_context_files=max_context_files,
+        max_context_bytes=max_context_bytes,
+        max_bundle_files=max_bundle_files,
+        max_bundle_bytes=max_bundle_bytes,
+        max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+    )
+
     projection_profile = _projection_profile()
     projection_value = _projection_value(
         plan,
-        artifact_plan_digest=artifact_plan_digest,
+        artifact_plan_digest=prepared.artifact_plan_digest,
         repository_id=source_identity.repository_id,
         source=source_identity,
-        views=prepared_views,
+        views=prepared.views,
     )
     projection_digest, projection_size = _measure_canonical_json(
         projection_value,
@@ -885,7 +1001,7 @@ def _prepare_import_inside_authority(
         sorted(
             {
                 dependency.record.digest
-                for view in prepared_views
+                for view in prepared.views
                 for dependency in (view.bundle, *(member[3] for member in view.members))
             }
         )
@@ -895,7 +1011,7 @@ def _prepare_import_inside_authority(
         "manifest_version": plan.manifest.version,
         "manifest_digest": plan.manifest_digest,
         "plan_digest": plan.plan_digest,
-        "projected_views": [view.intent.view_type for view in prepared_views],
+        "projected_views": [view.intent.view_type for view in prepared.views],
     }
     projection_generation = ViewGeneration.create(
         source_identity,
@@ -907,8 +1023,8 @@ def _prepare_import_inside_authority(
     )
     repository_source.verify_snapshot()
     return _PreparedImport(
-        artifact_plan_digest=artifact_plan_digest,
-        views=tuple(prepared_views),
+        artifact_plan_digest=prepared.artifact_plan_digest,
+        views=prepared.views,
         projection=projection_object,
         projection_profile=projection_profile,
         projection_generation=projection_generation,

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1114,16 +1114,37 @@ existing-only reopen nevertheless revalidate the complete durable aggregate
 and fail closed when publication dependencies or canonical closure data have
 been corrupted.
 
+The first M2 builder-profile adapter now publishes one exact current BM25
+compiler-cache view into a caller-created, caller-acquired fenced job. It
+requires a single required `full` BM25 request whose repository, retained
+source revision, and complete portable builder profile match the strict
+recapture/import plan. The mutable cache lease encloses raw BM25 recapture and
+whole-context evidence publication, then releases before the retained context
+is converted to one canonical view-bundle receipt plus every independently
+reachable member receipt. `publish_job_artifacts` remains the sole catalog
+mutation: it retains that complete receipt set through the atomic job/snapshot/
+ref transaction and returned-result attestation. The job path publishes only
+the BM25 generation, not the direct M1 importer's internal manifest projection.
+The caller still owns repository/source/profile registration, job creation,
+lease acquisition, and all receipt owners; the adapter adds no worker, CLI,
+runtime, vector, graph, or default-route wiring. Exact retry remains historical:
+a committed BM25 job returns its original snapshot without moving a ref that a
+later valid publication has already advanced.
+
 ### M2: Immutable generation publication
 
 Status: in progress. The receipt-retained, fenced SQLite publication primitive
-is implemented; builder adapters and production job/runtime wiring remain.
+and the explicit BM25 compiler-cache adapter are implemented; vector, graph,
+generic builder, and production job/runtime wiring remain.
 
 - Make every builder write to a unique staging generation.
 - Add per-view profile adapters that fail closed on incomplete compatibility
   inputs and prove every semantic axis participates in the profile identity.
+  The exact BM25 compiler-cache profile path is implemented; vector, graph, and
+  generic builder adapters remain.
 - Publish whole-view BM25, FAISS, and graph artifacts through the catalog and
-  object store without changing their ranking/query semantics.
+  object store without changing their ranking/query semantics. BM25 now has an
+  explicit fenced compiler-cache ingress; FAISS and graph ingress remain.
 - Use the implemented receipt-retaining coordinator for each adapter so exact
   digest, size, storage key, and media type remain retained through atomic
   catalog publication; catalog metadata alone must never make missing bytes

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -36,6 +36,7 @@ from codenib.artifacts import query_context_artifact
 from codenib.compiler.cache_import import (
     CompilerCacheBm25RecaptureResult,
     CompilerCacheImportResult,
+    CompilerCacheJobPublicationResult,
     CompilerCacheMultiViewImportResult,
     CompilerCacheTopologyGuard,
     CompilerCacheViewRecaptureResult,
@@ -44,6 +45,7 @@ from codenib.compiler.cache_import import (
     compiler_cache_source_selection,
     import_compiler_cache,
     import_compiler_cache_bm25,
+    publish_compiler_cache_bm25_job,
 )
 from codenib.compiler.index_builders import (
     BM25IndexBuilder,
@@ -56,6 +58,10 @@ from codenib.compiler.manifest_import import RepoManifestImportResult
 from codenib.compiler.manifest_materialization import (
     materialize_retained_repo_manifest_ref,
 )
+from codenib.compiler.manifest_storage import (
+    RepoManifestImportPlan,
+    plan_repo_manifest_import_bytes,
+)
 from codenib.compiler.retained_manifest_contract import REPO_MANIFEST_PROJECTION_VIEW
 from codenib.index.embedding.vector_store import CodeVectorStore
 from codenib.mcp.context import ServerContext
@@ -67,8 +73,14 @@ from codenib.source_fingerprint import (
     fingerprint_repository,
 )
 from codenib.storage import (
+    INDEX_JOB_REQUEST_CONTRACT,
     RETAINED_IMPORT_CATALOG_CONTRACT,
+    VIEW_BUNDLE_MEDIA_TYPE,
+    VIEW_BUNDLE_SCHEMA,
+    BlobInfo,
+    IndexJobStatus,
     LocalCAS,
+    PublishConflict,
     SQLiteCatalog,
     StorageIntegrityError,
     StorageValidationError,
@@ -247,6 +259,74 @@ class _LockAwareCAS(LocalCAS):
             ("cas.put_chunks", self._test_state["phase"])
         )
         return super().put_chunks(chunks, expected_digest, expected_size)
+
+
+class _JobTrackingCAS(LocalCAS):
+    def __init__(self, root: Path) -> None:
+        self.put_chunk_receipts: list[BlobInfo] = []
+        self.retained_receipt_sets: list[tuple[BlobInfo, ...]] = []
+        self.retention_active = False
+        self.after_put: Callable[[int], None] | None = None
+        super().__init__(root)
+
+    def put_chunks(
+        self,
+        chunks,
+        expected_digest: str,
+        expected_size: int,
+    ) -> BlobInfo:
+        receipt = super().put_chunks(chunks, expected_digest, expected_size)
+        self.put_chunk_receipts.append(receipt)
+        if self.after_put is not None:
+            self.after_put(len(self.put_chunk_receipts))
+        return receipt
+
+    def retain_receipts(self, expected, callback):
+        receipts = tuple(expected)
+        self.retained_receipt_sets.append(receipts)
+        assert not self.retention_active
+        self.retention_active = True
+        try:
+            return super().retain_receipts(receipts, callback)
+        finally:
+            self.retention_active = False
+
+
+class _ForgedPutReceiptCAS(_JobTrackingCAS):
+    def put_chunks(
+        self,
+        chunks,
+        expected_digest: str,
+        expected_size: int,
+    ) -> BlobInfo:
+        receipt = super().put_chunks(chunks, expected_digest, expected_size)
+        if len(self.put_chunk_receipts) == 1:
+            return BlobInfo(
+                digest=receipt.digest,
+                byte_size=receipt.byte_size,
+                storage_key="sha256/00/" + receipt.digest,
+            )
+        return receipt
+
+
+class _SkippingRetentionCAS(_JobTrackingCAS):
+    def retain_receipts(self, expected, callback):
+        del callback
+        receipts = tuple(expected)
+        self.retained_receipt_sets.append(receipts)
+        return object()
+
+
+class _RetentionAwareJobCatalog(SQLiteCatalog):
+    def __init__(self, path: Path, cas: _JobTrackingCAS) -> None:
+        self._tracking_cas = cas
+        self.job_publication_calls = 0
+        super().__init__(path)
+
+    def publish_job_outputs(self, *args, **kwargs):
+        assert self._tracking_cas.retention_active
+        self.job_publication_calls += 1
+        return super().publish_job_outputs(*args, **kwargs)
 
 
 class _LockAwareCatalog(SQLiteCatalog):
@@ -540,6 +620,10 @@ def test_compiler_cache_import_is_a_lazy_public_export() -> None:
         is CompilerRetainedPublicationResult
     )
     assert compiler_module.CompilerCacheTopologyGuard is CompilerCacheTopologyGuard
+    assert (
+        compiler_module.CompilerCacheJobPublicationResult
+        is CompilerCacheJobPublicationResult
+    )
     assert compiler_module.compile_and_import_repo is compile_and_import_repo
     assert compiler_module.CompilerCacheImportResult is CompilerCacheImportResult
     assert (
@@ -556,6 +640,10 @@ def test_compiler_cache_import_is_a_lazy_public_export() -> None:
     )
     assert compiler_module.import_compiler_cache is import_compiler_cache
     assert compiler_module.import_compiler_cache_bm25 is import_compiler_cache_bm25
+    assert (
+        compiler_module.publish_compiler_cache_bm25_job
+        is publish_compiler_cache_bm25_job
+    )
     assert list(inspect.signature(import_compiler_cache).parameters)[:11] == [
         "cache_dir",
         "views",
@@ -581,6 +669,22 @@ def test_compiler_cache_import_is_a_lazy_public_export() -> None:
         "catalog",
         "object_store",
     ]
+    assert list(inspect.signature(publish_compiler_cache_bm25_job).parameters)[:14] == [
+        "cache_dir",
+        "job_id",
+        "owner_id",
+        "fencing_token",
+        "repository_source",
+        "bm25_output_owner",
+        "context_output_owner",
+        "bm25_destination",
+        "context_destination",
+        "workspace_provider",
+        "repository_key",
+        "catalog",
+        "object_store",
+        "namespace_name",
+    ]
     compile_signature = inspect.signature(compile_and_import_repo)
     assert list(compile_signature.parameters)[:4] == [
         "compiler",
@@ -593,6 +697,572 @@ def test_compiler_cache_import_is_a_lazy_public_export() -> None:
     )
     assert compile_signature.parameters["cache_dir"].default is inspect.Parameter.empty
     assert "rebuild" not in compile_signature.parameters
+
+
+def _expected_bm25_job_plan(fixture: _CacheFixture) -> RepoManifestImportPlan:
+    manifest = RepoManifest.load(fixture.cache / "repo_manifest.json")
+    entry = manifest.indexes["bm25"]
+    planned = cache_import_module._plan_cache_view(
+        "bm25",
+        fixture.cache / "bm25",
+        fixture.bm25_destination,
+        repository_source=fixture.source,
+        view_config=entry.config,
+        forbidden_paths=(),
+        environ={},
+    )
+    _portable, payload = cache_import_module._portable_manifest(
+        manifest,
+        views=("bm25",),
+        planned_views={"bm25": planned},
+    )
+    return plan_repo_manifest_import_bytes(payload, views=("bm25",))
+
+
+def _register_bm25_job_subject(
+    catalog: SQLiteCatalog,
+    fixture: _CacheFixture,
+    plan: RepoManifestImportPlan,
+) -> tuple[str, str, str]:
+    repository_id = catalog.create_repository(_REPOSITORY_KEY)
+    source_revision_id = catalog.create_source_revision(
+        repository_id,
+        commit_sha=None,
+        dirty=True,
+        source_fingerprint=fixture.source.fingerprint,
+    )
+    intent = plan.views[0]
+    profile_id = catalog.create_view_profile(
+        "bm25",
+        intent.profile.config,
+        name=intent.profile.name,
+    )
+    assert profile_id == intent.profile_id
+    return repository_id, source_revision_id, profile_id
+
+
+def _create_bm25_job(
+    catalog: SQLiteCatalog,
+    *,
+    repository_id: str,
+    source_revision_id: str,
+    profile_id: str,
+    idempotency_key: str = "compiler-cache-bm25",
+    requested_mode: str = "full",
+    required: bool = True,
+    expected_ref_generation: int = 0,
+    extra_views: dict[str, dict[str, object]] | None = None,
+):
+    views: dict[str, dict[str, object]] = {
+        "bm25": {
+            "profile_id": profile_id,
+            "requested_mode": requested_mode,
+            "required": required,
+        }
+    }
+    if extra_views:
+        views.update(copy.deepcopy(extra_views))
+    return catalog.create_job(
+        repository_id,
+        source_revision_id,
+        idempotency_key,
+        {"contract": INDEX_JOB_REQUEST_CONTRACT, "views": views},
+        expected_ref_generation=expected_ref_generation,
+    )
+
+
+def _publish_bm25_job(
+    fixture: _CacheFixture,
+    *,
+    job_id: str,
+    owner_id: str,
+    fencing_token: int,
+    catalog: SQLiteCatalog,
+    cas: LocalCAS,
+    bm25_owner: PublishedWorkspaceReceiptOwner | None = None,
+    context_owner: PublishedWorkspaceReceiptOwner | None = None,
+    bm25_destination: Path | None = None,
+    context_destination: Path | None = None,
+) -> CompilerCacheJobPublicationResult:
+    return publish_compiler_cache_bm25_job(
+        fixture.cache,
+        job_id=job_id,
+        owner_id=owner_id,
+        fencing_token=fencing_token,
+        repository_source=fixture.source,
+        bm25_output_owner=bm25_owner or fixture.bm25_owner,
+        context_output_owner=context_owner or fixture.context_owner,
+        bm25_destination=bm25_destination or fixture.bm25_destination,
+        context_destination=context_destination or fixture.context_destination,
+        workspace_provider=fixture.provider,
+        repository_key=_REPOSITORY_KEY,
+        catalog=catalog,
+        object_store=cas,
+        environ={},
+    )
+
+
+def _seed_bm25_snapshot(
+    catalog: SQLiteCatalog,
+    cas: LocalCAS,
+    *,
+    repository_id: str,
+    source_revision_id: str,
+    profile_id: str,
+    payload: bytes,
+    expected_generation: int,
+) -> tuple[dict[str, object], str]:
+    receipt = cas.put_bytes(payload)
+    catalog.register_object(
+        receipt.digest,
+        storage_key=receipt.storage_key,
+        byte_size=receipt.byte_size,
+        media_type="application/x-test-old-bm25",
+    )
+    generation_id = catalog.stage_view_generation(
+        repository_id,
+        source_revision_id,
+        profile_id,
+        "bm25",
+        receipt.digest,
+        schema_version=f"old-bm25-{expected_generation + 1}",
+        metadata={"seed_generation": expected_generation + 1},
+    )
+    publication = catalog.publish_snapshot(
+        repository_id,
+        source_revision_id,
+        (generation_id,),
+        expected_generation=expected_generation,
+    )
+    return publication, receipt.digest
+
+
+def test_compiler_cache_bm25_job_publishes_only_exact_bundle_and_replays(
+    tmp_path: Path,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    retry_bm25_owner = PublishedWorkspaceReceiptOwner()
+    retry_context_owner = PublishedWorkspaceReceiptOwner()
+    plan = _expected_bm25_job_plan(fixture)
+    try:
+        with (
+            _JobTrackingCAS(tmp_path / "cas") as cas,
+            _RetentionAwareJobCatalog(
+                tmp_path / "catalog.sqlite",
+                cas,
+            ) as catalog,
+        ):
+            repository_id, source_revision_id, profile_id = _register_bm25_job_subject(
+                catalog, fixture, plan
+            )
+            job = _create_bm25_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+            )
+            lease = catalog.acquire_job_lease(
+                job.job_id,
+                owner_id="worker-1",
+                lease_duration_ms=60_000,
+            )
+
+            result = _publish_bm25_job(
+                fixture,
+                job_id=job.job_id,
+                owner_id=lease.owner_id,
+                fencing_token=lease.fencing_token,
+                catalog=catalog,
+                cas=cas,
+            )
+
+            assert type(result) is CompilerCacheJobPublicationResult
+            assert result.job.status is IndexJobStatus.SUCCEEDED
+            assert result.job.job_id == job.job_id
+            assert result.job.result_snapshot_id is not None
+            assert result.manifest.to_dict() == result.import_plan.manifest.to_dict()
+            assert result.manifest.repo_path == "source"
+            assert tuple(result.manifest.indexes) == ("bm25",)
+            assert result.import_plan.plan_digest == plan.plan_digest
+            assert result.recapture.output_view == fixture.bm25_destination
+            assert result.recapture.canonical_manifest_bytes == (
+                cache_import_module._pretty_manifest_bytes(result.import_plan.manifest)
+            )
+            assert len(cas.put_chunk_receipts) == 3
+            assert len({receipt.digest for receipt in cas.put_chunk_receipts}) == 3
+            expected_receipts = tuple(
+                sorted(cas.put_chunk_receipts, key=lambda receipt: receipt.digest)
+            )
+            assert cas.retained_receipt_sets == [expected_receipts]
+            assert catalog.job_publication_calls == 1
+            summary = catalog.get_manifest_summary(result.job.result_snapshot_id)
+            assert tuple(summary["views"]) == ("bm25",)
+            assert REPO_MANIFEST_PROJECTION_VIEW not in summary["views"]
+            bm25 = summary["views"]["bm25"]
+            assert bm25["profile"]["profile_id"] == profile_id
+            assert bm25["schema_version"] == VIEW_BUNDLE_SCHEMA
+            assert bm25["object"]["media_type"] == VIEW_BUNDLE_MEDIA_TYPE
+            assert len(bm25["member_objects"]) == 2
+            assert all(
+                member["media_type"] == "application/octet-stream"
+                for member in bm25["member_objects"]
+            )
+            for persisted in (bm25["object"], *bm25["member_objects"]):
+                receipt = cas.verify(persisted["digest"])
+                assert receipt.byte_size == persisted["byte_size"]
+                assert receipt.storage_key == persisted["storage_key"]
+            first_ref = catalog.resolve_ref(repository_id)
+            _seed_bm25_snapshot(
+                catalog,
+                cas,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+                payload=b"newer BM25 snapshot after completed job",
+                expected_generation=1,
+            )
+            advanced_ref = catalog.resolve_ref(repository_id)
+            assert advanced_ref["generation"] == first_ref["generation"] + 1
+            assert advanced_ref["snapshot_id"] != first_ref["snapshot_id"]
+
+            retry = _publish_bm25_job(
+                fixture,
+                job_id=job.job_id,
+                owner_id=lease.owner_id,
+                fencing_token=lease.fencing_token,
+                catalog=catalog,
+                cas=cas,
+                bm25_owner=retry_bm25_owner,
+                context_owner=retry_context_owner,
+                bm25_destination=fixture.workspace / "retry-bm25",
+                context_destination=fixture.workspace / "retry-context",
+            )
+            assert retry.job == result.job
+            assert retry.import_plan.plan_digest == result.import_plan.plan_digest
+            assert retry.job.result_snapshot_id == first_ref["snapshot_id"]
+            assert catalog.resolve_ref(repository_id) == advanced_ref
+            assert tuple(cas.put_chunk_receipts[:3]) == tuple(
+                cas.put_chunk_receipts[3:]
+            )
+            assert cas.retained_receipt_sets == [
+                expected_receipts,
+                expected_receipts,
+            ]
+            assert catalog.job_publication_calls == 2
+            assert fixture.bm25_owner.active
+            assert fixture.context_owner.active
+            assert retry_bm25_owner.active
+            assert retry_context_owner.active
+    finally:
+        retry_context_owner.close()
+        retry_bm25_owner.close()
+        fixture.close()
+
+
+@pytest.mark.parametrize(
+    ("case", "error"),
+    [
+        ("wrong_owner", PublishConflict),
+        ("wrong_fence", PublishConflict),
+        ("expired_lease", PublishConflict),
+        ("cancelled", StorageValidationError),
+        ("ref_drift", PublishConflict),
+    ],
+)
+def test_compiler_cache_bm25_job_failure_preserves_current_ref(
+    tmp_path: Path,
+    case: str,
+    error: type[Exception],
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    plan = _expected_bm25_job_plan(fixture)
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            clock = {"ms": 1_000}
+            catalog._connection.create_function(
+                "julianday",
+                1,
+                lambda _value: 2440587.5 + clock["ms"] / 86_400_000,
+            )
+            repository_id, source_revision_id, profile_id = _register_bm25_job_subject(
+                catalog, fixture, plan
+            )
+            _seed_bm25_snapshot(
+                catalog,
+                cas,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+                payload=b"usable old BM25 snapshot",
+                expected_generation=0,
+            )
+            job = _create_bm25_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+                expected_ref_generation=1,
+            )
+            lease = catalog.acquire_job_lease(
+                job.job_id,
+                owner_id="worker-1",
+                lease_duration_ms=1 if case == "expired_lease" else 60_000,
+            )
+            token = lease.fencing_token
+            owner_id = lease.owner_id
+            if case == "wrong_owner":
+                owner_id = "other-worker"
+            elif case == "wrong_fence":
+                token += 1
+            elif case == "expired_lease":
+                clock["ms"] = lease.lease_expires_at_ms + 1_000
+            elif case == "cancelled":
+                catalog.request_job_cancel(job.job_id)
+            elif case == "ref_drift":
+                _seed_bm25_snapshot(
+                    catalog,
+                    cas,
+                    repository_id=repository_id,
+                    source_revision_id=source_revision_id,
+                    profile_id=profile_id,
+                    payload=b"newer still-usable BM25 snapshot",
+                    expected_generation=1,
+                )
+            preserved = catalog.resolve_ref(repository_id)
+            preserved_view = preserved["manifest"]["views"]["bm25"]
+            preserved_payload = cas.read_bytes(preserved_view["object"]["digest"])
+
+            with pytest.raises(error):
+                _publish_bm25_job(
+                    fixture,
+                    job_id=job.job_id,
+                    owner_id=owner_id,
+                    fencing_token=token,
+                    catalog=catalog,
+                    cas=cas,
+                )
+
+            assert catalog.resolve_ref(repository_id) == preserved
+            assert cas.read_bytes(preserved_view["object"]["digest"]) == (
+                preserved_payload
+            )
+            assert catalog.get_job(job.job_id).status is not IndexJobStatus.SUCCEEDED
+    finally:
+        fixture.close()
+
+
+@pytest.mark.parametrize(
+    "case",
+    (
+        "not_full",
+        "optional",
+        "extra_view",
+        "profile_mismatch",
+        "source_mismatch",
+        "repository_mismatch",
+        "not_acquired",
+    ),
+)
+def test_compiler_cache_bm25_job_rejects_incompatible_request_before_cas(
+    tmp_path: Path,
+    case: str,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    plan = _expected_bm25_job_plan(fixture)
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            repository_id, source_revision_id, profile_id = _register_bm25_job_subject(
+                catalog, fixture, plan
+            )
+            requested_mode = "incremental" if case == "not_full" else "full"
+            required = case != "optional"
+            extra_views = None
+            if case == "extra_view":
+                vector_profile = catalog.create_view_profile(
+                    "vector",
+                    {"test_profile": "extra"},
+                )
+                extra_views = {
+                    "vector": {
+                        "profile_id": vector_profile,
+                        "requested_mode": "full",
+                        "required": False,
+                    }
+                }
+            if case == "profile_mismatch":
+                profile_id = catalog.create_view_profile(
+                    "bm25",
+                    {"test_profile": "wrong"},
+                )
+            if case == "source_mismatch":
+                source_revision_id = catalog.create_source_revision(
+                    repository_id,
+                    commit_sha=None,
+                    dirty=True,
+                    source_fingerprint="other-source-fingerprint",
+                )
+            if case == "repository_mismatch":
+                repository_id = catalog.create_repository("owner/other")
+                source_revision_id = catalog.create_source_revision(
+                    repository_id,
+                    commit_sha=None,
+                    dirty=True,
+                    source_fingerprint=fixture.source.fingerprint,
+                )
+            job = _create_bm25_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+                requested_mode=requested_mode,
+                required=required,
+                extra_views=extra_views,
+            )
+            if case == "not_acquired":
+                owner_id = "worker-1"
+                token = 1
+            else:
+                lease = catalog.acquire_job_lease(
+                    job.job_id,
+                    owner_id="worker-1",
+                    lease_duration_ms=60_000,
+                )
+                owner_id = lease.owner_id
+                token = lease.fencing_token
+            before_files = tuple(
+                sorted(
+                    path.relative_to(tmp_path / "cas").as_posix()
+                    for path in (tmp_path / "cas").rglob("*")
+                    if path.is_file()
+                )
+            )
+
+            with pytest.raises(StorageValidationError):
+                _publish_bm25_job(
+                    fixture,
+                    job_id=job.job_id,
+                    owner_id=owner_id,
+                    fencing_token=token,
+                    catalog=catalog,
+                    cas=cas,
+                )
+
+            after_files = tuple(
+                sorted(
+                    path.relative_to(tmp_path / "cas").as_posix()
+                    for path in (tmp_path / "cas").rglob("*")
+                    if path.is_file()
+                )
+            )
+            assert after_files == before_files
+            assert fixture.provider.run_count == 0
+            assert fixture.bm25_owner.state == "empty"
+            assert fixture.context_owner.state == "empty"
+            assert not fixture.bm25_destination.exists()
+            assert not fixture.context_destination.exists()
+    finally:
+        fixture.close()
+
+
+@pytest.mark.parametrize(
+    ("case", "cas_type", "error"),
+    (
+        ("source_drift", _JobTrackingCAS, RepositoryChangedError),
+        ("job_drift", _JobTrackingCAS, StorageValidationError),
+        ("receipt_substitution", _ForgedPutReceiptCAS, StorageValidationError),
+        ("callback_skipped", _SkippingRetentionCAS, StorageIntegrityError),
+    ),
+)
+def test_compiler_cache_bm25_job_rejects_post_ingest_drift_or_substitution(
+    tmp_path: Path,
+    case: str,
+    cas_type: type[_JobTrackingCAS],
+    error: type[Exception],
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    plan = _expected_bm25_job_plan(fixture)
+    try:
+        with (
+            cas_type(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            repository_id, source_revision_id, profile_id = _register_bm25_job_subject(
+                catalog, fixture, plan
+            )
+            _publication, preserved_digest = _seed_bm25_snapshot(
+                catalog,
+                cas,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+                payload=b"retained old snapshot before adversarial drift",
+                expected_generation=0,
+            )
+            job = _create_bm25_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+                expected_ref_generation=1,
+            )
+            lease = catalog.acquire_job_lease(
+                job.job_id,
+                owner_id="worker-1",
+                lease_duration_ms=60_000,
+            )
+            preserved_ref = catalog.resolve_ref(repository_id)
+
+            if case == "source_drift":
+
+                def drift_source(put_count: int) -> None:
+                    if put_count == 3:
+                        (fixture.repository / "sample.py").write_text(
+                            "VALUE = 2\n",
+                            encoding="utf-8",
+                        )
+
+                cas.after_put = drift_source
+            elif case == "job_drift":
+
+                def drift_job(put_count: int) -> None:
+                    if put_count == 3:
+                        catalog.request_job_cancel(job.job_id)
+
+                cas.after_put = drift_job
+
+            with pytest.raises(error):
+                _publish_bm25_job(
+                    fixture,
+                    job_id=job.job_id,
+                    owner_id=lease.owner_id,
+                    fencing_token=lease.fencing_token,
+                    catalog=catalog,
+                    cas=cas,
+                )
+
+            assert len(cas.put_chunk_receipts) == 3
+            assert catalog.resolve_ref(repository_id) == preserved_ref
+            assert cas.read_bytes(preserved_digest) == (
+                b"retained old snapshot before adversarial drift"
+            )
+            assert catalog.get_job(job.job_id).status is IndexJobStatus.RUNNING
+            publication_count = catalog._connection.execute(
+                "SELECT COUNT(*) FROM index_job_publications WHERE job_id = ?",
+                (job.job_id,),
+            ).fetchone()[0]
+            assert publication_count == 0
+            if case in {"source_drift", "job_drift"}:
+                assert cas.retained_receipt_sets == []
+            else:
+                assert len(cas.retained_receipt_sets) == 1
+    finally:
+        fixture.close()
 
 
 def test_compile_and_import_fresh_cache_uses_one_lease_and_storage_after_release(


### PR DESCRIPTION
## Summary

Add a BM25-only compiler-cache adapter that publishes one required `FULL` view to a caller-created and caller-acquired fenced job.

The adapter strictly recaptures an existing compiler cache, validates the exact repository, source revision, and portable BM25 profile, and publishes through the retained job-publication coordinator.

Related to #199.

## Changes

- Add `publish_compiler_cache_bm25_job(...)` and `CompilerCacheJobPublicationResult`.
- Require exactly one required `FULL` BM25 job view with matching repository, source revision, profile, lease, fence, and ref expectations.
- Publish the canonical BM25 view bundle and every member receipt through `publish_job_artifacts`.
- Preserve historical replay after a later valid publication advances the ref.
- Minimally factor manifest-import preparation while preserving existing direct-import behavior.
- Add lazy compiler exports, adversarial coverage, and the M2 roadmap status update.
- Intentionally add no worker, vector, graph, runtime, CLI, or default-route wiring.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/compiler/test_cache_import.py -k "compiler_cache_bm25_job or lazy_public_export" -x --tb=short` — 18 passed, 33 deselected
- `pytest -q test/compiler/test_manifest_import.py test/compiler/test_cache_import.py -x --tb=short` — 63 passed
- `pytest -q test/compiler -x --tb=short` — 875 passed with one existing fork deprecation warning
- `pytest -q test/storage/test_job_publication_coordinator.py -x --tb=short` — 31 passed
- Relevant job-publication, model, view-bundle, and SQLite storage suite — 278 passed
- Black, isort with the Black profile, flake8, and `git diff --check`
- Namespace check, generated capability check, strict MkDocs build, and public-doc boundary check

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published