### PR TITLE
feat(storage): add trusted local cache job resources

### DIFF
--- a/codenib/compiler/__init__.py
+++ b/codenib/compiler/__init__.py
@@ -51,6 +51,10 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
         CompilerCacheJobResourceFactory,
         CompilerCacheJobResourceScope,
     )
+    from codenib.compiler.job_resources import (
+        LocalCompilerCacheJobResourceFactory,
+        LocalCompilerCacheJobTarget,
+    )
     from codenib.compiler.manifest import ManifestIndexStateStore, RepoManifest
     from codenib.compiler.manifest_export import (
         RepoManifestExportReceipt,
@@ -167,6 +171,14 @@ _EXPORTS = {
         "codenib.compiler.job_resolver",
         "CompilerCacheJobResourceScope",
     ),
+    "LocalCompilerCacheJobResourceFactory": (
+        "codenib.compiler.job_resources",
+        "LocalCompilerCacheJobResourceFactory",
+    ),
+    "LocalCompilerCacheJobTarget": (
+        "codenib.compiler.job_resources",
+        "LocalCompilerCacheJobTarget",
+    ),
     "IndexCompiler": ("codenib.compiler.index_compiler", "IndexCompiler"),
     "IndexCompilerConfig": (
         "codenib.compiler.index_compiler",
@@ -274,6 +286,8 @@ __all__ = [
     "CompilerCacheJobResolver",
     "CompilerCacheJobResourceFactory",
     "CompilerCacheJobResourceScope",
+    "LocalCompilerCacheJobResourceFactory",
+    "LocalCompilerCacheJobTarget",
     "CompilerCacheMultiViewImportResult",
     "CompilerCacheTopologyGuard",
     "CompilerCacheVectorJobPublicationResult",

--- a/codenib/compiler/cache_import.py
+++ b/codenib/compiler/cache_import.py
@@ -1447,18 +1447,25 @@ def compiler_cache_source_selection(
     cache_dir: str | Path,
     *,
     max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> RepositorySourceSelection:
     """Return the exact source selection recorded by one compiler cache.
 
     The CLI needs this identity axis before it captures the retained repository
     source.  The import coordinator authenticates the same manifest again under
     its longer-lived cache lock, so a manifest replacement between these two
-    reads can only make the later import fail closed.
+    reads can only make the later import fail closed. A cooperative caller may
+    supply ``check_cancelled`` to interrupt contention for the short manifest
+    lock before source capture begins.
     """
 
     cache = lexical_directory_path(Path(cache_dir))
     bounded_limit = _manifest_limit(max_manifest_bytes)
-    with compiler_cache_lock(cache, create=False):
+    with compiler_cache_lock(
+        cache,
+        create=False,
+        check_cancelled=check_cancelled,
+    ):
         manifest = _parse_exact_manifest(
             _read_manifest(cache, max_manifest_bytes=bounded_limit),
             max_manifest_bytes=bounded_limit,

--- a/codenib/compiler/job_resources.py
+++ b/codenib/compiler/job_resources.py
@@ -138,7 +138,7 @@ class LocalCompilerCacheJobTarget:
         object.__setattr__(
             self,
             "environ",
-            _snapshot_environment({} if self.environ is None else self.environ),
+            _snapshot_environment(self.environ),
         )
         object.__setattr__(self, "_repository_id", repository.repository_id)
 

--- a/codenib/compiler/job_resources.py
+++ b/codenib/compiler/job_resources.py
@@ -1,0 +1,433 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Trusted local resources for prepare-only compiler-cache job attempts."""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import MappingProxyType
+from typing import Iterator, Mapping
+
+from .._atomic_directory import (
+    DirectoryOrphan,
+    _attach_publication_cleanup_owner,
+    _OrderedAction,
+    _run_context_with_cleanup_actions,
+    discard_owned_directory,
+    lexical_directory_path,
+)
+from .._captured_directory import PublishedWorkspaceReceiptOwner
+from .._local_workspace_provider import LocalWorkspaceProvider
+from ..artifacts.runtime import SourceBindingCleanupOwner
+from ..source_fingerprint import capture_repository_source, lexical_repository_path
+from ..storage.job_worker import IndexJobExecutionContext
+from ..storage.models import (
+    DEFAULT_NAMESPACE_NAME,
+    NamespaceIdentity,
+    RepositoryIdentity,
+    SourceRevision,
+    StorageIntegrityError,
+    StorageValidationError,
+)
+from ..storage.protocols import RetainedImportObjectStore
+from .cache_import import CompilerCacheJobExecutor, compiler_cache_source_selection
+from .job_resolver import CompilerCacheJobResourceScope
+from .manifest_import import _snapshot_environment
+from .snapshot_store import normalize_repo
+
+logger = logging.getLogger(__name__)
+
+_MAX_LOCAL_TARGETS = 4_096
+_NONCE_BYTES = 16
+
+
+def _paths_overlap(first: Path, second: Path) -> bool:
+    return first == second or first in second.parents or second in first.parents
+
+
+@dataclass(frozen=True, slots=True)
+class LocalCompilerCacheJobTarget:
+    """One explicitly trusted local repository/cache/workspace binding.
+
+    The target is configuration, not discovery.  Callers must construct it
+    from an already-authorized repository registry or CLI selection; the job
+    resolver receives no catalog capability and cannot turn arbitrary durable
+    repository IDs into filesystem paths.
+    """
+
+    repository_root: Path
+    cache_dir: Path
+    workspace_provider: LocalWorkspaceProvider
+    repository_key: str
+    namespace_name: str = DEFAULT_NAMESPACE_NAME
+    environ: Mapping[str, str] | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    _repository_id: str = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if type(self) is not LocalCompilerCacheJobTarget:
+            raise TypeError("local compiler cache target must use the exact type")
+        if not isinstance(self.repository_root, Path):
+            raise TypeError("compiler cache target repository root must be a Path")
+        if not isinstance(self.cache_dir, Path):
+            raise TypeError("compiler cache target cache directory must be a Path")
+        if type(self.workspace_provider) is not LocalWorkspaceProvider:
+            raise TypeError(
+                "compiler cache target requires an exact local workspace provider"
+            )
+        if type(self.repository_key) is not str or type(self.namespace_name) is not str:
+            raise TypeError(
+                "compiler cache target namespace and repository key must be exact text"
+            )
+
+        repository_root = lexical_repository_path(self.repository_root)
+        cache_dir = lexical_directory_path(self.cache_dir)
+        workspace_root = self.workspace_provider.allowed_root
+        if repository_root == repository_root.parent:
+            raise ValueError(
+                "compiler cache target repository cannot be a filesystem root"
+            )
+        if cache_dir == repository_root or cache_dir in repository_root.parents:
+            raise ValueError(
+                "compiler cache target cache cannot contain the repository"
+            )
+        if _paths_overlap(workspace_root, repository_root):
+            raise ValueError(
+                "compiler cache target workspace must not overlap the repository"
+            )
+        if _paths_overlap(workspace_root, cache_dir):
+            raise ValueError(
+                "compiler cache target workspace must not overlap the cache"
+            )
+
+        namespace = NamespaceIdentity(self.namespace_name)
+        repository = RepositoryIdentity(
+            namespace_id=namespace.namespace_id,
+            repository_key=self.repository_key,
+        )
+        if (
+            namespace.name != self.namespace_name
+            or repository.repository_key != self.repository_key
+        ):
+            raise StorageValidationError(
+                "compiler cache target namespace and repository key must be canonical"
+            )
+        try:
+            normalized_repository = normalize_repo(repository.repository_key)
+        except ValueError as exc:
+            raise StorageValidationError(
+                "compiler cache target repository key is not canonical"
+            ) from exc
+        if normalized_repository != repository.repository_key:
+            raise StorageValidationError(
+                "compiler cache target repository key is not canonical"
+            )
+        object.__setattr__(self, "repository_root", repository_root)
+        object.__setattr__(self, "cache_dir", cache_dir)
+        object.__setattr__(self, "repository_key", repository.repository_key)
+        object.__setattr__(self, "namespace_name", namespace.name)
+        object.__setattr__(
+            self,
+            "environ",
+            _snapshot_environment({} if self.environ is None else self.environ),
+        )
+        object.__setattr__(self, "_repository_id", repository.repository_id)
+
+    @property
+    def repository_id(self) -> str:
+        return self._repository_id
+
+    @property
+    def workspace_root(self) -> Path:
+        return self.workspace_provider.allowed_root
+
+
+@dataclass(slots=True)
+class _AttemptWorkspaceCleanupOwner:
+    """Close one receipt authority, then isolate its exact published tree."""
+
+    owner: PublishedWorkspaceReceiptOwner
+    destination: Path
+    label: str
+    _ownership: object | None = field(default=None, init=False, repr=False)
+    _closed: bool = field(default=False, init=False, repr=False)
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @staticmethod
+    def _record_orphan(orphan: DirectoryOrphan | None, *, label: str) -> None:
+        if orphan is None:
+            return
+        logger.warning(
+            "Compiler-cache job %s retained an orphan for quiescent GC: "
+            "path=%s digest=%s entries=%d bytes=%d verified=%s",
+            label,
+            orphan.path,
+            orphan.ownership_digest,
+            orphan.entries,
+            orphan.byte_count,
+            orphan.verified_at_isolation,
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        if self._ownership is None:
+            state = self.owner.state
+            if state == "active":
+                binding = self.owner.destination_binding
+                if binding.destination != self.destination:
+                    raise StorageIntegrityError(
+                        "compiler cache workspace receipt changed destination"
+                    )
+                self._ownership = binding.ownership
+            elif state == "closed":
+                self._closed = True
+                return
+            elif state != "empty":
+                raise StorageIntegrityError(
+                    "compiler cache workspace receipt has an invalid state"
+                )
+
+        self.owner.close()
+        if not self.owner.closed:
+            raise RuntimeError("compiler cache workspace receipt did not close")
+        if self._ownership is not None:
+            orphan = discard_owned_directory(self.destination, self._ownership)
+            self._record_orphan(orphan, label=self.label)
+        self._closed = True
+
+
+def _cleanup_owner_pending(owner: object) -> bool:
+    try:
+        return not bool(owner.closed)  # type: ignore[attr-defined]
+    except BaseException:  # noqa: B036 - uncertain cleanup must fail closed
+        return True
+
+
+def _inherit_cleanup_owners(
+    target: BaseException,
+    source: BaseException,
+) -> None:
+    try:
+        owners = BaseException.__getattribute__(
+            source,
+            "publication_cleanup_owners",
+        )
+    except BaseException:  # noqa: B036 - diagnostics are best effort
+        return
+    if type(owners) is not tuple:
+        return
+    for owner in owners:
+        _attach_publication_cleanup_owner(target, owner)
+
+
+def _check_stopped(context: IndexJobExecutionContext) -> None:
+    if context.control.stop_token.is_set():
+        raise RuntimeError("compiler cache job resource preparation stopped")
+
+
+def _attempt_nonce() -> str:
+    nonce = secrets.token_hex(_NONCE_BYTES)
+    if len(nonce) != 2 * _NONCE_BYTES or any(
+        character not in "0123456789abcdef" for character in nonce
+    ):
+        raise RuntimeError("compiler cache job destination nonce is invalid")
+    return nonce
+
+
+@dataclass(frozen=True, slots=True)
+class LocalCompilerCacheJobResourceFactory:
+    """Resolve configured local targets into fresh attempt-scoped resources."""
+
+    targets: tuple[LocalCompilerCacheJobTarget, ...]
+    _targets_by_repository_id: Mapping[str, LocalCompilerCacheJobTarget] = field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        if type(self) is not LocalCompilerCacheJobResourceFactory:
+            raise TypeError(
+                "local compiler cache resource factory must use the exact type"
+            )
+        if type(self.targets) is not tuple or not (
+            1 <= len(self.targets) <= _MAX_LOCAL_TARGETS
+        ):
+            raise ValueError(
+                "local compiler cache resource factory requires bounded targets"
+            )
+        targets_by_repository_id: dict[str, LocalCompilerCacheJobTarget] = {}
+        for target in self.targets:
+            if type(target) is not LocalCompilerCacheJobTarget:
+                raise TypeError(
+                    "local compiler cache resource factory target is invalid"
+                )
+            if target.repository_id in targets_by_repository_id:
+                raise ValueError(
+                    "local compiler cache resource factory has duplicate repository IDs"
+                )
+            targets_by_repository_id[target.repository_id] = target
+        object.__setattr__(
+            self,
+            "_targets_by_repository_id",
+            MappingProxyType(targets_by_repository_id),
+        )
+
+    def create_scope(
+        self,
+        context: IndexJobExecutionContext,
+        *,
+        object_store: RetainedImportObjectStore,
+    ) -> CompilerCacheJobResourceScope:
+        if type(context) is not IndexJobExecutionContext:
+            raise TypeError(
+                "local compiler cache resource factory requires an exact context"
+            )
+        if not isinstance(object_store, RetainedImportObjectStore):
+            raise TypeError(
+                "local compiler cache resource factory requires a retained import store"
+            )
+        target = self._targets_by_repository_id.get(context.job.repository_id)
+        if target is None:
+            raise StorageValidationError(
+                "compiler cache job repository has no trusted local target"
+            )
+        if len(context.views) != 1:
+            raise StorageValidationError(
+                "local compiler cache resource factory requires one job view"
+            )
+        view = context.views[0]
+        return CompilerCacheJobResourceScope(
+            object_store=object_store,
+            view_type=view.view_type,
+            resources=self._open(
+                context,
+                object_store=object_store,
+                target=target,
+            ),
+        )
+
+    @contextmanager
+    def _open(
+        self,
+        context: IndexJobExecutionContext,
+        *,
+        object_store: RetainedImportObjectStore,
+        target: LocalCompilerCacheJobTarget,
+    ) -> Iterator[CompilerCacheJobExecutor]:
+        nonce = _attempt_nonce()
+        prefix = f".codenib-cache-job-{nonce}"
+        view = context.views[0]
+        view_destination = target.workspace_root / f"{prefix}-{view.view_type}"
+        context_destination = target.workspace_root / f"{prefix}-context"
+        view_owner = PublishedWorkspaceReceiptOwner()
+        context_owner = PublishedWorkspaceReceiptOwner()
+        view_cleanup = _AttemptWorkspaceCleanupOwner(
+            view_owner,
+            view_destination,
+            view.view_type,
+        )
+        context_cleanup = _AttemptWorkspaceCleanupOwner(
+            context_owner,
+            context_destination,
+            "context",
+        )
+        source_owner = SourceBindingCleanupOwner()
+        cleanup_owners = (context_cleanup, view_cleanup, source_owner)
+        cleanup_actions = (
+            _OrderedAction(
+                label="compiler cache job context cleanup also failed",
+                action=context_cleanup.close,
+                complete=lambda: context_cleanup.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=context_cleanup,
+            ),
+            _OrderedAction(
+                label="compiler cache job view cleanup also failed",
+                action=view_cleanup.close,
+                complete=lambda: view_cleanup.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=view_cleanup,
+            ),
+            _OrderedAction(
+                label="compiler cache job source cleanup also failed",
+                action=source_owner.close,
+                complete=lambda: source_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=source_owner,
+            ),
+        )
+
+        try:
+            with _run_context_with_cleanup_actions(cleanup_actions):
+                _check_stopped(context)
+                target.workspace_provider.require_support()
+                source_selection = compiler_cache_source_selection(
+                    target.cache_dir,
+                    check_cancelled=lambda: _check_stopped(context),
+                )
+                _check_stopped(context)
+                repository_source = capture_repository_source(
+                    target.repository_root,
+                    exclude_roots=(target.cache_dir, target.workspace_root),
+                    selection=source_selection,
+                    _source_owner=source_owner.retain,
+                )
+                source_owner.retain(repository_source)
+                _check_stopped(context)
+                source_revision = SourceRevision.dirty(
+                    target.repository_id,
+                    source_fingerprint=repository_source.fingerprint,
+                    commit_sha=None,
+                )
+                if source_revision.source_revision_id != context.job.source_revision_id:
+                    raise StorageValidationError(
+                        "compiler cache job source has no current trusted local target"
+                    )
+                yield CompilerCacheJobExecutor(
+                    cache_dir=target.cache_dir,
+                    view_type=view.view_type,
+                    repository_source=repository_source,
+                    view_output_owner=view_owner,
+                    context_output_owner=context_owner,
+                    view_destination=view_destination,
+                    context_destination=context_destination,
+                    workspace_provider=target.workspace_provider,
+                    repository_key=target.repository_key,
+                    object_store=object_store,
+                    namespace_name=target.namespace_name,
+                    forbidden_paths=(target.cache_dir, target.workspace_root),
+                    environ=target.environ,
+                )
+        except BaseException as error:  # noqa: B036 - retain cleanup authority
+            pending = tuple(
+                owner for owner in cleanup_owners if _cleanup_owner_pending(owner)
+            )
+            if pending and isinstance(error, Exception):
+                wrapped = StorageIntegrityError(
+                    "compiler cache job attempt resource cleanup did not settle"
+                )
+                _inherit_cleanup_owners(wrapped, error)
+                for owner in pending:
+                    _attach_publication_cleanup_owner(wrapped, owner)
+                raise wrapped from error
+            raise
+
+
+__all__ = [
+    "LocalCompilerCacheJobResourceFactory",
+    "LocalCompilerCacheJobTarget",
+]

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1243,10 +1243,24 @@ receipt-retaining object-store instance supplied to the enclosing worker, and
 enters a caller-provided context manager for fresh source and workspace
 authorities. The scope exits on success and every executor failure; a factory
 that returns an executor attached to a different object store fails as an
-integrity error before cache, workspace, or CAS work. This is the lifecycle
-boundary for a production resolver, not the production binding itself: no
-trusted repository registry, local resource factory, source builder, or worker
-entry point is wired yet.
+integrity error before cache, workspace, or CAS work. This seam remains the
+lifecycle boundary rather than a path-discovery capability; the local binding
+below must receive its trusted targets explicitly.
+
+The first trusted local resource factory now implements that resolver seam for
+an explicit, caller-authorized target set. Each target freezes one canonical
+namespace/repository identity, repository root, existing compiler cache, private
+local workspace provider, and environment snapshot; durable repository IDs are
+looked up only in that set and never interpreted as paths. Every attempt gets a
+fresh retained source binding, receipt owners, and nonce destinations. Scope
+exit closes all authorities and atomically isolates each exact owned output for
+later quiescent GC instead of recursively deleting by path; an incomplete
+cleanup is promoted to a storage-integrity failure with a retryable owner. The
+factory rechecks cooperative stop state around cache selection and source
+capture and fails before workspace/CAS work when the current source revision no
+longer matches the job. This is still caller-supplied local configuration: no
+CLI/runtime target registry, cache-building adapter, scheduler, or default route
+uses it yet.
 
 ### M2: Immutable generation publication
 
@@ -1278,9 +1292,10 @@ local SQLite catalog. The backend-neutral prepare-only whole-job worker is
 implemented and verified with file-backed SQLite integration coverage. An
 explicit one-view compiler-cache executor now supplies parser-inert BM25 or
 schema-8 vector artifacts without catalog authority. Its resource-scoped
-resolver seam guarantees attempt-local cleanup and same-store binding, while
-the concrete production repository/resource resolver, source builders, and
-CLI, runtime, Web, MCP, and default wiring remain absent.
+resolver and trusted local target factory guarantee attempt-local cleanup,
+same-store binding, and exact configured repository/source identity, while
+source builders, production target configuration, and CLI, runtime, Web, MCP,
+and default wiring remain absent.
 
 - The backend-neutral worker now owns advisory scan/claim, per-attempt task
   authority, independent heartbeat sessions, cancellation precedence, bounded
@@ -1316,11 +1331,11 @@ CLI, runtime, Web, MCP, and default wiring remain absent.
   final fenced heartbeat, and then publishes before releasing receipt
   retention. Slow object hashing therefore cannot expire an otherwise healthy
   worker and force a duplicate attempt.
-- Add production resolver and prepare-only source-builder adapters, then wire
-  the worker into CLI, runtime, Web, MCP, and default routes. The explicit
-  compiler-cache executor may recapture an already-current single BM25 or
-  vector cache view under the worker, while the older self-publishing ingress
-  APIs remain compatibility paths and are never nested inside the worker.
+- Add production target configuration and prepare-only source-builder adapters,
+  then wire the worker into CLI, runtime, Web, MCP, and default routes. The
+  trusted local factory can recapture an already-current single BM25 or vector
+  cache view under the worker, while the older self-publishing ingress APIs
+  remain compatibility paths and are never nested inside the worker.
 - Expose the #266 status and update APIs with accurate incremental versus
   rebuild behavior.
 - Load a complete new bundle and swap it RCU-style; pin old bundles for in-flight

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -1411,6 +1411,36 @@ def test_local_compiler_cache_job_target_is_frozen_and_bounded(
         fixture.close()
 
 
+def test_local_compiler_cache_job_target_freezes_default_process_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    variable = "CODENIB_TEST_CACHE_CREDENTIAL"
+    initial = "configured-secret-value"
+    try:
+        monkeypatch.setenv(variable, initial)
+        target = LocalCompilerCacheJobTarget(
+            repository_root=fixture.repository,
+            cache_dir=fixture.cache,
+            workspace_provider=LocalWorkspaceProvider(fixture.workspace),
+            repository_key=_REPOSITORY_KEY,
+        )
+        explicit_empty_target = LocalCompilerCacheJobTarget(
+            repository_root=fixture.repository,
+            cache_dir=fixture.cache,
+            workspace_provider=LocalWorkspaceProvider(fixture.workspace),
+            repository_key=_REPOSITORY_KEY,
+            environ={},
+        )
+        monkeypatch.setenv(variable, "changed-after-target-construction")
+
+        assert target.environ[variable] == initial
+        assert explicit_empty_target.environ == {}
+    finally:
+        fixture.close()
+
+
 def test_local_compiler_cache_cleanup_owner_import_rejects_tuple_subclasses() -> None:
     class HostileOwners(tuple):
         def __iter__(self):
@@ -1550,11 +1580,13 @@ def test_local_compiler_cache_job_factory_retains_failed_cleanup_owner(
                 fail_context_discard,
             )
             if executor_fails:
+                real_execute = CompilerCacheJobExecutor.execute
 
                 def fail_execute(
-                    _executor: CompilerCacheJobExecutor,
-                    _context,
+                    executor: CompilerCacheJobExecutor,
+                    context,
                 ):
+                    real_execute(executor, context)
                     raise primary
 
                 monkeypatch.setattr(

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -23,6 +23,7 @@ import codenib.artifacts.portable_views as portable_views_module
 import codenib.artifacts.strict_vector as strict_vector_module
 import codenib.compiler as compiler_module
 import codenib.compiler.cache_import as cache_import_module
+import codenib.compiler.job_resources as job_resources_module
 import codenib.index.embedding.vector_store as vector_store_module
 from codenib import LocalWorkspaceProvider
 from codenib import cli as cli_module
@@ -67,6 +68,10 @@ from codenib.compiler.job_resolver import (
     CompilerCacheJobResolver,
     CompilerCacheJobResourceFactory,
     CompilerCacheJobResourceScope,
+)
+from codenib.compiler.job_resources import (
+    LocalCompilerCacheJobResourceFactory,
+    LocalCompilerCacheJobTarget,
 )
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.compiler.manifest_import import RepoManifestImportResult
@@ -791,6 +796,11 @@ def test_compiler_cache_import_is_a_lazy_public_export() -> None:
         compiler_module.CompilerCacheJobResourceScope is CompilerCacheJobResourceScope
     )
     assert (
+        compiler_module.LocalCompilerCacheJobResourceFactory
+        is LocalCompilerCacheJobResourceFactory
+    )
+    assert compiler_module.LocalCompilerCacheJobTarget is LocalCompilerCacheJobTarget
+    assert (
         compiler_module.CompilerCacheJobPreparationResult
         is CompilerCacheJobPreparationResult
     )
@@ -1359,6 +1369,247 @@ def test_compiler_cache_executor_delegates_only_final_publish_to_worker(
                 summary = catalog.get_manifest_summary(completed.result_snapshot_id)
                 assert tuple(summary["views"]) == ("bm25",)
                 assert summary["views"]["bm25"]["profile"]["profile_id"] == (profile_id)
+    finally:
+        fixture.close()
+
+
+def test_local_compiler_cache_job_target_is_frozen_and_bounded(
+    tmp_path: Path,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    environment = {"CODENIB_TEST_SETTING": "trusted"}
+    try:
+        target = LocalCompilerCacheJobTarget(
+            repository_root=fixture.repository,
+            cache_dir=fixture.cache,
+            workspace_provider=LocalWorkspaceProvider(fixture.workspace),
+            repository_key=_REPOSITORY_KEY,
+            environ=environment,
+        )
+        environment["CODENIB_TEST_SETTING"] = "changed"
+
+        assert target.repository_root == fixture.repository
+        assert target.cache_dir == fixture.cache
+        assert target.workspace_root == fixture.workspace
+        assert target.environ == {"CODENIB_TEST_SETTING": "trusted"}
+        assert isinstance(
+            LocalCompilerCacheJobResourceFactory((target,)),
+            CompilerCacheJobResourceFactory,
+        )
+        with pytest.raises(ValueError, match="duplicate repository IDs"):
+            LocalCompilerCacheJobResourceFactory((target, target))
+        with pytest.raises(ValueError, match="must not overlap the repository"):
+            LocalCompilerCacheJobTarget(
+                repository_root=fixture.repository,
+                cache_dir=fixture.cache,
+                workspace_provider=LocalWorkspaceProvider(
+                    fixture.repository / "job-workspace"
+                ),
+                repository_key=_REPOSITORY_KEY,
+            )
+    finally:
+        fixture.close()
+
+
+def test_local_compiler_cache_cleanup_owner_import_rejects_tuple_subclasses() -> None:
+    class HostileOwners(tuple):
+        def __iter__(self):
+            raise AssertionError("hostile cleanup owners iterated")
+
+    source = RuntimeError("source")
+    target = RuntimeError("target")
+    BaseException.__setattr__(
+        source,
+        "publication_cleanup_owners",
+        HostileOwners((object(),)),
+    )
+
+    job_resources_module._inherit_cleanup_owners(target, source)
+
+    with pytest.raises(AttributeError):
+        BaseException.__getattribute__(target, "publication_cleanup_owners")
+
+
+def test_local_compiler_cache_job_factory_runs_and_isolates_attempt_workspaces(
+    tmp_path: Path,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    plan = _expected_bm25_job_plan(fixture)
+    catalog_path = tmp_path / "worker.sqlite"
+    publication_calls: list[str] = []
+    provider = LocalWorkspaceProvider(fixture.workspace)
+    try:
+        try:
+            provider.require_support()
+        except UnsupportedWorkspaceCreation as exc:
+            pytest.skip(str(exc))
+        with _JobTrackingCAS(tmp_path / "cas") as cas:
+            with SQLiteCatalog(catalog_path) as catalog:
+                (
+                    repository_id,
+                    source_revision_id,
+                    profile_id,
+                ) = _register_bm25_job_subject(catalog, fixture, plan)
+                queued = _create_bm25_job(
+                    catalog,
+                    repository_id=repository_id,
+                    source_revision_id=source_revision_id,
+                    profile_id=profile_id,
+                )
+
+            target = LocalCompilerCacheJobTarget(
+                repository_root=fixture.repository,
+                cache_dir=fixture.cache,
+                workspace_provider=provider,
+                repository_key=_REPOSITORY_KEY,
+                environ={},
+            )
+            assert target.repository_id == repository_id
+            worker = IndexJobWorker(
+                catalog_factory=_CompilerCacheWorkerFactory(
+                    catalog_path,
+                    publication_calls,
+                ),
+                object_store=cas,
+                resolver=CompilerCacheJobResolver(
+                    resource_factory=LocalCompilerCacheJobResourceFactory((target,)),
+                    object_store=cas,
+                ),
+                lease_duration_ms=60_000,
+                heartbeat_interval_ms=5,
+                owner_id_factory=lambda: "local-compiler-cache-worker",
+            )
+
+            outcome = worker.run_once()
+
+            assert outcome.disposition is IndexJobWorkerDisposition.SUCCEEDED
+            assert outcome.job_id == queued.job_id
+            assert publication_calls == [queued.job_id]
+            assert len(cas.put_chunk_receipts) == 3
+            assert len(cas.retained_receipt_sets) == 1
+            assert not tuple(fixture.workspace.glob(".codenib-cache-job-*"))
+            orphans = tuple(fixture.workspace.glob(".*.discarded-*"))
+            assert len(orphans) == 2
+            assert all(orphan.is_dir() for orphan in orphans)
+            with SQLiteCatalog(catalog_path, create=False) as catalog:
+                completed = catalog.get_job(queued.job_id)
+                assert completed.status is IndexJobStatus.SUCCEEDED
+                assert completed.result_snapshot_id is not None
+    finally:
+        fixture.close()
+
+
+@pytest.mark.parametrize("executor_fails", (False, True))
+def test_local_compiler_cache_job_factory_retains_failed_cleanup_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    executor_fails: bool,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    plan = _expected_bm25_job_plan(fixture)
+    catalog_path = tmp_path / "worker.sqlite"
+    publication_calls: list[str] = []
+    provider = LocalWorkspaceProvider(fixture.workspace)
+    real_discard = job_resources_module.discard_owned_directory
+    primary = StorageIntegrityError("primary local executor integrity failure")
+    try:
+        try:
+            provider.require_support()
+        except UnsupportedWorkspaceCreation as exc:
+            pytest.skip(str(exc))
+        with _JobTrackingCAS(tmp_path / "cas") as cas:
+            with SQLiteCatalog(catalog_path) as catalog:
+                (
+                    repository_id,
+                    source_revision_id,
+                    profile_id,
+                ) = _register_bm25_job_subject(catalog, fixture, plan)
+                queued = _create_bm25_job(
+                    catalog,
+                    repository_id=repository_id,
+                    source_revision_id=source_revision_id,
+                    profile_id=profile_id,
+                )
+
+            target = LocalCompilerCacheJobTarget(
+                repository_root=fixture.repository,
+                cache_dir=fixture.cache,
+                workspace_provider=provider,
+                repository_key=_REPOSITORY_KEY,
+                environ={},
+            )
+
+            def fail_context_discard(path: Path, ownership: object):
+                if path.name.endswith("-context"):
+                    raise OSError("injected context isolation failure")
+                return real_discard(path, ownership)  # type: ignore[arg-type]
+
+            monkeypatch.setattr(
+                job_resources_module,
+                "discard_owned_directory",
+                fail_context_discard,
+            )
+            if executor_fails:
+
+                def fail_execute(
+                    _executor: CompilerCacheJobExecutor,
+                    _context,
+                ):
+                    raise primary
+
+                monkeypatch.setattr(
+                    CompilerCacheJobExecutor,
+                    "execute",
+                    fail_execute,
+                )
+            worker = IndexJobWorker(
+                catalog_factory=_CompilerCacheWorkerFactory(
+                    catalog_path,
+                    publication_calls,
+                ),
+                object_store=cas,
+                resolver=CompilerCacheJobResolver(
+                    resource_factory=LocalCompilerCacheJobResourceFactory((target,)),
+                    object_store=cas,
+                ),
+                lease_duration_ms=60_000,
+                heartbeat_interval_ms=5,
+                owner_id_factory=lambda: "cleanup-failure-worker",
+            )
+
+            if executor_fails:
+                with pytest.raises(StorageIntegrityError) as caught:
+                    worker.run_once()
+                assert caught.value is primary
+            else:
+                with pytest.raises(
+                    StorageIntegrityError,
+                    match="resource cleanup did not settle",
+                ) as caught:
+                    worker.run_once()
+
+            assert publication_calls == []
+            with SQLiteCatalog(catalog_path, create=False) as catalog:
+                running = catalog.get_job(queued.job_id)
+                assert running.status is IndexJobStatus.RUNNING
+                assert running.result_snapshot_id is None
+            cleanup_owners = caught.value.publication_cleanup_owners
+            pending = tuple(
+                owner
+                for owner in cleanup_owners
+                if type(owner).__name__ == "_AttemptWorkspaceCleanupOwner"
+                and not owner.closed
+            )
+            assert len(pending) == 1
+            monkeypatch.setattr(
+                job_resources_module,
+                "discard_owned_directory",
+                real_discard,
+            )
+            pending[0].close()
+            assert pending[0].closed
+            assert not tuple(fixture.workspace.glob(".codenib-cache-job-*"))
+            assert len(tuple(fixture.workspace.glob(".*.discarded-*"))) == 2
     finally:
         fixture.close()
 


### PR DESCRIPTION
## Summary

Add the trusted local target and attempt-resource binding for the prepare-only compiler-cache worker path.

PR #696 is merged and this branch is rebased directly onto main. This slice deliberately does not add a scheduler, CLI/runtime registration, or cache-building adapter.

## Changes

- freeze an explicit bounded set of authorized namespace/repository, source-root, cache, workspace-provider, and environment bindings
- preserve the default one-time process-environment snapshot so portable-artifact scans see configured credentials, while an explicit empty mapping remains an opt-out
- resolve durable repository IDs only through that trusted set and recapture the exact current source revision per attempt
- create fresh nonce-scoped BM25/vector and context workspace authorities for every execution attempt
- close authorities and isolate exact owned workspace trees for cooperative GC; escalate incomplete cleanup with retryable owners
- make the short manifest-selection cache lock cooperatively interruptible
- export the local factory/target and update the durable storage roadmap
- add end-to-end worker publication, topology rejection, orphan isolation, credential-snapshot, and cleanup-retry coverage
- exercise the combined executor/cleanup failure only after real attempt resources have been acquired

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- targeted target/environment/cleanup-owner tests: 3 passed
- native workspace-owner combined cleanup tests: 2 passed
- prior full compiler baseline before the review fix: 909 passed, 9 skipped
- final-head CI unit tier: 7,654 passed, 43 skipped
- mkdocs build --strict
- public docs link validation
- namespace consistency check
- pinned Black, isort, flake8, and pre-commit hooks

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
