### PR TITLE
feat(storage): publish vector cache job outputs

### DIFF
--- a/codenib/compiler/__init__.py
+++ b/codenib/compiler/__init__.py
@@ -32,12 +32,14 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
         CompilerCacheJobPublicationResult,
         CompilerCacheMultiViewImportResult,
         CompilerCacheTopologyGuard,
+        CompilerCacheVectorJobPublicationResult,
         CompilerCacheViewRecaptureResult,
         CompilerRetainedPublicationResult,
         compile_and_import_repo,
         import_compiler_cache,
         import_compiler_cache_bm25,
         publish_compiler_cache_bm25_job,
+        publish_compiler_cache_vector_job,
     )
     from codenib.compiler.index_builders import IndexBuilderRegistry
     from codenib.compiler.index_compiler import IndexCompiler, IndexCompilerConfig
@@ -101,6 +103,10 @@ _EXPORTS = {
         "codenib.compiler.cache_import",
         "CompilerCacheTopologyGuard",
     ),
+    "CompilerCacheVectorJobPublicationResult": (
+        "codenib.compiler.cache_import",
+        "CompilerCacheVectorJobPublicationResult",
+    ),
     "CompilerCacheViewRecaptureResult": (
         "codenib.compiler.cache_import",
         "CompilerCacheViewRecaptureResult",
@@ -124,6 +130,10 @@ _EXPORTS = {
     "publish_compiler_cache_bm25_job": (
         "codenib.compiler.cache_import",
         "publish_compiler_cache_bm25_job",
+    ),
+    "publish_compiler_cache_vector_job": (
+        "codenib.compiler.cache_import",
+        "publish_compiler_cache_vector_job",
     ),
     "IndexCompiler": ("codenib.compiler.index_compiler", "IndexCompiler"),
     "IndexCompilerConfig": (
@@ -229,12 +239,14 @@ __all__ = [
     "CompilerCacheJobPublicationResult",
     "CompilerCacheMultiViewImportResult",
     "CompilerCacheTopologyGuard",
+    "CompilerCacheVectorJobPublicationResult",
     "CompilerCacheViewRecaptureResult",
     "CompilerRetainedPublicationResult",
     "compile_and_import_repo",
     "import_compiler_cache",
     "import_compiler_cache_bm25",
     "publish_compiler_cache_bm25_job",
+    "publish_compiler_cache_vector_job",
     "IndexCompiler",
     "IndexCompilerConfig",
     "IndexBuilderRegistry",

--- a/codenib/compiler/cache_import.py
+++ b/codenib/compiler/cache_import.py
@@ -330,6 +330,65 @@ class CompilerCacheJobPublicationResult:
 
 
 @dataclass(frozen=True, slots=True)
+class CompilerCacheVectorJobPublicationResult:
+    """Exact data returned after one fenced vector job publication."""
+
+    manifest: RepoManifest
+    import_plan: RepoManifestImportPlan
+    recapture: CompilerCacheViewRecaptureResult
+    job: IndexJobRecord
+
+    def __post_init__(self) -> None:
+        if type(self) is not CompilerCacheVectorJobPublicationResult:
+            raise TypeError(
+                "compiler cache vector job publication must use the exact result type"
+            )
+        if type(self.manifest) is not RepoManifest:
+            raise TypeError("compiler cache vector job manifest is invalid")
+        if type(self.import_plan) is not RepoManifestImportPlan:
+            raise TypeError("compiler cache vector job import plan is invalid")
+        if type(self.recapture) is not CompilerCacheViewRecaptureResult:
+            raise TypeError("compiler cache vector job recapture is invalid")
+        if type(self.job) is not IndexJobRecord:
+            raise TypeError("compiler cache vector job record is invalid")
+        try:
+            manifest = RepoManifest.from_dict(copy.deepcopy(self.manifest.to_dict()))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise StorageIntegrityError(
+                "compiler cache vector job manifest cannot be detached"
+            ) from exc
+        plan_views = self.import_plan.views
+        request_views = _index_job_request(self.job).view_requests
+        expected_source = SourceRevision.dirty(
+            self.job.repository_id,
+            source_fingerprint=self.import_plan.source.fingerprint,
+            commit_sha=None,
+        )
+        if (
+            self.import_plan.selection.selected_views != ("vector",)
+            or len(plan_views) != 1
+            or plan_views[0].view_type != "vector"
+            or plan_views[0].profile.config.get("builder_schema") != 8
+            or len(request_views) != 1
+            or request_views[0].view_type != "vector"
+            or request_views[0].profile_id != plan_views[0].profile_id
+            or request_views[0].requested_mode is not IndexJobRequestedMode.FULL
+            or request_views[0].required is not True
+            or self.job.source_revision_id != expected_source.source_revision_id
+            or self.job.status is not IndexJobStatus.SUCCEEDED
+            or self.job.cancel_requested
+            or self.job.result_snapshot_id is None
+            or manifest.to_dict() != self.import_plan.manifest.to_dict()
+            or self.recapture.view_type != "vector"
+            or manifest.indexes["vector"].path != "views/vector"
+        ):
+            raise StorageIntegrityError(
+                "compiler cache vector job publication identities are inconsistent"
+            )
+        object.__setattr__(self, "manifest", manifest)
+
+
+@dataclass(frozen=True, slots=True)
 class CompilerCacheMultiViewImportResult:
     """Pure-data result of one atomic compiler-cache view-set import."""
 
@@ -797,14 +856,17 @@ def _detach_index_job_views(value: object) -> tuple[IndexJobViewRecord, ...]:
     return detached
 
 
-def _read_compiler_cache_bm25_job_binding(
+def _read_compiler_cache_job_binding(
     job_id: str,
     *,
+    view_type: str,
     catalog: JobPublicationCatalog,
     repository_source: RepositorySourceBinding,
     repository_key: str,
     namespace_name: str,
 ) -> _CompilerCacheJobBinding:
+    if type(view_type) is not str or view_type not in _SUPPORTED_CACHE_VIEWS:
+        raise TypeError("compiler cache job view type is invalid")
     source_snapshot = repository_source.authenticated_identity_snapshot()
     if type(source_snapshot) is not RepositorySourceIdentitySnapshot:
         raise TypeError("compiler cache repository identity has an invalid type")
@@ -836,12 +898,13 @@ def _read_compiler_cache_bm25_job_binding(
     if (
         len(views) != 1
         or views[0].job_id != job.job_id
-        or views[0].view_type != "bm25"
+        or views[0].view_type != view_type
         or views[0].requested_mode is not IndexJobRequestedMode.FULL
         or views[0].required is not True
     ):
         raise StorageValidationError(
-            "compiler cache job must request exactly required FULL BM25"
+            "compiler cache job must request exactly one required FULL "
+            f"{view_type} view"
         )
     if job.cancel_requested:
         raise StorageValidationError("compiler cache job is cancelled")
@@ -861,33 +924,40 @@ def _read_compiler_cache_bm25_job_binding(
     )
 
 
-def _require_compiler_cache_bm25_job_profile(
+def _require_compiler_cache_job_profile(
     binding: _CompilerCacheJobBinding,
     plan: RepoManifestImportPlan,
+    *,
+    view_type: str,
 ) -> None:
+    if type(view_type) is not str or view_type not in _SUPPORTED_CACHE_VIEWS:
+        raise TypeError("compiler cache job profile view type is invalid")
     if (
         type(plan) is not RepoManifestImportPlan
-        or plan.selection.selected_views != ("bm25",)
+        or plan.selection.selected_views != (view_type,)
         or len(plan.views) != 1
-        or plan.views[0].view_type != "bm25"
+        or plan.views[0].view_type != view_type
     ):
-        raise StorageIntegrityError("compiler cache BM25 import plan is inconsistent")
+        raise StorageIntegrityError(
+            f"compiler cache {view_type} import plan is inconsistent"
+        )
     if binding.view.profile_id != plan.views[0].profile_id:
         raise StorageValidationError(
-            "compiler cache BM25 profile does not match the job request"
+            f"compiler cache {view_type} profile does not match the job request"
         )
 
 
 def _preflight_cache_job_operation(
     cache_dir: str | Path,
     *,
+    view_type: str,
     job_id: str,
     owner_id: str,
     fencing_token: int,
     repository_source: RepositorySourceBinding,
-    bm25_output_owner: PublishedWorkspaceReceiptOwner,
+    view_output_owner: PublishedWorkspaceReceiptOwner,
     context_output_owner: PublishedWorkspaceReceiptOwner,
-    bm25_destination: Path,
+    view_destination: Path,
     context_destination: Path,
     workspace_provider: StrictWorkspaceProvider,
     repository_key: str,
@@ -903,6 +973,8 @@ def _preflight_cache_job_operation(
     forbidden_paths: Iterable[Path],
     environ: Mapping[str, str] | None,
 ) -> tuple[_ImportOperation, _CompilerCacheJobBinding, str, str, int]:
+    if type(view_type) is not str or view_type not in _SUPPORTED_CACHE_VIEWS:
+        raise TypeError("compiler cache job view type is invalid")
     normalized_job_id = _exact_text(job_id, "job ID", max_length=80)
     normalized_owner_id = _exact_text(owner_id, "lease owner ID", max_length=256)
     if (
@@ -912,10 +984,10 @@ def _preflight_cache_job_operation(
     ):
         raise StorageValidationError("fencing token must be a positive catalog int64")
     _preflight_authorities(
-        views=("bm25",),
+        views=(view_type,),
         repository_source=repository_source,
-        view_output_owners={"bm25": bm25_output_owner},
-        view_destinations={"bm25": bm25_destination},
+        view_output_owners={view_type: view_output_owner},
+        view_destinations={view_type: view_destination},
         context_output_owner=context_output_owner,
         context_destination=context_destination,
     )
@@ -955,8 +1027,9 @@ def _preflight_cache_job_operation(
         names=_OBJECT_STORE_METHODS,
     )
     _preflight_workspace_provider(workspace_provider)
-    binding = _read_compiler_cache_bm25_job_binding(
+    binding = _read_compiler_cache_job_binding(
         normalized_job_id,
+        view_type=view_type,
         catalog=catalog,
         repository_source=repository_source,
         repository_key=repository,
@@ -978,23 +1051,23 @@ def _preflight_cache_job_operation(
         environment=environment,
     )
     cache = lexical_directory_path(Path(cache_dir))
-    bm25_output = lexical_directory_path(bm25_destination)
+    view_output = lexical_directory_path(view_destination)
     context_output = lexical_directory_path(context_destination)
-    fixed_source_views = {"bm25": lexical_directory_path(cache / "bm25")}
+    fixed_source_views = {view_type: lexical_directory_path(cache / view_type)}
     policy_forbidden = _snapshot_forbidden_paths(
         (
             *inputs.forbidden_paths,
             cache,
             *fixed_source_views.values(),
-            bm25_output,
+            view_output,
             context_output,
         )
     )
     return (
         _ImportOperation(
             cache=cache,
-            view_owners={"bm25": bm25_output_owner},
-            view_outputs={"bm25": bm25_output},
+            view_owners={view_type: view_output_owner},
+            view_outputs={view_type: view_output},
             context_output=context_output,
             inputs=inputs,
             fixed_source_views=fixed_source_views,
@@ -1593,9 +1666,13 @@ def _prepare_compiler_cache_import_locked(
             "compiler cache portable manifest changed during import planning"
         )
     if job_binding is not None:
-        if type(job_binding) is not _CompilerCacheJobBinding or views != ("bm25",):
+        if type(job_binding) is not _CompilerCacheJobBinding or len(views) != 1:
             raise TypeError("compiler cache job binding is invalid")
-        _require_compiler_cache_bm25_job_profile(job_binding, import_plan)
+        _require_compiler_cache_job_profile(
+            job_binding,
+            import_plan,
+            view_type=views[0],
+        )
 
     recaptures: list[CompilerCacheViewRecaptureResult] = []
     for view in views:
@@ -1800,6 +1877,154 @@ def import_compiler_cache(
     )
 
 
+def _publish_compiler_cache_job(
+    cache_dir: str | Path,
+    *,
+    view_type: str,
+    job_id: str,
+    owner_id: str,
+    fencing_token: int,
+    repository_source: RepositorySourceBinding,
+    view_output_owner: PublishedWorkspaceReceiptOwner,
+    context_output_owner: PublishedWorkspaceReceiptOwner,
+    view_destination: Path,
+    context_destination: Path,
+    workspace_provider: StrictWorkspaceProvider,
+    repository_key: str,
+    catalog: JobPublicationCatalog,
+    object_store: RetainedImportObjectStore,
+    namespace_name: str,
+    max_manifest_bytes: int,
+    max_context_files: int,
+    max_context_bytes: int,
+    max_bundle_files: int,
+    max_bundle_bytes: int,
+    max_bundle_metadata_bytes: int,
+    forbidden_paths: Iterable[Path],
+    environ: Mapping[str, str] | None,
+) -> tuple[_PreparedCompilerCacheImport, IndexJobRecord]:
+    """Recapture and atomically publish one exact compiler-cache job view."""
+
+    operation, binding, normalized_job_id, normalized_owner_id, token = (
+        _preflight_cache_job_operation(
+            cache_dir,
+            view_type=view_type,
+            job_id=job_id,
+            owner_id=owner_id,
+            fencing_token=fencing_token,
+            repository_source=repository_source,
+            view_output_owner=view_output_owner,
+            context_output_owner=context_output_owner,
+            view_destination=view_destination,
+            context_destination=context_destination,
+            workspace_provider=workspace_provider,
+            repository_key=repository_key,
+            catalog=catalog,
+            object_store=object_store,
+            namespace_name=namespace_name,
+            max_manifest_bytes=max_manifest_bytes,
+            max_context_files=max_context_files,
+            max_context_bytes=max_context_bytes,
+            max_bundle_files=max_bundle_files,
+            max_bundle_bytes=max_bundle_bytes,
+            max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+            forbidden_paths=forbidden_paths,
+            environ=environ,
+        )
+    )
+    with compiler_cache_lock(operation.cache, create=False):
+        preparation = _prepare_compiler_cache_import_locked(
+            operation,
+            views=(view_type,),
+            repository_source=repository_source,
+            context_output_owner=context_output_owner,
+            workspace_provider=workspace_provider,
+            job_binding=binding,
+        )
+
+    # Job reads are advisory fail-fast gates. The final publication transaction
+    # remains authoritative for the owner, fence, expiry, cancellation, and ref
+    # generation; a previously committed exact success remains replayable.
+    current = _read_compiler_cache_job_binding(
+        normalized_job_id,
+        view_type=view_type,
+        catalog=catalog,
+        repository_source=repository_source,
+        repository_key=operation.inputs.repository_key,
+        namespace_name=operation.inputs.namespace_name,
+    )
+    _require_compiler_cache_job_profile(
+        current,
+        preparation.import_plan,
+        view_type=view_type,
+    )
+    if (
+        current.source_snapshot != binding.source_snapshot
+        or current.source_identity != binding.source_identity
+        or current.job.request_digest != binding.job.request_digest
+    ):
+        raise StorageIntegrityError(
+            "compiler cache job or repository source changed before CAS ingestion"
+        )
+
+    artifacts = context_output_owner.consume(
+        lambda receipt, publication: _prepare_job_view_artifacts_inside_authority(
+            receipt,
+            publication,
+            plan=preparation.import_plan,
+            repository_source=repository_source,
+            repository_key=operation.inputs.repository_key,
+            source_identity=binding.source_identity,
+            object_store=object_store,
+            environment=operation.inputs.environment,
+            forbidden_paths=operation.policy_forbidden,
+            max_context_files=operation.inputs.max_context_files,
+            max_context_bytes=operation.inputs.max_context_bytes,
+            max_bundle_files=operation.inputs.max_bundle_files,
+            max_bundle_bytes=operation.inputs.max_bundle_bytes,
+            max_bundle_metadata_bytes=operation.inputs.max_bundle_metadata_bytes,
+        )
+    )
+    if type(artifacts) is not tuple or len(artifacts) != 1:
+        raise StorageIntegrityError(
+            f"compiler cache {view_type} ingestion returned invalid job artifacts"
+        )
+    if repository_source.authenticated_identity_snapshot() != binding.source_snapshot:
+        raise StorageIntegrityError(
+            "compiler cache repository source changed during CAS ingestion"
+        )
+    current = _read_compiler_cache_job_binding(
+        normalized_job_id,
+        view_type=view_type,
+        catalog=catalog,
+        repository_source=repository_source,
+        repository_key=operation.inputs.repository_key,
+        namespace_name=operation.inputs.namespace_name,
+    )
+    _require_compiler_cache_job_profile(
+        current,
+        preparation.import_plan,
+        view_type=view_type,
+    )
+    if (
+        current.source_snapshot != binding.source_snapshot
+        or current.source_identity != binding.source_identity
+        or current.job.request_digest != binding.job.request_digest
+    ):
+        raise StorageIntegrityError(
+            "compiler cache job or repository source changed before publication"
+        )
+    completed = publish_job_artifacts(
+        normalized_job_id,
+        catalog=catalog,
+        object_store=object_store,
+        owner_id=normalized_owner_id,
+        fencing_token=token,
+        outputs=artifacts,
+    )
+    return preparation, completed
+
+
 def publish_compiler_cache_bm25_job(
     cache_dir: str | Path,
     *,
@@ -1836,111 +2061,30 @@ def publish_compiler_cache_bm25_job(
     catalog mutation path.
     """
 
-    operation, binding, normalized_job_id, normalized_owner_id, token = (
-        _preflight_cache_job_operation(
-            cache_dir,
-            job_id=job_id,
-            owner_id=owner_id,
-            fencing_token=fencing_token,
-            repository_source=repository_source,
-            bm25_output_owner=bm25_output_owner,
-            context_output_owner=context_output_owner,
-            bm25_destination=bm25_destination,
-            context_destination=context_destination,
-            workspace_provider=workspace_provider,
-            repository_key=repository_key,
-            catalog=catalog,
-            object_store=object_store,
-            namespace_name=namespace_name,
-            max_manifest_bytes=max_manifest_bytes,
-            max_context_files=max_context_files,
-            max_context_bytes=max_context_bytes,
-            max_bundle_files=max_bundle_files,
-            max_bundle_bytes=max_bundle_bytes,
-            max_bundle_metadata_bytes=max_bundle_metadata_bytes,
-            forbidden_paths=forbidden_paths,
-            environ=environ,
-        )
-    )
-    with compiler_cache_lock(operation.cache, create=False):
-        preparation = _prepare_compiler_cache_import_locked(
-            operation,
-            views=("bm25",),
-            repository_source=repository_source,
-            context_output_owner=context_output_owner,
-            workspace_provider=workspace_provider,
-            job_binding=binding,
-        )
-
-    # Job reads are advisory fail-fast gates. The final publication transaction
-    # remains authoritative for the owner, fence, expiry, cancellation, and ref
-    # generation; a previously committed exact success remains replayable.
-    current = _read_compiler_cache_bm25_job_binding(
-        normalized_job_id,
-        catalog=catalog,
+    preparation, completed = _publish_compiler_cache_job(
+        cache_dir,
+        view_type="bm25",
+        job_id=job_id,
+        owner_id=owner_id,
+        fencing_token=fencing_token,
         repository_source=repository_source,
-        repository_key=operation.inputs.repository_key,
-        namespace_name=operation.inputs.namespace_name,
-    )
-    _require_compiler_cache_bm25_job_profile(current, preparation.import_plan)
-    if (
-        current.source_snapshot != binding.source_snapshot
-        or current.source_identity != binding.source_identity
-        or current.job.request_digest != binding.job.request_digest
-    ):
-        raise StorageIntegrityError(
-            "compiler cache job or repository source changed before CAS ingestion"
-        )
-
-    artifacts = context_output_owner.consume(
-        lambda receipt, publication: _prepare_job_view_artifacts_inside_authority(
-            receipt,
-            publication,
-            plan=preparation.import_plan,
-            repository_source=repository_source,
-            repository_key=operation.inputs.repository_key,
-            source_identity=binding.source_identity,
-            object_store=object_store,
-            environment=operation.inputs.environment,
-            forbidden_paths=operation.policy_forbidden,
-            max_context_files=operation.inputs.max_context_files,
-            max_context_bytes=operation.inputs.max_context_bytes,
-            max_bundle_files=operation.inputs.max_bundle_files,
-            max_bundle_bytes=operation.inputs.max_bundle_bytes,
-            max_bundle_metadata_bytes=operation.inputs.max_bundle_metadata_bytes,
-        )
-    )
-    if type(artifacts) is not tuple or len(artifacts) != 1:
-        raise StorageIntegrityError(
-            "compiler cache BM25 ingestion returned invalid job artifacts"
-        )
-    if repository_source.authenticated_identity_snapshot() != binding.source_snapshot:
-        raise StorageIntegrityError(
-            "compiler cache repository source changed during CAS ingestion"
-        )
-    current = _read_compiler_cache_bm25_job_binding(
-        normalized_job_id,
-        catalog=catalog,
-        repository_source=repository_source,
-        repository_key=operation.inputs.repository_key,
-        namespace_name=operation.inputs.namespace_name,
-    )
-    _require_compiler_cache_bm25_job_profile(current, preparation.import_plan)
-    if (
-        current.source_snapshot != binding.source_snapshot
-        or current.source_identity != binding.source_identity
-        or current.job.request_digest != binding.job.request_digest
-    ):
-        raise StorageIntegrityError(
-            "compiler cache job or repository source changed before publication"
-        )
-    completed = publish_job_artifacts(
-        normalized_job_id,
+        view_output_owner=bm25_output_owner,
+        context_output_owner=context_output_owner,
+        view_destination=bm25_destination,
+        context_destination=context_destination,
+        workspace_provider=workspace_provider,
+        repository_key=repository_key,
         catalog=catalog,
         object_store=object_store,
-        owner_id=normalized_owner_id,
-        fencing_token=token,
-        outputs=artifacts,
+        namespace_name=namespace_name,
+        max_manifest_bytes=max_manifest_bytes,
+        max_context_files=max_context_files,
+        max_context_bytes=max_context_bytes,
+        max_bundle_files=max_bundle_files,
+        max_bundle_bytes=max_bundle_bytes,
+        max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
     )
     recapture = preparation.recaptures[0]
     if recapture.view_type != "bm25":  # pragma: no cover - adapter invariant
@@ -1955,6 +2099,76 @@ def publish_compiler_cache_bm25_job(
             output_records=recapture.output_records,
             canonical_manifest_bytes=preparation.canonical_manifest_bytes,
         ),
+        job=completed,
+    )
+
+
+def publish_compiler_cache_vector_job(
+    cache_dir: str | Path,
+    *,
+    job_id: str,
+    owner_id: str,
+    fencing_token: int,
+    repository_source: RepositorySourceBinding,
+    vector_output_owner: PublishedWorkspaceReceiptOwner,
+    context_output_owner: PublishedWorkspaceReceiptOwner,
+    vector_destination: Path,
+    context_destination: Path,
+    workspace_provider: StrictWorkspaceProvider,
+    repository_key: str,
+    catalog: JobPublicationCatalog,
+    object_store: RetainedImportObjectStore,
+    namespace_name: str = DEFAULT_NAMESPACE_NAME,
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+    max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
+    max_context_bytes: int = DEFAULT_MAX_CONTEXT_BYTES,
+    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
+    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
+    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> CompilerCacheVectorJobPublicationResult:
+    """Publish one exact current vector cache into a caller-owned fenced job.
+
+    The caller must already have registered the repository, source, and exact
+    vector profile, created the job, and acquired its active ref lease. Only
+    current schema-8 portable vector bytes are accepted. Native FAISS parsing,
+    embedding/model loading, and native runtime authorization are outside this
+    adapter; ``publish_job_artifacts`` is its sole catalog mutation path.
+    """
+
+    preparation, completed = _publish_compiler_cache_job(
+        cache_dir,
+        view_type="vector",
+        job_id=job_id,
+        owner_id=owner_id,
+        fencing_token=fencing_token,
+        repository_source=repository_source,
+        view_output_owner=vector_output_owner,
+        context_output_owner=context_output_owner,
+        view_destination=vector_destination,
+        context_destination=context_destination,
+        workspace_provider=workspace_provider,
+        repository_key=repository_key,
+        catalog=catalog,
+        object_store=object_store,
+        namespace_name=namespace_name,
+        max_manifest_bytes=max_manifest_bytes,
+        max_context_files=max_context_files,
+        max_context_bytes=max_context_bytes,
+        max_bundle_files=max_bundle_files,
+        max_bundle_bytes=max_bundle_bytes,
+        max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
+    )
+    recapture = preparation.recaptures[0]
+    if recapture.view_type != "vector":  # pragma: no cover - adapter invariant
+        raise AssertionError("compiler cache vector job selected another view")
+    return CompilerCacheVectorJobPublicationResult(
+        manifest=preparation.import_plan.manifest,
+        import_plan=preparation.import_plan,
+        recapture=recapture,
         job=completed,
     )
 
@@ -2185,10 +2399,12 @@ __all__ = [
     "CompilerCacheJobPublicationResult",
     "CompilerCacheMultiViewImportResult",
     "CompilerCacheTopologyGuard",
+    "CompilerCacheVectorJobPublicationResult",
     "CompilerCacheViewRecaptureResult",
     "CompilerRetainedPublicationResult",
     "compile_and_import_repo",
     "import_compiler_cache",
     "import_compiler_cache_bm25",
     "publish_compiler_cache_bm25_job",
+    "publish_compiler_cache_vector_job",
 ]

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1131,20 +1131,35 @@ runtime, vector, graph, or default-route wiring. Exact retry remains historical:
 a committed BM25 job returns its original snapshot without moving a ref that a
 later valid publication has already advanced.
 
+The matching vector adapter now publishes one exact current schema-8 compiler
+cache into the same caller-created, caller-acquired fenced job boundary. It
+requires exactly one required `full` vector request and derives the complete
+provider/model/route/revision/load-policy compatibility profile from the
+canonical cache import plan rather than accepting those identities as caller
+options. Strict recapture copies the canonical root config and each non-empty
+level's config, ordered JSON documents, and FAISS bytes; the resulting bundle
+and every per-file member receipt remain retained through atomic publication.
+FAISS bytes stay parser-inert, legacy pickle state is excluded, and this path
+neither loads an embedding model or client nor grants native vector runtime
+authorization. Exact replay returns the job's historical snapshot after later
+ref advancement. This remains an explicit ingress adapter only: it adds no
+builder, worker, CLI, runtime, graph, or default-route wiring.
+
 ### M2: Immutable generation publication
 
 Status: in progress. The receipt-retained, fenced SQLite publication primitive
-and the explicit BM25 compiler-cache adapter are implemented; vector, graph,
-generic builder, and production job/runtime wiring remain.
+and the explicit BM25 and schema-8 vector compiler-cache adapters are
+implemented; graph, generic builder, and production job/runtime wiring remain.
 
 - Make every builder write to a unique staging generation.
 - Add per-view profile adapters that fail closed on incomplete compatibility
   inputs and prove every semantic axis participates in the profile identity.
-  The exact BM25 compiler-cache profile path is implemented; vector, graph, and
-  generic builder adapters remain.
+  The exact BM25 and schema-8 vector compiler-cache profile paths are
+  implemented; graph and generic builder adapters remain.
 - Publish whole-view BM25, FAISS, and graph artifacts through the catalog and
-  object store without changing their ranking/query semantics. BM25 now has an
-  explicit fenced compiler-cache ingress; FAISS and graph ingress remain.
+  object store without changing their ranking/query semantics. BM25 and
+  parser-inert FAISS now have explicit fenced compiler-cache ingress; graph
+  ingress remains.
 - Use the implemented receipt-retaining coordinator for each adapter so exact
   digest, size, storage key, and media type remain retained through atomic
   catalog publication; catalog metadata alone must never make missing bytes

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -20,6 +20,7 @@ import pytest
 
 import codenib.compiler as compiler_module
 import codenib.compiler.cache_import as cache_import_module
+import codenib.index.embedding.vector_store as vector_store_module
 from codenib import LocalWorkspaceProvider
 from codenib import cli as cli_module
 from codenib._captured_directory import (
@@ -39,6 +40,7 @@ from codenib.compiler.cache_import import (
     CompilerCacheJobPublicationResult,
     CompilerCacheMultiViewImportResult,
     CompilerCacheTopologyGuard,
+    CompilerCacheVectorJobPublicationResult,
     CompilerCacheViewRecaptureResult,
     CompilerRetainedPublicationResult,
     compile_and_import_repo,
@@ -46,6 +48,7 @@ from codenib.compiler.cache_import import (
     import_compiler_cache,
     import_compiler_cache_bm25,
     publish_compiler_cache_bm25_job,
+    publish_compiler_cache_vector_job,
 )
 from codenib.compiler.index_builders import (
     BM25IndexBuilder,
@@ -59,6 +62,7 @@ from codenib.compiler.manifest_materialization import (
     materialize_retained_repo_manifest_ref,
 )
 from codenib.compiler.manifest_storage import (
+    VECTOR_PROFILE_AXES,
     RepoManifestImportPlan,
     plan_repo_manifest_import_bytes,
 )
@@ -624,6 +628,10 @@ def test_compiler_cache_import_is_a_lazy_public_export() -> None:
         compiler_module.CompilerCacheJobPublicationResult
         is CompilerCacheJobPublicationResult
     )
+    assert (
+        compiler_module.CompilerCacheVectorJobPublicationResult
+        is CompilerCacheVectorJobPublicationResult
+    )
     assert compiler_module.compile_and_import_repo is compile_and_import_repo
     assert compiler_module.CompilerCacheImportResult is CompilerCacheImportResult
     assert (
@@ -643,6 +651,10 @@ def test_compiler_cache_import_is_a_lazy_public_export() -> None:
     assert (
         compiler_module.publish_compiler_cache_bm25_job
         is publish_compiler_cache_bm25_job
+    )
+    assert (
+        compiler_module.publish_compiler_cache_vector_job
+        is publish_compiler_cache_vector_job
     )
     assert list(inspect.signature(import_compiler_cache).parameters)[:11] == [
         "cache_dir",
@@ -685,6 +697,32 @@ def test_compiler_cache_import_is_a_lazy_public_export() -> None:
         "object_store",
         "namespace_name",
     ]
+    vector_job_signature = inspect.signature(publish_compiler_cache_vector_job)
+    assert list(vector_job_signature.parameters)[:14] == [
+        "cache_dir",
+        "job_id",
+        "owner_id",
+        "fencing_token",
+        "repository_source",
+        "vector_output_owner",
+        "context_output_owner",
+        "vector_destination",
+        "context_destination",
+        "workspace_provider",
+        "repository_key",
+        "catalog",
+        "object_store",
+        "namespace_name",
+    ]
+    assert not {
+        "ref_name",
+        "expected_generation",
+        "embedding_provider",
+        "embedding_model",
+        "embedding_revision",
+        "embedding_load_policy",
+        "native_index_authorization",
+    } & set(vector_job_signature.parameters)
     compile_signature = inspect.signature(compile_and_import_repo)
     assert list(compile_signature.parameters)[:4] == [
         "compiler",
@@ -2483,6 +2521,795 @@ def _multiview_compiler_fixture(
         compiler=compiler,
         commit=commit,
     )
+
+
+@dataclass
+class _VectorJobFixture:
+    compiled: _MultiViewCompilerFixture
+    source: RepositorySourceBinding
+    workspace: Path
+    provider: _TestWorkspaceProvider
+    vector_owner: PublishedWorkspaceReceiptOwner
+    context_owner: PublishedWorkspaceReceiptOwner
+
+    @property
+    def cache(self) -> Path:
+        return self.compiled.cache
+
+    @property
+    def repository(self) -> Path:
+        return self.compiled.repository
+
+    @property
+    def vector_destination(self) -> Path:
+        return self.workspace / "published-vector"
+
+    @property
+    def context_destination(self) -> Path:
+        return self.workspace / "published-vector-context"
+
+    def close(self) -> None:
+        self.context_owner.close()
+        self.vector_owner.close()
+        self.source.close()
+
+
+def _vector_job_fixture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    marker: str,
+) -> _VectorJobFixture:
+    compiled = _multiview_compiler_fixture(
+        tmp_path,
+        monkeypatch,
+        marker=marker,
+    )
+    source = capture_repository_source(
+        compiled.repository,
+        exclude_roots=(compiled.cache,),
+    )
+    workspace = tmp_path / "vector-job-workspace"
+    workspace.mkdir(mode=0o700)
+    return _VectorJobFixture(
+        compiled=compiled,
+        source=source,
+        workspace=workspace,
+        provider=_TestWorkspaceProvider(),
+        vector_owner=PublishedWorkspaceReceiptOwner(),
+        context_owner=PublishedWorkspaceReceiptOwner(),
+    )
+
+
+def _expected_vector_job_plan(
+    fixture: _VectorJobFixture,
+) -> RepoManifestImportPlan:
+    manifest = RepoManifest.load(fixture.cache / "repo_manifest.json")
+    entry = manifest.indexes["vector"]
+    planned = cache_import_module._plan_cache_view(
+        "vector",
+        fixture.cache / "vector",
+        fixture.vector_destination,
+        repository_source=fixture.source,
+        view_config=entry.config,
+        forbidden_paths=(),
+        environ={},
+    )
+    _portable, payload = cache_import_module._portable_manifest(
+        manifest,
+        views=("vector",),
+        planned_views={"vector": planned},
+    )
+    return plan_repo_manifest_import_bytes(payload, views=("vector",))
+
+
+def _register_vector_job_subject(
+    catalog: SQLiteCatalog,
+    fixture: _VectorJobFixture,
+    plan: RepoManifestImportPlan,
+) -> tuple[str, str, str]:
+    repository_id = catalog.create_repository(_REPOSITORY_KEY)
+    source_revision_id = catalog.create_source_revision(
+        repository_id,
+        commit_sha=None,
+        dirty=True,
+        source_fingerprint=fixture.source.fingerprint,
+    )
+    intent = plan.views[0]
+    profile_id = catalog.create_view_profile(
+        "vector",
+        intent.profile.config,
+        name=intent.profile.name,
+    )
+    assert profile_id == intent.profile_id
+    return repository_id, source_revision_id, profile_id
+
+
+def _create_vector_job(
+    catalog: SQLiteCatalog,
+    *,
+    repository_id: str,
+    source_revision_id: str,
+    profile_id: str,
+    idempotency_key: str = "compiler-cache-vector",
+    view_type: str = "vector",
+    requested_mode: str = "full",
+    required: bool = True,
+    expected_ref_generation: int = 0,
+    extra_views: dict[str, dict[str, object]] | None = None,
+):
+    views: dict[str, dict[str, object]] = {
+        view_type: {
+            "profile_id": profile_id,
+            "requested_mode": requested_mode,
+            "required": required,
+        }
+    }
+    if extra_views:
+        views.update(copy.deepcopy(extra_views))
+    return catalog.create_job(
+        repository_id,
+        source_revision_id,
+        idempotency_key,
+        {"contract": INDEX_JOB_REQUEST_CONTRACT, "views": views},
+        expected_ref_generation=expected_ref_generation,
+    )
+
+
+def _publish_vector_job(
+    fixture: _VectorJobFixture,
+    *,
+    job_id: str,
+    owner_id: str,
+    fencing_token: int,
+    catalog: SQLiteCatalog,
+    cas: LocalCAS,
+    vector_owner: PublishedWorkspaceReceiptOwner | None = None,
+    context_owner: PublishedWorkspaceReceiptOwner | None = None,
+    vector_destination: Path | None = None,
+    context_destination: Path | None = None,
+) -> CompilerCacheVectorJobPublicationResult:
+    return publish_compiler_cache_vector_job(
+        fixture.cache,
+        job_id=job_id,
+        owner_id=owner_id,
+        fencing_token=fencing_token,
+        repository_source=fixture.source,
+        vector_output_owner=vector_owner or fixture.vector_owner,
+        context_output_owner=context_owner or fixture.context_owner,
+        vector_destination=vector_destination or fixture.vector_destination,
+        context_destination=context_destination or fixture.context_destination,
+        workspace_provider=fixture.provider,
+        repository_key=_REPOSITORY_KEY,
+        catalog=catalog,
+        object_store=cas,
+        environ={},
+    )
+
+
+def _seed_vector_snapshot(
+    catalog: SQLiteCatalog,
+    cas: LocalCAS,
+    *,
+    repository_id: str,
+    source_revision_id: str,
+    profile_id: str,
+    payload: bytes,
+    expected_generation: int,
+) -> tuple[dict[str, object], str]:
+    receipt = cas.put_bytes(payload)
+    catalog.register_object(
+        receipt.digest,
+        storage_key=receipt.storage_key,
+        byte_size=receipt.byte_size,
+        media_type="application/x-test-old-vector",
+    )
+    generation_id = catalog.stage_view_generation(
+        repository_id,
+        source_revision_id,
+        profile_id,
+        "vector",
+        receipt.digest,
+        schema_version=f"old-vector-{expected_generation + 1}",
+        metadata={"seed_generation": expected_generation + 1},
+    )
+    publication = catalog.publish_snapshot(
+        repository_id,
+        source_revision_id,
+        (generation_id,),
+        expected_generation=expected_generation,
+    )
+    return publication, receipt.digest
+
+
+def test_compiler_cache_vector_job_publishes_schema8_closure_and_replays(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _vector_job_fixture(tmp_path, monkeypatch, marker="VECTOR_JOB")
+    retry_vector_owner = PublishedWorkspaceReceiptOwner()
+    retry_context_owner = PublishedWorkspaceReceiptOwner()
+    plan = _expected_vector_job_plan(fixture)
+
+    def native_or_builder_must_not_run(*_args, **_kwargs):
+        raise AssertionError("vector job adapter invoked a native parser or builder")
+
+    monkeypatch.setattr(
+        vector_store_module.faiss,
+        "read_index",
+        native_or_builder_must_not_run,
+    )
+    monkeypatch.setattr(
+        vector_store_module.compat_pickle,
+        "load",
+        native_or_builder_must_not_run,
+    )
+    monkeypatch.setattr(
+        "codenib.index.embedding.builders.build_hierarchical_vector_store",
+        native_or_builder_must_not_run,
+    )
+    try:
+        with (
+            _JobTrackingCAS(tmp_path / "cas") as cas,
+            _RetentionAwareJobCatalog(
+                tmp_path / "catalog.sqlite",
+                cas,
+            ) as catalog,
+        ):
+            repository_id, source_revision_id, profile_id = (
+                _register_vector_job_subject(catalog, fixture, plan)
+            )
+            job = _create_vector_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+            )
+            lease = catalog.acquire_job_lease(
+                job.job_id,
+                owner_id="vector-worker-1",
+                lease_duration_ms=60_000,
+            )
+
+            result = _publish_vector_job(
+                fixture,
+                job_id=job.job_id,
+                owner_id=lease.owner_id,
+                fencing_token=lease.fencing_token,
+                catalog=catalog,
+                cas=cas,
+            )
+
+            assert type(result) is CompilerCacheVectorJobPublicationResult
+            assert result.job.status is IndexJobStatus.SUCCEEDED
+            assert result.job.job_id == job.job_id
+            assert result.job.result_snapshot_id is not None
+            assert result.manifest.to_dict() == result.import_plan.manifest.to_dict()
+            assert result.manifest.repo_path == "source"
+            assert tuple(result.manifest.indexes) == ("vector",)
+            assert result.import_plan.plan_digest == plan.plan_digest
+            assert result.import_plan.views[0].profile.config["builder_schema"] == 8
+            compatibility = result.import_plan.views[0].profile.config["compatibility"]
+            assert set(VECTOR_PROFILE_AXES) - {"builder_schema"} <= set(compatibility)
+            assert compatibility["embedding_load_policy"] == {
+                "revision": None,
+                "trust_remote_code": False,
+            }
+            assert result.recapture.output_view == fixture.vector_destination
+            expected_paths = (
+                "config_test__model.json",
+                "l2/config_test__model.json",
+                "l2/documents_test__model.json",
+                "l2/index_test__model.faiss",
+            )
+            assert tuple(record.path for record in result.recapture.output_records) == (
+                expected_paths
+            )
+            assert not any(
+                record.path.endswith(".pkl")
+                or "cache" in record.path
+                or "incremental_state" in record.path
+                for record in result.recapture.output_records
+            )
+            assert len(cas.put_chunk_receipts) == len(expected_paths) + 1
+            assert len({receipt.digest for receipt in cas.put_chunk_receipts}) == 5
+            expected_receipts = tuple(
+                sorted(cas.put_chunk_receipts, key=lambda receipt: receipt.digest)
+            )
+            assert cas.retained_receipt_sets == [expected_receipts]
+            assert catalog.job_publication_calls == 1
+            summary = catalog.get_manifest_summary(result.job.result_snapshot_id)
+            assert tuple(summary["views"]) == ("vector",)
+            assert REPO_MANIFEST_PROJECTION_VIEW not in summary["views"]
+            vector = summary["views"]["vector"]
+            assert vector["profile"]["profile_id"] == profile_id
+            assert vector["schema_version"] == VIEW_BUNDLE_SCHEMA
+            assert vector["object"]["media_type"] == VIEW_BUNDLE_MEDIA_TYPE
+            assert len(vector["member_objects"]) == len(expected_paths)
+            for persisted in (vector["object"], *vector["member_objects"]):
+                receipt = cas.verify(persisted["digest"])
+                assert receipt.byte_size == persisted["byte_size"]
+                assert receipt.storage_key == persisted["storage_key"]
+
+            first_ref = catalog.resolve_ref(repository_id)
+            _seed_vector_snapshot(
+                catalog,
+                cas,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+                payload=b"newer vector snapshot after completed job",
+                expected_generation=1,
+            )
+            advanced_ref = catalog.resolve_ref(repository_id)
+            assert advanced_ref["generation"] == first_ref["generation"] + 1
+            assert advanced_ref["snapshot_id"] != first_ref["snapshot_id"]
+
+            retry = _publish_vector_job(
+                fixture,
+                job_id=job.job_id,
+                owner_id=lease.owner_id,
+                fencing_token=lease.fencing_token,
+                catalog=catalog,
+                cas=cas,
+                vector_owner=retry_vector_owner,
+                context_owner=retry_context_owner,
+                vector_destination=fixture.workspace / "retry-vector",
+                context_destination=fixture.workspace / "retry-vector-context",
+            )
+            assert retry.job == result.job
+            assert retry.import_plan.plan_digest == result.import_plan.plan_digest
+            assert retry.job.result_snapshot_id == first_ref["snapshot_id"]
+            assert catalog.resolve_ref(repository_id) == advanced_ref
+            assert tuple(cas.put_chunk_receipts[:5]) == tuple(
+                cas.put_chunk_receipts[5:]
+            )
+            assert cas.retained_receipt_sets == [
+                expected_receipts,
+                expected_receipts,
+            ]
+            assert catalog.job_publication_calls == 2
+            assert fixture.vector_owner.active
+            assert fixture.context_owner.active
+            assert retry_vector_owner.active
+            assert retry_context_owner.active
+    finally:
+        retry_context_owner.close()
+        retry_vector_owner.close()
+        fixture.close()
+
+
+@pytest.mark.parametrize(
+    "case",
+    (
+        "wrong_view",
+        "not_full",
+        "optional",
+        "extra_view",
+        "profile_mismatch",
+        "source_mismatch",
+        "repository_mismatch",
+        "not_acquired",
+    ),
+)
+def test_compiler_cache_vector_job_rejects_incompatible_request_before_cas(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+) -> None:
+    fixture = _vector_job_fixture(tmp_path, monkeypatch, marker=f"REQUEST_{case}")
+    plan = _expected_vector_job_plan(fixture)
+    try:
+        with (
+            _JobTrackingCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            repository_id, source_revision_id, profile_id = (
+                _register_vector_job_subject(catalog, fixture, plan)
+            )
+            view_type = "vector"
+            requested_mode = "incremental" if case == "not_full" else "full"
+            required = case != "optional"
+            extra_views = None
+            if case == "wrong_view":
+                view_type = "bm25"
+                profile_id = catalog.create_view_profile(
+                    "bm25",
+                    {"test_profile": "wrong-view"},
+                )
+            elif case == "extra_view":
+                bm25_profile = catalog.create_view_profile(
+                    "bm25",
+                    {"test_profile": "extra"},
+                )
+                extra_views = {
+                    "bm25": {
+                        "profile_id": bm25_profile,
+                        "requested_mode": "full",
+                        "required": False,
+                    }
+                }
+            elif case == "profile_mismatch":
+                profile_id = catalog.create_view_profile(
+                    "vector",
+                    {"test_profile": "wrong"},
+                )
+            elif case == "source_mismatch":
+                source_revision_id = catalog.create_source_revision(
+                    repository_id,
+                    commit_sha=None,
+                    dirty=True,
+                    source_fingerprint="other-source-fingerprint",
+                )
+            elif case == "repository_mismatch":
+                repository_id = catalog.create_repository("owner/other")
+                source_revision_id = catalog.create_source_revision(
+                    repository_id,
+                    commit_sha=None,
+                    dirty=True,
+                    source_fingerprint=fixture.source.fingerprint,
+                )
+            job = _create_vector_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+                view_type=view_type,
+                requested_mode=requested_mode,
+                required=required,
+                extra_views=extra_views,
+            )
+            if case == "not_acquired":
+                owner_id = "vector-worker-1"
+                token = 1
+            else:
+                lease = catalog.acquire_job_lease(
+                    job.job_id,
+                    owner_id="vector-worker-1",
+                    lease_duration_ms=60_000,
+                )
+                owner_id = lease.owner_id
+                token = lease.fencing_token
+
+            with pytest.raises(StorageValidationError):
+                _publish_vector_job(
+                    fixture,
+                    job_id=job.job_id,
+                    owner_id=owner_id,
+                    fencing_token=token,
+                    catalog=catalog,
+                    cas=cas,
+                )
+
+            assert cas.put_chunk_receipts == []
+            assert cas.retained_receipt_sets == []
+            assert fixture.provider.run_count == 0
+            assert fixture.vector_owner.state == "empty"
+            assert fixture.context_owner.state == "empty"
+            assert not fixture.vector_destination.exists()
+            assert not fixture.context_destination.exists()
+    finally:
+        fixture.close()
+
+
+@pytest.mark.parametrize(
+    ("case", "error"),
+    [
+        ("wrong_owner", PublishConflict),
+        ("wrong_fence", PublishConflict),
+        ("expired_lease", PublishConflict),
+        ("cancelled", StorageValidationError),
+        ("ref_drift", PublishConflict),
+    ],
+)
+def test_compiler_cache_vector_job_failure_preserves_current_ref(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+    error: type[Exception],
+) -> None:
+    fixture = _vector_job_fixture(tmp_path, monkeypatch, marker=f"LEASE_{case}")
+    plan = _expected_vector_job_plan(fixture)
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            clock = {"ms": 1_000}
+            catalog._connection.create_function(
+                "julianday",
+                1,
+                lambda _value: 2440587.5 + clock["ms"] / 86_400_000,
+            )
+            repository_id, source_revision_id, profile_id = (
+                _register_vector_job_subject(catalog, fixture, plan)
+            )
+            _seed_vector_snapshot(
+                catalog,
+                cas,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+                payload=b"usable old vector snapshot",
+                expected_generation=0,
+            )
+            job = _create_vector_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+                expected_ref_generation=1,
+            )
+            lease = catalog.acquire_job_lease(
+                job.job_id,
+                owner_id="vector-worker-1",
+                lease_duration_ms=1 if case == "expired_lease" else 60_000,
+            )
+            token = lease.fencing_token
+            owner_id = lease.owner_id
+            if case == "wrong_owner":
+                owner_id = "other-vector-worker"
+            elif case == "wrong_fence":
+                token += 1
+            elif case == "expired_lease":
+                clock["ms"] = lease.lease_expires_at_ms + 1_000
+            elif case == "cancelled":
+                catalog.request_job_cancel(job.job_id)
+            elif case == "ref_drift":
+                _seed_vector_snapshot(
+                    catalog,
+                    cas,
+                    repository_id=repository_id,
+                    source_revision_id=source_revision_id,
+                    profile_id=profile_id,
+                    payload=b"newer still-usable vector snapshot",
+                    expected_generation=1,
+                )
+            preserved = catalog.resolve_ref(repository_id)
+            preserved_view = preserved["manifest"]["views"]["vector"]
+            preserved_payload = cas.read_bytes(preserved_view["object"]["digest"])
+
+            with pytest.raises(error):
+                _publish_vector_job(
+                    fixture,
+                    job_id=job.job_id,
+                    owner_id=owner_id,
+                    fencing_token=token,
+                    catalog=catalog,
+                    cas=cas,
+                )
+
+            assert catalog.resolve_ref(repository_id) == preserved
+            assert cas.read_bytes(preserved_view["object"]["digest"]) == (
+                preserved_payload
+            )
+            assert catalog.get_job(job.job_id).status is not IndexJobStatus.SUCCEEDED
+    finally:
+        fixture.close()
+
+
+def test_compiler_cache_vector_job_profile_binds_every_semantic_axis(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _vector_job_fixture(tmp_path, monkeypatch, marker="PROFILE_AXES")
+    plan = _expected_vector_job_plan(fixture)
+    intent = plan.views[0]
+    axes = (*VECTOR_PROFILE_AXES, "embedding_load_policy")
+    try:
+        for index, axis in enumerate(axes):
+            vector_owner = PublishedWorkspaceReceiptOwner()
+            context_owner = PublishedWorkspaceReceiptOwner()
+            try:
+                with (
+                    _JobTrackingCAS(tmp_path / f"cas-{index}") as cas,
+                    SQLiteCatalog(tmp_path / f"catalog-{index}.sqlite") as catalog,
+                ):
+                    repository_id, source_revision_id, _profile_id = (
+                        _register_vector_job_subject(catalog, fixture, plan)
+                    )
+                    wrong_config = copy.deepcopy(intent.profile.config)
+                    if axis == "builder_schema":
+                        wrong_config[axis] = 9
+                    else:
+                        wrong_config["compatibility"][axis] = {"mismatched_axis": axis}
+                    wrong_profile_id = catalog.create_view_profile(
+                        "vector",
+                        wrong_config,
+                        name=intent.profile.name,
+                    )
+                    assert wrong_profile_id != intent.profile_id
+                    job = _create_vector_job(
+                        catalog,
+                        repository_id=repository_id,
+                        source_revision_id=source_revision_id,
+                        profile_id=wrong_profile_id,
+                        idempotency_key=f"wrong-vector-profile-{index}",
+                    )
+                    lease = catalog.acquire_job_lease(
+                        job.job_id,
+                        owner_id=f"vector-profile-worker-{index}",
+                        lease_duration_ms=60_000,
+                    )
+
+                    with pytest.raises(
+                        StorageValidationError,
+                        match="vector profile does not match",
+                    ):
+                        _publish_vector_job(
+                            fixture,
+                            job_id=job.job_id,
+                            owner_id=lease.owner_id,
+                            fencing_token=lease.fencing_token,
+                            catalog=catalog,
+                            cas=cas,
+                            vector_owner=vector_owner,
+                            context_owner=context_owner,
+                            vector_destination=fixture.workspace
+                            / f"wrong-profile-vector-{index}",
+                            context_destination=fixture.workspace
+                            / f"wrong-profile-context-{index}",
+                        )
+
+                    assert cas.put_chunk_receipts == []
+                    assert cas.retained_receipt_sets == []
+                    assert vector_owner.state == "empty"
+                    assert context_owner.state == "empty"
+            finally:
+                context_owner.close()
+                vector_owner.close()
+        assert fixture.provider.run_count == 0
+    finally:
+        fixture.close()
+
+
+def test_compiler_cache_vector_job_rejects_schema7_before_workspace_or_cas(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _vector_job_fixture(tmp_path, monkeypatch, marker="SCHEMA7")
+    plan = _expected_vector_job_plan(fixture)
+    manifest_path = fixture.cache / "repo_manifest.json"
+    manifest = RepoManifest.load(manifest_path)
+    manifest.indexes["vector"].config["builder_schema"] = 7
+    manifest.indexes["vector"].metadata["builder_schema"] = 7
+    manifest.save(manifest_path)
+    manifest_path.chmod(0o600)
+    try:
+        with (
+            _JobTrackingCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            repository_id, source_revision_id, profile_id = (
+                _register_vector_job_subject(catalog, fixture, plan)
+            )
+            job = _create_vector_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+            )
+            lease = catalog.acquire_job_lease(
+                job.job_id,
+                owner_id="vector-worker-1",
+                lease_duration_ms=60_000,
+            )
+
+            with pytest.raises(ValueError, match="no exact current vector"):
+                _publish_vector_job(
+                    fixture,
+                    job_id=job.job_id,
+                    owner_id=lease.owner_id,
+                    fencing_token=lease.fencing_token,
+                    catalog=catalog,
+                    cas=cas,
+                )
+
+            assert cas.put_chunk_receipts == []
+            assert cas.retained_receipt_sets == []
+            assert fixture.provider.run_count == 0
+            assert fixture.vector_owner.state == "empty"
+            assert fixture.context_owner.state == "empty"
+            assert not fixture.vector_destination.exists()
+            assert not fixture.context_destination.exists()
+    finally:
+        fixture.close()
+
+
+@pytest.mark.parametrize(
+    ("case", "cas_type", "error"),
+    (
+        ("source_drift", _JobTrackingCAS, RepositoryChangedError),
+        ("job_drift", _JobTrackingCAS, StorageValidationError),
+        ("receipt_substitution", _ForgedPutReceiptCAS, StorageValidationError),
+        ("callback_skipped", _SkippingRetentionCAS, StorageIntegrityError),
+    ),
+)
+def test_compiler_cache_vector_job_rejects_post_ingest_drift_or_substitution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+    cas_type: type[_JobTrackingCAS],
+    error: type[Exception],
+) -> None:
+    fixture = _vector_job_fixture(tmp_path, monkeypatch, marker=f"DRIFT_{case}")
+    plan = _expected_vector_job_plan(fixture)
+    try:
+        with (
+            cas_type(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            repository_id, source_revision_id, profile_id = (
+                _register_vector_job_subject(catalog, fixture, plan)
+            )
+            _publication, preserved_digest = _seed_vector_snapshot(
+                catalog,
+                cas,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+                payload=b"retained old vector snapshot before adversarial drift",
+                expected_generation=0,
+            )
+            job = _create_vector_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+                expected_ref_generation=1,
+            )
+            lease = catalog.acquire_job_lease(
+                job.job_id,
+                owner_id="vector-worker-1",
+                lease_duration_ms=60_000,
+            )
+            preserved_ref = catalog.resolve_ref(repository_id)
+
+            if case == "source_drift":
+
+                def drift_source(put_count: int) -> None:
+                    if put_count == 5:
+                        fixture.compiled.source_file.write_text(
+                            "VECTOR_JOB_SOURCE_DRIFT = True\n",
+                            encoding="utf-8",
+                        )
+
+                cas.after_put = drift_source
+            elif case == "job_drift":
+
+                def drift_job(put_count: int) -> None:
+                    if put_count == 5:
+                        catalog.request_job_cancel(job.job_id)
+
+                cas.after_put = drift_job
+
+            with pytest.raises(error):
+                _publish_vector_job(
+                    fixture,
+                    job_id=job.job_id,
+                    owner_id=lease.owner_id,
+                    fencing_token=lease.fencing_token,
+                    catalog=catalog,
+                    cas=cas,
+                )
+
+            assert len(cas.put_chunk_receipts) == 5
+            assert catalog.resolve_ref(repository_id) == preserved_ref
+            assert cas.read_bytes(preserved_digest) == (
+                b"retained old vector snapshot before adversarial drift"
+            )
+            assert catalog.get_job(job.job_id).status is IndexJobStatus.RUNNING
+            publication_count = catalog._connection.execute(
+                "SELECT COUNT(*) FROM index_job_publications WHERE job_id = ?",
+                (job.job_id,),
+            ).fetchone()[0]
+            assert publication_count == 0
+            if case in {"source_drift", "job_drift"}:
+                assert cas.retained_receipt_sets == []
+            else:
+                assert len(cas.retained_receipt_sets) == 1
+    finally:
+        fixture.close()
 
 
 def test_real_compiler_cache_import_retry_update_and_latest_query(


### PR DESCRIPTION
## Summary

Add an explicit schema-8 vector-only compiler-cache adapter that publishes one caller-created, caller-acquired fenced job through the retained immutable artifact path. The adapter preserves exact historical replay after later ref advancement and keeps native vector execution outside the publication boundary.

Related to #199.

## Changes

- Add `CompilerCacheVectorJobPublicationResult` and the lazy public `publish_compiler_cache_vector_job` API.
- Reuse the existing single-view compiler-cache job path for BM25 and vector publication while preserving the BM25 API and direct manifest-import behavior.
- Require exactly one required `FULL` vector request with an exact repository, dirty source revision, canonical schema-8 vector profile, acquired attempt, and uncancelled running job or exact successful replay.
- Recapture the canonical vector root config and, for every non-empty level, its config, ordered JSON documents, and opaque FAISS bytes; retain one canonical bundle plus every per-file member receipt through atomic job/snapshot/ref publication.
- Reject schema-7 cache ingress before workspace or CAS mutation. Exclude pickle and mutable cache state, and do not parse FAISS, load pickle, construct an embedding model or client, or grant native runtime authorization.
- Keep provider/model/revision/load-policy identity derived from the canonical cache plan; add no caller overrides, storage schema or protocol changes, builder, worker, CLI, runtime, web/MCP, graph, or default-route wiring.
- Add request/profile/lease/fence/cancellation/ref-drift, source/job drift, receipt substitution, skipped retention callback, profile-axis, native-inertness, closure, replay, and regression coverage; update the storage roadmap without marking M2 complete.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- Vector adapter target: `20 passed, 51 deselected`
- BM25 job regression: `17 passed, 54 deselected`
- Complete cache-import file: `71 passed`
- Complete compiler suite: `895 passed, 1` pre-existing fork deprecation warning
- Relevant job-publication and view-bundle storage suite: `251 passed`
- Complete storage suite on the byte-identical candidate tree: `661 passed, 1` pre-existing fork deprecation warning
- `mkdocs build --strict`
- Black, repository-configured isort, flake8, namespace, and diff checks

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published