### PR TITLE
feat(wiki): persist configurable multimodal bundles

### DIFF
--- a/codenib/web/config.py
+++ b/codenib/web/config.py
@@ -34,6 +34,23 @@ DEFAULT_CONFIG_PATH = "qa_config.yaml"
 CACHE_DIR_NAME = REPO_INDEX_DIRNAME
 REGISTRY_FILENAME = "qa_registry.json"
 CONFIG_EXTENDS_KEY = "extends"
+_TRUE_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
+_FALSE_ENV_VALUES = frozenset({"", "0", "false", "no", "off"})
+
+
+def _validated_bool(value: Any, *, source: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{source} must be a boolean")
+    return value
+
+
+def _parse_env_bool(value: str, *, source: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in _TRUE_ENV_VALUES:
+        return True
+    if normalized in _FALSE_ENV_VALUES:
+        return False
+    raise ValueError(f"{source} must be a boolean")
 
 
 def _model_provider(model: str) -> Optional[str]:
@@ -221,6 +238,10 @@ class QAConfig:
     per_language: int = 1
 
     def __post_init__(self) -> None:
+        self.wiki_visual_facts_enabled = _validated_bool(
+            self.wiki_visual_facts_enabled,
+            source="wiki_visual_facts_enabled",
+        )
         self.model_options = validate_model_options(
             self.model_options,
             source="model_options",
@@ -339,11 +360,12 @@ def load_config(path: Optional[str] = None) -> QAConfig:
             data.get("wiki_media_options"),
             source="wiki_media_options",
         ),
-        wiki_visual_facts_enabled=bool(
+        wiki_visual_facts_enabled=_validated_bool(
             data.get(
                 "wiki_visual_facts_enabled",
                 defaults.wiki_visual_facts_enabled,
-            )
+            ),
+            source="wiki_visual_facts_enabled",
         ),
         wiki_visual_facts_model=data.get("wiki_visual_facts_model"),
         wiki_visual_facts_api_base=data.get("wiki_visual_facts_api_base"),
@@ -411,9 +433,10 @@ def load_config(path: Optional[str] = None) -> QAConfig:
     if os.environ.get("CODENIB_WIKI_MEDIA_API_KEY"):
         cfg.wiki_media_api_key = os.environ["CODENIB_WIKI_MEDIA_API_KEY"]
     if os.environ.get("CODENIB_WIKI_VISUAL_FACTS_ENABLED") is not None:
-        cfg.wiki_visual_facts_enabled = os.environ[
-            "CODENIB_WIKI_VISUAL_FACTS_ENABLED"
-        ].strip().lower() in ("1", "true", "yes", "on")
+        cfg.wiki_visual_facts_enabled = _parse_env_bool(
+            os.environ["CODENIB_WIKI_VISUAL_FACTS_ENABLED"],
+            source="CODENIB_WIKI_VISUAL_FACTS_ENABLED",
+        )
     if os.environ.get("CODENIB_WIKI_VISUAL_FACTS_MODEL"):
         cfg.wiki_visual_facts_model = os.environ["CODENIB_WIKI_VISUAL_FACTS_MODEL"]
     if os.environ.get("CODENIB_WIKI_VISUAL_FACTS_API_BASE"):

--- a/codenib/web/config.py
+++ b/codenib/web/config.py
@@ -147,6 +147,15 @@ class QAConfig:
     wiki_media_api_base: Optional[str] = None
     wiki_media_api_key: Optional[str] = field(default=None, repr=False)
     wiki_media_options: Dict[str, Any] = field(default_factory=dict)
+    # Optional OpenAI-compatible VLM endpoint for extracting structured visual
+    # facts from repository-owned images/diagrams before grounding them to code.
+    # Disabled by default so local/offline builds keep using deterministic
+    # metadata extraction.
+    wiki_visual_facts_enabled: bool = False
+    wiki_visual_facts_model: Optional[str] = None
+    wiki_visual_facts_api_base: Optional[str] = None
+    wiki_visual_facts_api_key: Optional[str] = field(default=None, repr=False)
+    wiki_visual_facts_options: Dict[str, Any] = field(default_factory=dict)
     # Optional OpenAI-compatible endpoint for the Ask agent. Provider-native
     # models (for example Vertex or Anthropic) normally leave these unset.
     model_api_base: Optional[str] = None
@@ -224,6 +233,10 @@ class QAConfig:
             self.wiki_media_options,
             source="wiki_media_options",
         )
+        self.wiki_visual_facts_options = validate_model_options(
+            self.wiki_visual_facts_options,
+            source="wiki_visual_facts_options",
+        )
 
     def index_types(self) -> List[str]:
         return ["bm25", "vector"] if self.mode == "hybrid" else ["bm25"]
@@ -297,6 +310,16 @@ class QAConfig:
             return True
         return bool(self.wiki_media_model and self.wiki_media_api_base)
 
+    @property
+    def wiki_visual_fact_extraction_enabled(self) -> bool:
+        """Whether repository media should be sent to a configured VLM."""
+
+        return bool(
+            self.wiki_visual_facts_enabled
+            and self.wiki_visual_facts_model
+            and self.wiki_visual_facts_api_base
+        )
+
 
 def load_config(path: Optional[str] = None) -> QAConfig:
     """Load a layered demo config from YAML, then apply env overrides."""
@@ -315,6 +338,19 @@ def load_config(path: Optional[str] = None) -> QAConfig:
         wiki_media_options=validate_model_options(
             data.get("wiki_media_options"),
             source="wiki_media_options",
+        ),
+        wiki_visual_facts_enabled=bool(
+            data.get(
+                "wiki_visual_facts_enabled",
+                defaults.wiki_visual_facts_enabled,
+            )
+        ),
+        wiki_visual_facts_model=data.get("wiki_visual_facts_model"),
+        wiki_visual_facts_api_base=data.get("wiki_visual_facts_api_base"),
+        wiki_visual_facts_api_key=data.get("wiki_visual_facts_api_key"),
+        wiki_visual_facts_options=validate_model_options(
+            data.get("wiki_visual_facts_options"),
+            source="wiki_visual_facts_options",
         ),
         model_api_base=data.get("model_api_base"),
         model_api_key=data.get("model_api_key"),
@@ -374,6 +410,18 @@ def load_config(path: Optional[str] = None) -> QAConfig:
         cfg.wiki_media_api_base = os.environ["CODENIB_WIKI_MEDIA_API_BASE"]
     if os.environ.get("CODENIB_WIKI_MEDIA_API_KEY"):
         cfg.wiki_media_api_key = os.environ["CODENIB_WIKI_MEDIA_API_KEY"]
+    if os.environ.get("CODENIB_WIKI_VISUAL_FACTS_ENABLED") is not None:
+        cfg.wiki_visual_facts_enabled = os.environ[
+            "CODENIB_WIKI_VISUAL_FACTS_ENABLED"
+        ].strip().lower() in ("1", "true", "yes", "on")
+    if os.environ.get("CODENIB_WIKI_VISUAL_FACTS_MODEL"):
+        cfg.wiki_visual_facts_model = os.environ["CODENIB_WIKI_VISUAL_FACTS_MODEL"]
+    if os.environ.get("CODENIB_WIKI_VISUAL_FACTS_API_BASE"):
+        cfg.wiki_visual_facts_api_base = os.environ[
+            "CODENIB_WIKI_VISUAL_FACTS_API_BASE"
+        ]
+    if os.environ.get("CODENIB_WIKI_VISUAL_FACTS_API_KEY"):
+        cfg.wiki_visual_facts_api_key = os.environ["CODENIB_WIKI_VISUAL_FACTS_API_KEY"]
     if os.environ.get("CODENIB_DEMO_API_BASE"):
         cfg.model_api_base = os.environ["CODENIB_DEMO_API_BASE"]
     if os.environ.get("CODENIB_DEMO_API_KEY"):
@@ -400,6 +448,14 @@ def load_config(path: Optional[str] = None) -> QAConfig:
             parse_model_options_json(
                 os.environ["CODENIB_WIKI_MEDIA_OPTIONS"],
                 source="CODENIB_WIKI_MEDIA_OPTIONS",
+            ),
+        )
+    if os.environ.get("CODENIB_WIKI_VISUAL_FACTS_OPTIONS"):
+        cfg.wiki_visual_facts_options = merge_model_options(
+            cfg.wiki_visual_facts_options,
+            parse_model_options_json(
+                os.environ["CODENIB_WIKI_VISUAL_FACTS_OPTIONS"],
+                source="CODENIB_WIKI_VISUAL_FACTS_OPTIONS",
             ),
         )
     if os.environ.get("CODENIB_DEMO_DATA_DIR"):

--- a/codenib/wiki/__init__.py
+++ b/codenib/wiki/__init__.py
@@ -36,6 +36,14 @@ from .media_knowledge import (
     search_visual_context,
 )
 from .media_pipeline import build_multimodal_repository_knowledge
+from .media_storage import (
+    MULTIMODAL_KNOWLEDGE_BUNDLE_SCHEMA,
+    MULTIMODAL_KNOWLEDGE_BUNDLE_VERSION,
+    build_multimodal_knowledge_bundle,
+    load_multimodal_knowledge_bundle,
+    save_multimodal_knowledge_bundle,
+    validate_multimodal_knowledge_bundle,
+)
 from .media_tools import MultimodalKnowledgeToolRouter, multimodal_tool_schemas
 from .media_vlm import (
     OpenAICompatibleVisualFactExtractor,
@@ -43,12 +51,15 @@ from .media_vlm import (
 )
 
 __all__ = [
+    "MULTIMODAL_KNOWLEDGE_BUNDLE_SCHEMA",
+    "MULTIMODAL_KNOWLEDGE_BUNDLE_VERSION",
     "MultimodalKnowledgeToolRouter",
     "WikiBuilder",
     "OpenAICompatibleVisualFactExtractor",
     "VisualGroundingScorer",
     "build_media_evidence_pack",
     "build_multimodal_knowledge_view",
+    "build_multimodal_knowledge_bundle",
     "build_multimodal_repository_knowledge",
     "build_visual_facts_manifest",
     "deterministic_visual_facts",
@@ -64,6 +75,9 @@ __all__ = [
     "merge_incremental_visual_facts",
     "multimodal_tool_schemas",
     "plan_incremental_visual_fact_update",
+    "load_multimodal_knowledge_bundle",
+    "save_multimodal_knowledge_bundle",
     "search_visual_context",
+    "validate_multimodal_knowledge_bundle",
     "visual_fact_extractor_from_config",
 ]

--- a/codenib/wiki/__init__.py
+++ b/codenib/wiki/__init__.py
@@ -37,7 +37,10 @@ from .media_knowledge import (
 )
 from .media_pipeline import build_multimodal_repository_knowledge
 from .media_tools import MultimodalKnowledgeToolRouter, multimodal_tool_schemas
-from .media_vlm import OpenAICompatibleVisualFactExtractor
+from .media_vlm import (
+    OpenAICompatibleVisualFactExtractor,
+    visual_fact_extractor_from_config,
+)
 
 __all__ = [
     "MultimodalKnowledgeToolRouter",
@@ -62,4 +65,5 @@ __all__ = [
     "multimodal_tool_schemas",
     "plan_incremental_visual_fact_update",
     "search_visual_context",
+    "visual_fact_extractor_from_config",
 ]

--- a/codenib/wiki/media_pipeline.py
+++ b/codenib/wiki/media_pipeline.py
@@ -21,6 +21,7 @@ from .media_grounding import (
     ground_visual_facts_to_sources,
 )
 from .media_knowledge import build_multimodal_knowledge_view
+from .media_storage import build_multimodal_knowledge_bundle
 
 
 def build_multimodal_repository_knowledge(
@@ -65,13 +66,13 @@ def build_multimodal_repository_knowledge(
         visual_facts_manifest,
         grounding_manifest,
     )
-    return {
-        "media_manifest": media_manifest,
-        "visual_facts_manifest": visual_facts_manifest,
-        "source_candidate_count": len(source_candidates),
-        "grounding_manifest": grounding_manifest,
-        "knowledge_view": knowledge_view,
-    }
+    return build_multimodal_knowledge_bundle(
+        media_manifest=media_manifest,
+        visual_facts_manifest=visual_facts_manifest,
+        source_candidate_count=len(source_candidates),
+        grounding_manifest=grounding_manifest,
+        knowledge_view=knowledge_view,
+    )
 
 
 def _repository_root(repo_path: str | Path) -> Path:

--- a/codenib/wiki/media_storage.py
+++ b/codenib/wiki/media_storage.py
@@ -6,16 +6,38 @@
 
 from __future__ import annotations
 
+import copy
+import hmac
+import io
 import json
+import math
 import os
+import re
 import tempfile
 from hashlib import sha256
 from pathlib import Path
 from typing import Any, Mapping
 
+from .._bounded_json import validate_bounded_json_stream, validate_json_complexity
+from ._safe_file_reads import read_regular_bytes
+from .media_artifacts import MEDIA_MANIFEST_SCHEMA, MEDIA_MANIFEST_VERSION
+from .media_facts import (
+    MEDIA_FACTS_SCHEMA,
+    MEDIA_FACTS_VERSION,
+    compute_visual_facts_manifest_sha256,
+)
+from .media_grounding import MEDIA_GROUNDING_SCHEMA, MEDIA_GROUNDING_VERSION
+from .media_knowledge import MULTIMODAL_KNOWLEDGE_SCHEMA, MULTIMODAL_KNOWLEDGE_VERSION
+
 MULTIMODAL_KNOWLEDGE_BUNDLE_SCHEMA = "codenib.multimodal-knowledge-bundle.v1"
 MULTIMODAL_KNOWLEDGE_BUNDLE_VERSION = 1
 _MAX_BUNDLE_BYTES = 128 * 1024 * 1024
+_MAX_BUNDLE_NODES = 2_000_000
+_MAX_BUNDLE_TOKENS = 4_000_000
+_MAX_COMPONENT_ITEMS = 32_768
+_MAX_SOURCE_CANDIDATES = 8_192
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
+_SOURCE_SELECTION_DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}")
 
 
 def build_multimodal_knowledge_bundle(
@@ -33,22 +55,20 @@ def build_multimodal_knowledge_bundle(
         "schema_version": MULTIMODAL_KNOWLEDGE_BUNDLE_VERSION,
         "media_manifest": dict(media_manifest),
         "visual_facts_manifest": dict(visual_facts_manifest),
-        "source_candidate_count": int(source_candidate_count),
+        "source_candidate_count": source_candidate_count,
         "grounding_manifest": dict(grounding_manifest),
         "knowledge_view": dict(knowledge_view),
         "component_sha256": {
-            "media_manifest": str(media_manifest.get("manifest_sha256") or ""),
-            "visual_facts_manifest": str(
-                visual_facts_manifest.get("manifest_sha256") or ""
-            ),
-            "grounding_manifest": str(grounding_manifest.get("manifest_sha256") or ""),
-            "knowledge_view": str(knowledge_view.get("view_sha256") or ""),
+            "media_manifest": media_manifest.get("manifest_sha256"),
+            "visual_facts_manifest": visual_facts_manifest.get("manifest_sha256"),
+            "grounding_manifest": grounding_manifest.get("manifest_sha256"),
+            "knowledge_view": knowledge_view.get("view_sha256"),
         },
     }
     bundle["bundle_sha256"] = _stable_sha256(
         {key: value for key, value in bundle.items() if key != "bundle_sha256"}
     )
-    return bundle
+    return validate_multimodal_knowledge_bundle(bundle)
 
 
 def save_multimodal_knowledge_bundle(
@@ -58,18 +78,28 @@ def save_multimodal_knowledge_bundle(
     """Atomically write a multimodal knowledge bundle as stable JSON."""
 
     validated = validate_multimodal_knowledge_bundle(bundle)
-    destination = Path(path)
+    destination = Path(path).expanduser()
     destination.parent.mkdir(parents=True, exist_ok=True)
+    payload = (
+        json.dumps(
+            validated,
+            allow_nan=False,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        ).encode("utf-8")
+        + b"\n"
+    )
+    if len(payload) > _MAX_BUNDLE_BYTES:
+        raise ValueError("multimodal knowledge bundle exceeds the byte limit")
     fd, temp_name = tempfile.mkstemp(
         prefix=f".{destination.name}.",
         suffix=".tmp",
         dir=str(destination.parent),
-        text=True,
     )
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            json.dump(validated, handle, ensure_ascii=False, indent=2, sort_keys=True)
-            handle.write("\n")
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(temp_name, destination)
@@ -83,15 +113,29 @@ def save_multimodal_knowledge_bundle(
 def load_multimodal_knowledge_bundle(path: str | Path) -> dict[str, Any]:
     """Load and validate a persisted multimodal knowledge bundle."""
 
-    source = Path(path)
-    size = source.stat().st_size
-    if size > _MAX_BUNDLE_BYTES:
-        raise ValueError("multimodal knowledge bundle exceeds the byte limit")
-    with source.open("rb") as handle:
-        raw = handle.read(_MAX_BUNDLE_BYTES + 1)
-    if len(raw) > _MAX_BUNDLE_BYTES:
-        raise ValueError("multimodal knowledge bundle exceeds the byte limit")
-    data = json.loads(raw.decode("utf-8"))
+    source = Path(path).expanduser()
+    raw = read_regular_bytes(source, max_bytes=_MAX_BUNDLE_BYTES)
+    if raw is None:
+        raise ValueError(
+            "multimodal knowledge bundle must be a stable regular file "
+            "within the byte limit"
+        )
+    validate_bounded_json_stream(
+        io.BytesIO(raw),
+        label="multimodal knowledge bundle",
+        max_bytes=_MAX_BUNDLE_BYTES,
+        max_nodes=_MAX_BUNDLE_NODES,
+        max_lexical_tokens=_MAX_BUNDLE_TOKENS,
+    )
+    try:
+        data = json.loads(
+            raw.decode("utf-8", errors="strict"),
+            object_pairs_hook=_reject_duplicate_object,
+            parse_constant=_reject_nonfinite_number,
+            parse_float=_finite_float,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("multimodal knowledge bundle contains invalid JSON") from exc
     return validate_multimodal_knowledge_bundle(data)
 
 
@@ -103,50 +147,334 @@ def validate_multimodal_knowledge_bundle(bundle: Mapping[str, Any]) -> dict[str,
     data = dict(bundle)
     if data.get("schema") != MULTIMODAL_KNOWLEDGE_BUNDLE_SCHEMA:
         raise ValueError("multimodal knowledge bundle schema is unsupported")
-    if data.get("schema_version") != MULTIMODAL_KNOWLEDGE_BUNDLE_VERSION:
+    if (
+        type(data.get("schema_version")) is not int
+        or data["schema_version"] != MULTIMODAL_KNOWLEDGE_BUNDLE_VERSION
+    ):
         raise ValueError("multimodal knowledge bundle version is unsupported")
-    for key in (
-        "media_manifest",
-        "visual_facts_manifest",
-        "grounding_manifest",
-        "knowledge_view",
-        "component_sha256",
-    ):
-        if not isinstance(data.get(key), Mapping):
-            raise ValueError(f"multimodal knowledge bundle field {key!r} is invalid")
-        data[key] = dict(data[key])
+    media_manifest = _mapping(data.get("media_manifest"), label="media_manifest")
+    visual_facts_manifest = _mapping(
+        data.get("visual_facts_manifest"),
+        label="visual_facts_manifest",
+    )
+    grounding_manifest = _mapping(
+        data.get("grounding_manifest"),
+        label="grounding_manifest",
+    )
+    knowledge_view = _mapping(data.get("knowledge_view"), label="knowledge_view")
+    component_sha256 = _mapping(
+        data.get("component_sha256"),
+        label="component_sha256",
+    )
+    data.update(
+        {
+            "media_manifest": media_manifest,
+            "visual_facts_manifest": visual_facts_manifest,
+            "grounding_manifest": grounding_manifest,
+            "knowledge_view": knowledge_view,
+            "component_sha256": component_sha256,
+        }
+    )
     source_candidate_count = data.get("source_candidate_count")
-    if isinstance(source_candidate_count, bool) or not isinstance(
-        source_candidate_count, int
+    if (
+        type(source_candidate_count) is not int
+        or not 0 <= source_candidate_count <= _MAX_SOURCE_CANDIDATES
     ):
         raise ValueError(
             "multimodal knowledge bundle source_candidate_count is invalid"
         )
-    if source_candidate_count < 0:
-        raise ValueError(
-            "multimodal knowledge bundle source_candidate_count is invalid"
-        )
+
+    component_digests = {
+        "media_manifest": _validate_media_manifest(media_manifest),
+        "visual_facts_manifest": _validate_visual_facts_manifest(
+            visual_facts_manifest,
+        ),
+        "grounding_manifest": _validate_grounding_manifest(grounding_manifest),
+        "knowledge_view": _validate_knowledge_view(knowledge_view),
+    }
+    if (
+        visual_facts_manifest["media_manifest_sha256"]
+        != component_digests["media_manifest"]
+    ):
+        raise ValueError("visual facts manifest is bound to another media manifest")
+    if (
+        grounding_manifest["visual_facts_manifest_sha256"]
+        != component_digests["visual_facts_manifest"]
+    ):
+        raise ValueError("grounding manifest is bound to another visual facts manifest")
+    linked_view_digests = {
+        "media_manifest": knowledge_view.get("media_manifest_sha256"),
+        "visual_facts_manifest": knowledge_view.get("visual_facts_manifest_sha256"),
+        "grounding_manifest": knowledge_view.get("grounding_manifest_sha256"),
+    }
+    if any(
+        linked_view_digests[key] != component_digests[key]
+        for key in linked_view_digests
+    ):
+        raise ValueError("multimodal knowledge view component binding does not match")
+    if set(component_sha256) != set(component_digests):
+        raise ValueError("multimodal knowledge component hash inventory is invalid")
+    for key, digest in component_sha256.items():
+        if type(key) is not str or not key:
+            raise ValueError("multimodal knowledge component hash key is invalid")
+        _digest(digest, label=f"component_sha256.{key}")
+    if any(
+        component_sha256.get(key) != digest for key, digest in component_digests.items()
+    ):
+        raise ValueError("multimodal knowledge component hash does not match")
+
     expected_hash = _stable_sha256(
         {key: value for key, value in data.items() if key != "bundle_sha256"}
     )
-    recorded_hash = data.get("bundle_sha256")
-    if recorded_hash:
-        if recorded_hash != expected_hash:
-            raise ValueError("multimodal knowledge bundle hash does not match")
-    else:
-        data["bundle_sha256"] = expected_hash
-    return data
+    recorded_hash = _digest(data.get("bundle_sha256"), label="bundle_sha256")
+    if not hmac.compare_digest(recorded_hash, expected_hash):
+        raise ValueError("multimodal knowledge bundle hash does not match")
+
+    normalized = copy.deepcopy(data)
+    validate_json_complexity(
+        normalized,
+        label="multimodal knowledge bundle",
+        max_nodes=_MAX_BUNDLE_NODES,
+    )
+    if len(_canonical_json_bytes(normalized)) > _MAX_BUNDLE_BYTES:
+        raise ValueError("multimodal knowledge bundle exceeds the byte limit")
+    return normalized
+
+
+def _validate_media_manifest(manifest: Mapping[str, Any]) -> str:
+    if (
+        manifest.get("schema") != MEDIA_MANIFEST_SCHEMA
+        or type(manifest.get("version")) is not int
+        or manifest["version"] != MEDIA_MANIFEST_VERSION
+    ):
+        raise ValueError("media manifest schema is unsupported")
+    artifacts = _mapping_list(
+        manifest.get("artifacts"),
+        label="media_manifest.artifacts",
+    )
+    _matching_count(
+        manifest.get("artifact_count"),
+        artifacts,
+        label="media_manifest.artifact_count",
+    )
+    metadata = _mapping(manifest.get("metadata"), label="media_manifest.metadata")
+    expected = _component_sha256(
+        {
+            "schema": manifest["schema"],
+            "version": manifest["version"],
+            "commit": _text(manifest.get("commit"), label="media_manifest.commit"),
+            "source_selection_digest": _source_selection_digest(
+                manifest.get("source_selection_digest"),
+                label="media_manifest.source_selection_digest",
+            ),
+            "artifacts": artifacts,
+            "metadata": metadata,
+        }
+    )
+    recorded = _digest(
+        manifest.get("manifest_sha256"),
+        label="media_manifest.manifest_sha256",
+    )
+    if not hmac.compare_digest(recorded, expected):
+        raise ValueError("media manifest hash does not match")
+    return recorded
+
+
+def _validate_visual_facts_manifest(manifest: Mapping[str, Any]) -> str:
+    if (
+        manifest.get("schema") != MEDIA_FACTS_SCHEMA
+        or type(manifest.get("version")) is not int
+        or manifest["version"] != MEDIA_FACTS_VERSION
+    ):
+        raise ValueError("visual facts manifest schema is unsupported")
+    facts = _mapping_list(
+        manifest.get("facts"),
+        label="visual_facts_manifest.facts",
+    )
+    _matching_count(
+        manifest.get("fact_count"),
+        facts,
+        label="visual_facts_manifest.fact_count",
+    )
+    media_digest = _digest(
+        manifest.get("media_manifest_sha256"),
+        label="visual_facts_manifest.media_manifest_sha256",
+    )
+    expected = compute_visual_facts_manifest_sha256(
+        schema=manifest["schema"],
+        version=manifest["version"],
+        media_manifest_sha256=media_digest,
+        facts=facts,
+    )
+    recorded = _digest(
+        manifest.get("manifest_sha256"),
+        label="visual_facts_manifest.manifest_sha256",
+    )
+    if not hmac.compare_digest(recorded, expected):
+        raise ValueError("visual facts manifest hash does not match")
+    return recorded
+
+
+def _validate_grounding_manifest(manifest: Mapping[str, Any]) -> str:
+    if (
+        manifest.get("schema") != MEDIA_GROUNDING_SCHEMA
+        or type(manifest.get("version")) is not int
+        or manifest["version"] != MEDIA_GROUNDING_VERSION
+    ):
+        raise ValueError("grounding manifest schema is unsupported")
+    bindings = _mapping_list(
+        manifest.get("bindings"),
+        label="grounding_manifest.bindings",
+    )
+    _matching_count(
+        manifest.get("binding_count"),
+        bindings,
+        label="grounding_manifest.binding_count",
+    )
+    facts_digest = _digest(
+        manifest.get("visual_facts_manifest_sha256"),
+        label="grounding_manifest.visual_facts_manifest_sha256",
+    )
+    expected = _component_sha256(
+        {
+            "schema": manifest["schema"],
+            "version": manifest["version"],
+            "visual_facts_manifest_sha256": facts_digest,
+            "bindings": bindings,
+        }
+    )
+    recorded = _digest(
+        manifest.get("manifest_sha256"),
+        label="grounding_manifest.manifest_sha256",
+    )
+    if not hmac.compare_digest(recorded, expected):
+        raise ValueError("grounding manifest hash does not match")
+    return recorded
+
+
+def _validate_knowledge_view(view: Mapping[str, Any]) -> str:
+    if (
+        view.get("schema") != MULTIMODAL_KNOWLEDGE_SCHEMA
+        or type(view.get("version")) is not int
+        or view["version"] != MULTIMODAL_KNOWLEDGE_VERSION
+    ):
+        raise ValueError("multimodal knowledge view schema is unsupported")
+    entries = _mapping_list(
+        view.get("entries"),
+        label="knowledge_view.entries",
+    )
+    _matching_count(
+        view.get("entry_count"),
+        entries,
+        label="knowledge_view.entry_count",
+    )
+    for key in (
+        "media_manifest_sha256",
+        "visual_facts_manifest_sha256",
+        "grounding_manifest_sha256",
+    ):
+        _digest(view.get(key), label=f"knowledge_view.{key}")
+    expected = _component_sha256(
+        {key: value for key, value in view.items() if key != "view_sha256"}
+    )
+    recorded = _digest(view.get("view_sha256"), label="knowledge_view.view_sha256")
+    if not hmac.compare_digest(recorded, expected):
+        raise ValueError("multimodal knowledge view hash does not match")
+    return recorded
+
+
+def _mapping(value: Any, *, label: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"multimodal knowledge bundle field {label!r} is invalid")
+    return dict(value)
+
+
+def _mapping_list(value: Any, *, label: str) -> list[dict[str, Any]]:
+    if (
+        not isinstance(value, list)
+        or len(value) > _MAX_COMPONENT_ITEMS
+        or any(not isinstance(item, Mapping) for item in value)
+    ):
+        raise ValueError(f"multimodal knowledge bundle field {label!r} is invalid")
+    return [dict(item) for item in value]
+
+
+def _matching_count(value: Any, items: list[Any], *, label: str) -> None:
+    if type(value) is not int or value != len(items):
+        raise ValueError(f"multimodal knowledge bundle field {label!r} is invalid")
+
+
+def _text(value: Any, *, label: str) -> str:
+    if type(value) is not str:
+        raise ValueError(f"multimodal knowledge bundle field {label!r} is invalid")
+    return value
+
+
+def _digest(value: Any, *, label: str) -> str:
+    if type(value) is not str or _SHA256_RE.fullmatch(value) is None:
+        raise ValueError(f"multimodal knowledge bundle field {label!r} is invalid")
+    return value
+
+
+def _source_selection_digest(value: Any, *, label: str) -> str:
+    if type(value) is not str or _SOURCE_SELECTION_DIGEST_RE.fullmatch(value) is None:
+        raise ValueError(f"multimodal knowledge bundle field {label!r} is invalid")
+    return value
 
 
 def _stable_sha256(payload: Mapping[str, Any]) -> str:
-    return sha256(
-        json.dumps(
+    return sha256(_canonical_json_bytes(payload)).hexdigest()
+
+
+def _component_sha256(payload: Mapping[str, Any]) -> str:
+    try:
+        encoded = json.dumps(
             payload,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    except (OverflowError, RecursionError, TypeError, ValueError) as exc:
+        raise ValueError(
+            "multimodal knowledge component must contain bounded JSON values"
+        ) from exc
+    return sha256(encoded).hexdigest()
+
+
+def _canonical_json_bytes(payload: Any) -> bytes:
+    try:
+        return json.dumps(
+            payload,
+            allow_nan=False,
             ensure_ascii=False,
             separators=(",", ":"),
             sort_keys=True,
         ).encode("utf-8")
-    ).hexdigest()
+    except (OverflowError, RecursionError, TypeError, ValueError) as exc:
+        raise ValueError(
+            "multimodal knowledge bundle must contain bounded JSON values"
+        ) from exc
+
+
+def _reject_duplicate_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_number(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_float(value: str) -> float:
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError("non-finite JSON number")
+    return result
 
 
 __all__ = [

--- a/codenib/wiki/media_storage.py
+++ b/codenib/wiki/media_storage.py
@@ -13,6 +13,7 @@ import json
 import math
 import os
 import re
+import stat
 import tempfile
 from hashlib import sha256
 from pathlib import Path
@@ -92,6 +93,14 @@ def save_multimodal_knowledge_bundle(
     )
     if len(payload) > _MAX_BUNDLE_BYTES:
         raise ValueError("multimodal knowledge bundle exceeds the byte limit")
+    try:
+        existing = os.stat(destination, follow_symlinks=False)
+    except FileNotFoundError:
+        existing_mode = None
+    else:
+        existing_mode = (
+            stat.S_IMODE(existing.st_mode) if stat.S_ISREG(existing.st_mode) else None
+        )
     fd, temp_name = tempfile.mkstemp(
         prefix=f".{destination.name}.",
         suffix=".tmp",
@@ -101,6 +110,8 @@ def save_multimodal_knowledge_bundle(
         with os.fdopen(fd, "wb") as handle:
             handle.write(payload)
             handle.flush()
+            if existing_mode is not None:
+                os.fchmod(handle.fileno(), existing_mode)
             os.fsync(handle.fileno())
         os.replace(temp_name, destination)
     finally:

--- a/codenib/wiki/media_storage.py
+++ b/codenib/wiki/media_storage.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stable storage helpers for multimodal repository knowledge bundles."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, Mapping
+
+MULTIMODAL_KNOWLEDGE_BUNDLE_SCHEMA = "codenib.multimodal-knowledge-bundle.v1"
+MULTIMODAL_KNOWLEDGE_BUNDLE_VERSION = 1
+_MAX_BUNDLE_BYTES = 128 * 1024 * 1024
+
+
+def build_multimodal_knowledge_bundle(
+    *,
+    media_manifest: Mapping[str, Any],
+    visual_facts_manifest: Mapping[str, Any],
+    source_candidate_count: int,
+    grounding_manifest: Mapping[str, Any],
+    knowledge_view: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Wrap multimodal pipeline outputs in a versioned, hashable bundle."""
+
+    bundle: dict[str, Any] = {
+        "schema": MULTIMODAL_KNOWLEDGE_BUNDLE_SCHEMA,
+        "schema_version": MULTIMODAL_KNOWLEDGE_BUNDLE_VERSION,
+        "media_manifest": dict(media_manifest),
+        "visual_facts_manifest": dict(visual_facts_manifest),
+        "source_candidate_count": int(source_candidate_count),
+        "grounding_manifest": dict(grounding_manifest),
+        "knowledge_view": dict(knowledge_view),
+        "component_sha256": {
+            "media_manifest": str(media_manifest.get("manifest_sha256") or ""),
+            "visual_facts_manifest": str(
+                visual_facts_manifest.get("manifest_sha256") or ""
+            ),
+            "grounding_manifest": str(grounding_manifest.get("manifest_sha256") or ""),
+            "knowledge_view": str(knowledge_view.get("view_sha256") or ""),
+        },
+    }
+    bundle["bundle_sha256"] = _stable_sha256(
+        {key: value for key, value in bundle.items() if key != "bundle_sha256"}
+    )
+    return bundle
+
+
+def save_multimodal_knowledge_bundle(
+    bundle: Mapping[str, Any],
+    path: str | Path,
+) -> None:
+    """Atomically write a multimodal knowledge bundle as stable JSON."""
+
+    validated = validate_multimodal_knowledge_bundle(bundle)
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=str(destination.parent),
+        text=True,
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(validated, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, destination)
+    finally:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+
+
+def load_multimodal_knowledge_bundle(path: str | Path) -> dict[str, Any]:
+    """Load and validate a persisted multimodal knowledge bundle."""
+
+    source = Path(path)
+    size = source.stat().st_size
+    if size > _MAX_BUNDLE_BYTES:
+        raise ValueError("multimodal knowledge bundle exceeds the byte limit")
+    with source.open("rb") as handle:
+        raw = handle.read(_MAX_BUNDLE_BYTES + 1)
+    if len(raw) > _MAX_BUNDLE_BYTES:
+        raise ValueError("multimodal knowledge bundle exceeds the byte limit")
+    data = json.loads(raw.decode("utf-8"))
+    return validate_multimodal_knowledge_bundle(data)
+
+
+def validate_multimodal_knowledge_bundle(bundle: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a normalized bundle or raise ``ValueError`` for invalid input."""
+
+    if not isinstance(bundle, Mapping):
+        raise ValueError("multimodal knowledge bundle must be an object")
+    data = dict(bundle)
+    if data.get("schema") != MULTIMODAL_KNOWLEDGE_BUNDLE_SCHEMA:
+        raise ValueError("multimodal knowledge bundle schema is unsupported")
+    if data.get("schema_version") != MULTIMODAL_KNOWLEDGE_BUNDLE_VERSION:
+        raise ValueError("multimodal knowledge bundle version is unsupported")
+    for key in (
+        "media_manifest",
+        "visual_facts_manifest",
+        "grounding_manifest",
+        "knowledge_view",
+        "component_sha256",
+    ):
+        if not isinstance(data.get(key), Mapping):
+            raise ValueError(f"multimodal knowledge bundle field {key!r} is invalid")
+        data[key] = dict(data[key])
+    source_candidate_count = data.get("source_candidate_count")
+    if isinstance(source_candidate_count, bool) or not isinstance(
+        source_candidate_count, int
+    ):
+        raise ValueError(
+            "multimodal knowledge bundle source_candidate_count is invalid"
+        )
+    if source_candidate_count < 0:
+        raise ValueError(
+            "multimodal knowledge bundle source_candidate_count is invalid"
+        )
+    expected_hash = _stable_sha256(
+        {key: value for key, value in data.items() if key != "bundle_sha256"}
+    )
+    recorded_hash = data.get("bundle_sha256")
+    if recorded_hash:
+        if recorded_hash != expected_hash:
+            raise ValueError("multimodal knowledge bundle hash does not match")
+    else:
+        data["bundle_sha256"] = expected_hash
+    return data
+
+
+def _stable_sha256(payload: Mapping[str, Any]) -> str:
+    return sha256(
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+__all__ = [
+    "MULTIMODAL_KNOWLEDGE_BUNDLE_SCHEMA",
+    "MULTIMODAL_KNOWLEDGE_BUNDLE_VERSION",
+    "build_multimodal_knowledge_bundle",
+    "load_multimodal_knowledge_bundle",
+    "save_multimodal_knowledge_bundle",
+    "validate_multimodal_knowledge_bundle",
+]

--- a/codenib/wiki/media_vlm.py
+++ b/codenib/wiki/media_vlm.py
@@ -151,6 +151,8 @@ class OpenAICompatibleVisualFactExtractor:
 
 def visual_fact_extractor_from_config(
     config: Any,
+    *,
+    repo_path: str | Path | None = None,
 ) -> OpenAICompatibleVisualFactExtractor | None:
     """Build a visual-fact extractor from ``QAConfig``-shaped settings."""
 
@@ -158,7 +160,10 @@ def visual_fact_extractor_from_config(
         return None
     model = str(getattr(config, "wiki_visual_facts_model", None) or "").strip()
     api_base = str(getattr(config, "wiki_visual_facts_api_base", None) or "").strip()
-    options = dict(getattr(config, "wiki_visual_facts_options", {}) or {})
+    raw_options = getattr(config, "wiki_visual_facts_options", {}) or {}
+    if not isinstance(raw_options, Mapping):
+        raise ValueError("wiki visual fact options must be a mapping")
+    options = dict(raw_options)
     timeout = options.get("timeout", 120.0)
     provider = str(options.get("provider") or "openai-compatible")
     return OpenAICompatibleVisualFactExtractor(
@@ -167,6 +172,7 @@ def visual_fact_extractor_from_config(
         api_key=getattr(config, "wiki_visual_facts_api_key", None),
         timeout=timeout,
         provider=provider,
+        repo_path=repo_path,
     )
 
 

--- a/codenib/wiki/media_vlm.py
+++ b/codenib/wiki/media_vlm.py
@@ -149,6 +149,27 @@ class OpenAICompatibleVisualFactExtractor:
         return data
 
 
+def visual_fact_extractor_from_config(
+    config: Any,
+) -> OpenAICompatibleVisualFactExtractor | None:
+    """Build a visual-fact extractor from ``QAConfig``-shaped settings."""
+
+    if not bool(getattr(config, "wiki_visual_fact_extraction_enabled", False)):
+        return None
+    model = str(getattr(config, "wiki_visual_facts_model", None) or "").strip()
+    api_base = str(getattr(config, "wiki_visual_facts_api_base", None) or "").strip()
+    options = dict(getattr(config, "wiki_visual_facts_options", {}) or {})
+    timeout = options.get("timeout", 120.0)
+    provider = str(options.get("provider") or "openai-compatible")
+    return OpenAICompatibleVisualFactExtractor(
+        model=model,
+        api_base=api_base,
+        api_key=getattr(config, "wiki_visual_facts_api_key", None),
+        timeout=timeout,
+        provider=provider,
+    )
+
+
 def _response_content_json(response: Mapping[str, Any]) -> dict[str, Any]:
     choices = response.get("choices")
     if not isinstance(choices, list) or not choices:
@@ -274,4 +295,4 @@ def _chat_completions_endpoint(api_base: str) -> str:
     return parsed._replace(path=path, fragment="").geturl()
 
 
-__all__ = ["OpenAICompatibleVisualFactExtractor"]
+__all__ = ["OpenAICompatibleVisualFactExtractor", "visual_fact_extractor_from_config"]

--- a/docs/experiments/multimodal_repository_knowledge.md
+++ b/docs/experiments/multimodal_repository_knowledge.md
@@ -82,6 +82,22 @@ CODENIB_WIKI_VISUAL_FACTS_OPTIONS='{"provider":"qwen","timeout":120}'
 Offline and CI runs keep using deterministic local extraction unless the VLM is
 explicitly enabled and both model and endpoint are provided.
 
+Callers can bind the validated configuration to the repository root and pass
+the resulting extractor directly into the one-step pipeline:
+
+```python
+from codenib.web.config import load_config
+from codenib.wiki import (
+    build_multimodal_repository_knowledge,
+    visual_fact_extractor_from_config,
+)
+
+repo = "/path/to/repository"
+config = load_config()
+extractor = visual_fact_extractor_from_config(config, repo_path=repo)
+bundle = build_multimodal_repository_knowledge(repo, extractor=extractor)
+```
+
 ### VisualGroundingManifest
 
 `codenib.wiki.media_grounding` grounds extracted visual entities to repository
@@ -123,9 +139,11 @@ component_sha256
 bundle_sha256
 ```
 
-The storage helper writes bundle JSON atomically and validates loaded bundles,
-including schema version, required object fields, byte limits, and bundle hash.
-This gives downstream consumers a stable artifact boundary instead of an ad hoc
+The storage helper writes bundle JSON atomically and validates loaded bundles.
+Validation recomputes every component digest, checks the cross-component digest
+bindings and outer bundle hash, bounds JSON bytes and structure, and rejects
+duplicate keys, non-finite numbers, and unstable or symlinked input files. This
+gives downstream consumers a stable artifact boundary instead of an ad hoc
 script JSON dump.
 
 ### Incremental updates

--- a/docs/experiments/multimodal_repository_knowledge.md
+++ b/docs/experiments/multimodal_repository_knowledge.md
@@ -57,6 +57,31 @@ bounded local artifact as a data URL, asks for JSON-only structured visual
 facts, and normalizes the response into the same `VisualFactPack` schema. This
 keeps the multimodal knowledge pipeline independent of a specific model family.
 
+The extractor is disabled by default. It can be configured through `QAConfig`
+or environment variables:
+
+```yaml
+wiki_visual_facts_enabled: true
+wiki_visual_facts_model: qwen-vl
+wiki_visual_facts_api_base: http://localhost:8000/v1
+wiki_visual_facts_options:
+  provider: qwen
+  timeout: 120
+```
+
+Equivalent environment variables:
+
+```text
+CODENIB_WIKI_VISUAL_FACTS_ENABLED=true
+CODENIB_WIKI_VISUAL_FACTS_MODEL=qwen-vl
+CODENIB_WIKI_VISUAL_FACTS_API_BASE=http://localhost:8000/v1
+CODENIB_WIKI_VISUAL_FACTS_API_KEY=...
+CODENIB_WIKI_VISUAL_FACTS_OPTIONS='{"provider":"qwen","timeout":120}'
+```
+
+Offline and CI runs keep using deterministic local extraction unless the VLM is
+explicitly enabled and both model and endpoint are provided.
+
 ### VisualGroundingManifest
 
 `codenib.wiki.media_grounding` grounds extracted visual entities to repository
@@ -82,6 +107,26 @@ a queryable view. It exposes three functions that future MCP tools can wrap:
 surface as an MCP-compatible tool router with stable tool schemas and bounded
 input validation. This keeps the query surface testable before wiring it into a
 server-specific MCP registration path.
+
+### Multimodal knowledge bundle
+
+`codenib.wiki.media_storage` wraps the pipeline output as a versioned bundle:
+
+```text
+schema: codenib.multimodal-knowledge-bundle.v1
+schema_version: 1
+media_manifest
+visual_facts_manifest
+grounding_manifest
+knowledge_view
+component_sha256
+bundle_sha256
+```
+
+The storage helper writes bundle JSON atomically and validates loaded bundles,
+including schema version, required object fields, byte limits, and bundle hash.
+This gives downstream consumers a stable artifact boundary instead of an ad hoc
+script JSON dump.
 
 ### Incremental updates
 
@@ -191,6 +236,17 @@ The same deterministic bundle can be written from the command line:
 python scripts/build_multimodal_knowledge.py /path/to/repository \
   --output /tmp/multimodal-knowledge.json \
   --exclude-root /path/to/repository/generated
+```
+
+To use an OpenAI-compatible VLM for visual fact extraction:
+
+```text
+export CODENIB_WIKI_VISUAL_FACTS_API_KEY=...
+python scripts/build_multimodal_knowledge.py /path/to/repository \
+  --output /tmp/multimodal-knowledge.json \
+  --visual-facts-model qwen-vl \
+  --visual-facts-api-base http://localhost:8000/v1 \
+  --visual-facts-provider qwen
 ```
 
 ```python

--- a/scripts/build_multimodal_knowledge.py
+++ b/scripts/build_multimodal_knowledge.py
@@ -20,6 +20,7 @@ if _PROJECT_ROOT not in sys.path:
 from codenib.wiki import (  # noqa: E402
     OpenAICompatibleVisualFactExtractor,
     build_multimodal_repository_knowledge,
+    save_multimodal_knowledge_bundle,
 )
 
 
@@ -104,12 +105,7 @@ def main(argv: list[str] | None = None) -> int:
         max_artifacts=args.max_artifacts,
         max_source_candidates=args.max_source_candidates,
     )
-    output = Path(args.output)
-    output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(
-        json.dumps(bundle, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    save_multimodal_knowledge_bundle(bundle, args.output)
     counts = {
         "media_artifacts": bundle["media_manifest"]["artifact_count"],
         "visual_fact_packs": bundle["visual_facts_manifest"]["fact_count"],

--- a/scripts/build_multimodal_knowledge.py
+++ b/scripts/build_multimodal_knowledge.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -16,7 +17,10 @@ _PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
 if _PROJECT_ROOT not in sys.path:
     sys.path.insert(0, _PROJECT_ROOT)
 
-from codenib.wiki import build_multimodal_repository_knowledge  # noqa: E402
+from codenib.wiki import (  # noqa: E402
+    OpenAICompatibleVisualFactExtractor,
+    build_multimodal_repository_knowledge,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -51,6 +55,35 @@ def build_parser() -> argparse.ArgumentParser:
         default=8192,
         help="Maximum source-symbol candidates to consider for grounding",
     )
+    parser.add_argument(
+        "--visual-facts-model",
+        default=None,
+        help=(
+            "Optional OpenAI-compatible VLM model for extracting visual facts. "
+            "When omitted, deterministic local extraction is used."
+        ),
+    )
+    parser.add_argument(
+        "--visual-facts-api-base",
+        default=None,
+        help="OpenAI-compatible API base URL for --visual-facts-model",
+    )
+    parser.add_argument(
+        "--visual-facts-api-key-env",
+        default="CODENIB_WIKI_VISUAL_FACTS_API_KEY",
+        help="Environment variable that contains the visual-facts API key",
+    )
+    parser.add_argument(
+        "--visual-facts-provider",
+        default="openai-compatible",
+        help="Provider label recorded in extracted visual facts",
+    )
+    parser.add_argument(
+        "--visual-facts-timeout",
+        type=float,
+        default=120.0,
+        help="Timeout in seconds for each visual-fact VLM request",
+    )
     return parser
 
 
@@ -62,10 +95,12 @@ def main(argv: list[str] | None = None) -> int:
         parser.error(f"repository root does not exist: {repo}")
     if not repo.is_dir():
         parser.error(f"repository root is not a directory: {repo}")
+    extractor = _build_visual_fact_extractor(args, repo_path=repo)
     bundle = build_multimodal_repository_knowledge(
         repo,
         commit=args.commit,
         exclude_roots=tuple(args.exclude_root),
+        extractor=extractor,
         max_artifacts=args.max_artifacts,
         max_source_candidates=args.max_source_candidates,
     )
@@ -84,6 +119,26 @@ def main(argv: list[str] | None = None) -> int:
     }
     print(json.dumps(counts, sort_keys=True))
     return 0
+
+
+def _build_visual_fact_extractor(
+    args: argparse.Namespace,
+    *,
+    repo_path: Path,
+) -> OpenAICompatibleVisualFactExtractor | None:
+    model = str(args.visual_facts_model or "").strip()
+    api_base = str(args.visual_facts_api_base or "").strip()
+    if not model and not api_base:
+        return None
+    extractor = OpenAICompatibleVisualFactExtractor(
+        model=model,
+        api_base=api_base,
+        api_key=os.environ.get(str(args.visual_facts_api_key_env or "")),
+        timeout=args.visual_facts_timeout,
+        provider=args.visual_facts_provider,
+        repo_path=repo_path,
+    )
+    return extractor
 
 
 if __name__ == "__main__":

--- a/scripts/build_multimodal_knowledge.py
+++ b/scripts/build_multimodal_knowledge.py
@@ -96,7 +96,10 @@ def main(argv: list[str] | None = None) -> int:
         parser.error(f"repository root does not exist: {repo}")
     if not repo.is_dir():
         parser.error(f"repository root is not a directory: {repo}")
-    extractor = _build_visual_fact_extractor(args, repo_path=repo)
+    try:
+        extractor = _build_visual_fact_extractor(args, repo_path=repo)
+    except ValueError as exc:
+        parser.error(str(exc))
     bundle = build_multimodal_repository_knowledge(
         repo,
         commit=args.commit,

--- a/test/scripts/test_build_multimodal_knowledge.py
+++ b/test/scripts/test_build_multimodal_knowledge.py
@@ -8,6 +8,8 @@ import json
 import subprocess
 import sys
 
+from scripts.build_multimodal_knowledge import build_parser
+
 
 def test_build_multimodal_knowledge_script_writes_bundle(tmp_path):
     repo = tmp_path / "repo"
@@ -78,3 +80,31 @@ def test_build_multimodal_knowledge_script_rejects_missing_repository(tmp_path):
     assert completed.returncode != 0
     assert "repository root does not exist" in completed.stderr
     assert not output.exists()
+
+
+def test_build_multimodal_knowledge_parser_accepts_vlm_options(tmp_path):
+    output = tmp_path / "bundle.json"
+
+    args = build_parser().parse_args(
+        [
+            str(tmp_path),
+            "--output",
+            str(output),
+            "--visual-facts-model",
+            "qwen-vl",
+            "--visual-facts-api-base",
+            "https://vlm.example/v1",
+            "--visual-facts-api-key-env",
+            "TEST_VLM_KEY",
+            "--visual-facts-provider",
+            "qwen",
+            "--visual-facts-timeout",
+            "15",
+        ]
+    )
+
+    assert args.visual_facts_model == "qwen-vl"
+    assert args.visual_facts_api_base == "https://vlm.example/v1"
+    assert args.visual_facts_api_key_env == "TEST_VLM_KEY"
+    assert args.visual_facts_provider == "qwen"
+    assert args.visual_facts_timeout == 15

--- a/test/scripts/test_build_multimodal_knowledge.py
+++ b/test/scripts/test_build_multimodal_knowledge.py
@@ -55,6 +55,8 @@ def test_build_multimodal_knowledge_script_writes_bundle(tmp_path):
     bundle = json.loads(output.read_text(encoding="utf-8"))
     assert counts["media_artifacts"] == 1
     assert counts["knowledge_entries"] == 1
+    assert bundle["schema"] == "codenib.multimodal-knowledge-bundle.v1"
+    assert len(bundle["bundle_sha256"]) == 64
     assert bundle["media_manifest"]["commit"] == "abc123"
     assert bundle["knowledge_view"]["entry_count"] == 1
 

--- a/test/scripts/test_build_multimodal_knowledge.py
+++ b/test/scripts/test_build_multimodal_knowledge.py
@@ -110,3 +110,31 @@ def test_build_multimodal_knowledge_parser_accepts_vlm_options(tmp_path):
     assert args.visual_facts_api_key_env == "TEST_VLM_KEY"
     assert args.visual_facts_provider == "qwen"
     assert args.visual_facts_timeout == 15
+
+
+def test_build_multimodal_knowledge_script_rejects_partial_vlm_config(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    output = tmp_path / "bundle.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "scripts/build_multimodal_knowledge.py",
+            str(repo),
+            "--output",
+            str(output),
+            "--visual-facts-model",
+            "qwen-vl",
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "visual fact api_base is invalid" in completed.stderr
+    assert "Traceback" not in completed.stderr
+    assert not output.exists()

--- a/test/web/test_config.py
+++ b/test/web/test_config.py
@@ -86,6 +86,26 @@ def test_wiki_visual_facts_config_is_disabled_by_default(tmp_path: Path) -> None
     assert config.wiki_visual_facts_options == {}
 
 
+def test_wiki_visual_facts_config_rejects_truthy_string(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text('wiki_visual_facts_enabled: "false"\n')
+
+    with pytest.raises(ValueError, match="must be a boolean"):
+        load_config(str(config_path))
+
+
+def test_wiki_visual_facts_environment_rejects_invalid_boolean(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("wiki_agent: false\n")
+    monkeypatch.setenv("CODENIB_WIKI_VISUAL_FACTS_ENABLED", "ture")
+
+    with pytest.raises(ValueError, match="CODENIB_WIKI_VISUAL_FACTS_ENABLED"):
+        load_config(str(config_path))
+
+
 def test_wiki_visual_facts_environment_overrides_file_config(
     tmp_path: Path,
     monkeypatch,

--- a/test/web/test_config.py
+++ b/test/web/test_config.py
@@ -28,12 +28,14 @@ def test_wiki_media_config_enables_local_renderer_without_endpoint(
     tmp_path: Path,
 ) -> None:
     config_path = tmp_path / "config.yaml"
-    config_path.write_text("""
+    config_path.write_text(
+        """
 wiki_media_model: local/svg
 wiki_media_options:
   provider: local
   width: 1024
-""".lstrip())
+""".lstrip()
+    )
 
     config = load_config(str(config_path))
 
@@ -47,11 +49,13 @@ def test_wiki_media_environment_overrides_file_config(
     monkeypatch,
 ) -> None:
     config_path = tmp_path / "config.yaml"
-    config_path.write_text("""
+    config_path.write_text(
+        """
 wiki_media_model: local/svg
 wiki_media_options:
   provider: local
-""".lstrip())
+""".lstrip()
+    )
     monkeypatch.setenv("CODENIB_WIKI_MEDIA_MODEL", "openai/image-1")
     monkeypatch.setenv("CODENIB_WIKI_MEDIA_API_BASE", "https://images.example/v1")
     monkeypatch.setenv("CODENIB_WIKI_MEDIA_API_KEY", "secret")
@@ -69,6 +73,50 @@ wiki_media_options:
     assert config.wiki_media_options == {
         "provider": "openai",
         "timeout": 30,
+    }
+
+
+def test_wiki_visual_facts_config_is_disabled_by_default(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("wiki_agent: false\n")
+
+    config = load_config(str(config_path))
+
+    assert config.wiki_visual_fact_extraction_enabled is False
+    assert config.wiki_visual_facts_options == {}
+
+
+def test_wiki_visual_facts_environment_overrides_file_config(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+wiki_visual_facts_enabled: false
+wiki_visual_facts_model: file-model
+wiki_visual_facts_options:
+  provider: file-provider
+""".lstrip()
+    )
+    monkeypatch.setenv("CODENIB_WIKI_VISUAL_FACTS_ENABLED", "true")
+    monkeypatch.setenv("CODENIB_WIKI_VISUAL_FACTS_MODEL", "qwen-vl")
+    monkeypatch.setenv("CODENIB_WIKI_VISUAL_FACTS_API_BASE", "https://vlm.example/v1")
+    monkeypatch.setenv("CODENIB_WIKI_VISUAL_FACTS_API_KEY", "secret")
+    monkeypatch.setenv(
+        "CODENIB_WIKI_VISUAL_FACTS_OPTIONS",
+        '{"provider":"local-vlm","timeout":45}',
+    )
+
+    config = load_config(str(config_path))
+
+    assert config.wiki_visual_fact_extraction_enabled is True
+    assert config.wiki_visual_facts_model == "qwen-vl"
+    assert config.wiki_visual_facts_api_base == "https://vlm.example/v1"
+    assert config.wiki_visual_facts_api_key == "secret"
+    assert config.wiki_visual_facts_options == {
+        "provider": "local-vlm",
+        "timeout": 45,
     }
 
 

--- a/test/wiki/test_media_pipeline.py
+++ b/test/wiki/test_media_pipeline.py
@@ -77,6 +77,9 @@ def test_build_multimodal_repository_knowledge_wraps_pipeline(tmp_path):
 
     bundle = build_multimodal_repository_knowledge(tmp_path, commit="abc123")
 
+    assert bundle["schema"] == "codenib.multimodal-knowledge-bundle.v1"
+    assert bundle["schema_version"] == 1
+    assert len(bundle["bundle_sha256"]) == 64
     assert bundle["media_manifest"]["artifact_count"] == 1
     assert bundle["visual_facts_manifest"]["fact_count"] == 1
     assert bundle["source_candidate_count"] >= 1

--- a/test/wiki/test_media_storage.py
+++ b/test/wiki/test_media_storage.py
@@ -4,11 +4,16 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 
 import pytest
 
 import codenib.wiki.media_storage as media_storage
+from codenib.wiki.media_artifacts import MEDIA_MANIFEST_SCHEMA
+from codenib.wiki.media_facts import MEDIA_FACTS_SCHEMA
+from codenib.wiki.media_grounding import MEDIA_GROUNDING_SCHEMA
+from codenib.wiki.media_knowledge import MULTIMODAL_KNOWLEDGE_SCHEMA
 from codenib.wiki.media_storage import (
     MULTIMODAL_KNOWLEDGE_BUNDLE_SCHEMA,
     build_multimodal_knowledge_bundle,
@@ -18,29 +23,86 @@ from codenib.wiki.media_storage import (
 )
 
 
-def _bundle():
+def _sha256_json(value, *, ensure_ascii=True):
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=ensure_ascii,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _bundle(*, metadata=None):
+    media_manifest = {
+        "schema": MEDIA_MANIFEST_SCHEMA,
+        "version": 1,
+        "commit": "abc123",
+        "source_selection_digest": "sha256:" + "a" * 64,
+        "artifact_count": 0,
+        "artifacts": [],
+        "metadata": dict(metadata or {}),
+    }
+    media_manifest["manifest_sha256"] = _sha256_json(
+        {
+            key: value
+            for key, value in media_manifest.items()
+            if key not in {"artifact_count", "manifest_sha256"}
+        }
+    )
+    visual_facts_manifest = {
+        "schema": MEDIA_FACTS_SCHEMA,
+        "version": 1,
+        "media_manifest_sha256": media_manifest["manifest_sha256"],
+        "fact_count": 0,
+        "facts": [],
+    }
+    visual_facts_manifest["manifest_sha256"] = _sha256_json(
+        {
+            key: value
+            for key, value in visual_facts_manifest.items()
+            if key not in {"fact_count", "manifest_sha256"}
+        }
+    )
+    grounding_manifest = {
+        "schema": MEDIA_GROUNDING_SCHEMA,
+        "version": 1,
+        "visual_facts_manifest_sha256": visual_facts_manifest["manifest_sha256"],
+        "binding_count": 0,
+        "bindings": [],
+    }
+    grounding_manifest["manifest_sha256"] = _sha256_json(
+        {
+            key: value
+            for key, value in grounding_manifest.items()
+            if key not in {"binding_count", "manifest_sha256"}
+        }
+    )
+    knowledge_view = {
+        "schema": MULTIMODAL_KNOWLEDGE_SCHEMA,
+        "version": 1,
+        "media_manifest_sha256": media_manifest["manifest_sha256"],
+        "visual_facts_manifest_sha256": visual_facts_manifest["manifest_sha256"],
+        "grounding_manifest_sha256": grounding_manifest["manifest_sha256"],
+        "entry_count": 0,
+        "entries": [],
+    }
+    knowledge_view["view_sha256"] = _sha256_json(knowledge_view)
     return build_multimodal_knowledge_bundle(
-        media_manifest={
-            "manifest_sha256": "media-hash",
-            "artifact_count": 1,
-            "artifacts": [],
-        },
-        visual_facts_manifest={
-            "manifest_sha256": "facts-hash",
-            "fact_count": 1,
-            "facts": [],
-        },
+        media_manifest=media_manifest,
+        visual_facts_manifest=visual_facts_manifest,
         source_candidate_count=3,
-        grounding_manifest={
-            "manifest_sha256": "grounding-hash",
-            "binding_count": 2,
-            "bindings": [],
-        },
-        knowledge_view={
-            "view_sha256": "view-hash",
-            "entry_count": 1,
-            "entries": [],
-        },
+        grounding_manifest=grounding_manifest,
+        knowledge_view=knowledge_view,
+    )
+
+
+def _rehash_bundle(bundle):
+    bundle["bundle_sha256"] = _sha256_json(
+        {key: value for key, value in bundle.items() if key != "bundle_sha256"},
+        ensure_ascii=False,
     )
 
 
@@ -50,10 +112,10 @@ def test_build_multimodal_knowledge_bundle_records_schema_and_hashes():
     assert bundle["schema"] == MULTIMODAL_KNOWLEDGE_BUNDLE_SCHEMA
     assert bundle["schema_version"] == 1
     assert bundle["component_sha256"] == {
-        "media_manifest": "media-hash",
-        "visual_facts_manifest": "facts-hash",
-        "grounding_manifest": "grounding-hash",
-        "knowledge_view": "view-hash",
+        "media_manifest": bundle["media_manifest"]["manifest_sha256"],
+        "visual_facts_manifest": bundle["visual_facts_manifest"]["manifest_sha256"],
+        "grounding_manifest": bundle["grounding_manifest"]["manifest_sha256"],
+        "knowledge_view": bundle["knowledge_view"]["view_sha256"],
     }
     assert len(bundle["bundle_sha256"]) == 64
     assert (
@@ -83,6 +145,47 @@ def test_validate_multimodal_knowledge_bundle_rejects_tampering():
         validate_multimodal_knowledge_bundle(bundle)
 
 
+def test_validate_bundle_recomputes_component_hashes_after_outer_rehash():
+    bundle = _bundle()
+    bundle["media_manifest"]["commit"] = "tampered"
+    _rehash_bundle(bundle)
+
+    with pytest.raises(ValueError, match="media manifest hash"):
+        validate_multimodal_knowledge_bundle(bundle)
+
+
+def test_validate_bundle_rejects_missing_bundle_hash():
+    bundle = _bundle()
+    bundle.pop("bundle_sha256")
+
+    with pytest.raises(ValueError, match="bundle_sha256"):
+        validate_multimodal_knowledge_bundle(bundle)
+
+
+def test_validate_bundle_rejects_unknown_component_hash():
+    bundle = _bundle()
+    bundle["component_sha256"]["unknown"] = "f" * 64
+    _rehash_bundle(bundle)
+
+    with pytest.raises(ValueError, match="component hash inventory"):
+        validate_multimodal_knowledge_bundle(bundle)
+
+
+def test_validate_bundle_returns_an_independent_copy():
+    bundle = _bundle()
+
+    validated = validate_multimodal_knowledge_bundle(bundle)
+    validated["media_manifest"]["artifacts"].append({"path": "changed"})
+
+    assert bundle["media_manifest"]["artifacts"] == []
+
+
+def test_bundle_component_hashes_support_unicode_metadata():
+    bundle = _bundle(metadata={"caption": "架构图"})
+
+    assert validate_multimodal_knowledge_bundle(bundle) == bundle
+
+
 def test_load_multimodal_knowledge_bundle_rejects_oversized_file(tmp_path, monkeypatch):
     monkeypatch.setattr(media_storage, "_MAX_BUNDLE_BYTES", 8)
     path = tmp_path / "bundle.json"
@@ -90,3 +193,36 @@ def test_load_multimodal_knowledge_bundle_rejects_oversized_file(tmp_path, monke
 
     with pytest.raises(ValueError, match="byte limit"):
         load_multimodal_knowledge_bundle(path)
+
+
+def test_load_multimodal_knowledge_bundle_rejects_duplicate_keys(tmp_path):
+    bundle = _bundle()
+    serialized = json.dumps(bundle)
+    path = tmp_path / "bundle.json"
+    path.write_text(
+        serialized[:-1] + f', "schema": "{MULTIMODAL_KNOWLEDGE_BUNDLE_SCHEMA}"}}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        load_multimodal_knowledge_bundle(path)
+
+
+def test_load_multimodal_knowledge_bundle_rejects_nonfinite_numbers(tmp_path):
+    bundle = _bundle()
+    serialized = json.dumps(bundle)
+    path = tmp_path / "bundle.json"
+    path.write_text(serialized[:-1] + ', "unexpected": NaN}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="non-finite JSON number"):
+        load_multimodal_knowledge_bundle(path)
+
+
+def test_load_multimodal_knowledge_bundle_rejects_symlink(tmp_path):
+    target = tmp_path / "target.json"
+    save_multimodal_knowledge_bundle(_bundle(), target)
+    link = tmp_path / "bundle.json"
+    link.symlink_to(target)
+
+    with pytest.raises(ValueError, match="stable regular file"):
+        load_multimodal_knowledge_bundle(link)

--- a/test/wiki/test_media_storage.py
+++ b/test/wiki/test_media_storage.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import stat
 
 import pytest
 
@@ -135,6 +136,16 @@ def test_save_and_load_multimodal_knowledge_bundle_round_trips(tmp_path):
     assert json.loads(path.read_text(encoding="utf-8"))["schema"] == (
         MULTIMODAL_KNOWLEDGE_BUNDLE_SCHEMA
     )
+
+
+def test_save_multimodal_knowledge_bundle_preserves_existing_permissions(tmp_path):
+    path = tmp_path / "bundle.json"
+    path.write_text("old generation", encoding="utf-8")
+    path.chmod(0o640)
+
+    save_multimodal_knowledge_bundle(_bundle(), path)
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o640
 
 
 def test_validate_multimodal_knowledge_bundle_rejects_tampering():

--- a/test/wiki/test_media_storage.py
+++ b/test/wiki/test_media_storage.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import codenib.wiki.media_storage as media_storage
+from codenib.wiki.media_storage import (
+    MULTIMODAL_KNOWLEDGE_BUNDLE_SCHEMA,
+    build_multimodal_knowledge_bundle,
+    load_multimodal_knowledge_bundle,
+    save_multimodal_knowledge_bundle,
+    validate_multimodal_knowledge_bundle,
+)
+
+
+def _bundle():
+    return build_multimodal_knowledge_bundle(
+        media_manifest={
+            "manifest_sha256": "media-hash",
+            "artifact_count": 1,
+            "artifacts": [],
+        },
+        visual_facts_manifest={
+            "manifest_sha256": "facts-hash",
+            "fact_count": 1,
+            "facts": [],
+        },
+        source_candidate_count=3,
+        grounding_manifest={
+            "manifest_sha256": "grounding-hash",
+            "binding_count": 2,
+            "bindings": [],
+        },
+        knowledge_view={
+            "view_sha256": "view-hash",
+            "entry_count": 1,
+            "entries": [],
+        },
+    )
+
+
+def test_build_multimodal_knowledge_bundle_records_schema_and_hashes():
+    bundle = _bundle()
+
+    assert bundle["schema"] == MULTIMODAL_KNOWLEDGE_BUNDLE_SCHEMA
+    assert bundle["schema_version"] == 1
+    assert bundle["component_sha256"] == {
+        "media_manifest": "media-hash",
+        "visual_facts_manifest": "facts-hash",
+        "grounding_manifest": "grounding-hash",
+        "knowledge_view": "view-hash",
+    }
+    assert len(bundle["bundle_sha256"]) == 64
+    assert (
+        validate_multimodal_knowledge_bundle(bundle)["bundle_sha256"]
+        == bundle["bundle_sha256"]
+    )
+
+
+def test_save_and_load_multimodal_knowledge_bundle_round_trips(tmp_path):
+    path = tmp_path / "nested" / "bundle.json"
+    bundle = _bundle()
+
+    save_multimodal_knowledge_bundle(bundle, path)
+    loaded = load_multimodal_knowledge_bundle(path)
+
+    assert loaded == bundle
+    assert json.loads(path.read_text(encoding="utf-8"))["schema"] == (
+        MULTIMODAL_KNOWLEDGE_BUNDLE_SCHEMA
+    )
+
+
+def test_validate_multimodal_knowledge_bundle_rejects_tampering():
+    bundle = _bundle()
+    bundle["source_candidate_count"] = 4
+
+    with pytest.raises(ValueError, match="hash"):
+        validate_multimodal_knowledge_bundle(bundle)
+
+
+def test_load_multimodal_knowledge_bundle_rejects_oversized_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(media_storage, "_MAX_BUNDLE_BYTES", 8)
+    path = tmp_path / "bundle.json"
+    path.write_text("x" * 9, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="byte limit"):
+        load_multimodal_knowledge_bundle(path)

--- a/test/wiki/test_media_vlm.py
+++ b/test/wiki/test_media_vlm.py
@@ -274,7 +274,7 @@ def test_visual_fact_extractor_from_config_returns_none_when_disabled():
     assert visual_fact_extractor_from_config(config) is None
 
 
-def test_visual_fact_extractor_from_config_builds_provider():
+def test_visual_fact_extractor_from_config_builds_provider(tmp_path):
     config = SimpleNamespace(
         wiki_visual_fact_extraction_enabled=True,
         wiki_visual_facts_model="qwen-vl",
@@ -286,10 +286,23 @@ def test_visual_fact_extractor_from_config_builds_provider():
         },
     )
 
-    extractor = visual_fact_extractor_from_config(config)
+    extractor = visual_fact_extractor_from_config(config, repo_path=tmp_path)
 
     assert isinstance(extractor, OpenAICompatibleVisualFactExtractor)
     assert extractor.model == "qwen-vl"
     assert extractor.endpoint == "https://vlm.example/v1/chat/completions"
     assert extractor.provider == "qwen"
     assert extractor.timeout == 9
+    assert extractor.repo_path == tmp_path.resolve()
+
+
+def test_visual_fact_extractor_from_config_rejects_non_mapping_options():
+    config = SimpleNamespace(
+        wiki_visual_fact_extraction_enabled=True,
+        wiki_visual_facts_model="qwen-vl",
+        wiki_visual_facts_api_base="https://vlm.example/v1",
+        wiki_visual_facts_options=["timeout", 9],
+    )
+
+    with pytest.raises(ValueError, match="options must be a mapping"):
+        visual_fact_extractor_from_config(config)

--- a/test/wiki/test_media_vlm.py
+++ b/test/wiki/test_media_vlm.py
@@ -6,12 +6,16 @@ from __future__ import annotations
 
 import hashlib
 import json
+from types import SimpleNamespace
 
 import pytest
 
 import codenib.wiki.media_vlm as media_vlm
 from codenib.wiki.media_facts import build_visual_facts_manifest
-from codenib.wiki.media_vlm import OpenAICompatibleVisualFactExtractor
+from codenib.wiki.media_vlm import (
+    OpenAICompatibleVisualFactExtractor,
+    visual_fact_extractor_from_config,
+)
 
 
 class _Response:
@@ -262,3 +266,30 @@ def test_visual_fact_extractor_rejects_non_json_content():
 
     with pytest.raises(json.JSONDecodeError):
         extractor.extract(_artifact())
+
+
+def test_visual_fact_extractor_from_config_returns_none_when_disabled():
+    config = SimpleNamespace(wiki_visual_fact_extraction_enabled=False)
+
+    assert visual_fact_extractor_from_config(config) is None
+
+
+def test_visual_fact_extractor_from_config_builds_provider():
+    config = SimpleNamespace(
+        wiki_visual_fact_extraction_enabled=True,
+        wiki_visual_facts_model="qwen-vl",
+        wiki_visual_facts_api_base="https://vlm.example/v1",
+        wiki_visual_facts_api_key="secret",
+        wiki_visual_facts_options={
+            "provider": "qwen",
+            "timeout": 9,
+        },
+    )
+
+    extractor = visual_fact_extractor_from_config(config)
+
+    assert isinstance(extractor, OpenAICompatibleVisualFactExtractor)
+    assert extractor.model == "qwen-vl"
+    assert extractor.endpoint == "https://vlm.example/v1/chat/completions"
+    assert extractor.provider == "qwen"
+    assert extractor.timeout == 9


### PR DESCRIPTION
## Summary

Complete the final acceptance block for #655: configurable optional VLM extraction and a versioned, hash-validated multimodal knowledge bundle. Deterministic local extraction remains the default.

Closes #655.

## Changes

- Add validated YAML, environment, and CLI controls for OpenAI-compatible visual fact extraction, with explicit repository-root binding and fail-closed enablement.
- Persist pipeline output as codenib.multimodal-knowledge-bundle.v1 with atomic writes that preserve existing file permissions, bounded stable reads, component digest recomputation, cross-component binding checks, and outer bundle hash validation.
- Reject duplicate JSON keys, non-finite values, unstable or symlinked bundle inputs, malformed component inventories, and partial CLI VLM configuration.
- Document the configuration, pipeline wiring, and persisted artifact contract.
- Preserve Marina Mackay as author of the three original stacked commits and keep the maintainer hardening as a separate follow-up commit.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Focused wiki, config, and script suite after review fixes: 501 passed.
- Unit marker with the repository-known Web caplog baseline deselected: 7411 passed, 35 skipped, 191 deselected.
- The excluded baseline test was also reproduced alone: it emits the expected log to stderr but the existing caplog assertion sees no records; this PR does not modify that test or logging path.
- Black, isort, flake8 plus bugbear, namespace validation, Python compilation, and diff checks passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published