### PR TITLE
test(json): make escape scan gate deterministic

### DIFF
--- a/test/test_bounded_json.py
+++ b/test/test_bounded_json.py
@@ -10,7 +10,6 @@ import math
 import subprocess
 import sys
 import textwrap
-import time
 from pathlib import Path
 
 import pytest
@@ -313,24 +312,72 @@ def test_bounded_array_rejects_malformed_framing(payload: bytes) -> None:
         list(iter_bounded_json_array(io.BytesIO(payload), label="documents"))
 
 
-def test_escape_dense_string_scanning_scales_linearly() -> None:
-    def elapsed(pairs: int) -> float:
-        payload = b'["' + (b"\\\\" * pairs) + b'"]'
-        started = time.perf_counter()
-        assert list(
-            iter_bounded_json_array(
-                io.BytesIO(payload),
+def test_escape_dense_string_scanning_scales_linearly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib._bounded_json as bounded_json
+
+    real_pattern = bounded_json._STRING_SPECIAL
+
+    class _TrackingStringSpecial:
+        def __init__(self) -> None:
+            self.search_calls = 0
+            self.scanned_bytes = 0
+
+        def search(self, block: bytes, offset: int):
+            self.search_calls += 1
+            match = real_pattern.search(block, offset)
+            end = match.start() + 1 if match is not None else len(block)
+            self.scanned_bytes += end - offset
+            return match
+
+    tracker = _TrackingStringSpecial()
+    monkeypatch.setattr(bounded_json, "_STRING_SPECIAL", tracker)
+
+    bytes_method_calls: list[str] = []
+    previous_profile = sys.getprofile()
+    previous_profile_disable = getattr(previous_profile, "disable", None)
+    previous_profile_enable = getattr(previous_profile, "enable", None)
+    if previous_profile is not None and not callable(previous_profile):
+        if not callable(previous_profile_disable) or not callable(
+            previous_profile_enable
+        ):
+            raise AssertionError("active profiler cannot be restored safely")
+        previous_profile_disable()
+
+    def track_bytes_methods(frame, event: str, argument: object) -> None:
+        if event == "c_call" and type(getattr(argument, "__self__", None)) is bytes:
+            method_name = getattr(argument, "__name__", None)
+            if isinstance(method_name, str):
+                bytes_method_calls.append(method_name)
+        if callable(previous_profile):
+            previous_profile(frame, event, argument)
+
+    pairs = 10_000
+    payload = b'["' + (b"\\\\" * pairs) + b'"]'
+    sys.setprofile(track_bytes_methods)
+    try:
+        observed = list(
+            bounded_json.iter_bounded_json_array(
+                _ChunkReader(payload, 257),
                 label="escape-dense documents",
                 max_element_bytes=len(payload),
             )
-        ) == ["\\" * pairs]
-        return time.perf_counter() - started
+        )
+    finally:
+        sys.setprofile(None)
+        if callable(previous_profile):
+            sys.setprofile(previous_profile)
+        elif previous_profile is not None:
+            assert callable(previous_profile_enable)
+            previous_profile_enable()
 
-    # Use the best of two runs to reduce scheduler noise. The larger input is
-    # four times the size; the old repeated-find loop grew quadratically.
-    small = min(elapsed(100_000) for _ in range(2))
-    large = min(elapsed(400_000) for _ in range(2))
-    assert large < max(0.25, small * 8)
+    # The regex accounts for the complete scan. No independent bytes method may
+    # rescan a block on every escape; odd blocks also exercise split pairs.
+    assert observed == ["\\" * pairs]
+    assert tracker.search_calls == pairs + 1
+    assert tracker.scanned_bytes == pairs + 1
+    assert bytes_method_calls == []
 
 
 def test_canonical_array_chunks_match_the_existing_json_contract() -> None:


### PR DESCRIPTION
## Summary

Replace the scheduler-sensitive wall-clock complexity check for escape-dense bounded JSON with deterministic operation accounting. This removes a 64-worker xdist flake without weakening the regression gate for the former quadratic repeated-find scanner.

## Changes

- Track exact `_STRING_SPECIAL.search` calls and cumulatively scanned bytes while parsing an escape-dense string.
- Reject any independent bound `bytes` method invoked during the parse window, so the former dual-`find` loop and added side scans fail deterministically.
- Exercise odd 257-byte input blocks so escaped pairs cross reader boundaries.
- Preserve callable profilers and active `cProfile` instances across both normal and exceptional paths.
- Remove the wall-clock ratio and its scheduler-dependent timing threshold.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- CPython 3.10, 3.12, and 3.14 bounded-JSON suites: `42 passed` on each tested version.
- CPython 3.12/3.14 xdist bounded-JSON suites passed; the original revision also passed 100 xdist repetitions and 500 high-contention repetitions.
- Injected extra-`find` counterfactual fails as required on all three Python versions while exact regex calls and spans remain `10,001`.
- Callable-profiler and active-`cProfile` restoration passed, including a forced parse exception.
- Relevant dependent selector: `260 passed`.
- Black 24.8.0, isort 5.13.2, flake8 7.1.1 with bugbear, and `git diff --check` passed.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published