### PR TITLE
feat(storage): add compiler cache worker executor

### DIFF
--- a/codenib/artifacts/portable_views.py
+++ b/codenib/artifacts/portable_views.py
@@ -16,7 +16,7 @@ import stat
 import sys
 from contextlib import contextmanager
 from pathlib import Path, PurePosixPath
-from typing import Any, Iterable, Iterator, Literal, Mapping
+from typing import Any, Callable, Iterable, Iterator, Literal, Mapping
 
 from .. import compat_pickle
 from .._atomic_directory import (
@@ -88,6 +88,22 @@ MAX_PORTABLE_FAISS_INDEX_BYTES = 8 * 1024 * 1024 * 1024
 _JSON_READ_CHUNK_BYTES = 1024 * 1024
 _MAX_SOURCE_PATH_BYTES = 4_096
 _MAX_SOURCE_PATH_COMPONENTS = 256
+
+
+class _InterruptibleReader:
+    __slots__ = ("_source", "_check_cancelled")
+
+    def __init__(self, source: Any, check_cancelled: Callable[[], None]) -> None:
+        self._source = source
+        self._check_cancelled = check_cancelled
+
+    def read(self, size: int = -1) -> bytes:
+        self._check_cancelled()
+        block = self._source.read(size)
+        self._check_cancelled()
+        return block
+
+
 SourceTrust = Literal["portable-inert", "trusted-local"]
 
 
@@ -1452,17 +1468,26 @@ def _iter_content_bound_documents(
     forbidden_paths: Iterable[Path],
     environ: Mapping[str, str],
     authenticated_source_files: frozenset[str],
+    check_cancelled: Callable[[], None] | None = None,
 ) -> Iterable[dict[str, Any]]:
+    if check_cancelled is not None:
+        check_cancelled()
     relative = PurePosixPath(path.relative_to(reader.root).as_posix())
     with reader.open_file(
         relative,
         max_bytes=MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
     ) as source:
         documents = iter_bounded_json_array(
-            source,
+            (
+                source
+                if check_cancelled is None
+                else _InterruptibleReader(source, check_cancelled)
+            ),
             label=f"portable {view_type} documents",
         )
         for index, document in enumerate(documents):
+            if check_cancelled is not None:
+                check_cancelled()
             if not isinstance(document, dict) or set(document) != {
                 "page_content",
                 "metadata",
@@ -1504,7 +1529,11 @@ def _iter_content_bound_documents(
                 environ=environ,
                 label=f"portable {view_type} document {index}",
             )
+            if check_cancelled is not None:
+                check_cancelled()
             yield normalized_document
+    if check_cancelled is not None:
+        check_cancelled()
 
 
 def _require_content_bound_canonical_documents(
@@ -1516,7 +1545,10 @@ def _require_content_bound_canonical_documents(
     forbidden_paths: Iterable[Path],
     environ: Mapping[str, str],
     authenticated_source_files: frozenset[str],
+    check_cancelled: Callable[[], None] | None = None,
 ) -> int:
+    if check_cancelled is not None:
+        check_cancelled()
     count = 0
     size = 0
     digest = hashlib.sha256()
@@ -1531,11 +1563,14 @@ def _require_content_bound_canonical_documents(
             forbidden_paths=forbidden_paths,
             environ=environ,
             authenticated_source_files=authenticated_source_files,
+            check_cancelled=check_cancelled,
         ):
             count += 1
             yield document
 
     for chunk in canonical_json_array_chunks(values()):
+        if check_cancelled is not None:
+            check_cancelled()
         size += len(chunk)
         if size > MAX_PORTABLE_DOCUMENTS_JSON_BYTES:
             raise ValueError(f"portable {view_type} documents exceed their byte limit")
@@ -1543,6 +1578,8 @@ def _require_content_bound_canonical_documents(
     record = reader.record(path)
     if size != record.size or digest.hexdigest() != record.sha256:
         raise ValueError(f"portable {view_type} documents are not canonical JSON")
+    if check_cancelled is not None:
+        check_cancelled()
     return count
 
 
@@ -2017,6 +2054,7 @@ def _validate_vector_layout(
     authenticated_source_files: frozenset[str] | None = None,
     document_forbidden_paths: Iterable[Path] = (),
     document_environ: Mapping[str, str] | None = None,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> tuple[
     str,
     dict[Path, list[dict[str, Any]]],
@@ -2043,6 +2081,8 @@ def _validate_vector_layout(
     inventory_files = _owned_inventory_paths(root, ownership, kind="file")
 
     for level in _VECTOR_LEVELS:
+        if check_cancelled is not None:
+            check_cancelled()
         count = config.get(f"{level}_documents") if not legacy_counts else None
         if count is not None and (
             not isinstance(count, int) or isinstance(count, bool) or count < 0
@@ -2124,6 +2164,7 @@ def _validate_vector_layout(
                     forbidden_paths=document_forbidden_paths,
                     environ={} if document_environ is None else document_environ,
                     authenticated_source_files=authenticated_source_files,
+                    check_cancelled=check_cancelled,
                 )
                 payload = []
             else:
@@ -3037,7 +3078,10 @@ def _validate_portable_vector_view(
     initial_tree: object,
     reader: _ViewReader,
     authenticated_source_files: frozenset[str] | None = None,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> None:
+    if check_cancelled is not None:
+        check_cancelled()
     assert_no_secret_fields(view_config, source="portable vector view config")
     portable_artifact_policy = authenticated_source_files is not None
     route = resolve_embedding_artifact_route(
@@ -3117,6 +3161,7 @@ def _validate_portable_vector_view(
         authenticated_source_files=authenticated_source_files,
         document_forbidden_paths=forbidden,
         document_environ=environment,
+        check_cancelled=check_cancelled,
     )
     if document_format != "json" or stale_paths:
         raise ValueError("portable vector view is not in its normalized final form")
@@ -3127,6 +3172,8 @@ def _validate_portable_vector_view(
         counts=counts,
     )
     for level in _VECTOR_LEVELS:
+        if check_cancelled is not None:
+            check_cancelled()
         if counts[level] <= 0:
             continue
         level_root = root / level
@@ -3152,6 +3199,8 @@ def _validate_portable_vector_view(
                 environ=environment,
                 reader=reader,
             )
+    if check_cancelled is not None:
+        check_cancelled()
 
 
 def _validate_content_bound_portable_query_view_reader_with_identity(
@@ -3164,6 +3213,7 @@ def _validate_content_bound_portable_query_view_reader_with_identity(
     forbidden_paths: Iterable[Path] = (),
     environ: Mapping[str, str] | None = None,
     _framework_sandwiched: bool = False,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> None:
     """Validate one portable view through retained view and source authorities.
 
@@ -3214,6 +3264,8 @@ def _validate_content_bound_portable_query_view_reader_with_identity(
         reader = _PublicationViewReader(publication, initial_tree)
 
     def validate_semantics() -> None:
+        if check_cancelled is not None:
+            check_cancelled()
         with repository_source.read_session():
             policy_paths = (repository_identity.root, *forbidden)
             _assert_authenticated_publishable_json_value(
@@ -3243,7 +3295,10 @@ def _validate_content_bound_portable_query_view_reader_with_identity(
                     initial_tree=initial_tree,
                     reader=reader,
                     authenticated_source_files=authenticated_source_files,
+                    check_cancelled=check_cancelled,
                 )
+        if check_cancelled is not None:
+            check_cancelled()
 
     final_checks = [
         (

--- a/codenib/artifacts/strict_bm25.py
+++ b/codenib/artifacts/strict_bm25.py
@@ -10,7 +10,7 @@ import hashlib
 import inspect
 import json
 import os
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
@@ -67,6 +67,30 @@ _WINDOWS_DRIVE_PREFIX = tuple(
 _CURRENT_BM25_BUILDER_SCHEMA = 8
 _STRICT_BM25_PLAN_DOMAIN = b"codenib-portable-bm25-strict-workspace-v1"
 _STRICT_BM25_FILES = frozenset({"documents.json", "bm25_metadata.json"})
+
+
+class _InterruptibleReader:
+    __slots__ = ("_source", "_check_cancelled")
+
+    def __init__(self, source: Any, check_cancelled: Callable[[], None]) -> None:
+        self._source = source
+        self._check_cancelled = check_cancelled
+
+    def read(self, size: int = -1) -> bytes:
+        self._check_cancelled()
+        block = self._source.read(size)
+        self._check_cancelled()
+        return block
+
+
+def _interruptible_chunks(
+    chunks: Iterable[bytes],
+    check_cancelled: Callable[[], None] | None,
+) -> Iterator[bytes]:
+    for chunk in chunks:
+        if check_cancelled is not None:
+            check_cancelled()
+        yield chunk
 
 
 def _reject_duplicate_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -575,16 +599,25 @@ def _normalized_documents(
     forbidden_paths: tuple[Path, ...],
     environ: Mapping[str, str],
     authenticated_source_files: frozenset[str],
+    check_cancelled: Callable[[], None] | None = None,
 ) -> Iterable[dict[str, Any]]:
+    if check_cancelled is not None:
+        check_cancelled()
     with reader.open_file(
         "documents.json",
         max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
     ) as source:
         documents = iter_bounded_json_array(
-            source,
+            (
+                source
+                if check_cancelled is None
+                else _InterruptibleReader(source, check_cancelled)
+            ),
             label="portable BM25 documents",
         )
         for index, document in enumerate(documents):
+            if check_cancelled is not None:
+                check_cancelled()
             if not isinstance(document, dict) or set(document) != {
                 "page_content",
                 "metadata",
@@ -624,6 +657,8 @@ def _normalized_documents(
                 label=f"portable BM25 document {index}",
             )
             yield normalized
+    if check_cancelled is not None:
+        check_cancelled()
 
 
 def _record_chunks(
@@ -631,6 +666,7 @@ def _record_chunks(
     chunks: Iterable[bytes],
     *,
     max_bytes: int,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> TreeFileRecord:
     iterator = iter(chunks)
     digest = hashlib.sha256()
@@ -638,6 +674,8 @@ def _record_chunks(
     primary_error: BaseException | None = None
     try:
         for chunk in iterator:
+            if check_cancelled is not None:
+                check_cancelled()
             if not isinstance(chunk, bytes):
                 raise TypeError("strict BM25 output chunks must be bytes")
             size += len(chunk)
@@ -677,7 +715,10 @@ def _payloads(
     forbidden_paths: tuple[Path, ...],
     environ: Mapping[str, str],
     authenticated_source_files: frozenset[str],
+    check_cancelled: Callable[[], None] | None = None,
 ) -> tuple[bytes, Iterable[bytes]]:
+    if check_cancelled is not None:
+        check_cancelled()
     # Apply whole-file lexical framing before any decoded document allocation.
     # Aggregate counts are bounded by authenticated bytes; the iterator below
     # independently preserves the stricter per-document complexity budgets.
@@ -688,12 +729,18 @@ def _payloads(
         max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
     ) as source:
         validate_bounded_json_stream(
-            source,
+            (
+                source
+                if check_cancelled is None
+                else _InterruptibleReader(source, check_cancelled)
+            ),
             label="portable BM25 documents",
             max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
             max_nodes=lexical_budget,
             max_lexical_tokens=lexical_budget,
         )
+    if check_cancelled is not None:
+        check_cancelled()
     metadata = _load_json_object(
         reader,
         "bm25_metadata.json",
@@ -740,6 +787,7 @@ def _payloads(
             forbidden_paths=forbidden_paths,
             environ=environ,
             authenticated_source_files=authenticated_source_files,
+            check_cancelled=check_cancelled,
         )
     )
     return metadata_bytes, documents
@@ -948,7 +996,10 @@ def _planned_view_from_publication(
     environ: Mapping[str, str],
     authenticated_source_files: frozenset[str],
     source_label: str,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> PlannedBm25View:
+    if check_cancelled is not None:
+        check_cancelled()
     ownership, source_records, reader = _captured_source_view(
         expected_ownership,
         publication,
@@ -960,12 +1011,16 @@ def _planned_view_from_publication(
         forbidden_paths=forbidden_paths,
         environ=environ,
         authenticated_source_files=authenticated_source_files,
+        check_cancelled=check_cancelled,
     )
     documents_record = _record_chunks(
         "documents.json",
         document_chunks,
         max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+        check_cancelled=check_cancelled,
     )
+    if check_cancelled is not None:
+        check_cancelled()
     metadata_record = TreeFileRecord(
         path="bm25_metadata.json",
         mode=0o600,
@@ -1124,7 +1179,10 @@ def _candidate_records(
     forbidden_paths: tuple[Path, ...],
     environ: Mapping[str, str],
     authenticated_source_files: frozenset[str],
+    check_cancelled: Callable[[], None] | None = None,
 ) -> tuple[TreeFileRecord, ...]:
+    if check_cancelled is not None:
+        check_cancelled()
     ownership = candidate.capture_ownership(entry_policy=_entry_policy)
     observed = tuple(directory_ownership_file_records(ownership))  # type: ignore[arg-type]
     if (
@@ -1143,6 +1201,7 @@ def _candidate_records(
         forbidden_paths=forbidden_paths,
         environ=environ,
         authenticated_source_files=authenticated_source_files,
+        check_cancelled=check_cancelled,
     )
     records = tuple(
         sorted(
@@ -1151,6 +1210,7 @@ def _candidate_records(
                     "documents.json",
                     document_chunks,
                     max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+                    check_cancelled=check_cancelled,
                 ),
                 TreeFileRecord(
                     path="bm25_metadata.json",
@@ -1163,6 +1223,8 @@ def _candidate_records(
         )
     )
     reader.verify_root()
+    if check_cancelled is not None:
+        check_cancelled()
     return records
 
 
@@ -1328,7 +1390,10 @@ def _plan_recaptured_bm25_view_with_identity(
     view_config: Mapping[str, Any],
     forbidden_paths: tuple[Path, ...],
     environ: Mapping[str, str],
+    check_cancelled: Callable[[], None] | None = None,
 ) -> PlannedBm25View:
+    if check_cancelled is not None:
+        check_cancelled()
     config_digest, forbidden, authenticated_files = _policy(
         repository_identity,
         view_config,
@@ -1339,6 +1404,8 @@ def _plan_recaptured_bm25_view_with_identity(
         lexical_source,
         entry_policy=_entry_policy,
     )
+    if check_cancelled is not None:
+        check_cancelled()
 
     def consume_source(publication: PublicationDirectoryReader) -> PlannedBm25View:
         return _planned_view_from_publication(
@@ -1350,6 +1417,7 @@ def _plan_recaptured_bm25_view_with_identity(
             environ=environ,
             authenticated_source_files=authenticated_files,
             source_label="strict BM25 recapture source",
+            check_cancelled=check_cancelled,
         )
 
     with repository_source.read_session():
@@ -1368,6 +1436,7 @@ def _plan_recaptured_bm25_view(
     view_config: Mapping[str, Any],
     forbidden_paths: Iterable[Path] = (),
     environ: Mapping[str, str] | None = None,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> PlannedBm25View:
     """Privately pre-plan an ordinary BM25 tree without workspace mutation."""
 
@@ -1375,6 +1444,8 @@ def _plan_recaptured_bm25_view(
         raise TypeError("strict BM25 repository source has an invalid type")
     if not repository_source.usable:
         raise RuntimeError("strict BM25 repository source is not usable")
+    if check_cancelled is not None:
+        check_cancelled()
     repository_identity = _authenticated_repository_identity(repository_source)
     lexical_source, _lexical_destination = _recapture_locations(
         source,
@@ -1394,6 +1465,7 @@ def _plan_recaptured_bm25_view(
         view_config=config_snapshot,
         forbidden_paths=forbidden_tail,
         environ=environment,
+        check_cancelled=check_cancelled,
     )
 
 
@@ -1409,7 +1481,10 @@ def _publish_recaptured_bm25_view_with_identity(
     view_config: Mapping[str, Any],
     forbidden_paths: tuple[Path, ...],
     environ: Mapping[str, str],
+    check_cancelled: Callable[[], None] | None = None,
 ) -> dict[str, Any]:
+    if check_cancelled is not None:
+        check_cancelled()
     config_digest, forbidden, authenticated_files = _policy(
         repository_identity,
         view_config,
@@ -1428,6 +1503,8 @@ def _publish_recaptured_bm25_view_with_identity(
         lexical_source,
         entry_policy=_entry_policy,
     )
+    if check_cancelled is not None:
+        check_cancelled()
     _require_plan_for_ownership(
         planned,
         source_ownership=observed_source_ownership,
@@ -1442,6 +1519,8 @@ def _publish_recaptured_bm25_view_with_identity(
     )
 
     def operation(session: StrictWorkspaceSession) -> None:
+        if check_cancelled is not None:
+            check_cancelled()
         if session.request != request:
             raise RuntimeError("strict BM25 provider changed its request")
 
@@ -1462,11 +1541,18 @@ def _publish_recaptured_bm25_view_with_identity(
                 forbidden_paths=forbidden,
                 environ=environ,
                 authenticated_source_files=authenticated_files,
+                check_cancelled=check_cancelled,
             )
             written = tuple(
                 sorted(
                     (
-                        session.write_file("documents.json", document_chunks),
+                        session.write_file(
+                            "documents.json",
+                            _interruptible_chunks(
+                                document_chunks,
+                                check_cancelled,
+                            ),
+                        ),
                         session.write_file("bm25_metadata.json", (metadata_bytes,)),
                     ),
                     key=lambda item: item.path,
@@ -1486,6 +1572,7 @@ def _publish_recaptured_bm25_view_with_identity(
                         forbidden_paths=forbidden,
                         environ=environ,
                         authenticated_source_files=authenticated_files,
+                        check_cancelled=check_cancelled,
                     )
                     != planned.output_records
                 ):
@@ -1497,7 +1584,11 @@ def _publish_recaptured_bm25_view_with_identity(
                 planned.source_ownership,  # type: ignore[arg-type]
                 replay_source,
             )
+        if check_cancelled is not None:
+            check_cancelled()
         session.publish_validated(validate_candidate)
+        if check_cancelled is not None:
+            check_cancelled()
 
     # Recheck mutable authority state after the potentially long source scan
     # and immediately before the provider can provision its first workspace.
@@ -1506,6 +1597,8 @@ def _publish_recaptured_bm25_view_with_identity(
         workspace_provider=workspace_provider,
         output_receipt_owner=output_receipt_owner,
     )
+    if check_cancelled is not None:
+        check_cancelled()
     _require_missing_recapture_destination(lexical_destination)
     run_strict_workspace(
         workspace_provider,
@@ -1513,6 +1606,8 @@ def _publish_recaptured_bm25_view_with_identity(
         receipt_owner=output_receipt_owner,
         operation=operation,
     )
+    if check_cancelled is not None:
+        check_cancelled()
     if not output_receipt_owner.active:
         raise RuntimeError("strict BM25 publication returned without a receipt")
     receipt = output_receipt_owner.receipt
@@ -1532,6 +1627,7 @@ def _publish_recaptured_bm25_view(
     view_config: Mapping[str, Any],
     forbidden_paths: Iterable[Path] = (),
     environ: Mapping[str, str] | None = None,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> dict[str, Any]:
     """Privately publish one exact pre-planned ordinary BM25 tree."""
 
@@ -1540,6 +1636,8 @@ def _publish_recaptured_bm25_view(
         workspace_provider=workspace_provider,
         output_receipt_owner=output_receipt_owner,
     )
+    if check_cancelled is not None:
+        check_cancelled()
     repository_identity = _authenticated_repository_identity(repository_source)
     lexical_source, lexical_destination = _recapture_locations(
         source,
@@ -1563,6 +1661,7 @@ def _publish_recaptured_bm25_view(
         view_config=config_snapshot,
         forbidden_paths=forbidden_tail,
         environ=environment,
+        check_cancelled=check_cancelled,
     )
 
 

--- a/codenib/artifacts/strict_vector.py
+++ b/codenib/artifacts/strict_vector.py
@@ -10,7 +10,7 @@ import hashlib
 import inspect
 import json
 import os
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
@@ -136,6 +136,30 @@ _LEVEL_CONFIG_FIELDS = frozenset(
         "num_documents",
     }
 )
+
+
+class _InterruptibleReader:
+    __slots__ = ("_source", "_check_cancelled")
+
+    def __init__(self, source: Any, check_cancelled: Callable[[], None]) -> None:
+        self._source = source
+        self._check_cancelled = check_cancelled
+
+    def read(self, size: int = -1) -> bytes:
+        self._check_cancelled()
+        block = self._source.read(size)
+        self._check_cancelled()
+        return block
+
+
+def _interruptible_chunks(
+    chunks: Iterable[bytes],
+    check_cancelled: Callable[[], None] | None,
+) -> Iterator[bytes]:
+    for chunk in chunks:
+        if check_cancelled is not None:
+            check_cancelled()
+        yield chunk
 
 
 def _reject_duplicate_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -586,16 +610,25 @@ def _normalized_documents(
     environ: Mapping[str, str],
     authenticated_source_files: frozenset[str],
     counter: list[int] | None = None,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> Iterable[dict[str, Any]]:
+    if check_cancelled is not None:
+        check_cancelled()
     with reader.open_file(
         relative,
         max_bytes=MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
     ) as source:
         documents = iter_bounded_json_array(
-            source,
+            (
+                source
+                if check_cancelled is None
+                else _InterruptibleReader(source, check_cancelled)
+            ),
             label=f"schema-8 vector {level} documents",
         )
         for index, document in enumerate(documents):
+            if check_cancelled is not None:
+                check_cancelled()
             page_content, metadata = validate_schema_8_vector_document_row(
                 document,
                 row_index=index,
@@ -624,6 +657,8 @@ def _normalized_documents(
             if counter is not None:
                 counter[0] += 1
             yield normalized
+    if check_cancelled is not None:
+        check_cancelled()
 
 
 def _document_record(
@@ -634,6 +669,7 @@ def _document_record(
     forbidden_paths: tuple[Path, ...],
     environ: Mapping[str, str],
     authenticated_source_files: frozenset[str],
+    check_cancelled: Callable[[], None] | None = None,
 ) -> tuple[TreeFileRecord, int]:
     counter = [0]
     record = _record_chunks(
@@ -647,6 +683,7 @@ def _document_record(
                 environ=environ,
                 authenticated_source_files=authenticated_source_files,
                 counter=counter,
+                check_cancelled=check_cancelled,
             )
         ),
         max_bytes=MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
@@ -841,7 +878,10 @@ def _derived_vector(
     reader: _PublicationVectorReader,
     *,
     policy: _VectorPolicy,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> _DerivedVector:
+    if check_cancelled is not None:
+        check_cancelled()
     root_name = f"config_{policy.model_suffix}.json"
     root_config = _load_json_object(
         reader,
@@ -895,6 +935,8 @@ def _derived_vector(
     expected_query_files = {root_name}
     expected_query_directories: set[str] = set()
     for level in _VECTOR_LEVELS:
+        if check_cancelled is not None:
+            check_cancelled()
         raw_count = root_config.get(f"{level}_documents")
         if type(raw_count) is not int or raw_count < 0:
             raise ValueError(f"schema-8 vector {level} count is invalid")
@@ -942,7 +984,10 @@ def _derived_vector(
             forbidden_paths=policy.forbidden_paths,
             environ=policy.environment,
             authenticated_source_files=policy.authenticated_source_files,
+            check_cancelled=check_cancelled,
         )
+        if check_cancelled is not None:
+            check_cancelled()
         if observed_count != raw_count:
             raise ValueError(
                 f"schema-8 vector {level} document count differs from root config"
@@ -1039,6 +1084,9 @@ def _derived_vector(
     }
     if observed_directories != expected_query_directories:
         raise ValueError("schema-8 vector cache level directories are not exact")
+
+    if check_cancelled is not None:
+        check_cancelled()
 
     return _DerivedVector(
         output_records=tuple(sorted(output_records, key=lambda item: item.path)),
@@ -1225,7 +1273,10 @@ def _planned_view_from_publication(
     repository_identity: RepositorySourceIdentitySnapshot,
     policy: _VectorPolicy,
     source_label: str,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> PlannedVectorView:
+    if check_cancelled is not None:
+        check_cancelled()
     ownership, source_records, reader = _captured_source_view(
         expected_ownership,
         publication,
@@ -1234,7 +1285,10 @@ def _planned_view_from_publication(
     derived = _derived_vector(
         reader,
         policy=policy,
+        check_cancelled=check_cancelled,
     )
+    if check_cancelled is not None:
+        check_cancelled()
     source_digest = directory_ownership_digest(ownership)  # type: ignore[arg-type]
     plan = _workspace_plan(
         source_digest=source_digest,
@@ -1264,7 +1318,10 @@ def _plan_recaptured_vector_view_with_identity(
     view_config: Mapping[str, Any],
     forbidden_paths: tuple[Path, ...],
     environ: Mapping[str, str],
+    check_cancelled: Callable[[], None] | None = None,
 ) -> PlannedVectorView:
+    if check_cancelled is not None:
+        check_cancelled()
     policy = _policy(
         repository_identity,
         view_config,
@@ -1276,6 +1333,8 @@ def _plan_recaptured_vector_view_with_identity(
         lexical_source,
         entry_policy=entry_policy,
     )
+    if check_cancelled is not None:
+        check_cancelled()
 
     def consume_source(publication: PublicationDirectoryReader) -> PlannedVectorView:
         return _planned_view_from_publication(
@@ -1284,6 +1343,7 @@ def _plan_recaptured_vector_view_with_identity(
             repository_identity=repository_identity,
             policy=policy,
             source_label="strict vector recapture source",
+            check_cancelled=check_cancelled,
         )
 
     with repository_source.read_session():
@@ -1302,6 +1362,7 @@ def _plan_recaptured_vector_view(
     view_config: Mapping[str, Any],
     forbidden_paths: Iterable[Path] = (),
     environ: Mapping[str, str] | None = None,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> PlannedVectorView:
     """Privately pre-plan a schema-8 vector cache without workspace mutation."""
 
@@ -1309,6 +1370,8 @@ def _plan_recaptured_vector_view(
         raise TypeError("strict vector repository source has an invalid type")
     if not repository_source.usable:
         raise RuntimeError("strict vector repository source is not usable")
+    if check_cancelled is not None:
+        check_cancelled()
     repository_identity = _authenticated_repository_identity(repository_source)
     lexical_source, _lexical_destination = _recapture_locations(
         source,
@@ -1330,6 +1393,7 @@ def _plan_recaptured_vector_view(
         view_config=config_snapshot,
         forbidden_paths=forbidden_tail,
         environ=environment,
+        check_cancelled=check_cancelled,
     )
 
 
@@ -1371,7 +1435,10 @@ def _replay_vector_source(
     *,
     planned: PlannedVectorView,
     policy: _VectorPolicy,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> None:
+    if check_cancelled is not None:
+        check_cancelled()
     ownership, source_records, reader = _captured_source_view(
         planned.source_ownership,
         publication,
@@ -1386,6 +1453,7 @@ def _replay_vector_source(
     derived = _derived_vector(
         reader,
         policy=policy,
+        check_cancelled=check_cancelled,
     )
     if (
         derived.output_records != planned.output_records
@@ -1396,11 +1464,17 @@ def _replay_vector_source(
 
     written: list[TreeFileRecord] = []
     root_name = f"config_{planned.model_suffix}.json"
+    if check_cancelled is not None:
+        check_cancelled()
     written.append(session.write_file(root_name, (derived.root_config_payload,)))
     for relative, payload in derived.level_config_payloads:
+        if check_cancelled is not None:
+            check_cancelled()
         written.append(session.write_file(relative, (payload,)))
 
     for level, count in planned.counts:
+        if check_cancelled is not None:
+            check_cancelled()
         if count <= 0:
             continue
         documents_relative = f"{level}/documents_{planned.model_suffix}.json"
@@ -1415,7 +1489,10 @@ def _replay_vector_source(
             written.append(
                 session.write_file(
                     documents_relative,
-                    source.iter_bytes(chunk_size=_JSON_READ_CHUNK_BYTES),
+                    _interruptible_chunks(
+                        source.iter_bytes(chunk_size=_JSON_READ_CHUNK_BYTES),
+                        check_cancelled,
+                    ),
                 )
             )
         index_relative = f"{level}/index_{planned.model_suffix}.faiss"
@@ -1426,10 +1503,15 @@ def _replay_vector_source(
             written.append(
                 session.write_file(
                     index_relative,
-                    source.iter_bytes(chunk_size=_JSON_READ_CHUNK_BYTES),
+                    _interruptible_chunks(
+                        source.iter_bytes(chunk_size=_JSON_READ_CHUNK_BYTES),
+                        check_cancelled,
+                    ),
                 )
             )
 
+    if check_cancelled is not None:
+        check_cancelled()
     if tuple(sorted(written, key=lambda item: item.path)) != planned.output_records:
         raise RuntimeError("strict vector replay differs from its exact plan")
 
@@ -1444,7 +1526,10 @@ def _candidate_records(
     view_config: Mapping[str, Any],
     forbidden_paths: tuple[Path, ...],
     environ: Mapping[str, str],
+    check_cancelled: Callable[[], None] | None = None,
 ) -> tuple[TreeFileRecord, ...]:
+    if check_cancelled is not None:
+        check_cancelled()
     observed = candidate.file_records()
     observed_inventory = candidate.inventory()
     records_by_path = {record.path: record for record in observed}
@@ -1481,6 +1566,8 @@ def _candidate_records(
         environ=environ,
         _framework_sandwiched=True,
     )
+    if check_cancelled is not None:
+        check_cancelled()
     return observed
 
 
@@ -1496,7 +1583,10 @@ def _publish_recaptured_vector_view_with_identity(
     view_config: Mapping[str, Any],
     forbidden_paths: tuple[Path, ...],
     environ: Mapping[str, str],
+    check_cancelled: Callable[[], None] | None = None,
 ) -> dict[str, Any]:
+    if check_cancelled is not None:
+        check_cancelled()
     policy = _policy(
         repository_identity,
         view_config,
@@ -1516,6 +1606,8 @@ def _publish_recaptured_vector_view_with_identity(
         lexical_source,
         entry_policy=entry_policy,
     )
+    if check_cancelled is not None:
+        check_cancelled()
     _require_plan(
         planned,
         source_ownership=observed_source_ownership,
@@ -1530,6 +1622,8 @@ def _publish_recaptured_vector_view_with_identity(
     )
 
     def operation(session: StrictWorkspaceSession) -> None:
+        if check_cancelled is not None:
+            check_cancelled()
         if session.request != request:
             raise RuntimeError("strict vector provider changed its request")
 
@@ -1539,6 +1633,7 @@ def _publish_recaptured_vector_view_with_identity(
                 publication,
                 planned=planned,
                 policy=policy,
+                check_cancelled=check_cancelled,
             )
 
         def validate_candidate(candidate: PublicationDirectoryReader) -> None:
@@ -1553,6 +1648,7 @@ def _publish_recaptured_vector_view_with_identity(
                         view_config=policy.view_config,
                         forbidden_paths=forbidden_paths,
                         environ=policy.environment,
+                        check_cancelled=check_cancelled,
                     )
                     != planned.output_records
                 ):
@@ -1564,7 +1660,11 @@ def _publish_recaptured_vector_view_with_identity(
                 planned.source_ownership,  # type: ignore[arg-type]
                 replay_source,
             )
+        if check_cancelled is not None:
+            check_cancelled()
         session.publish_validated(validate_candidate)
+        if check_cancelled is not None:
+            check_cancelled()
 
     # Recheck mutable authority state immediately before a workspace may be
     # provisioned.  Planning never grants a provider permission to replace an
@@ -1574,6 +1674,8 @@ def _publish_recaptured_vector_view_with_identity(
         workspace_provider=workspace_provider,
         output_receipt_owner=output_receipt_owner,
     )
+    if check_cancelled is not None:
+        check_cancelled()
     _require_missing_destination(lexical_destination)
     run_strict_workspace(
         workspace_provider,
@@ -1581,6 +1683,8 @@ def _publish_recaptured_vector_view_with_identity(
         receipt_owner=output_receipt_owner,
         operation=operation,
     )
+    if check_cancelled is not None:
+        check_cancelled()
     if not output_receipt_owner.active:
         raise RuntimeError("strict vector publication returned without a receipt")
     receipt = output_receipt_owner.receipt
@@ -1600,6 +1704,7 @@ def _publish_recaptured_vector_view(
     view_config: Mapping[str, Any],
     forbidden_paths: Iterable[Path] = (),
     environ: Mapping[str, str] | None = None,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> dict[str, Any]:
     """Privately publish one exact pre-planned schema-8 vector tree."""
 
@@ -1608,6 +1713,8 @@ def _publish_recaptured_vector_view(
         workspace_provider=workspace_provider,
         output_receipt_owner=output_receipt_owner,
     )
+    if check_cancelled is not None:
+        check_cancelled()
     repository_identity = _authenticated_repository_identity(repository_source)
     lexical_source, lexical_destination = _recapture_locations(
         source,
@@ -1633,6 +1740,7 @@ def _publish_recaptured_vector_view(
         view_config=config_snapshot,
         forbidden_paths=forbidden_tail,
         environ=environment,
+        check_cancelled=check_cancelled,
     )
 
 

--- a/codenib/artifacts/strict_vector.py
+++ b/codenib/artifacts/strict_vector.py
@@ -1565,6 +1565,7 @@ def _candidate_records(
         forbidden_paths=forbidden_paths,
         environ=environ,
         _framework_sandwiched=True,
+        check_cancelled=check_cancelled,
     )
     if check_cancelled is not None:
         check_cancelled()

--- a/codenib/compiler/__init__.py
+++ b/codenib/compiler/__init__.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
     from codenib.compiler.cache_import import (
         CompilerCacheBm25RecaptureResult,
         CompilerCacheImportResult,
+        CompilerCacheJobExecutor,
+        CompilerCacheJobPreparationResult,
         CompilerCacheJobPublicationResult,
         CompilerCacheMultiViewImportResult,
         CompilerCacheTopologyGuard,
@@ -38,6 +40,7 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
         compile_and_import_repo,
         import_compiler_cache,
         import_compiler_cache_bm25,
+        prepare_compiler_cache_job_view,
         publish_compiler_cache_bm25_job,
         publish_compiler_cache_vector_job,
     )
@@ -91,6 +94,14 @@ _EXPORTS = {
         "codenib.compiler.cache_import",
         "CompilerCacheImportResult",
     ),
+    "CompilerCacheJobExecutor": (
+        "codenib.compiler.cache_import",
+        "CompilerCacheJobExecutor",
+    ),
+    "CompilerCacheJobPreparationResult": (
+        "codenib.compiler.cache_import",
+        "CompilerCacheJobPreparationResult",
+    ),
     "CompilerCacheJobPublicationResult": (
         "codenib.compiler.cache_import",
         "CompilerCacheJobPublicationResult",
@@ -126,6 +137,10 @@ _EXPORTS = {
     "import_compiler_cache_bm25": (
         "codenib.compiler.cache_import",
         "import_compiler_cache_bm25",
+    ),
+    "prepare_compiler_cache_job_view": (
+        "codenib.compiler.cache_import",
+        "prepare_compiler_cache_job_view",
     ),
     "publish_compiler_cache_bm25_job": (
         "codenib.compiler.cache_import",
@@ -236,6 +251,8 @@ __all__ = [
     # Index compilation
     "CompilerCacheBm25RecaptureResult",
     "CompilerCacheImportResult",
+    "CompilerCacheJobExecutor",
+    "CompilerCacheJobPreparationResult",
     "CompilerCacheJobPublicationResult",
     "CompilerCacheMultiViewImportResult",
     "CompilerCacheTopologyGuard",
@@ -245,6 +262,7 @@ __all__ = [
     "compile_and_import_repo",
     "import_compiler_cache",
     "import_compiler_cache_bm25",
+    "prepare_compiler_cache_job_view",
     "publish_compiler_cache_bm25_job",
     "publish_compiler_cache_vector_job",
     "IndexCompiler",

--- a/codenib/compiler/cache_import.py
+++ b/codenib/compiler/cache_import.py
@@ -60,12 +60,19 @@ from ..source_fingerprint import (
     RepositorySourceIdentitySnapshot,
     is_secure_source_fingerprint_v2,
 )
+from ..storage.job_worker import (
+    IndexJobExecutionContext,
+    IndexJobExecutionResult,
+    IndexJobViewExecutionResult,
+)
 from ..storage.models import (
     DEFAULT_NAMESPACE_NAME,
+    IndexJobEffectiveMode,
     IndexJobRecord,
     IndexJobRequest,
     IndexJobRequestedMode,
     IndexJobStatus,
+    IndexJobViewOutcome,
     IndexJobViewRecord,
     RepositoryIdentity,
     SourceRevision,
@@ -78,11 +85,12 @@ from ..storage.protocols import (
     RetainedImportCatalog,
     RetainedImportObjectStore,
 )
-from ..storage.publication import publish_job_artifacts
+from ..storage.publication import IndexJobViewArtifact, publish_job_artifacts
 from ..storage.view_bundle import (
     DEFAULT_MAX_BUNDLE_BYTES,
     DEFAULT_MAX_BUNDLE_FILES,
     DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    VIEW_BUNDLE_SCHEMA,
 )
 from .cache_lock import compiler_cache_lock
 from .index_compiler import IndexCompiler
@@ -385,6 +393,82 @@ class CompilerCacheVectorJobPublicationResult:
             raise StorageIntegrityError(
                 "compiler cache vector job publication identities are inconsistent"
             )
+        object.__setattr__(self, "manifest", manifest)
+
+
+@dataclass(frozen=True, slots=True)
+class CompilerCacheJobPreparationResult:
+    """Exact prepare-only output for one worker-owned compiler-cache view."""
+
+    job: IndexJobRecord
+    view: IndexJobViewRecord
+    manifest: RepoManifest
+    import_plan: RepoManifestImportPlan
+    recapture: CompilerCacheViewRecaptureResult
+    context_artifact: ContextArtifactResult
+    artifact: IndexJobViewArtifact
+
+    def __post_init__(self) -> None:
+        if type(self) is not CompilerCacheJobPreparationResult:
+            raise TypeError(
+                "compiler cache job preparation must use the exact result type"
+            )
+        if type(self.job) is not IndexJobRecord:
+            raise TypeError("compiler cache prepared job record is invalid")
+        if type(self.view) is not IndexJobViewRecord:
+            raise TypeError("compiler cache prepared job view is invalid")
+        if type(self.manifest) is not RepoManifest:
+            raise TypeError("compiler cache prepared manifest is invalid")
+        if type(self.import_plan) is not RepoManifestImportPlan:
+            raise TypeError("compiler cache prepared import plan is invalid")
+        if type(self.recapture) is not CompilerCacheViewRecaptureResult:
+            raise TypeError("compiler cache prepared recapture is invalid")
+        if type(self.context_artifact) is not ContextArtifactResult:
+            raise TypeError("compiler cache prepared context artifact is invalid")
+        if type(self.artifact) is not IndexJobViewArtifact:
+            raise TypeError("compiler cache prepared view artifact is invalid")
+        try:
+            job = _detach_index_job_record(self.job)
+            view = _detach_index_job_views((self.view,))[0]
+            manifest = RepoManifest.from_dict(copy.deepcopy(self.manifest.to_dict()))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise StorageIntegrityError(
+                "compiler cache job preparation cannot be detached"
+            ) from exc
+        plan_views = self.import_plan.views
+        expected_source = SourceRevision.dirty(
+            job.repository_id,
+            source_fingerprint=self.import_plan.source.fingerprint,
+            commit_sha=None,
+        )
+        if (
+            job.status is not IndexJobStatus.RUNNING
+            or job.cancel_requested
+            or job.attempt_count < 1
+            or job.started_at_ms is None
+            or _index_job_request(job).view_requests != (view,)
+            or view.requested_mode is not IndexJobRequestedMode.FULL
+            or view.required is not True
+            or self.import_plan.selection.selected_views != (view.view_type,)
+            or len(plan_views) != 1
+            or plan_views[0].view_type != view.view_type
+            or plan_views[0].profile_id != view.profile_id
+            or job.source_revision_id != expected_source.source_revision_id
+            or manifest.to_dict() != self.import_plan.manifest.to_dict()
+            or tuple(manifest.indexes) != (view.view_type,)
+            or manifest.indexes[view.view_type].path != f"views/{view.view_type}"
+            or self.recapture.view_type != view.view_type
+            or self.context_artifact.views != (view.view_type,)
+            or self.context_artifact.commit != manifest.commit
+            or self.artifact.view_type != view.view_type
+            or self.artifact.profile_id != view.profile_id
+            or self.artifact.schema_version != VIEW_BUNDLE_SCHEMA
+        ):
+            raise StorageIntegrityError(
+                "compiler cache job preparation identities are inconsistent"
+            )
+        object.__setattr__(self, "job", job)
+        object.__setattr__(self, "view", view)
         object.__setattr__(self, "manifest", manifest)
 
 
@@ -856,17 +940,20 @@ def _detach_index_job_views(value: object) -> tuple[IndexJobViewRecord, ...]:
     return detached
 
 
-def _read_compiler_cache_job_binding(
-    job_id: str,
+def _compiler_cache_job_binding(
+    job_value: object,
+    views_value: object,
     *,
     view_type: str,
-    catalog: JobPublicationCatalog,
     repository_source: RepositorySourceBinding,
     repository_key: str,
     namespace_name: str,
+    allow_succeeded: bool,
 ) -> _CompilerCacheJobBinding:
     if type(view_type) is not str or view_type not in _SUPPORTED_CACHE_VIEWS:
         raise TypeError("compiler cache job view type is invalid")
+    if type(allow_succeeded) is not bool:
+        raise TypeError("compiler cache job replay policy must be a boolean")
     source_snapshot = repository_source.authenticated_identity_snapshot()
     if type(source_snapshot) is not RepositorySourceIdentitySnapshot:
         raise TypeError("compiler cache repository identity has an invalid type")
@@ -879,15 +966,11 @@ def _read_compiler_cache_job_binding(
         source_fingerprint=source_snapshot.fingerprint,
         commit_sha=None,
     )
-    job = _detach_index_job_record(catalog.get_job(job_id))
-    if job.job_id != job_id:
-        raise StorageIntegrityError("catalog returned a different index job")
-    views = _detach_index_job_views(catalog.get_job_views(job_id))
+    job = _detach_index_job_record(job_value)
+    views = _detach_index_job_views(views_value)
     expected_views = _index_job_request(job).view_requests
     if views != expected_views:
-        raise StorageIntegrityError(
-            "catalog job view rows differ from the canonical request"
-        )
+        raise StorageIntegrityError("job views differ from the canonical request")
     if (
         job.repository_id != repository_identity.repository_id
         or job.source_revision_id != source_identity.source_revision_id
@@ -908,9 +991,13 @@ def _read_compiler_cache_job_binding(
         )
     if job.cancel_requested:
         raise StorageValidationError("compiler cache job is cancelled")
-    if job.status not in {IndexJobStatus.RUNNING, IndexJobStatus.SUCCEEDED}:
+    allowed_statuses = {IndexJobStatus.RUNNING}
+    if allow_succeeded:
+        allowed_statuses.add(IndexJobStatus.SUCCEEDED)
+    if job.status not in allowed_statuses:
         raise StorageValidationError(
-            "compiler cache job must be active or an exact successful replay"
+            "compiler cache job must be active"
+            + (" or an exact successful replay" if allow_succeeded else "")
         )
     if job.attempt_count < 1 or job.started_at_ms is None:
         raise StorageValidationError(
@@ -921,6 +1008,30 @@ def _read_compiler_cache_job_binding(
         view=views[0],
         source_snapshot=source_snapshot,
         source_identity=source_identity,
+    )
+
+
+def _read_compiler_cache_job_binding(
+    job_id: str,
+    *,
+    view_type: str,
+    catalog: JobPublicationCatalog,
+    repository_source: RepositorySourceBinding,
+    repository_key: str,
+    namespace_name: str,
+) -> _CompilerCacheJobBinding:
+    job = _detach_index_job_record(catalog.get_job(job_id))
+    if job.job_id != job_id:
+        raise StorageIntegrityError("catalog returned a different index job")
+    views = _detach_index_job_views(catalog.get_job_views(job_id))
+    return _compiler_cache_job_binding(
+        job,
+        views,
+        view_type=view_type,
+        repository_source=repository_source,
+        repository_key=repository_key,
+        namespace_name=namespace_name,
+        allow_succeeded=True,
     )
 
 
@@ -1077,6 +1188,122 @@ def _preflight_cache_job_operation(
         normalized_job_id,
         normalized_owner_id,
         fencing_token,
+    )
+
+
+def _preflight_cache_job_preparation_operation(
+    cache_dir: str | Path,
+    *,
+    view_type: str,
+    job: IndexJobRecord,
+    views: tuple[IndexJobViewRecord, ...],
+    repository_source: RepositorySourceBinding,
+    view_output_owner: PublishedWorkspaceReceiptOwner,
+    context_output_owner: PublishedWorkspaceReceiptOwner,
+    view_destination: Path,
+    context_destination: Path,
+    workspace_provider: StrictWorkspaceProvider,
+    repository_key: str,
+    object_store: RetainedImportObjectStore,
+    namespace_name: str,
+    max_manifest_bytes: int,
+    max_context_files: int,
+    max_context_bytes: int,
+    max_bundle_files: int,
+    max_bundle_bytes: int,
+    max_bundle_metadata_bytes: int,
+    forbidden_paths: Iterable[Path],
+    environ: Mapping[str, str] | None,
+) -> tuple[_ImportOperation, _CompilerCacheJobBinding]:
+    """Validate a worker preparation without accepting catalog authority."""
+
+    if type(view_type) is not str or view_type not in _SUPPORTED_CACHE_VIEWS:
+        raise TypeError("compiler cache job view type is invalid")
+    _preflight_authorities(
+        views=(view_type,),
+        repository_source=repository_source,
+        view_output_owners={view_type: view_output_owner},
+        view_destinations={view_type: view_destination},
+        context_output_owner=context_output_owner,
+        context_destination=context_destination,
+    )
+    repository = _exact_text(repository_key, "repository key")
+    try:
+        normalized_repository = normalize_repo(repository)
+    except ValueError as exc:
+        raise StorageValidationError("repository key is not canonical") from exc
+    if normalized_repository != repository:
+        raise StorageValidationError("repository key is not canonical")
+    namespace = _exact_text(namespace_name, "namespace name")
+    manifest_limit = _manifest_limit(max_manifest_bytes)
+    context_files = _positive_limit(max_context_files, "context file limit")
+    context_bytes = _positive_limit(max_context_bytes, "context byte limit")
+    bundle_files = _positive_limit(max_bundle_files, "bundle file limit")
+    bundle_bytes = _positive_limit(max_bundle_bytes, "bundle byte limit")
+    bundle_metadata_bytes = _positive_limit(
+        max_bundle_metadata_bytes,
+        "bundle metadata byte limit",
+    )
+    environment = _snapshot_environment(environ)
+    forbidden = _snapshot_forbidden_paths(forbidden_paths)
+    if not isinstance(object_store, RetainedImportObjectStore):
+        raise TypeError(
+            "compiler cache job object store lacks retained streaming capabilities"
+        )
+    _require_static_methods(
+        object_store,
+        label="compiler cache job object store",
+        names=_OBJECT_STORE_METHODS,
+    )
+    _preflight_workspace_provider(workspace_provider)
+    binding = _compiler_cache_job_binding(
+        job,
+        views,
+        view_type=view_type,
+        repository_source=repository_source,
+        repository_key=repository,
+        namespace_name=namespace,
+        allow_succeeded=False,
+    )
+    inputs = _ImportPreflight(
+        repository_key=repository,
+        namespace_name=namespace,
+        ref_name=binding.job.ref_name,
+        expected_generation=binding.job.expected_ref_generation,
+        max_manifest_bytes=manifest_limit,
+        max_context_files=context_files,
+        max_context_bytes=context_bytes,
+        max_bundle_files=bundle_files,
+        max_bundle_bytes=bundle_bytes,
+        max_bundle_metadata_bytes=bundle_metadata_bytes,
+        max_projection_bytes=DEFAULT_MAX_PROJECTION_BYTES,
+        forbidden_paths=forbidden,
+        environment=environment,
+    )
+    cache = lexical_directory_path(Path(cache_dir))
+    view_output = lexical_directory_path(view_destination)
+    context_output = lexical_directory_path(context_destination)
+    fixed_source_views = {view_type: lexical_directory_path(cache / view_type)}
+    policy_forbidden = _snapshot_forbidden_paths(
+        (
+            *inputs.forbidden_paths,
+            cache,
+            *fixed_source_views.values(),
+            view_output,
+            context_output,
+        )
+    )
+    return (
+        _ImportOperation(
+            cache=cache,
+            view_owners={view_type: view_output_owner},
+            view_outputs={view_type: view_output},
+            context_output=context_output,
+            inputs=inputs,
+            fixed_source_views=fixed_source_views,
+            policy_forbidden=policy_forbidden,
+        ),
+        binding,
     )
 
 
@@ -1796,6 +2023,67 @@ def _commit_prepared_compiler_cache_import(
     )
 
 
+def _ingest_prepared_compiler_cache_job(
+    preparation: _PreparedCompilerCacheImport,
+    operation: _ImportOperation,
+    binding: _CompilerCacheJobBinding,
+    *,
+    view_type: str,
+    repository_source: RepositorySourceBinding,
+    context_output_owner: PublishedWorkspaceReceiptOwner,
+    object_store: RetainedImportObjectStore,
+) -> IndexJobViewArtifact:
+    """Ingest one prepared cache view without granting catalog authority."""
+
+    if type(preparation) is not _PreparedCompilerCacheImport:
+        raise TypeError("compiler cache job preparation is invalid")
+    if type(operation) is not _ImportOperation:
+        raise TypeError("compiler cache job operation is invalid")
+    if type(binding) is not _CompilerCacheJobBinding:
+        raise TypeError("compiler cache job binding is invalid")
+    _require_compiler_cache_job_profile(
+        binding,
+        preparation.import_plan,
+        view_type=view_type,
+    )
+    artifacts = context_output_owner.consume(
+        lambda receipt, publication: _prepare_job_view_artifacts_inside_authority(
+            receipt,
+            publication,
+            plan=preparation.import_plan,
+            repository_source=repository_source,
+            repository_key=operation.inputs.repository_key,
+            source_identity=binding.source_identity,
+            object_store=object_store,
+            environment=operation.inputs.environment,
+            forbidden_paths=operation.policy_forbidden,
+            max_context_files=operation.inputs.max_context_files,
+            max_context_bytes=operation.inputs.max_context_bytes,
+            max_bundle_files=operation.inputs.max_bundle_files,
+            max_bundle_bytes=operation.inputs.max_bundle_bytes,
+            max_bundle_metadata_bytes=operation.inputs.max_bundle_metadata_bytes,
+        )
+    )
+    if type(artifacts) is not tuple or len(artifacts) != 1:
+        raise StorageIntegrityError(
+            f"compiler cache {view_type} ingestion returned invalid job artifacts"
+        )
+    if repository_source.authenticated_identity_snapshot() != binding.source_snapshot:
+        raise StorageIntegrityError(
+            "compiler cache repository source changed during CAS ingestion"
+        )
+    artifact = artifacts[0]
+    if (
+        type(artifact) is not IndexJobViewArtifact
+        or artifact.view_type != binding.view.view_type
+        or artifact.profile_id != binding.view.profile_id
+    ):
+        raise StorageIntegrityError(
+            "compiler cache ingestion returned a different requested view"
+        )
+    return artifact
+
+
 def import_compiler_cache(
     cache_dir: str | Path,
     *,
@@ -1875,6 +2163,170 @@ def import_compiler_cache(
         catalog=catalog,
         object_store=object_store,
     )
+
+
+def prepare_compiler_cache_job_view(
+    cache_dir: str | Path,
+    *,
+    view_type: str,
+    job: IndexJobRecord,
+    views: tuple[IndexJobViewRecord, ...],
+    repository_source: RepositorySourceBinding,
+    view_output_owner: PublishedWorkspaceReceiptOwner,
+    context_output_owner: PublishedWorkspaceReceiptOwner,
+    view_destination: Path,
+    context_destination: Path,
+    workspace_provider: StrictWorkspaceProvider,
+    repository_key: str,
+    object_store: RetainedImportObjectStore,
+    namespace_name: str = DEFAULT_NAMESPACE_NAME,
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+    max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
+    max_context_bytes: int = DEFAULT_MAX_CONTEXT_BYTES,
+    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
+    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
+    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> CompilerCacheJobPreparationResult:
+    """Prepare one exact compiler-cache view for worker-owned publication.
+
+    This adapter intentionally accepts no catalog, lease owner, or fencing
+    token. It authenticates the already-claimed worker job, recaptures the
+    requested FULL cache view, and stores the immutable publication closure in
+    the caller-provided object store. The durable worker remains the sole
+    authority that may publish the returned artifact.
+    """
+
+    operation, binding = _preflight_cache_job_preparation_operation(
+        cache_dir,
+        view_type=view_type,
+        job=job,
+        views=views,
+        repository_source=repository_source,
+        view_output_owner=view_output_owner,
+        context_output_owner=context_output_owner,
+        view_destination=view_destination,
+        context_destination=context_destination,
+        workspace_provider=workspace_provider,
+        repository_key=repository_key,
+        object_store=object_store,
+        namespace_name=namespace_name,
+        max_manifest_bytes=max_manifest_bytes,
+        max_context_files=max_context_files,
+        max_context_bytes=max_context_bytes,
+        max_bundle_files=max_bundle_files,
+        max_bundle_bytes=max_bundle_bytes,
+        max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
+    )
+    with compiler_cache_lock(operation.cache, create=False):
+        preparation = _prepare_compiler_cache_import_locked(
+            operation,
+            views=(view_type,),
+            repository_source=repository_source,
+            context_output_owner=context_output_owner,
+            workspace_provider=workspace_provider,
+            job_binding=binding,
+        )
+    artifact = _ingest_prepared_compiler_cache_job(
+        preparation,
+        operation,
+        binding,
+        view_type=view_type,
+        repository_source=repository_source,
+        context_output_owner=context_output_owner,
+        object_store=object_store,
+    )
+    if len(preparation.recaptures) != 1:
+        raise StorageIntegrityError(
+            "compiler cache job preparation returned invalid recapture evidence"
+        )
+    return CompilerCacheJobPreparationResult(
+        job=binding.job,
+        view=binding.view,
+        manifest=preparation.import_plan.manifest,
+        import_plan=preparation.import_plan,
+        recapture=preparation.recaptures[0],
+        context_artifact=preparation.context_artifact,
+        artifact=artifact,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class CompilerCacheJobExecutor:
+    """One-shot worker executor for one current BM25 or vector cache view.
+
+    A resolver must supply fresh receipt owners and destinations for every
+    attempt. The object store must be the same retained backend configured on
+    the enclosing worker. Resource cleanup remains the resolver/caller's
+    responsibility after the attempt settles.
+    """
+
+    cache_dir: str | Path
+    view_type: str
+    repository_source: RepositorySourceBinding
+    view_output_owner: PublishedWorkspaceReceiptOwner
+    context_output_owner: PublishedWorkspaceReceiptOwner
+    view_destination: Path
+    context_destination: Path
+    workspace_provider: StrictWorkspaceProvider
+    repository_key: str
+    object_store: RetainedImportObjectStore
+    namespace_name: str = DEFAULT_NAMESPACE_NAME
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES
+    max_context_files: int = DEFAULT_MAX_CONTEXT_FILES
+    max_context_bytes: int = DEFAULT_MAX_CONTEXT_BYTES
+    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES
+    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES
+    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES
+    forbidden_paths: Iterable[Path] = ()
+    environ: Mapping[str, str] | None = None
+
+    def execute(
+        self,
+        context: IndexJobExecutionContext,
+    ) -> IndexJobExecutionResult:
+        """Prepare the claimed view without receiving catalog authority."""
+
+        if type(context) is not IndexJobExecutionContext:
+            raise TypeError("compiler cache executor requires an exact job context")
+        prepared = prepare_compiler_cache_job_view(
+            self.cache_dir,
+            view_type=self.view_type,
+            job=context.job,
+            views=context.views,
+            repository_source=self.repository_source,
+            view_output_owner=self.view_output_owner,
+            context_output_owner=self.context_output_owner,
+            view_destination=self.view_destination,
+            context_destination=self.context_destination,
+            workspace_provider=self.workspace_provider,
+            repository_key=self.repository_key,
+            object_store=self.object_store,
+            namespace_name=self.namespace_name,
+            max_manifest_bytes=self.max_manifest_bytes,
+            max_context_files=self.max_context_files,
+            max_context_bytes=self.max_context_bytes,
+            max_bundle_files=self.max_bundle_files,
+            max_bundle_bytes=self.max_bundle_bytes,
+            max_bundle_metadata_bytes=self.max_bundle_metadata_bytes,
+            forbidden_paths=self.forbidden_paths,
+            environ=self.environ,
+        )
+        return IndexJobExecutionResult(
+            views=(
+                IndexJobViewExecutionResult.create(
+                    prepared.view,
+                    effective_mode=IndexJobEffectiveMode.FULL,
+                    outcome=IndexJobViewOutcome.SUCCEEDED,
+                    artifact=prepared.artifact,
+                    payload={"adapter": "compiler_cache", "prepared": True},
+                ),
+            ),
+            retryable=False,
+        )
 
 
 def _publish_compiler_cache_job(
@@ -1967,32 +2419,15 @@ def _publish_compiler_cache_job(
             "compiler cache job or repository source changed before CAS ingestion"
         )
 
-    artifacts = context_output_owner.consume(
-        lambda receipt, publication: _prepare_job_view_artifacts_inside_authority(
-            receipt,
-            publication,
-            plan=preparation.import_plan,
-            repository_source=repository_source,
-            repository_key=operation.inputs.repository_key,
-            source_identity=binding.source_identity,
-            object_store=object_store,
-            environment=operation.inputs.environment,
-            forbidden_paths=operation.policy_forbidden,
-            max_context_files=operation.inputs.max_context_files,
-            max_context_bytes=operation.inputs.max_context_bytes,
-            max_bundle_files=operation.inputs.max_bundle_files,
-            max_bundle_bytes=operation.inputs.max_bundle_bytes,
-            max_bundle_metadata_bytes=operation.inputs.max_bundle_metadata_bytes,
-        )
+    artifact = _ingest_prepared_compiler_cache_job(
+        preparation,
+        operation,
+        binding,
+        view_type=view_type,
+        repository_source=repository_source,
+        context_output_owner=context_output_owner,
+        object_store=object_store,
     )
-    if type(artifacts) is not tuple or len(artifacts) != 1:
-        raise StorageIntegrityError(
-            f"compiler cache {view_type} ingestion returned invalid job artifacts"
-        )
-    if repository_source.authenticated_identity_snapshot() != binding.source_snapshot:
-        raise StorageIntegrityError(
-            "compiler cache repository source changed during CAS ingestion"
-        )
     current = _read_compiler_cache_job_binding(
         normalized_job_id,
         view_type=view_type,
@@ -2020,7 +2455,7 @@ def _publish_compiler_cache_job(
         object_store=object_store,
         owner_id=normalized_owner_id,
         fencing_token=token,
-        outputs=artifacts,
+        outputs=(artifact,),
     )
     return preparation, completed
 
@@ -2396,6 +2831,8 @@ def _fingerprints_adjustment(
 __all__ = [
     "CompilerCacheBm25RecaptureResult",
     "CompilerCacheImportResult",
+    "CompilerCacheJobExecutor",
+    "CompilerCacheJobPreparationResult",
     "CompilerCacheJobPublicationResult",
     "CompilerCacheMultiViewImportResult",
     "CompilerCacheTopologyGuard",
@@ -2405,6 +2842,7 @@ __all__ = [
     "compile_and_import_repo",
     "import_compiler_cache",
     "import_compiler_cache_bm25",
+    "prepare_compiler_cache_job_view",
     "publish_compiler_cache_bm25_job",
     "publish_compiler_cache_vector_job",
 ]

--- a/codenib/compiler/cache_import.py
+++ b/codenib/compiler/cache_import.py
@@ -19,7 +19,7 @@ import hashlib
 import inspect
 import re
 import stat
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
@@ -63,6 +63,7 @@ from ..source_fingerprint import (
 from ..storage.job_worker import (
     IndexJobExecutionContext,
     IndexJobExecutionResult,
+    IndexJobStopToken,
     IndexJobViewExecutionResult,
 )
 from ..storage.models import (
@@ -127,6 +128,25 @@ from .snapshot_store import normalize_repo
 _COMMIT_RE = re.compile(r"[0-9a-f]{40}\Z", re.ASCII)
 _SUPPORTED_CACHE_VIEWS = ("bm25", "vector")
 _CATALOG_INT64_MAX = 9_223_372_036_854_775_807
+
+
+class _CompilerCacheJobStopped(RuntimeError):
+    """Internal cooperative stop signal for prepare-only worker work."""
+
+
+def _compiler_cache_job_stop_check(
+    stop_token: IndexJobStopToken | None,
+) -> Callable[[], None] | None:
+    if stop_token is None:
+        return None
+    if not isinstance(stop_token, IndexJobStopToken):
+        raise TypeError("compiler cache job stop token is invalid")
+
+    def check_cancelled() -> None:
+        if stop_token.is_set():
+            raise _CompilerCacheJobStopped("compiler cache job preparation stopped")
+
+    return check_cancelled
 
 
 class CompilerCacheTopologyGuard(Protocol):
@@ -1553,6 +1573,7 @@ def _plan_cache_view(
     view_config: Mapping[str, Any],
     forbidden_paths: tuple[Path, ...],
     environ: Mapping[str, str],
+    check_cancelled: Callable[[], None] | None = None,
 ) -> Any:
     if view == "bm25":
         return _plan_recaptured_bm25_view(
@@ -1562,6 +1583,7 @@ def _plan_cache_view(
             view_config=view_config,
             forbidden_paths=forbidden_paths,
             environ=environ,
+            check_cancelled=check_cancelled,
         )
     if view == "vector":
         return _plan_recaptured_vector_view(
@@ -1571,6 +1593,7 @@ def _plan_cache_view(
             view_config=view_config,
             forbidden_paths=forbidden_paths,
             environ=environ,
+            check_cancelled=check_cancelled,
         )
     raise AssertionError(f"unsupported compiler cache view: {view}")
 
@@ -1587,6 +1610,7 @@ def _publish_cache_view(
     view_config: Mapping[str, Any],
     forbidden_paths: tuple[Path, ...],
     environ: Mapping[str, str],
+    check_cancelled: Callable[[], None] | None = None,
 ) -> dict[str, Any]:
     if view == "bm25":
         return _publish_recaptured_bm25_view(
@@ -1599,6 +1623,7 @@ def _publish_cache_view(
             view_config=view_config,
             forbidden_paths=forbidden_paths,
             environ=environ,
+            check_cancelled=check_cancelled,
         )
     if view == "vector":
         return _publish_recaptured_vector_view(
@@ -1611,6 +1636,7 @@ def _publish_cache_view(
             view_config=view_config,
             forbidden_paths=forbidden_paths,
             environ=environ,
+            check_cancelled=check_cancelled,
         )
     raise AssertionError(f"unsupported compiler cache view: {view}")
 
@@ -1811,11 +1837,14 @@ def _prepare_compiler_cache_import_locked(
     workspace_provider: StrictWorkspaceProvider,
     expected_manifest: RepoManifest | None = None,
     job_binding: _CompilerCacheJobBinding | None = None,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> _PreparedCompilerCacheImport:
     """Recapture selected views while the caller holds the cache lease."""
 
     cache = operation.cache
     inputs = operation.inputs
+    if check_cancelled is not None:
+        check_cancelled()
     source_manifest_bytes = _read_manifest(
         cache,
         max_manifest_bytes=inputs.max_manifest_bytes,
@@ -1824,6 +1853,8 @@ def _prepare_compiler_cache_import_locked(
         source_manifest_bytes,
         max_manifest_bytes=inputs.max_manifest_bytes,
     )
+    if check_cancelled is not None:
+        check_cancelled()
     if expected_manifest is not None:
         if type(expected_manifest) is not RepoManifest:
             raise TypeError("compiler update returned an invalid repository manifest")
@@ -1854,6 +1885,8 @@ def _prepare_compiler_cache_import_locked(
     )
     if source_views != operation.fixed_source_views:  # pragma: no cover
         raise AssertionError("compiler cache fixed view sources changed")
+    if check_cancelled is not None:
+        check_cancelled()
 
     # Every raw-cache recapture plan plus the exact portable manifest and
     # retained import plan exists before the first provider call can mutate
@@ -1862,6 +1895,8 @@ def _prepare_compiler_cache_import_locked(
     # workspace mutation.
     planned_views: dict[str, Any] = {}
     for view in views:
+        if check_cancelled is not None:
+            check_cancelled()
         planned = _plan_cache_view(
             view,
             source_views[view],
@@ -1870,7 +1905,10 @@ def _prepare_compiler_cache_import_locked(
             view_config=entries[view].config,
             forbidden_paths=operation.policy_forbidden,
             environ=inputs.environment,
+            check_cancelled=check_cancelled,
         )
+        if check_cancelled is not None:
+            check_cancelled()
         if view == "bm25":
             _require_source_fingerprints(entries[view], planned)
         _planned_adjustments(view, planned)
@@ -1885,6 +1923,8 @@ def _prepare_compiler_cache_import_locked(
         views=views,
         max_manifest_bytes=inputs.max_manifest_bytes,
     )
+    if check_cancelled is not None:
+        check_cancelled()
     if (
         import_plan.selection.selected_views != views
         or import_plan.manifest.to_dict() != portable_manifest.to_dict()
@@ -1903,6 +1943,8 @@ def _prepare_compiler_cache_import_locked(
 
     recaptures: list[CompilerCacheViewRecaptureResult] = []
     for view in views:
+        if check_cancelled is not None:
+            check_cancelled()
         planned = planned_views[view]
         adjustments = _publish_cache_view(
             view,
@@ -1915,7 +1957,10 @@ def _prepare_compiler_cache_import_locked(
             view_config=entries[view].config,
             forbidden_paths=operation.policy_forbidden,
             environ=inputs.environment,
+            check_cancelled=check_cancelled,
         )
+        if check_cancelled is not None:
+            check_cancelled()
         if adjustments != _planned_adjustments(view, planned):
             raise StorageIntegrityError(
                 f"compiler cache {view} publication differs from its exact plan"
@@ -1930,6 +1975,8 @@ def _prepare_compiler_cache_import_locked(
             )
         )
 
+    if check_cancelled is not None:
+        check_cancelled()
     planned_context = plan_context_artifact_strict(
         portable_manifest,
         repository=inputs.repository_key,
@@ -1944,6 +1991,8 @@ def _prepare_compiler_cache_import_locked(
         raise StorageIntegrityError(
             "compiler cache context plan differs from its portable manifest"
         )
+    if check_cancelled is not None:
+        check_cancelled()
     context_artifact = publish_planned_context_artifact_strict(
         operation.context_output,
         planned=planned_context,
@@ -1955,6 +2004,8 @@ def _prepare_compiler_cache_import_locked(
         output_receipt_owner=context_output_owner,
         environ=inputs.environment,
     )
+    if check_cancelled is not None:
+        check_cancelled()
     observed_manifest_bytes = _read_context_manifest(
         context_output_owner,
         max_manifest_bytes=inputs.max_manifest_bytes,
@@ -1974,6 +2025,8 @@ def _prepare_compiler_cache_import_locked(
         raise StorageIntegrityError(
             "compiler cache repository manifest changed during recapture"
         )
+    if check_cancelled is not None:
+        check_cancelled()
     return _PreparedCompilerCacheImport(
         manifest=manifest,
         recaptures=tuple(recaptures),
@@ -2032,6 +2085,7 @@ def _ingest_prepared_compiler_cache_job(
     repository_source: RepositorySourceBinding,
     context_output_owner: PublishedWorkspaceReceiptOwner,
     object_store: RetainedImportObjectStore,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> IndexJobViewArtifact:
     """Ingest one prepared cache view without granting catalog authority."""
 
@@ -2041,6 +2095,8 @@ def _ingest_prepared_compiler_cache_job(
         raise TypeError("compiler cache job operation is invalid")
     if type(binding) is not _CompilerCacheJobBinding:
         raise TypeError("compiler cache job binding is invalid")
+    if check_cancelled is not None:
+        check_cancelled()
     _require_compiler_cache_job_profile(
         binding,
         preparation.import_plan,
@@ -2062,8 +2118,11 @@ def _ingest_prepared_compiler_cache_job(
             max_bundle_files=operation.inputs.max_bundle_files,
             max_bundle_bytes=operation.inputs.max_bundle_bytes,
             max_bundle_metadata_bytes=operation.inputs.max_bundle_metadata_bytes,
+            check_cancelled=check_cancelled,
         )
     )
+    if check_cancelled is not None:
+        check_cancelled()
     if type(artifacts) is not tuple or len(artifacts) != 1:
         raise StorageIntegrityError(
             f"compiler cache {view_type} ingestion returned invalid job artifacts"
@@ -2081,6 +2140,8 @@ def _ingest_prepared_compiler_cache_job(
         raise StorageIntegrityError(
             "compiler cache ingestion returned a different requested view"
         )
+    if check_cancelled is not None:
+        check_cancelled()
     return artifact
 
 
@@ -2180,6 +2241,7 @@ def prepare_compiler_cache_job_view(
     repository_key: str,
     object_store: RetainedImportObjectStore,
     namespace_name: str = DEFAULT_NAMESPACE_NAME,
+    stop_token: IndexJobStopToken | None = None,
     max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
     max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
     max_context_bytes: int = DEFAULT_MAX_CONTEXT_BYTES,
@@ -2195,9 +2257,14 @@ def prepare_compiler_cache_job_view(
     token. It authenticates the already-claimed worker job, recaptures the
     requested FULL cache view, and stores the immutable publication closure in
     the caller-provided object store. The durable worker remains the sole
-    authority that may publish the returned artifact.
+    authority that may publish the returned artifact. When supplied, the
+    worker's read-only stop token makes lock waits, recapture, and CAS
+    ingestion cooperatively interruptible without exposing mutation authority.
     """
 
+    check_cancelled = _compiler_cache_job_stop_check(stop_token)
+    if check_cancelled is not None:
+        check_cancelled()
     operation, binding = _preflight_cache_job_preparation_operation(
         cache_dir,
         view_type=view_type,
@@ -2221,7 +2288,13 @@ def prepare_compiler_cache_job_view(
         forbidden_paths=forbidden_paths,
         environ=environ,
     )
-    with compiler_cache_lock(operation.cache, create=False):
+    if check_cancelled is not None:
+        check_cancelled()
+    with compiler_cache_lock(
+        operation.cache,
+        create=False,
+        check_cancelled=check_cancelled,
+    ):
         preparation = _prepare_compiler_cache_import_locked(
             operation,
             views=(view_type,),
@@ -2229,7 +2302,10 @@ def prepare_compiler_cache_job_view(
             context_output_owner=context_output_owner,
             workspace_provider=workspace_provider,
             job_binding=binding,
+            check_cancelled=check_cancelled,
         )
+    if check_cancelled is not None:
+        check_cancelled()
     artifact = _ingest_prepared_compiler_cache_job(
         preparation,
         operation,
@@ -2238,11 +2314,14 @@ def prepare_compiler_cache_job_view(
         repository_source=repository_source,
         context_output_owner=context_output_owner,
         object_store=object_store,
+        check_cancelled=check_cancelled,
     )
     if len(preparation.recaptures) != 1:
         raise StorageIntegrityError(
             "compiler cache job preparation returned invalid recapture evidence"
         )
+    if check_cancelled is not None:
+        check_cancelled()
     return CompilerCacheJobPreparationResult(
         job=binding.job,
         view=binding.view,
@@ -2306,6 +2385,7 @@ class CompilerCacheJobExecutor:
             repository_key=self.repository_key,
             object_store=self.object_store,
             namespace_name=self.namespace_name,
+            stop_token=context.control.stop_token,
             max_manifest_bytes=self.max_manifest_bytes,
             max_context_files=self.max_context_files,
             max_context_bytes=self.max_context_bytes,

--- a/codenib/compiler/cache_lock.py
+++ b/codenib/compiler/cache_lock.py
@@ -30,6 +30,7 @@ COMPILER_CACHE_LOCK_FILENAME = ".index-compiler.lock"
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _LOCK_OPEN_RETRIES = 8
 _WINDOWS_LOCK_RETRY_SECONDS = 0.05
+_INTERRUPTIBLE_LOCK_RETRY_SECONDS = 0.05
 _ACTIVE_POSIX_LOCK_DESCRIPTORS: set[int] = set()
 _POSIX_FORK_GENERATION = 0
 _POSIX_LOCK_LIFECYCLE_DEPTH = threading.local()
@@ -855,6 +856,7 @@ def _posix_compiler_cache_lock(
     cache_dir: str | Path,
     *,
     create: bool = True,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> Iterator[None]:
     cache_directory = (
         _open_posix_cache_directory(cache_dir)
@@ -891,8 +893,22 @@ def _posix_compiler_cache_lock(
                     create=False,
                 )
             assert fcntl is not None  # narrowed by _require_posix_primitives
-            fcntl.flock(descriptor, fcntl.LOCK_EX)
+            if check_cancelled is None:
+                fcntl.flock(descriptor, fcntl.LOCK_EX)
+            else:
+                while True:
+                    check_cancelled()
+                    try:
+                        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    except OSError as exc:
+                        if exc.errno not in {errno.EACCES, errno.EAGAIN}:
+                            raise
+                        time.sleep(_INTERRUPTIBLE_LOCK_RETRY_SECONDS)
+                        continue
+                    break
             locked = True
+            if check_cancelled is not None:
+                check_cancelled()
             _validate_posix_lock_entry(
                 descriptor,
                 directory_descriptor,
@@ -1067,11 +1083,17 @@ def _open_windows_lock_file(
     raise RuntimeError(f"compiler cache lock changed repeatedly: {lock_path}")
 
 
-def _acquire_windows_lock(descriptor: int) -> None:
+def _acquire_windows_lock(
+    descriptor: int,
+    *,
+    check_cancelled: Callable[[], None] | None = None,
+) -> None:
     assert msvcrt is not None
     runtime: Any = msvcrt
     contention = {errno.EACCES, errno.EAGAIN, errno.EDEADLK}
     while True:
+        if check_cancelled is not None:
+            check_cancelled()
         # The CRT permits a locked range to extend beyond EOF, so an empty
         # coordination inode needs no initialization write.
         os.lseek(descriptor, 0, os.SEEK_SET)
@@ -1120,6 +1142,7 @@ def _windows_compiler_cache_lock(
     cache_dir: str | Path,
     *,
     create: bool = True,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> Iterator[None]:
     if msvcrt is None:
         raise RuntimeError("compiler cache locking requires Windows msvcrt support")
@@ -1150,8 +1173,16 @@ def _windows_compiler_cache_lock(
                 descriptor_owner,
                 create=False,
             )
-        _acquire_windows_lock(descriptor)
+        if check_cancelled is None:
+            _acquire_windows_lock(descriptor)
+        else:
+            _acquire_windows_lock(
+                descriptor,
+                check_cancelled=check_cancelled,
+            )
         locked = True
+        if check_cancelled is not None:
+            check_cancelled()
         if _validate_windows_cache(cache) != cache_identity:
             raise RuntimeError(f"compiler cache path changed: {cache}")
         _validate_windows_lock_entry(
@@ -1196,6 +1227,7 @@ def compiler_cache_lock(
     cache_dir: str | Path,
     *,
     create: bool = True,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> Iterator[None]:
     """Serialize cooperating users of one private compiler cache.
 
@@ -1209,6 +1241,12 @@ def compiler_cache_lock(
     and its fixed lock file must already exist, and neither is created while
     acquiring the lease.
 
+    ``check_cancelled`` may be supplied by a cooperative caller that needs
+    bounded lock-wait cancellation. It is called before each nonblocking lock
+    attempt and once after acquisition; it must return normally to continue or
+    raise the caller's cancellation exception. Existing callers retain the
+    blocking lock path when no callback is supplied.
+
     This helper protects participating compiler/importer operations from each
     other.  It does not validate or defend the manifest and view tree against
     a user who actively replaces paths while the lock is held.
@@ -1216,19 +1254,35 @@ def compiler_cache_lock(
 
     if type(create) is not bool:
         raise TypeError("compiler cache lock create policy must be an exact bool")
+    if check_cancelled is not None and not callable(check_cancelled):
+        raise TypeError("compiler cache lock cancellation check must be callable")
     if os.name == "nt":
         lock = (
-            _windows_compiler_cache_lock(cache_dir)
+            _windows_compiler_cache_lock(
+                cache_dir,
+                check_cancelled=check_cancelled,
+            )
             if create
-            else _windows_compiler_cache_lock(cache_dir, create=False)
+            else _windows_compiler_cache_lock(
+                cache_dir,
+                create=False,
+                check_cancelled=check_cancelled,
+            )
         )
         with lock:
             yield
         return
     lock = (
-        _posix_compiler_cache_lock(cache_dir)
+        _posix_compiler_cache_lock(
+            cache_dir,
+            check_cancelled=check_cancelled,
+        )
         if create
-        else _posix_compiler_cache_lock(cache_dir, create=False)
+        else _posix_compiler_cache_lock(
+            cache_dir,
+            create=False,
+            check_cancelled=check_cancelled,
+        )
     )
     with lock:
         yield

--- a/codenib/compiler/manifest_import.py
+++ b/codenib/compiler/manifest_import.py
@@ -25,7 +25,7 @@ import inspect
 import json
 import os
 import re
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from types import MappingProxyType
@@ -714,8 +714,22 @@ def _validate_context_matches_plan(
         )
 
 
-def _drain(chunks: Iterable[bytes]) -> None:
-    for _chunk in chunks:
+def _interruptible_chunks(
+    chunks: Iterable[bytes],
+    check_cancelled: Callable[[], None] | None,
+) -> Iterator[bytes]:
+    for chunk in chunks:
+        if check_cancelled is not None:
+            check_cancelled()
+        yield chunk
+
+
+def _drain(
+    chunks: Iterable[bytes],
+    *,
+    check_cancelled: Callable[[], None] | None = None,
+) -> None:
+    for _chunk in _interruptible_chunks(chunks, check_cancelled):
         pass
 
 
@@ -735,11 +749,14 @@ def _prepare_manifest_views_inside_authority(
     max_bundle_files: int,
     max_bundle_bytes: int,
     max_bundle_metadata_bytes: int,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> _PreparedManifestViews:
     if type(receipt) is not PublishedWorkspaceReceipt:
         raise TypeError("retained context receipt has an invalid type")
     if type(publication) is not PublicationDirectoryReader:
         raise TypeError("retained context reader has an invalid type")
+    if check_cancelled is not None:
+        check_cancelled()
     artifact_plan_digest = _snapshot_workspace_plan_digest(receipt)
     verified = verify_context_artifact_reader(
         publication,
@@ -754,6 +771,8 @@ def _prepare_manifest_views_inside_authority(
         verified=verified,
         repository_key=repository_key,
     )
+    if check_cancelled is not None:
+        check_cancelled()
 
     planned: list[
         tuple[ViewImportIntent, PublicationDirectoryReader, PlannedViewBundle]
@@ -761,6 +780,8 @@ def _prepare_manifest_views_inside_authority(
     # Every selected view is semantically validated and fully bundle-planned
     # before the first object-store producer is invoked.
     for intent in plan.views:
+        if check_cancelled is not None:
+            check_cancelled()
         prefix = PurePosixPath("views") / intent.view_type
         view_reader = publication.subtree(prefix)
         validate_content_bound_portable_query_view_reader(
@@ -781,20 +802,26 @@ def _prepare_manifest_views_inside_authority(
             max_bytes=max_bundle_bytes,
             max_metadata_bytes=max_bundle_metadata_bytes,
         )
+        if check_cancelled is not None:
+            check_cancelled()
         planned.append((intent, view_reader, bundle))
 
     prepared_views: list[_PreparedView] = []
     stored_by_digest: dict[str, _StoredObject] = {}
     for intent, view_reader, bundle in planned:
+        if check_cancelled is not None:
+            check_cancelled()
         raw_bundle = consume_planned_view_bundle(
             publication,
             bundle,
             lambda chunks, bundle=bundle: object_store.put_chunks(  # type: ignore[attr-defined]
-                chunks,
+                _interruptible_chunks(chunks, check_cancelled),
                 bundle.digest,
                 bundle.byte_size,
             ),
         )
+        if check_cancelled is not None:
+            check_cancelled()
         bundle_object = _exact_blob_object(
             raw_bundle,
             expected_digest=bundle.digest,
@@ -811,6 +838,8 @@ def _prepare_manifest_views_inside_authority(
 
         members: list[tuple[str, int, int, _StoredObject]] = []
         for member in bundle.members:
+            if check_cancelled is not None:
+                check_cancelled()
             existing = stored_by_digest.get(member.digest)
             with view_reader.iter_authenticated_chunks(
                 member.path,
@@ -818,10 +847,12 @@ def _prepare_manifest_views_inside_authority(
             ) as chunks:
                 if existing is None:
                     raw_member = object_store.put_chunks(  # type: ignore[attr-defined]
-                        chunks,
+                        _interruptible_chunks(chunks, check_cancelled),
                         member.digest,
                         member.byte_size,
                     )
+                    if check_cancelled is not None:
+                        check_cancelled()
                     stored = _exact_blob_object(
                         raw_member,
                         expected_digest=member.digest,
@@ -831,7 +862,7 @@ def _prepare_manifest_views_inside_authority(
                     )
                     stored_by_digest[stored.record.digest] = stored
                 else:
-                    _drain(chunks)
+                    _drain(chunks, check_cancelled=check_cancelled)
                     if (
                         existing.record.byte_size != member.byte_size
                         or existing.record.media_type != _MEMBER_MEDIA_TYPE
@@ -860,6 +891,9 @@ def _prepare_manifest_views_inside_authority(
             )
         )
 
+    if check_cancelled is not None:
+        check_cancelled()
+
     return _PreparedManifestViews(
         artifact_plan_digest=artifact_plan_digest,
         views=tuple(prepared_views),
@@ -882,6 +916,7 @@ def _prepare_job_view_artifacts_inside_authority(
     max_bundle_files: int,
     max_bundle_bytes: int,
     max_bundle_metadata_bytes: int,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> tuple[IndexJobViewArtifact, ...]:
     """Ingest exact selected-view receipts without a manifest projection."""
 
@@ -900,9 +935,12 @@ def _prepare_job_view_artifacts_inside_authority(
         max_bundle_files=max_bundle_files,
         max_bundle_bytes=max_bundle_bytes,
         max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        check_cancelled=check_cancelled,
     )
     artifacts: list[IndexJobViewArtifact] = []
     for view in prepared.views:
+        if check_cancelled is not None:
+            check_cancelled()
         members = _unique_stored_objects(member[3] for member in view.members)
         artifact = IndexJobViewArtifact.create(
             view.intent.view_type,
@@ -931,7 +969,11 @@ def _prepare_job_view_artifacts_inside_authority(
                 "retained job artifact differs from its prepared view generation"
             )
         artifacts.append(artifact)
+    if check_cancelled is not None:
+        check_cancelled()
     repository_source.verify_snapshot()
+    if check_cancelled is not None:
+        check_cancelled()
     return tuple(artifacts)
 
 

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1224,11 +1224,24 @@ authorization. Exact replay returns the job's historical snapshot after later
 ref advancement. This remains an explicit ingress adapter only: it adds no
 builder, worker, CLI, runtime, graph, or default-route wiring.
 
+The same BM25 and schema-8 vector recapture paths now also expose an explicit
+prepare-only worker bridge. It authenticates the complete running job request,
+requires exactly one required `full` view, recaptures and ingests the immutable
+bundle closure into the worker's retained object store, and returns an
+`IndexJobExecutionResult` without accepting a catalog, lease owner, fencing
+token, ref, or generation authority. The durable worker therefore remains the
+only final publisher. This bridge consumes an already-current compiler cache;
+it is not a source builder or production resolver, and every attempt still
+requires fresh caller-owned source, workspace receipt, and destination
+authorities. The existing self-publishing adapters remain compatibility entry
+points rather than being called from the worker.
+
 ### M2: Immutable generation publication
 
 Status: in progress. The receipt-retained, fenced SQLite publication primitive
-and the explicit BM25 and schema-8 vector compiler-cache adapters are
-implemented; graph, generic builder, and production job/runtime wiring remain.
+and the explicit BM25 and schema-8 vector compiler-cache adapters, including
+their prepare-only worker bridge, are implemented; graph, generic source
+builders, production resolution, and job/runtime wiring remain.
 
 - Make every builder write to a unique staging generation.
 - Add per-view profile adapters that fail closed on incomplete compatibility
@@ -1250,9 +1263,10 @@ implemented; graph, generic builder, and production job/runtime wiring remain.
 
 Status: in progress. Schema-v6 durable execution control is implemented for the
 local SQLite catalog. The backend-neutral prepare-only whole-job worker is
-implemented and verified with file-backed SQLite integration coverage;
-production resolver/builder adapters and CLI, runtime, Web, MCP, and default
-wiring remain absent.
+implemented and verified with file-backed SQLite integration coverage. An
+explicit one-view compiler-cache executor now supplies parser-inert BM25 or
+schema-8 vector artifacts without catalog authority; production source
+builders/resolvers and CLI, runtime, Web, MCP, and default wiring remain absent.
 
 - The backend-neutral worker now owns advisory scan/claim, per-attempt task
   authority, independent heartbeat sessions, cancellation precedence, bounded
@@ -1288,10 +1302,11 @@ wiring remain absent.
   final fenced heartbeat, and then publishes before releasing receipt
   retention. Slow object hashing therefore cannot expire an otherwise healthy
   worker and force a duplicate attempt.
-- Add production resolver and prepare-only builder adapters, then wire the
-  worker into CLI, runtime, Web, MCP, and default routes. The existing BM25 and
-  vector compiler-cache ingress adapters intentionally remain explicit
-  self-publishing paths and are not composed under this worker.
+- Add production resolver and prepare-only source-builder adapters, then wire
+  the worker into CLI, runtime, Web, MCP, and default routes. The explicit
+  compiler-cache executor may recapture an already-current single BM25 or
+  vector cache view under the worker, while the older self-publishing ingress
+  APIs remain compatibility paths and are never nested inside the worker.
 - Expose the #266 status and update APIs with accurate incremental versus
   rebuild behavior.
 - Load a complete new bundle and swap it RCU-style; pin old bundles for in-flight

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -10,6 +10,7 @@ import inspect
 import json
 import os
 import subprocess
+import threading
 from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -18,6 +19,7 @@ from typing import TypeVar
 
 import pytest
 
+import codenib.artifacts.strict_vector as strict_vector_module
 import codenib.compiler as compiler_module
 import codenib.compiler.cache_import as cache_import_module
 import codenib.index.embedding.vector_store as vector_store_module
@@ -53,6 +55,7 @@ from codenib.compiler.cache_import import (
     publish_compiler_cache_bm25_job,
     publish_compiler_cache_vector_job,
 )
+from codenib.compiler.cache_lock import compiler_cache_lock
 from codenib.compiler.index_builders import (
     BM25IndexBuilder,
     IndexBuilderRegistry,
@@ -86,6 +89,7 @@ from codenib.storage import (
     VIEW_BUNDLE_SCHEMA,
     BlobInfo,
     IndexJobStatus,
+    IndexJobStopReason,
     IndexJobWorker,
     IndexJobWorkerDisposition,
     LocalCAS,
@@ -98,6 +102,35 @@ from codenib.storage import (
 _Result = TypeVar("_Result")
 _COMMIT = "a" * 40
 _REPOSITORY_KEY = "owner/repo"
+
+
+class _TestStopToken:
+    def __init__(self, *, notify_after_checks: int | None = None) -> None:
+        self._event = threading.Event()
+        self._lock = threading.Lock()
+        self._checks = 0
+        self._notify_after_checks = notify_after_checks
+        self.polled = threading.Event()
+
+    @property
+    def reason(self) -> IndexJobStopReason | None:
+        if self._event.is_set():
+            return IndexJobStopReason.CANCEL_REQUESTED
+        return None
+
+    def is_set(self) -> bool:
+        with self._lock:
+            self._checks += 1
+            threshold = self._notify_after_checks
+            if threshold is not None and self._checks >= threshold:
+                self.polled.set()
+        return self._event.is_set()
+
+    def wait(self, timeout: float | None = None) -> bool:
+        return self._event.wait(timeout)
+
+    def set(self) -> None:
+        self._event.set()
 
 
 class _DeterministicEmbedding:
@@ -793,6 +826,7 @@ def test_compiler_cache_import_is_a_lazy_public_export() -> None:
         "embedding_model",
         "native_index_authorization",
     } & set(preparation_signature.parameters)
+    assert "stop_token" in preparation_signature.parameters
     executor_signature = inspect.signature(CompilerCacheJobExecutor)
     assert not {
         "catalog",
@@ -924,6 +958,7 @@ def _prepare_bm25_job(
     job,
     views,
     cas: LocalCAS,
+    stop_token: _TestStopToken | None = None,
 ) -> CompilerCacheJobPreparationResult:
     return prepare_compiler_cache_job_view(
         fixture.cache,
@@ -938,6 +973,7 @@ def _prepare_bm25_job(
         workspace_provider=fixture.provider,
         repository_key=_REPOSITORY_KEY,
         object_store=cas,
+        stop_token=stop_token,
         environ={},
     )
 
@@ -991,6 +1027,72 @@ def test_prepare_compiler_cache_job_view_leaves_catalog_running(
             assert len(cas.put_chunk_receipts) == 3
             assert cas.retained_receipt_sets == []
             assert fixture.provider.run_count == 2
+    finally:
+        fixture.close()
+
+
+@pytest.mark.timeout(10)
+def test_prepare_compiler_cache_job_stops_while_waiting_for_cache_lock(
+    tmp_path: Path,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    plan = _expected_bm25_job_plan(fixture)
+    token = _TestStopToken(notify_after_checks=4)
+    failures: list[BaseException] = []
+    try:
+        with (
+            _JobTrackingCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            repository_id, source_revision_id, profile_id = _register_bm25_job_subject(
+                catalog, fixture, plan
+            )
+            queued = _create_bm25_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+            )
+            catalog.acquire_job_lease(
+                queued.job_id,
+                owner_id="cancelled-prepare-worker",
+                lease_duration_ms=60_000,
+            )
+            running = catalog.get_job(queued.job_id)
+            views = catalog.get_job_views(queued.job_id)
+
+            def prepare() -> None:
+                try:
+                    _prepare_bm25_job(
+                        fixture,
+                        job=running,
+                        views=views,
+                        cas=cas,
+                        stop_token=token,
+                    )
+                except BaseException as exc:  # noqa: B036 - asserted below
+                    failures.append(exc)
+
+            with compiler_cache_lock(fixture.cache, create=False):
+                thread = threading.Thread(target=prepare)
+                thread.start()
+                assert token.polled.wait(timeout=3)
+                token.set()
+                thread.join(timeout=3)
+                assert not thread.is_alive()
+
+            assert len(failures) == 1
+            assert type(failures[0]).__name__ == "_CompilerCacheJobStopped"
+            assert str(failures[0]) == "compiler cache job preparation stopped"
+            assert catalog.get_job(queued.job_id) == running
+            assert catalog.get_job(queued.job_id).status is IndexJobStatus.RUNNING
+            assert cas.put_chunk_receipts == []
+            assert cas.retained_receipt_sets == []
+            assert fixture.provider.run_count == 0
+            assert fixture.bm25_owner.state == "empty"
+            assert fixture.context_owner.state == "empty"
+            assert not fixture.bm25_destination.exists()
+            assert not fixture.context_destination.exists()
     finally:
         fixture.close()
 
@@ -2971,6 +3073,32 @@ def _publish_vector_job(
     )
 
 
+def _prepare_vector_job(
+    fixture: _VectorJobFixture,
+    *,
+    job,
+    views,
+    cas: LocalCAS,
+    stop_token: _TestStopToken | None = None,
+) -> CompilerCacheJobPreparationResult:
+    return prepare_compiler_cache_job_view(
+        fixture.cache,
+        view_type="vector",
+        job=job,
+        views=views,
+        repository_source=fixture.source,
+        view_output_owner=fixture.vector_owner,
+        context_output_owner=fixture.context_owner,
+        view_destination=fixture.vector_destination,
+        context_destination=fixture.context_destination,
+        workspace_provider=fixture.provider,
+        repository_key=_REPOSITORY_KEY,
+        object_store=cas,
+        stop_token=stop_token,
+        environ={},
+    )
+
+
 def test_prepare_compiler_cache_vector_job_uses_only_portable_schema8(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -3043,6 +3171,125 @@ def test_prepare_compiler_cache_vector_job_uses_only_portable_schema8(
             assert len(cas.put_chunk_receipts) == 5
             assert cas.retained_receipt_sets == []
             assert catalog.get_job(queued.job_id) == running
+            assert fixture.provider.run_count == 2
+    finally:
+        fixture.close()
+
+
+def test_prepare_compiler_cache_vector_job_stops_during_document_recapture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _vector_job_fixture(tmp_path, monkeypatch, marker="STOP_RECAPTURE")
+    plan = _expected_vector_job_plan(fixture)
+    token = _TestStopToken()
+    real_normalized_documents = strict_vector_module._normalized_documents
+
+    def stop_after_first_document(*args, **kwargs):
+        for document in real_normalized_documents(*args, **kwargs):
+            token.set()
+            yield document
+
+    monkeypatch.setattr(
+        strict_vector_module,
+        "_normalized_documents",
+        stop_after_first_document,
+    )
+    try:
+        with (
+            _JobTrackingCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            repository_id, source_revision_id, profile_id = (
+                _register_vector_job_subject(catalog, fixture, plan)
+            )
+            queued = _create_vector_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+            )
+            catalog.acquire_job_lease(
+                queued.job_id,
+                owner_id="stopped-vector-worker",
+                lease_duration_ms=60_000,
+            )
+            running = catalog.get_job(queued.job_id)
+            views = catalog.get_job_views(queued.job_id)
+
+            with pytest.raises(
+                RuntimeError,
+                match="compiler cache job preparation stopped",
+            ):
+                _prepare_vector_job(
+                    fixture,
+                    job=running,
+                    views=views,
+                    cas=cas,
+                    stop_token=token,
+                )
+
+            assert token.reason is IndexJobStopReason.CANCEL_REQUESTED
+            assert catalog.get_job(queued.job_id) == running
+            assert catalog.get_job(queued.job_id).status is IndexJobStatus.RUNNING
+            assert cas.put_chunk_receipts == []
+            assert cas.retained_receipt_sets == []
+            assert fixture.provider.run_count == 0
+            assert fixture.vector_owner.state == "empty"
+            assert fixture.context_owner.state == "empty"
+            assert not fixture.vector_destination.exists()
+            assert not fixture.context_destination.exists()
+    finally:
+        fixture.close()
+
+
+def test_prepare_compiler_cache_vector_job_stops_between_cas_objects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _vector_job_fixture(tmp_path, monkeypatch, marker="STOP_CAS")
+    plan = _expected_vector_job_plan(fixture)
+    token = _TestStopToken()
+    try:
+        with (
+            _JobTrackingCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            repository_id, source_revision_id, profile_id = (
+                _register_vector_job_subject(catalog, fixture, plan)
+            )
+            queued = _create_vector_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+            )
+            catalog.acquire_job_lease(
+                queued.job_id,
+                owner_id="stopped-cas-worker",
+                lease_duration_ms=60_000,
+            )
+            running = catalog.get_job(queued.job_id)
+            views = catalog.get_job_views(queued.job_id)
+            cas.after_put = lambda count: token.set() if count == 1 else None
+
+            with pytest.raises(
+                RuntimeError,
+                match="compiler cache job preparation stopped",
+            ):
+                _prepare_vector_job(
+                    fixture,
+                    job=running,
+                    views=views,
+                    cas=cas,
+                    stop_token=token,
+                )
+
+            assert token.reason is IndexJobStopReason.CANCEL_REQUESTED
+            assert catalog.get_job(queued.job_id) == running
+            assert catalog.get_job(queued.job_id).status is IndexJobStatus.RUNNING
+            assert len(cas.put_chunk_receipts) == 1
+            assert cas.retained_receipt_sets == []
             assert fixture.provider.run_count == 2
     finally:
         fixture.close()

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -37,6 +37,8 @@ from codenib.artifacts import query_context_artifact
 from codenib.compiler.cache_import import (
     CompilerCacheBm25RecaptureResult,
     CompilerCacheImportResult,
+    CompilerCacheJobExecutor,
+    CompilerCacheJobPreparationResult,
     CompilerCacheJobPublicationResult,
     CompilerCacheMultiViewImportResult,
     CompilerCacheTopologyGuard,
@@ -47,6 +49,7 @@ from codenib.compiler.cache_import import (
     compiler_cache_source_selection,
     import_compiler_cache,
     import_compiler_cache_bm25,
+    prepare_compiler_cache_job_view,
     publish_compiler_cache_bm25_job,
     publish_compiler_cache_vector_job,
 )
@@ -83,6 +86,8 @@ from codenib.storage import (
     VIEW_BUNDLE_SCHEMA,
     BlobInfo,
     IndexJobStatus,
+    IndexJobWorker,
+    IndexJobWorkerDisposition,
     LocalCAS,
     PublishConflict,
     SQLiteCatalog,
@@ -331,6 +336,36 @@ class _RetentionAwareJobCatalog(SQLiteCatalog):
         assert self._tracking_cas.retention_active
         self.job_publication_calls += 1
         return super().publish_job_outputs(*args, **kwargs)
+
+
+class _CompilerCacheWorkerCatalog(SQLiteCatalog):
+    def __init__(self, path: Path, publication_calls: list[str]) -> None:
+        self._publication_calls = publication_calls
+        super().__init__(path, create=False)
+
+    def publish_job_outputs(self, job_id: str, **kwargs):
+        self._publication_calls.append(job_id)
+        return super().publish_job_outputs(job_id, **kwargs)
+
+
+class _CompilerCacheWorkerFactory:
+    def __init__(self, path: Path, publication_calls: list[str]) -> None:
+        self.path = path
+        self.publication_calls = publication_calls
+
+    def __call__(self) -> _CompilerCacheWorkerCatalog:
+        return _CompilerCacheWorkerCatalog(self.path, self.publication_calls)
+
+
+class _StaticCompilerCacheResolver:
+    def __init__(self, executor: CompilerCacheJobExecutor) -> None:
+        self.executor = executor
+        self.calls = 0
+
+    def resolve(self, job, views):
+        assert tuple(view.job_id for view in views) == (job.job_id,) * len(views)
+        self.calls += 1
+        return self.executor
 
 
 class _LockAwareCatalog(SQLiteCatalog):
@@ -628,6 +663,11 @@ def test_compiler_cache_import_is_a_lazy_public_export() -> None:
         compiler_module.CompilerCacheJobPublicationResult
         is CompilerCacheJobPublicationResult
     )
+    assert compiler_module.CompilerCacheJobExecutor is CompilerCacheJobExecutor
+    assert (
+        compiler_module.CompilerCacheJobPreparationResult
+        is CompilerCacheJobPreparationResult
+    )
     assert (
         compiler_module.CompilerCacheVectorJobPublicationResult
         is CompilerCacheVectorJobPublicationResult
@@ -655,6 +695,10 @@ def test_compiler_cache_import_is_a_lazy_public_export() -> None:
     assert (
         compiler_module.publish_compiler_cache_vector_job
         is publish_compiler_cache_vector_job
+    )
+    assert (
+        compiler_module.prepare_compiler_cache_job_view
+        is prepare_compiler_cache_job_view
     )
     assert list(inspect.signature(import_compiler_cache).parameters)[:11] == [
         "cache_dir",
@@ -723,6 +767,40 @@ def test_compiler_cache_import_is_a_lazy_public_export() -> None:
         "embedding_load_policy",
         "native_index_authorization",
     } & set(vector_job_signature.parameters)
+    preparation_signature = inspect.signature(prepare_compiler_cache_job_view)
+    assert list(preparation_signature.parameters)[:13] == [
+        "cache_dir",
+        "view_type",
+        "job",
+        "views",
+        "repository_source",
+        "view_output_owner",
+        "context_output_owner",
+        "view_destination",
+        "context_destination",
+        "workspace_provider",
+        "repository_key",
+        "object_store",
+        "namespace_name",
+    ]
+    assert not {
+        "catalog",
+        "owner_id",
+        "fencing_token",
+        "ref_name",
+        "expected_generation",
+        "embedding_provider",
+        "embedding_model",
+        "native_index_authorization",
+    } & set(preparation_signature.parameters)
+    executor_signature = inspect.signature(CompilerCacheJobExecutor)
+    assert not {
+        "catalog",
+        "owner_id",
+        "fencing_token",
+        "ref_name",
+        "expected_generation",
+    } & set(executor_signature.parameters)
     compile_signature = inspect.signature(compile_and_import_repo)
     assert list(compile_signature.parameters)[:4] == [
         "compiler",
@@ -838,6 +916,212 @@ def _publish_bm25_job(
         object_store=cas,
         environ={},
     )
+
+
+def _prepare_bm25_job(
+    fixture: _CacheFixture,
+    *,
+    job,
+    views,
+    cas: LocalCAS,
+) -> CompilerCacheJobPreparationResult:
+    return prepare_compiler_cache_job_view(
+        fixture.cache,
+        view_type="bm25",
+        job=job,
+        views=views,
+        repository_source=fixture.source,
+        view_output_owner=fixture.bm25_owner,
+        context_output_owner=fixture.context_owner,
+        view_destination=fixture.bm25_destination,
+        context_destination=fixture.context_destination,
+        workspace_provider=fixture.provider,
+        repository_key=_REPOSITORY_KEY,
+        object_store=cas,
+        environ={},
+    )
+
+
+def test_prepare_compiler_cache_job_view_leaves_catalog_running(
+    tmp_path: Path,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    plan = _expected_bm25_job_plan(fixture)
+    try:
+        with (
+            _JobTrackingCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            repository_id, source_revision_id, profile_id = _register_bm25_job_subject(
+                catalog, fixture, plan
+            )
+            queued = _create_bm25_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+            )
+            catalog.acquire_job_lease(
+                queued.job_id,
+                owner_id="prepare-only-worker",
+                lease_duration_ms=60_000,
+            )
+            running = catalog.get_job(queued.job_id)
+            views = catalog.get_job_views(queued.job_id)
+
+            result = _prepare_bm25_job(
+                fixture,
+                job=running,
+                views=views,
+                cas=cas,
+            )
+
+            assert type(result) is CompilerCacheJobPreparationResult
+            assert result.job == running
+            assert result.view == views[0]
+            assert result.manifest.to_dict() == result.import_plan.manifest.to_dict()
+            assert result.recapture.view_type == "bm25"
+            assert result.context_artifact.views == ("bm25",)
+            assert result.artifact.view_type == "bm25"
+            assert result.artifact.profile_id == profile_id
+            assert result.artifact.schema_version == VIEW_BUNDLE_SCHEMA
+            assert len(result.artifact.member_artifacts) == 2
+            assert catalog.get_job(queued.job_id) == running
+            assert catalog.get_job(queued.job_id).status is IndexJobStatus.RUNNING
+            assert len(cas.put_chunk_receipts) == 3
+            assert cas.retained_receipt_sets == []
+            assert fixture.provider.run_count == 2
+    finally:
+        fixture.close()
+
+
+@pytest.mark.parametrize("case", ("profile", "source", "request"))
+def test_prepare_compiler_cache_job_rejects_mismatch_before_workspace_or_cas(
+    tmp_path: Path,
+    case: str,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    plan = _expected_bm25_job_plan(fixture)
+    try:
+        with (
+            _JobTrackingCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            repository_id, source_revision_id, profile_id = _register_bm25_job_subject(
+                catalog, fixture, plan
+            )
+            requested_mode = "full"
+            if case == "profile":
+                profile_id = catalog.create_view_profile(
+                    "bm25",
+                    {"builder": "incompatible"},
+                )
+            elif case == "source":
+                source_revision_id = catalog.create_source_revision(
+                    repository_id,
+                    commit_sha=None,
+                    dirty=True,
+                    source_fingerprint="other-source-fingerprint",
+                )
+            else:
+                requested_mode = "incremental"
+            queued = _create_bm25_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+                requested_mode=requested_mode,
+            )
+            catalog.acquire_job_lease(
+                queued.job_id,
+                owner_id="prepare-only-worker",
+                lease_duration_ms=60_000,
+            )
+
+            with pytest.raises(StorageValidationError):
+                _prepare_bm25_job(
+                    fixture,
+                    job=catalog.get_job(queued.job_id),
+                    views=catalog.get_job_views(queued.job_id),
+                    cas=cas,
+                )
+
+            assert cas.put_chunk_receipts == []
+            assert cas.retained_receipt_sets == []
+            assert fixture.provider.run_count == 0
+            assert fixture.bm25_owner.state == "empty"
+            assert fixture.context_owner.state == "empty"
+            assert not fixture.bm25_destination.exists()
+            assert not fixture.context_destination.exists()
+    finally:
+        fixture.close()
+
+
+def test_compiler_cache_executor_delegates_only_final_publish_to_worker(
+    tmp_path: Path,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    plan = _expected_bm25_job_plan(fixture)
+    catalog_path = tmp_path / "worker.sqlite"
+    publication_calls: list[str] = []
+    try:
+        with _JobTrackingCAS(tmp_path / "cas") as cas:
+            with SQLiteCatalog(catalog_path) as catalog:
+                (
+                    repository_id,
+                    source_revision_id,
+                    profile_id,
+                ) = _register_bm25_job_subject(catalog, fixture, plan)
+                queued = _create_bm25_job(
+                    catalog,
+                    repository_id=repository_id,
+                    source_revision_id=source_revision_id,
+                    profile_id=profile_id,
+                )
+
+            executor = CompilerCacheJobExecutor(
+                cache_dir=fixture.cache,
+                view_type="bm25",
+                repository_source=fixture.source,
+                view_output_owner=fixture.bm25_owner,
+                context_output_owner=fixture.context_owner,
+                view_destination=fixture.bm25_destination,
+                context_destination=fixture.context_destination,
+                workspace_provider=fixture.provider,
+                repository_key=_REPOSITORY_KEY,
+                object_store=cas,
+                environ={},
+            )
+            resolver = _StaticCompilerCacheResolver(executor)
+            worker = IndexJobWorker(
+                catalog_factory=_CompilerCacheWorkerFactory(
+                    catalog_path,
+                    publication_calls,
+                ),
+                object_store=cas,
+                resolver=resolver,
+                lease_duration_ms=60_000,
+                heartbeat_interval_ms=5,
+                owner_id_factory=lambda: "compiler-cache-worker",
+            )
+
+            outcome = worker.run_once()
+
+            assert outcome.disposition is IndexJobWorkerDisposition.SUCCEEDED
+            assert outcome.job_id == queued.job_id
+            assert resolver.calls == 1
+            assert publication_calls == [queued.job_id]
+            assert len(cas.put_chunk_receipts) == 3
+            assert len(cas.retained_receipt_sets) == 1
+            with SQLiteCatalog(catalog_path, create=False) as catalog:
+                completed = catalog.get_job(queued.job_id)
+                assert completed.status is IndexJobStatus.SUCCEEDED
+                assert completed.result_snapshot_id is not None
+                summary = catalog.get_manifest_summary(completed.result_snapshot_id)
+                assert tuple(summary["views"]) == ("bm25",)
+                assert summary["views"]["bm25"]["profile"]["profile_id"] == (profile_id)
+    finally:
+        fixture.close()
 
 
 def _seed_bm25_snapshot(
@@ -2685,6 +2969,83 @@ def _publish_vector_job(
         object_store=cas,
         environ={},
     )
+
+
+def test_prepare_compiler_cache_vector_job_uses_only_portable_schema8(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _vector_job_fixture(tmp_path, monkeypatch, marker="PREPARE_VECTOR")
+    plan = _expected_vector_job_plan(fixture)
+
+    def native_or_builder_must_not_run(*_args, **_kwargs):
+        raise AssertionError("vector preparation invoked a native parser or builder")
+
+    monkeypatch.setattr(
+        vector_store_module.faiss,
+        "read_index",
+        native_or_builder_must_not_run,
+    )
+    monkeypatch.setattr(
+        vector_store_module.compat_pickle,
+        "load",
+        native_or_builder_must_not_run,
+    )
+    monkeypatch.setattr(
+        "codenib.index.embedding.builders.build_hierarchical_vector_store",
+        native_or_builder_must_not_run,
+    )
+    try:
+        with (
+            _JobTrackingCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            repository_id, source_revision_id, profile_id = (
+                _register_vector_job_subject(catalog, fixture, plan)
+            )
+            queued = _create_vector_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+            )
+            catalog.acquire_job_lease(
+                queued.job_id,
+                owner_id="prepare-vector-worker",
+                lease_duration_ms=60_000,
+            )
+            running = catalog.get_job(queued.job_id)
+            views = catalog.get_job_views(queued.job_id)
+
+            result = prepare_compiler_cache_job_view(
+                fixture.cache,
+                view_type="vector",
+                job=running,
+                views=views,
+                repository_source=fixture.source,
+                view_output_owner=fixture.vector_owner,
+                context_output_owner=fixture.context_owner,
+                view_destination=fixture.vector_destination,
+                context_destination=fixture.context_destination,
+                workspace_provider=fixture.provider,
+                repository_key=_REPOSITORY_KEY,
+                object_store=cas,
+                environ={},
+            )
+
+            assert type(result) is CompilerCacheJobPreparationResult
+            assert result.job == running
+            assert result.view == views[0]
+            assert result.recapture.view_type == "vector"
+            assert result.import_plan.views[0].profile.config["builder_schema"] == 8
+            assert result.artifact.schema_version == VIEW_BUNDLE_SCHEMA
+            assert len(result.artifact.member_artifacts) == 4
+            assert len(cas.put_chunk_receipts) == 5
+            assert cas.retained_receipt_sets == []
+            assert catalog.get_job(queued.job_id) == running
+            assert fixture.provider.run_count == 2
+    finally:
+        fixture.close()
 
 
 def _seed_vector_snapshot(

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -19,6 +19,7 @@ from typing import TypeVar
 
 import pytest
 
+import codenib.artifacts.portable_views as portable_views_module
 import codenib.artifacts.strict_vector as strict_vector_module
 import codenib.compiler as compiler_module
 import codenib.compiler.cache_import as cache_import_module
@@ -3236,6 +3237,89 @@ def test_prepare_compiler_cache_vector_job_stops_during_document_recapture(
             assert cas.retained_receipt_sets == []
             assert fixture.provider.run_count == 0
             assert fixture.vector_owner.state == "empty"
+            assert fixture.context_owner.state == "empty"
+            assert not fixture.vector_destination.exists()
+            assert not fixture.context_destination.exists()
+    finally:
+        fixture.close()
+
+
+def test_prepare_compiler_cache_vector_job_stops_during_candidate_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _vector_job_fixture(tmp_path, monkeypatch, marker="STOP_VALIDATE")
+    plan = _expected_vector_job_plan(fixture)
+    token = _TestStopToken()
+    candidate_scan_reached = threading.Event()
+    real_iter_documents = portable_views_module.iter_bounded_json_array
+    real_assert_no_secrets = portable_views_module.assert_no_secret_fields
+
+    def stop_when_candidate_document_is_parsed(*args, **kwargs):
+        for document in real_iter_documents(*args, **kwargs):
+            token.set()
+            candidate_scan_reached.set()
+            yield document
+
+    def reject_work_after_stop(value, *, source):
+        if token.reason is not None and source.startswith("portable vector document"):
+            pytest.fail("candidate validation continued after cancellation")
+        return real_assert_no_secrets(value, source=source)
+
+    monkeypatch.setattr(
+        portable_views_module,
+        "iter_bounded_json_array",
+        stop_when_candidate_document_is_parsed,
+    )
+    monkeypatch.setattr(
+        portable_views_module,
+        "assert_no_secret_fields",
+        reject_work_after_stop,
+    )
+    try:
+        with (
+            _JobTrackingCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            repository_id, source_revision_id, profile_id = (
+                _register_vector_job_subject(catalog, fixture, plan)
+            )
+            queued = _create_vector_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+            )
+            catalog.acquire_job_lease(
+                queued.job_id,
+                owner_id="stopped-validation-worker",
+                lease_duration_ms=60_000,
+            )
+            running = catalog.get_job(queued.job_id)
+            views = catalog.get_job_views(queued.job_id)
+
+            with pytest.raises(
+                RuntimeError,
+                match="compiler cache job preparation stopped",
+            ):
+                _prepare_vector_job(
+                    fixture,
+                    job=running,
+                    views=views,
+                    cas=cas,
+                    stop_token=token,
+                )
+
+            assert candidate_scan_reached.is_set()
+            assert token.reason is IndexJobStopReason.CANCEL_REQUESTED
+            assert catalog.get_job(queued.job_id) == running
+            assert catalog.get_job(queued.job_id).status is IndexJobStatus.RUNNING
+            assert cas.put_chunk_receipts == []
+            assert cas.retained_receipt_sets == []
+            assert fixture.provider.run_count == 1
+            # Validation began after the workspace was staged, so the receipt
+            # owner retains its cleanup authority until the fixture closes it.
+            assert fixture.vector_owner.state == "cleanup"
             assert fixture.context_owner.state == "empty"
             assert not fixture.vector_destination.exists()
             assert not fixture.context_destination.exists()

--- a/test/compiler/test_cache_lock.py
+++ b/test/compiler/test_cache_lock.py
@@ -478,6 +478,51 @@ def test_serializes_threads(tmp_path: Path) -> None:
     assert errors == []
 
 
+@pytest.mark.timeout(5)
+def test_interruptible_wait_releases_claim_without_entering_cache(
+    tmp_path: Path,
+) -> None:
+    cache = tmp_path / "cache"
+    polled = threading.Event()
+    cancelled = threading.Event()
+    entered = threading.Event()
+    failures: list[BaseException] = []
+
+    class LockWaitCancelled(RuntimeError):
+        pass
+
+    def check_cancelled() -> None:
+        polled.set()
+        if cancelled.is_set():
+            raise LockWaitCancelled("stop requested")
+
+    def contender() -> None:
+        try:
+            with compiler_cache_lock(
+                cache,
+                create=False,
+                check_cancelled=check_cancelled,
+            ):
+                entered.set()
+        except BaseException as exc:  # noqa: B036 - asserted in parent
+            failures.append(exc)
+
+    with compiler_cache_lock(cache):
+        thread = threading.Thread(target=contender)
+        thread.start()
+        assert polled.wait(timeout=2)
+        assert not entered.is_set()
+        cancelled.set()
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+
+    assert not entered.is_set()
+    assert len(failures) == 1
+    assert type(failures[0]) is LockWaitCancelled
+    with compiler_cache_lock(cache, create=False):
+        pass
+
+
 @pytest.mark.skipif(
     os.name not in {"posix", "nt"},
     reason="requires a supported process-locking platform",


### PR DESCRIPTION
## Summary

Add the first catalog-free compiler-cache executor for the durable worker introduced by #692. It prepares an exact current BM25 or schema-8 vector artifact closure while keeping final publication solely under `IndexJobWorker` authority.

Related to #199.

## Changes

- Add `CompilerCacheJobPreparationResult`, `prepare_compiler_cache_job_view`, and `CompilerCacheJobExecutor` as lazy public compiler exports.
- Authenticate one exact running job with one required `FULL` BM25 or vector view, without accepting catalog, owner, fence, ref, or generation authority.
- Recapture immutable BM25 or parser-inert schema-8 vector evidence into the same retained object store used by the enclosing worker.
- Reuse one ingestion path for prepare-only execution and the legacy self-publishing compatibility APIs without nesting those APIs inside the worker.
- Prove mismatch failures happen before workspace/CAS mutation and prove a real SQLite-backed worker performs exactly one final publication.
- Update the M2/M3 status and remaining production-routing boundary in `docs/storage_backend_roadmap.md`.

This PR does not add a source builder, production resolver, CLI/runtime/Web/MCP wiring, RCU switching, or a default-route change.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- Focused executor/preparation coverage: 7 passed.
- `python -m pytest test/compiler/test_cache_import.py --tb=short`: 76 passed, 1 skipped. One preceding run hit the existing source-inventory metadata timing case; its exact rerun and the complete file rerun passed.
- `python -m pytest test/compiler --tb=short`: 895 passed, 6 skipped.
- `python -m mkdocs build --strict`: passed.
- Pinned Black 24.8.0, isort 5.13.2, and flake8 7.1.1 + bugbear hook environments: passed.
- `git diff --check origin/main...HEAD`: passed.
- The broader unit marker was attempted earlier and stopped only at the unchanged-base native workspace-owner test because this host lacks the required extension; the same exact test failed on the unmodified #692 tree. PR CI supplies the native-enabled unit gate.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
