### PR TITLE
test(storage): stabilize half-state lease boundary

### DIFF
--- a/test/storage/test_sqlite_jobs.py
+++ b/test/storage/test_sqlite_jobs.py
@@ -1072,6 +1072,17 @@ def test_expired_nonrunning_half_state_is_reclaimed_without_fencing_aba(
 ) -> None:
     path = tmp_path / "catalog.sqlite3"
     with SQLiteCatalog(path) as catalog:
+        # Keep the pre-expiry assertion deterministic while still exercising
+        # SQLite's clock.  Under xdist this test can otherwise be descheduled
+        # past its short lease between acquisition and the active-slot check.
+        clock = {"raw_ms": 0}
+        catalog._connection.create_function(
+            "julianday",
+            1,
+            lambda _value: 2440587.5 + clock["raw_ms"] / 86_400_000,
+        )
+        assert catalog._db_now_ms() == 0
+
         first = _job_setup(catalog, idempotency_key="first")
         second = catalog.create_job(
             first.repository_id,
@@ -1117,8 +1128,10 @@ def test_expired_nonrunning_half_state_is_reclaimed_without_fencing_aba(
                 lease_duration_ms=30_000,
             )
 
-    time.sleep(0.12)
     with SQLiteCatalog(path) as catalog:
+        # The test clock is connection-local.  Reopening restores the real DB
+        # clock, which is beyond the synthetic lease and permits takeover.
+        assert catalog._db_now_ms() > stale.lease_expires_at_ms
         current = catalog.acquire_job_lease(
             second.job_id, owner_id="worker-2", lease_duration_ms=30_000
         )


### PR DESCRIPTION
## Summary

Make the expired non-running half-state lease test deterministic under heavy pytest-xdist scheduling. The production lease and fencing implementation is unchanged.

A scheduled Full CI run on `fb2dfb2e` used 64 workers and consumed the test-only 100 ms lease before the pre-expiry assertion, so the catalog correctly performed takeover while the test still expected an active-lease conflict.

## Changes

- Pin the SQLite connection-local `julianday` clock for the pre-expiry active-lease assertion.
- Reopen the catalog with its real database clock to continue proving expiry, takeover, fencing-token advancement, and stale-worker rejection.
- Remove the wall-clock sleep from this boundary test.
- Change no production code.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- CPython 3.12.13 with pytest-xdist auto workers and 100 duplicate collections: `300 passed`
- CPython 3.12 cold-process cancelled case: `50 passed`
- CPython 3.12 jobs and publication suite: `96 passed`
- CPython 3.12 complete storage suite: `661 passed`
- CPython 3.14.6 with pytest-xdist and 100 duplicate collections: `300 passed`
- CPython 3.14 jobs and publication suite: `96 passed`
- CPython 3.14 complete storage suite: `661 passed`
- Black 24.8.0, isort 5.13.2, flake8 7.1.1 with bugbear, and `git diff --check`

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published