### PR TITLE
fix(storage): renew leases through publication retention

### DIFF
--- a/codenib/storage/job_worker.py
+++ b/codenib/storage/job_worker.py
@@ -753,6 +753,14 @@ class _ClaimAuthorityLost(Exception):
         self.authority = authority
 
 
+class _PublicationAuthorityLost(Exception):
+    """Stop retained publication after its heartbeat authority was lost."""
+
+
+class _PublicationCancelRequested(Exception):
+    """Stop retained publication after observing durable cancellation."""
+
+
 class _AttemptCausalEvidence:
     """Thread-safe causal frontier and exact worker-observed event evidence."""
 
@@ -1660,6 +1668,7 @@ class IndexJobWorker:
         result: IndexJobExecutionResult | None = None
         failure_code: str | None = None
         phase_base_exception: BaseException | None = None
+        keep_heartbeat_for_publication = False
         try:
             pump.start()
             if not stop_state.is_set():
@@ -1739,11 +1748,81 @@ class IndexJobWorker:
             except BaseException as exc:  # noqa: B036 - preserve first failure
                 if phase_base_exception is None:
                     phase_base_exception = exc
-            try:
+            keep_heartbeat_for_publication = (
+                phase_base_exception is None
+                and control.fault is None
+                and pump.fault is None
+                and not stop_state.is_set()
+                and failure_code is None
+                and result is not None
+                and result.publishable
+            )
+            if not keep_heartbeat_for_publication:
+                try:
+                    pump.stop_and_join()
+                except BaseException as exc:  # noqa: B036 - preserve first failure
+                    if phase_base_exception is None:
+                        phase_base_exception = exc
+
+        if keep_heartbeat_for_publication:
+            heartbeat_settled = False
+
+            def settle_heartbeat() -> None:
+                nonlocal heartbeat_settled
                 pump.stop_and_join()
-            except BaseException as exc:  # noqa: B036 - preserve first failure
-                if phase_base_exception is None:
-                    phase_base_exception = exc
+                heartbeat_settled = True
+                if pump.fault is not None:
+                    raise pump.fault
+
+            def before_catalog_publish() -> None:
+                settle_heartbeat()
+                if stop_state.reason is IndexJobStopReason.AUTHORITY_LOST:
+                    raise _PublicationAuthorityLost
+                if stop_state.reason is IndexJobStopReason.CANCEL_REQUESTED:
+                    raise _PublicationCancelRequested
+                heartbeat = self._final_heartbeat(
+                    catalog,
+                    authority,
+                    causal_evidence,
+                )
+                if heartbeat is None:
+                    raise _PublicationAuthorityLost
+                if heartbeat.cancel_requested:
+                    raise _PublicationCancelRequested
+
+            publication_failure: BaseException | None = None
+            try:
+                terminal = self._reconcile_attempt(
+                    catalog,
+                    authority,
+                    causal_floor_ms=causal_evidence.causal_floor_ms,
+                )
+                if terminal is not None:
+                    settle_heartbeat()
+                    return terminal
+                return self._publish_result(
+                    catalog,
+                    job,
+                    authority,
+                    result,
+                    causal_evidence,
+                    before_catalog_publish=before_catalog_publish,
+                )
+            except BaseException as exc:  # noqa: B036 - settle before rethrow
+                publication_failure = exc
+                raise
+            finally:
+                if not heartbeat_settled:
+                    try:
+                        pump.stop_and_join()
+                    except BaseException as cleanup_exc:  # noqa: B036
+                        if publication_failure is None:
+                            raise
+                        _add_secondary_exception_note(
+                            publication_failure,
+                            cleanup_exc,
+                            "heartbeat cleanup also failed",
+                        )
 
         if phase_base_exception is not None:
             raise phase_base_exception
@@ -2446,10 +2525,22 @@ class IndexJobWorker:
         authority: _AttemptAuthority,
         result: IndexJobExecutionResult,
         causal_evidence: _AttemptCausalEvidence,
+        *,
+        before_catalog_publish: Callable[[], None] | None = None,
     ) -> IndexJobWorkerRunResult:
         _artifacts, expected_outputs, _receipts = _preflight_job_artifacts(
             result.artifacts
         )
+        pre_catalog_failure: BaseException | None = None
+
+        def run_before_catalog_publish() -> None:
+            nonlocal pre_catalog_failure
+            try:
+                assert before_catalog_publish is not None
+                before_catalog_publish()
+            except BaseException as exc:  # noqa: B036 - exact rethrow below
+                pre_catalog_failure = exc
+                raise
 
         def reconcile_conflict() -> IndexJobWorkerRunResult | None:
             causal_floor_ms = causal_evidence.causal_floor_ms
@@ -2461,7 +2552,6 @@ class IndexJobWorker:
                 allow_competing_non_success=True,
             )
 
-        causal_floor_ms = causal_evidence.causal_floor_ms
         try:
             completed = publish_job_artifacts(
                 authority.job_id,
@@ -2471,10 +2561,33 @@ class IndexJobWorker:
                 fencing_token=authority.fencing_token,
                 outputs=result.artifacts,
                 _retention_cleanup_as_integrity=True,
+                _before_catalog_publish=(
+                    run_before_catalog_publish
+                    if before_catalog_publish is not None
+                    else None
+                ),
+            )
+        except _PublicationCancelRequested:
+            return self._complete_attempt(
+                catalog,
+                authority,
+                outcome=IndexJobCompletion.CANCELLED,
+                error_code=None,
+                error_message=None,
+                causal_evidence=causal_evidence,
+            )
+        except _PublicationAuthorityLost:
+            terminal = reconcile_conflict()
+            return terminal or self._run_result(
+                IndexJobWorkerDisposition.LOST_AUTHORITY,
+                authority,
             )
         except Exception as exc:
+            if exc is pre_catalog_failure:
+                raise
             if isinstance(exc, StorageIntegrityError):
                 raise
+            causal_floor_ms = causal_evidence.causal_floor_ms
             if isinstance(exc, PublishConflict):
                 terminal = reconcile_conflict()
             else:
@@ -2517,6 +2630,7 @@ class IndexJobWorker:
                 error_message=None,
                 causal_evidence=causal_evidence,
             )
+        causal_floor_ms = causal_evidence.causal_floor_ms
         completed = _attest_job_identity(completed, authority)
         _attest_completed_publication(
             completed,

--- a/codenib/storage/publication.py
+++ b/codenib/storage/publication.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from itertools import islice
 from typing import Any
@@ -245,13 +245,16 @@ def publish_job_artifacts(
     fencing_token: int,
     outputs: Sequence[IndexJobViewArtifact],
     _retention_cleanup_as_integrity: bool = False,
+    _before_catalog_publish: Callable[[], None] | None = None,
 ) -> IndexJobRecord:
     """Retain exact receipts while the catalog atomically publishes them.
 
     No catalog read occurs before the object store has revalidated and retained
     the complete receipt set. The retention callback encloses the catalog's
     ``BEGIN IMMEDIATE`` through commit/rollback and validates the returned
-    successful job before allowing the retention scope to end.
+    successful job before allowing the retention scope to end. The private
+    pre-publication hook, when supplied, runs inside that retention scope after
+    receipt verification and immediately before the catalog mutation.
     """
 
     normalized_job_id = _bounded_exact_text(job_id, "job ID", 80)
@@ -262,6 +265,8 @@ def publish_job_artifacts(
     # after an attested callback for catalog commit-response loss.
     if type(_retention_cleanup_as_integrity) is not bool:
         raise TypeError("retention cleanup policy must be an exact boolean")
+    if _before_catalog_publish is not None and not callable(_before_catalog_publish):
+        raise TypeError("pre-publication hook must be callable")
     _artifacts, frozen_outputs, retained_receipts = _preflight_job_artifacts(outputs)
 
     if not isinstance(object_store, ReceiptRetainingObjectStore):
@@ -296,6 +301,8 @@ def publish_job_artifacts(
             if callback_violation is None:
                 callback_violation = violation
             raise violation
+        if _before_catalog_publish is not None:
+            _before_catalog_publish()
         completed = catalog.publish_job_outputs(
             normalized_job_id,
             owner_id=normalized_owner,

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1282,6 +1282,12 @@ wiring remain absent.
   surfaced as an integrity alarm rather than mistaken for catalog response
   loss, while direct publication callers retain their established exception
   identity contract.
+- Publication preflight and exact receipt revalidation remain covered by the
+  attempt heartbeat. The pump settles only inside the retained callback, where
+  the worker checks heartbeat fault, cancellation, and authority, performs one
+  final fenced heartbeat, and then publishes before releasing receipt
+  retention. Slow object hashing therefore cannot expire an otherwise healthy
+  worker and force a duplicate attempt.
 - Add production resolver and prepare-only builder adapters, then wire the
   worker into CLI, runtime, Web, MCP, and default routes. The existing BM25 and
   vector compiler-cache ingress adapters intentionally remain explicit

--- a/test/storage/test_job_publication_coordinator.py
+++ b/test/storage/test_job_publication_coordinator.py
@@ -354,6 +354,10 @@ def test_retention_encloses_catalog_transaction_and_return_attestation() -> None
     store = _RetainingOnlyStore(events)
     catalog = _CatalogSpy(completed, store, events)
 
+    def before_catalog_publish() -> None:
+        assert store.active
+        events.append("pre-catalog-hook")
+
     result = publish_job_artifacts(
         completed.job_id,
         catalog=catalog,  # type: ignore[arg-type]
@@ -361,11 +365,13 @@ def test_retention_encloses_catalog_transaction_and_return_attestation() -> None
         owner_id="worker-1",
         fencing_token=7,
         outputs=outputs,
+        _before_catalog_publish=before_catalog_publish,
     )
 
     assert result == completed
     assert events == [
         "retain-enter",
+        "pre-catalog-hook",
         "catalog-enter",
         "catalog-return",
         "callback-returned",
@@ -375,6 +381,35 @@ def test_retention_encloses_catalog_transaction_and_return_attestation() -> None
     assert tuple(output.view_type for output in catalog.outputs) == ("bm25",)
     assert isinstance(store, ReceiptRetainingObjectStore)
     assert not isinstance(store, StreamingObjectStore)
+
+
+def test_prepublication_hook_failure_is_exact_and_skips_the_catalog() -> None:
+    outputs = (_artifact("bm25", "1", b"primary"),)
+    completed = _completed_job(outputs)
+    events: list[object] = []
+    store = _RetainingOnlyStore(events)
+    catalog = _CatalogSpy(completed, store, events)
+    failure = RuntimeError("pre-catalog hook failed")
+
+    def fail_before_catalog_publish() -> None:
+        assert store.active
+        events.append("pre-catalog-hook")
+        raise failure
+
+    with pytest.raises(RuntimeError) as caught:
+        publish_job_artifacts(
+            completed.job_id,
+            catalog=catalog,  # type: ignore[arg-type]
+            object_store=store,
+            owner_id="worker-1",
+            fencing_token=7,
+            outputs=outputs,
+            _before_catalog_publish=fail_before_catalog_publish,
+        )
+
+    assert caught.value is failure
+    assert events == ["retain-enter", "pre-catalog-hook", "retain-exit"]
+    assert catalog.calls == 0
 
 
 def test_receipts_are_frozen_sorted_and_deduplicated_before_retention() -> None:

--- a/test/storage/test_job_worker.py
+++ b/test/storage/test_job_worker.py
@@ -2248,7 +2248,120 @@ def test_interrupted_heartbeat_settle_finishes_cleanup_before_rethrow(
     assert caught.value is failure
     assert backend.completion_calls == []
     assert backend.publication_calls == []
+    # Publication now keeps renewing through receipt verification and settles
+    # the pump only inside the retained callback, before the catalog mutation.
+    assert len(store.retained) == 1
+    assert set(backend.sessions) == set(backend.closed_sessions)
+    assert not any(
+        thread.name.startswith("codenib-job-heartbeat-")
+        for thread in threading.enumerate()
+    )
+
+
+@pytest.mark.parametrize("failure_phase", ("settle", "final_heartbeat"))
+def test_prepublication_failure_is_not_reclassified_as_response_loss(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_phase: str,
+) -> None:
+    backend = _Backend()
+    job = backend.add_job(f"prepublication-{failure_phase}")
+    worker, store, _factory = _worker(backend, _default_resolver())
+    failure = RuntimeError(f"{failure_phase} failed before catalog publication")
+
+    def commit_takeover() -> None:
+        session_id = backend.main_session_id
+        assert session_id is not None
+        _FakeCatalog(backend, session_id)._commit_takeover(
+            job.job_id,
+            lease_duration_ms=300,
+        )
+
+    if failure_phase == "settle":
+        original_stop = job_worker_module._HeartbeatPump.stop_and_join
+        armed = True
+
+        def stop_then_fail(pump: object) -> None:
+            nonlocal armed
+            original_stop(pump)  # type: ignore[arg-type]
+            if armed:
+                armed = False
+                commit_takeover()
+                raise failure
+
+        monkeypatch.setattr(
+            job_worker_module._HeartbeatPump,
+            "stop_and_join",
+            stop_then_fail,
+        )
+    else:
+
+        def heartbeat_then_fail(*_args: object) -> None:
+            commit_takeover()
+            raise failure
+
+        monkeypatch.setattr(worker, "_final_heartbeat", heartbeat_then_fail)
+
+    with pytest.raises(RuntimeError) as caught:
+        worker.run_once()
+
+    assert caught.value is failure
+    assert len(store.retained) == 1
+    assert backend.publication_calls == []
+    assert backend.completions[(job.job_id, 1)].outcome is IndexJobCompletion.REQUEUE
+    assert backend.jobs[job.job_id].attempt_count == 2
+    assert set(backend.sessions) == set(backend.closed_sessions)
+    assert not any(
+        thread.name.startswith("codenib-job-heartbeat-")
+        for thread in threading.enumerate()
+    )
+
+
+def test_prepublication_terminal_does_not_hide_a_pending_heartbeat_fault(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = _Backend()
+    job = backend.add_job("prepublication-terminal-heartbeat-fault")
+    worker, store, _factory = _worker(backend, _default_resolver())
+    failure = RuntimeError("heartbeat failed while terminal state was reconciled")
+    original_reconcile = worker._reconcile_attempt
+    original_stop = job_worker_module._HeartbeatPump.stop_and_join
+    takeover_armed = True
+    fault_armed = True
+
+    def reconcile_after_takeover(*args: object, **kwargs: object):
+        nonlocal takeover_armed
+        if takeover_armed:
+            takeover_armed = False
+            session_id = backend.main_session_id
+            assert session_id is not None
+            _FakeCatalog(backend, session_id)._commit_takeover(
+                job.job_id,
+                lease_duration_ms=300,
+            )
+        return original_reconcile(*args, **kwargs)
+
+    def stop_then_fault(pump: object) -> None:
+        nonlocal fault_armed
+        original_stop(pump)  # type: ignore[arg-type]
+        if fault_armed:
+            fault_armed = False
+            pump.fault = failure  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(worker, "_reconcile_attempt", reconcile_after_takeover)
+    monkeypatch.setattr(
+        job_worker_module._HeartbeatPump,
+        "stop_and_join",
+        stop_then_fault,
+    )
+
+    with pytest.raises(RuntimeError) as caught:
+        worker.run_once()
+
+    assert caught.value is failure
     assert store.retained == []
+    assert backend.publication_calls == []
+    assert backend.completions[(job.job_id, 1)].outcome is IndexJobCompletion.REQUEUE
+    assert backend.jobs[job.job_id].attempt_count == 2
     assert set(backend.sessions) == set(backend.closed_sessions)
     assert not any(
         thread.name.startswith("codenib-job-heartbeat-")
@@ -3506,7 +3619,7 @@ def test_final_heartbeat_cancellation_wins_over_publishable_result() -> None:
     assert result.disposition is IndexJobWorkerDisposition.CANCELLED
     assert backend.completion_calls[-1]["outcome"] is IndexJobCompletion.CANCELLED
     assert backend.publication_calls == []
-    assert store.retained == []
+    assert len(store.retained) == 1
 
 
 def test_heartbeat_authority_conflict_stops_without_stale_closure() -> None:

--- a/test/storage/test_job_worker_sqlite.py
+++ b/test/storage/test_job_worker_sqlite.py
@@ -60,6 +60,9 @@ class _CatalogProbe:
         self.publication_calls = 0
         self.lose_publication_response = lose_publication_response
         self.publication_response_lost = False
+        self.retention_heartbeat_ready = threading.Event()
+        self._retention_heartbeat_after_count: int | None = None
+        self._retention_lease_expiry_target: int | None = None
 
     def record_session(self, catalog: SQLiteCatalog) -> None:
         with self.lock:
@@ -82,6 +85,19 @@ class _CatalogProbe:
             self.heartbeats.append((threading.get_ident(), id(catalog), heartbeat))
             if len(self.heartbeats) >= self.heartbeat_target:
                 self.heartbeat_ready.set()
+            if (
+                self._retention_heartbeat_after_count is not None
+                and len(self.heartbeats) > self._retention_heartbeat_after_count
+                and heartbeat.lease.lease_expires_at_ms  # type: ignore[attr-defined]
+                >= self._retention_lease_expiry_target
+            ):
+                self.retention_heartbeat_ready.set()
+
+    def arm_retention_heartbeat(self, lease_expiry_target: int) -> None:
+        with self.lock:
+            self._retention_heartbeat_after_count = len(self.heartbeats)
+            self._retention_lease_expiry_target = lease_expiry_target
+            self.retention_heartbeat_ready.clear()
 
     def begin_publication(self) -> None:
         with self.lock:
@@ -177,6 +193,22 @@ class _CleanupFailingCAS(_TrackingCAS):
         super().retain_receipts(expected, callback)
         self.callback_completed = True
         raise self.failure
+
+
+class _BlockingRetainingCAS(_TrackingCAS):
+    def __init__(self, root: Path) -> None:
+        super().__init__(root)
+        self.retention_entered = threading.Event()
+        self.release_retention = threading.Event()
+
+    def retain_receipts(
+        self,
+        expected: tuple[BlobInfo, ...],
+        callback: Callable[[], Any],
+    ) -> Any:
+        self.retention_entered.set()
+        assert self.release_retention.wait(timeout=30)
+        return super().retain_receipts(expected, callback)
 
 
 class _StaticResolver:
@@ -340,13 +372,14 @@ def _worker(
     resolver: _StaticResolver,
     *,
     owner_id: str,
+    lease_duration_ms: int = 60_000,
     heartbeat_interval_ms: int = 5,
 ) -> IndexJobWorker:
     return IndexJobWorker(
         catalog_factory=factory,
         object_store=object_store,
         resolver=resolver,
-        lease_duration_ms=60_000,
+        lease_duration_ms=lease_duration_ms,
         heartbeat_interval_ms=heartbeat_interval_ms,
         owner_id_factory=lambda: owner_id,
     )
@@ -433,6 +466,77 @@ def test_slow_executor_observes_repeated_independent_heartbeats(
         assert first_session == second_session
         assert first.lease.lease_expires_at_ms < second.lease.lease_expires_at_ms
         assert len({session for _thread, session in probe.sessions}) >= 2
+
+
+def test_receipt_verification_keeps_publication_heartbeat_authority_live(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "retained-heartbeat.sqlite3"
+    clock = {"ms": 1_000}
+    job, _profiles = _create_job(
+        path,
+        view_types=("bm25",),
+        clock=clock,
+    )
+    probe = _CatalogProbe()
+    factory = _SQLiteSessionFactory(path, probe, clock=clock)
+    with _BlockingRetainingCAS(tmp_path / "cas") as object_store:
+        executor = _SuccessfulExecutor(object_store)
+        resolver = _StaticResolver(executor)
+        first = _worker(
+            factory,
+            object_store,
+            resolver,
+            owner_id="retained-heartbeat-a",
+            lease_duration_ms=30,
+            heartbeat_interval_ms=1,
+        )
+        contender = _worker(
+            factory,
+            object_store,
+            resolver,
+            owner_id="retained-heartbeat-b",
+            lease_duration_ms=30,
+            heartbeat_interval_ms=1,
+        )
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            first_future = pool.submit(first.run_once)
+            try:
+                assert object_store.retention_entered.wait(timeout=30)
+                initial_expiry = executor.contexts[0].lease.lease_expires_at_ms
+                probe.arm_retention_heartbeat(initial_expiry + 100)
+                assert probe.retention_heartbeat_ready.wait(timeout=30)
+
+                # The original claim is now expired under the catalog clock,
+                # while heartbeats observed during receipt retention extended
+                # the active lease beyond this point.
+                clock["ms"] = initial_expiry + 50
+                assert contender.run_once() == IndexJobWorkerRunResult.idle()
+            finally:
+                object_store.release_retention.set()
+            result = first_future.result(timeout=30)
+
+        assert result == IndexJobWorkerRunResult(
+            IndexJobWorkerDisposition.SUCCEEDED,
+            job.job_id,
+            1,
+        )
+        assert executor.calls == 1
+        assert resolver.calls == 1
+        assert len(object_store.retained_calls) == 1
+        assert probe.publication_calls == 1
+        with SQLiteCatalog(path, create=False) as catalog:
+            _install_clock(catalog, clock)
+            completed = catalog.get_job(job.job_id)
+            assert completed.status is IndexJobStatus.SUCCEEDED
+            assert completed.attempt_count == 1
+            assert catalog.list_job_attempt_completions(job.job_id) == ()
+            assert tuple(
+                event.attempt_count for event in catalog.list_job_events(job.job_id)
+            ) == (1,)
+            resolved = catalog.resolve_ref(job.repository_id)
+            assert resolved["generation"] == 1
+            assert resolved["manifest"]["views"]["bm25"]["metadata"] == {"attempt": 1}
 
 
 def test_running_cancel_is_observed_and_closes_only_cancelled(


### PR DESCRIPTION
## Summary
Follow-up to #692: keep a healthy index-job worker fenced while publication preflight and exact receipt verification are still running. This prevents slow LocalCAS hashing or retention from expiring the lease and triggering a duplicate takeover attempt before the retained catalog publication begins.

## Changes
- Keep the heartbeat pump active through artifact preflight and retained receipt verification.
- Settle the pump inside the retained callback, surface heartbeat faults and cancellation or authority loss, then perform one final fenced renewal immediately before catalog publication.
- Preserve exact pre-catalog failure identity so heartbeat failures cannot be reconciled as catalog publication response loss.
- Add deterministic SQLite takeover, cancellation, exception-provenance, pump-fault precedence, and publication-hook ordering regressions.
- Record the strengthened publication authority boundary in the storage roadmap.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- Full storage suite: 1,038 passed on Python 3.10, 3.12, and 3.14.
- Python 3.12 unit tier: 7,597 passed and 34 skipped; the environment-only Docker sandbox module was excluded because `/usr/bin/docker` is unavailable locally.
- Black, isort with the Black profile, flake8, py_compile, and `git diff --check` passed on the changed Python files.
- The original 30 ms lease / 80 ms blocked-retention SQLite+LocalCAS reproduction now completes one attempt and one publication; the contender remains idle.

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published