### PR TITLE
feat(storage): add bounded cache worker CLI

### DIFF
--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -19,6 +19,7 @@ import stat
 import subprocess
 import sys
 from collections import Counter
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Iterable, Sequence
@@ -2562,6 +2563,54 @@ class _CompilerCacheImportTopology:
 
 
 @dataclass(frozen=True, slots=True)
+class _ExistingIndexJobCatalogFactory:
+    """Open exact existing-only SQLite sessions for one worker invocation."""
+
+    catalog_path: Path
+    catalog_identity: tuple[int, int, int]
+
+    @contextmanager
+    def __call__(self):
+        from ._atomic_directory import _OrderedAction, _run_context_with_cleanup_actions
+        from .storage import SQLiteCatalog
+
+        catalog_owner = _RetainedMaterializationResourceOwner()
+        cleanup_actions = (
+            (
+                "worker SQLite catalog exit binding validation also failed",
+                lambda: _require_retained_catalog_binding(
+                    self.catalog_path,
+                    self.catalog_identity,
+                ),
+            ),
+            _OrderedAction(
+                label="worker SQLite catalog cleanup also failed",
+                action=catalog_owner.close,
+                complete=lambda: catalog_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=catalog_owner,
+            ),
+        )
+        with _run_context_with_cleanup_actions(cleanup_actions):
+            _require_retained_catalog_binding(
+                self.catalog_path,
+                self.catalog_identity,
+            )
+            catalog = catalog_owner.acquire(
+                lambda: SQLiteCatalog(
+                    self.catalog_path,
+                    create=False,
+                    expected_file_identity=self.catalog_identity,
+                )
+            )
+            _require_retained_catalog_binding(
+                self.catalog_path,
+                self.catalog_identity,
+            )
+            yield catalog
+
+
+@dataclass(frozen=True, slots=True)
 class _CompilerRetainedStorageTopology:
     repo_path: Path
     repository_identity: tuple[int, int]
@@ -3504,6 +3553,7 @@ def _run_artifact_import_cache(args: argparse.Namespace) -> int:
         topology = _require_compiler_cache_import_topology(paths)
     except CLIError:
         raise
+
     except (OSError, RuntimeError, ValueError, sqlite3.Error) as exc:
         wrapped = CLIError(str(exc))
         _inherit_publication_cleanup_owners(wrapped, exc)
@@ -3702,6 +3752,116 @@ def _run_artifact_import_cache(args: argparse.Namespace) -> int:
             raise
         if isinstance(
             primary_error, (OSError, RuntimeError, ValueError, sqlite3.Error)
+        ):
+            wrapped = CLIError(str(primary_error))
+            _inherit_publication_cleanup_owners(wrapped, primary_error)
+            raise wrapped from primary_error
+        raise
+
+
+def _run_jobs_run_once(args: argparse.Namespace) -> int:
+    """Run one bounded prepare-only compiler-cache worker scan."""
+
+    from . import LocalWorkspaceProvider
+    from ._atomic_directory import _OrderedAction, _run_context_with_cleanup_actions
+    from .compiler.job_resolver import CompilerCacheJobResolver
+    from .compiler.job_resources import (
+        LocalCompilerCacheJobResourceFactory,
+        LocalCompilerCacheJobTarget,
+    )
+    from .storage import IndexJobWorker, LocalCAS
+
+    repository, namespace = _retained_materialization_identity(
+        args.repository,
+        args.namespace,
+    )
+    paths = _compiler_cache_import_paths(args, views=("bm25",))
+    try:
+        provider = LocalWorkspaceProvider(paths.workspace_root)
+        provider.require_support()
+        topology = _require_compiler_cache_import_topology(paths)
+    except CLIError:
+        raise
+    except (OSError, RuntimeError, ValueError, sqlite3.Error) as exc:
+        wrapped = CLIError(str(exc))
+        _inherit_publication_cleanup_owners(wrapped, exc)
+        raise wrapped from exc
+
+    result = None
+    try:
+        object_store_owner = _RetainedMaterializationResourceOwner()
+        cleanup_actions = (
+            _OrderedAction(
+                label="worker local CAS cleanup also failed",
+                action=object_store_owner.close,
+                complete=lambda: object_store_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=object_store_owner,
+            ),
+        )
+        with _run_context_with_cleanup_actions(cleanup_actions):
+            object_store = object_store_owner.acquire(
+                lambda: LocalCAS(
+                    topology.cas_root,
+                    require_preprovisioned=True,
+                )
+            )
+            target = LocalCompilerCacheJobTarget(
+                repository_root=paths.repo_path,
+                cache_dir=topology.cache_dir,
+                workspace_provider=provider,
+                repository_key=repository,
+                namespace_name=namespace,
+                environ=_publication_environment(),
+            )
+            resources = LocalCompilerCacheJobResourceFactory((target,))
+            worker = IndexJobWorker(
+                catalog_factory=_ExistingIndexJobCatalogFactory(
+                    topology.catalog_path,
+                    topology.catalog_identity,
+                ),
+                object_store=object_store,
+                resolver=CompilerCacheJobResolver(
+                    resource_factory=resources,
+                    object_store=object_store,
+                ),
+                lease_duration_ms=args.lease_duration_ms,
+                heartbeat_interval_ms=args.heartbeat_interval_ms,
+                scan_limit=args.scan_limit,
+                candidate_filter=resources.accepts_candidate,
+            )
+            result = worker.run_once()
+        if result is None:  # pragma: no cover - worker always returns a result
+            raise RuntimeError("index job worker returned no run result")
+        payload = {
+            "attempt_count": result.attempt_count,
+            "disposition": result.disposition.value,
+            "job_id": result.job_id,
+        }
+        if args.json:
+            print(
+                json.dumps(
+                    payload,
+                    allow_nan=False,
+                    ensure_ascii=True,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+            )
+        else:
+            print(f"Disposition: {result.disposition.value}")
+            print(f"Job:         {result.job_id or '-'}")
+            print(
+                "Attempt:     "
+                + ("-" if result.attempt_count is None else str(result.attempt_count))
+            )
+        return 0
+    except BaseException as primary_error:  # noqa: B036 - preserve cancellation
+        if isinstance(primary_error, CLIError):
+            raise
+        if isinstance(
+            primary_error,
+            (OSError, RuntimeError, ValueError, sqlite3.Error),
         ):
             wrapped = CLIError(str(primary_error))
             _inherit_publication_cleanup_owners(wrapped, primary_error)
@@ -5841,6 +6001,79 @@ def build_parser() -> argparse.ArgumentParser:
         default="project",
     )
     artifact_config_parser.set_defaults(handler=_run_artifact_mcp_config)
+
+    jobs_parser = subparsers.add_parser(
+        "jobs",
+        help="inspect and execute durable index jobs",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    jobs_subparsers = jobs_parser.add_subparsers(
+        dest="jobs_command",
+        required=True,
+    )
+    jobs_run_once_parser = jobs_subparsers.add_parser(
+        "run-once",
+        help="scan one bounded page and execute at most one supported job",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    jobs_run_once_parser.add_argument(
+        "repo",
+        help="trusted local repository source for eligible jobs",
+    )
+    jobs_run_once_parser.add_argument(
+        "--cache-dir",
+        required=True,
+        help="existing compiler cache containing current BM25/vector views",
+    )
+    jobs_run_once_parser.add_argument(
+        "--catalog",
+        required=True,
+        help="existing initialized SQLite catalog path",
+    )
+    jobs_run_once_parser.add_argument(
+        "--cas-root",
+        required=True,
+        help="existing fully preprovisioned local CAS root",
+    )
+    jobs_run_once_parser.add_argument(
+        "--workspace-root",
+        required=True,
+        help="existing private owner-only LocalWorkspaceProvider root",
+    )
+    jobs_run_once_parser.add_argument(
+        "--repository",
+        required=True,
+        help="canonical owner/repository key eligible for this worker",
+    )
+    jobs_run_once_parser.add_argument(
+        "--namespace",
+        default="default",
+        help="logical catalog namespace",
+    )
+    jobs_run_once_parser.add_argument(
+        "--lease-duration-ms",
+        type=_argparse_positive_int,
+        default=30_000,
+        help="job lease duration",
+    )
+    jobs_run_once_parser.add_argument(
+        "--heartbeat-interval-ms",
+        type=_argparse_positive_int,
+        default=5_000,
+        help="worker heartbeat interval (must be less than one third of the lease)",
+    )
+    jobs_run_once_parser.add_argument(
+        "--scan-limit",
+        type=_argparse_positive_int,
+        default=64,
+        help="maximum advisory candidates examined in this pass (at most 256)",
+    )
+    jobs_run_once_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="print the canonical run result as compact JSON",
+    )
+    jobs_run_once_parser.set_defaults(handler=_run_jobs_run_once)
 
     publish_parser = subparsers.add_parser(
         "publish",

--- a/codenib/compiler/job_resources.py
+++ b/codenib/compiler/job_resources.py
@@ -29,6 +29,9 @@ from ..source_fingerprint import capture_repository_source, lexical_repository_p
 from ..storage.job_worker import IndexJobExecutionContext
 from ..storage.models import (
     DEFAULT_NAMESPACE_NAME,
+    IndexJobRecord,
+    IndexJobRequest,
+    IndexJobRequestedMode,
     NamespaceIdentity,
     RepositoryIdentity,
     SourceRevision,
@@ -45,6 +48,7 @@ logger = logging.getLogger(__name__)
 
 _MAX_LOCAL_TARGETS = 4_096
 _NONCE_BYTES = 16
+_SUPPORTED_CACHE_VIEWS = frozenset({"bm25", "vector"})
 
 
 def _paths_overlap(first: Path, second: Path) -> bool:
@@ -286,6 +290,42 @@ class LocalCompilerCacheJobResourceFactory:
             MappingProxyType(targets_by_repository_id),
         )
 
+    def accepts_candidate(self, job: IndexJobRecord) -> bool:
+        """Return exact pre-claim eligibility for this configured target set."""
+
+        if type(job) is not IndexJobRecord:
+            raise StorageValidationError(
+                "local compiler cache candidate must be an exact job record"
+            )
+        if job.repository_id not in self._targets_by_repository_id:
+            return False
+        try:
+            request = IndexJobRequest(
+                repository_id=job.repository_id,
+                source_revision_id=job.source_revision_id,
+                ref_name=job.ref_name,
+                idempotency_key=job.idempotency_key,
+                expected_ref_generation=job.expected_ref_generation,
+                max_attempts=job.max_attempts,
+                request_json=job.request_json,
+            )
+        except StorageValidationError as exc:
+            raise StorageIntegrityError(
+                "local compiler cache candidate request is invalid"
+            ) from exc
+        if request.job_id != job.job_id or request.request_digest != job.request_digest:
+            raise StorageIntegrityError(
+                "local compiler cache candidate request identity is inconsistent"
+            )
+        views = request.view_requests
+        return (
+            len(views) == 1
+            and views[0].job_id == job.job_id
+            and views[0].view_type in _SUPPORTED_CACHE_VIEWS
+            and views[0].requested_mode is IndexJobRequestedMode.FULL
+            and views[0].required is True
+        )
+
     def create_scope(
         self,
         context: IndexJobExecutionContext,
@@ -305,9 +345,12 @@ class LocalCompilerCacheJobResourceFactory:
             raise StorageValidationError(
                 "compiler cache job repository has no trusted local target"
             )
-        if len(context.views) != 1:
+        if (
+            len(context.views) != 1
+            or context.views[0].view_type not in _SUPPORTED_CACHE_VIEWS
+        ):
             raise StorageValidationError(
-                "local compiler cache resource factory requires one job view"
+                "local compiler cache resource factory requires one supported job view"
             )
         view = context.views[0]
         return CompilerCacheJobResourceScope(

--- a/codenib/storage/job_worker.py
+++ b/codenib/storage/job_worker.py
@@ -1496,6 +1496,7 @@ class IndexJobWorker:
         lease_duration_ms: int,
         heartbeat_interval_ms: int,
         scan_limit: int = 64,
+        candidate_filter: Callable[[IndexJobRecord], bool] | None = None,
         owner_id_factory: Callable[[], str] = _default_owner_id,
         monotonic: Callable[[], float] = time.monotonic,
     ) -> None:
@@ -1518,6 +1519,8 @@ class IndexJobWorker:
                 raise StorageValidationError(
                     "worker and bound resolver must use the same object store"
                 )
+        if candidate_filter is not None and not callable(candidate_filter):
+            raise TypeError("worker candidate filter must be callable")
         if not callable(owner_id_factory):
             raise TypeError("worker owner ID factory must be callable")
         if not callable(monotonic):
@@ -1547,6 +1550,7 @@ class IndexJobWorker:
         self._lease_duration_ms = lease_duration
         self._heartbeat_interval_ms = heartbeat_interval
         self._scan_limit = page_limit
+        self._candidate_filter = candidate_filter
         self._owner_id_factory = owner_id_factory
         self._monotonic = monotonic
         self._run_lock = threading.Lock()
@@ -1582,6 +1586,8 @@ class IndexJobWorker:
             limit=self._scan_limit,
         )
         for candidate in page.jobs:
+            if not self._accept_candidate(candidate):
+                continue
             owner = _bounded_exact_text(
                 self._owner_id_factory(),
                 "worker owner ID",
@@ -1608,6 +1614,38 @@ class IndexJobWorker:
                     lost.authority,
                 )
         return IndexJobWorkerRunResult.idle()
+
+    def _accept_candidate(self, candidate: IndexJobRecord) -> bool:
+        """Run one trusted, mutation-free eligibility check before claim."""
+
+        candidate_filter = self._candidate_filter
+        if candidate_filter is None:
+            return True
+        expected = _detach_job_record(candidate)
+        filtered_candidate = _detach_job_record(expected)
+        try:
+            accepted = candidate_filter(filtered_candidate)
+        except StorageIntegrityError:
+            raise
+        except StorageValidationError as exc:
+            raise StorageIntegrityError(
+                "worker candidate filter rejected a canonical candidate"
+            ) from exc
+        except Exception as exc:
+            raise StorageIntegrityError("worker candidate filter failed") from exc
+        if type(accepted) is not bool:
+            raise StorageIntegrityError(
+                "worker candidate filter returned a non-exact decision"
+            )
+        try:
+            observed = _detach_job_record(filtered_candidate)
+        except StorageValidationError as exc:
+            raise StorageIntegrityError(
+                "worker candidate filter damaged its candidate"
+            ) from exc
+        if observed != expected:
+            raise StorageIntegrityError("worker candidate filter changed its candidate")
+        return accepted
 
     def _acquire_candidate(
         self,

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -16,13 +16,15 @@ missing destination or replaces the exact generation named by an active
 receipt, then transfers the new generation to a caller-owned
 `PublishedWorkspaceReceiptOwner`.
 
-The provider is not enabled by CodeNib's default compiler or runtime path. Four
+The provider is not enabled by CodeNib's default compiler or runtime path. Five
 explicit routes use it: `codenib index --publish-retained` builds and publishes
 current BM25/vector views in one compiler-cache lease, `codenib artifact
-import-cache` recaptures an already existing selected cache, `codenib artifact
-materialize` publishes a retained catalog ref or immutable snapshot to a
-missing portable-artifact directory, and retained `codenib mcp` cold-start
-materializes and holds one such generation for a single stdio server lifetime.
+import-cache` recaptures an already existing selected cache, `codenib jobs
+run-once` prepares and publishes at most one eligible durable cache job,
+`codenib artifact materialize` publishes a retained catalog ref or immutable
+snapshot to a missing portable-artifact directory, and retained `codenib mcp`
+cold-start materializes and holds one such generation for a single stdio server
+lifetime.
 Storage-backend defaults are separate from route defaults. SQLite WAL and the
 local filesystem SHA-256 CAS are CodeNib's canonical supported production
 backends, not temporary bridges. PostgreSQL and S3-compatible adapters remain
@@ -294,6 +296,52 @@ committed before its result was observed, retry the exact same source, cache,
 repository, namespace, and ref with the original `--expected-generation`.
 The retry gets fresh missing evidence destinations but resolves the same
 snapshot and generation without advancing the ref again.
+
+## Run one durable cache job
+
+`codenib jobs run-once` examines one bounded advisory catalog page and executes
+at most one job for one explicitly configured local repository target. The job
+must already exist in the catalog and request exactly one required `full` BM25
+or vector view whose profile and dirty source-revision identity match the
+current compiler cache. This command does not create jobs, build or update a
+stale cache, loop continuously, or hot-switch a query runtime.
+
+The repository, cache, SQLite catalog, strict LocalCAS, and private workspace
+root obey the same physical-separation and existing-only requirements as
+`artifact import-cache`. The worker opens an independent exact SQLite session
+for its main transaction and every heartbeat, while retaining one strict CAS
+authority for the complete pass. A claim-time eligibility filter runs before
+owner allocation or catalog mutation: jobs for other repository IDs, multi-view
+requests, optional views, incremental requests, graph, and other unsupported
+builders remain untouched in the queue.
+
+For example, process at most one current-cache job from the first 64 advisory
+candidates:
+
+```bash
+codenib jobs run-once /srv/src/repository \
+  --cache-dir /var/lib/codenib/compiler-cache/repository \
+  --catalog /var/lib/codenib/catalog.sqlite3 \
+  --cas-root /var/lib/codenib/cas \
+  --workspace-root /var/lib/codenib/workspaces \
+  --repository owner/repository
+```
+
+`--scan-limit` may select 1 through 256 candidates. Lease and heartbeat timing
+are configurable, but the heartbeat must remain less than one third of the
+lease. The default text output reports disposition, job ID, and attempt; use
+`--json` for one compact canonical object. A processed retry, failure,
+cancellation, or authority loss is a durable worker disposition rather than a
+CLI infrastructure failure. Storage-integrity, topology, and cleanup failures
+still make the command fail.
+
+Each attempt captures a fresh retained source and uses new nonce-scoped view
+and context destinations. After CAS ingestion and worker-owned publication, the
+receipt authorities close and the exact owned directories are atomically moved
+to authenticated orphan names for later quiescent GC; the command never
+recursively deletes a mutable path. More than one page, cross-page fairness,
+backoff, signal handling, and continuous draining belong to the separate M3
+scheduler entry.
 
 ## Materialize a retained artifact
 

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1258,16 +1258,25 @@ later quiescent GC instead of recursively deleting by path; an incomplete
 cleanup is promoted to a storage-integrity failure with a retryable owner. The
 factory rechecks cooperative stop state around cache selection and source
 capture and fails before workspace/CAS work when the current source revision no
-longer matches the job. This is still caller-supplied local configuration: no
-CLI/runtime target registry, cache-building adapter, scheduler, or default route
-uses it yet.
+longer matches the job.
+
+The first production CLI binding now exposes that target as `codenib jobs
+run-once`. It freezes the same existing-only repository/cache/catalog/CAS/
+workspace topology used by retained cache import, opens independent exact
+SQLite sessions for the main pass and heartbeat, and retains the strict local
+CAS for the whole invocation. A trusted candidate filter runs on a detached
+canonical job before owner allocation or lease acquisition, so foreign
+repositories and unsupported view requests remain untouched. One invocation
+still examines only one bounded advisory page and executes at most one eligible
+job; continuous scheduling, cache-building adapters, runtime registration, and
+default routing remain absent.
 
 ### M2: Immutable generation publication
 
 Status: in progress. The receipt-retained, fenced SQLite publication primitive
 and the explicit BM25 and schema-8 vector compiler-cache adapters, including
 their prepare-only worker bridge, are implemented; graph, generic source
-builders, production resolution, and job/runtime wiring remain.
+builders, cache-building execution, and remaining runtime wiring remain.
 
 - Make every builder write to a unique staging generation.
 - Add per-view profile adapters that fail closed on incomplete compatibility
@@ -1294,8 +1303,8 @@ explicit one-view compiler-cache executor now supplies parser-inert BM25 or
 schema-8 vector artifacts without catalog authority. Its resource-scoped
 resolver and trusted local target factory guarantee attempt-local cleanup,
 same-store binding, and exact configured repository/source identity, while
-source builders, production target configuration, and CLI, runtime, Web, MCP,
-and default wiring remain absent.
+the explicit CLI can run one bounded current-cache pass. Source builders,
+continuous scheduling, runtime, Web, MCP, and default wiring remain absent.
 
 - The backend-neutral worker now owns advisory scan/claim, per-attempt task
   authority, independent heartbeat sessions, cancellation precedence, bounded
@@ -1305,9 +1314,12 @@ and default wiring remain absent.
   API boundary is not a sandbox for deliberately introspective in-process
   Python code.
 - One `run_once` pass examines one bounded advisory page and tries its candidates
-  in canonical order. Cross-page fairness, cursor scheduling, and continuous
-  draining remain responsibilities of the future runtime scheduler rather than
-  silently making one worker call unbounded.
+  in canonical order. An optional trusted filter now attests a detached
+  candidate before owner allocation or claim, rejects non-boolean, failing, or
+  mutating filters as integrity alarms, and lets a scoped worker leave foreign
+  or unsupported jobs untouched. Cross-page fairness, cursor scheduling, and
+  continuous draining remain responsibilities of the future runtime scheduler
+  rather than silently making one worker call unbounded.
 - File-backed SQLite sessions in one interpreter coordinate existing-only
   validation, transactions, and connection close by resolved catalog path, so
   a heartbeat cannot invalidate a concurrent cancellation or worker-session
@@ -1331,11 +1343,12 @@ and default wiring remain absent.
   final fenced heartbeat, and then publishes before releasing receipt
   retention. Slow object hashing therefore cannot expire an otherwise healthy
   worker and force a duplicate attempt.
-- Add production target configuration and prepare-only source-builder adapters,
-  then wire the worker into CLI, runtime, Web, MCP, and default routes. The
-  trusted local factory can recapture an already-current single BM25 or vector
-  cache view under the worker, while the older self-publishing ingress APIs
-  remain compatibility paths and are never nested inside the worker.
+- Extend the explicit one-target CLI binding into continuous scheduling and add
+  prepare-only source-builder adapters, then wire the worker into runtime, Web,
+  MCP, and default routes. The trusted local factory can recapture an
+  already-current single BM25 or vector cache view under the worker, while the
+  older self-publishing ingress APIs remain compatibility paths and are never
+  nested inside the worker.
 - Expose the #266 status and update APIs with accurate incremental versus
   rebuild behavior.
 - Load a complete new bundle and swap it RCU-style; pin old bundles for in-flight

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -1460,6 +1460,81 @@ def test_local_compiler_cache_cleanup_owner_import_rejects_tuple_subclasses() ->
         BaseException.__getattribute__(target, "publication_cleanup_owners")
 
 
+@pytest.mark.parametrize(
+    ("case", "expected"),
+    (
+        ("full_bm25", True),
+        ("full_vector", True),
+        ("incremental", False),
+        ("optional", False),
+        ("multi_view", False),
+        ("graph", False),
+    ),
+)
+def test_local_compiler_cache_candidate_filter_accepts_only_supported_shape(
+    tmp_path: Path,
+    case: str,
+    expected: bool,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    plan = _expected_bm25_job_plan(fixture)
+    try:
+        with SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog:
+            repository_id, source_revision_id, bm25_profile_id = (
+                _register_bm25_job_subject(catalog, fixture, plan)
+            )
+            view_type = "bm25"
+            profile_id = bm25_profile_id
+            if case in {"full_vector", "multi_view"}:
+                vector_profile_id = catalog.create_view_profile(
+                    "vector",
+                    {"test_profile": case},
+                )
+                if case == "full_vector":
+                    view_type = "vector"
+                    profile_id = vector_profile_id
+            elif case == "graph":
+                view_type = "graph"
+                profile_id = catalog.create_view_profile(
+                    "graph",
+                    {"test_profile": case},
+                )
+            views = {
+                view_type: {
+                    "profile_id": profile_id,
+                    "requested_mode": (
+                        "incremental" if case == "incremental" else "full"
+                    ),
+                    "required": case != "optional",
+                }
+            }
+            if case == "multi_view":
+                views["vector"] = {
+                    "profile_id": vector_profile_id,
+                    "requested_mode": "full",
+                    "required": True,
+                }
+            queued = catalog.create_job(
+                repository_id,
+                source_revision_id,
+                f"candidate-{case}",
+                {"contract": INDEX_JOB_REQUEST_CONTRACT, "views": views},
+            )
+
+        target = LocalCompilerCacheJobTarget(
+            repository_root=fixture.repository,
+            cache_dir=fixture.cache,
+            workspace_provider=LocalWorkspaceProvider(fixture.workspace),
+            repository_key=_REPOSITORY_KEY,
+            environ={},
+        )
+        resources = LocalCompilerCacheJobResourceFactory((target,))
+
+        assert resources.accepts_candidate(queued) is expected
+    finally:
+        fixture.close()
+
+
 def test_local_compiler_cache_job_factory_runs_and_isolates_attempt_workspaces(
     tmp_path: Path,
 ) -> None:
@@ -1486,6 +1561,20 @@ def test_local_compiler_cache_job_factory_runs_and_isolates_attempt_workspaces(
                     source_revision_id=source_revision_id,
                     profile_id=profile_id,
                 )
+                foreign_repository_id = catalog.create_repository("owner/foreign")
+                foreign_source_revision_id = catalog.create_source_revision(
+                    foreign_repository_id,
+                    commit_sha=None,
+                    dirty=True,
+                    source_fingerprint=fixture.source.fingerprint,
+                )
+                foreign = _create_bm25_job(
+                    catalog,
+                    repository_id=foreign_repository_id,
+                    source_revision_id=foreign_source_revision_id,
+                    profile_id=profile_id,
+                    idempotency_key="foreign-compiler-cache-bm25",
+                )
 
             target = LocalCompilerCacheJobTarget(
                 repository_root=fixture.repository,
@@ -1495,6 +1584,9 @@ def test_local_compiler_cache_job_factory_runs_and_isolates_attempt_workspaces(
                 environ={},
             )
             assert target.repository_id == repository_id
+            resources = LocalCompilerCacheJobResourceFactory((target,))
+            assert resources.accepts_candidate(queued)
+            assert not resources.accepts_candidate(foreign)
             worker = IndexJobWorker(
                 catalog_factory=_CompilerCacheWorkerFactory(
                     catalog_path,
@@ -1502,9 +1594,10 @@ def test_local_compiler_cache_job_factory_runs_and_isolates_attempt_workspaces(
                 ),
                 object_store=cas,
                 resolver=CompilerCacheJobResolver(
-                    resource_factory=LocalCompilerCacheJobResourceFactory((target,)),
+                    resource_factory=resources,
                     object_store=cas,
                 ),
+                candidate_filter=resources.accepts_candidate,
                 lease_duration_ms=60_000,
                 heartbeat_interval_ms=5,
                 owner_id_factory=lambda: "local-compiler-cache-worker",
@@ -1525,6 +1618,9 @@ def test_local_compiler_cache_job_factory_runs_and_isolates_attempt_workspaces(
                 completed = catalog.get_job(queued.job_id)
                 assert completed.status is IndexJobStatus.SUCCEEDED
                 assert completed.result_snapshot_id is not None
+                untouched = catalog.get_job(foreign.job_id)
+                assert untouched.status is IndexJobStatus.QUEUED
+                assert untouched.attempt_count == 0
     finally:
         fixture.close()
 
@@ -1744,6 +1840,75 @@ def test_compiler_cache_scope_cleanup_cannot_replace_executor_failure(
                 running = catalog.get_job(queued.job_id)
                 assert running.status is IndexJobStatus.RUNNING
                 assert running.result_snapshot_id is None
+    finally:
+        fixture.close()
+
+
+def test_jobs_run_once_cli_publishes_one_trusted_local_cache_job(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    plan = _expected_bm25_job_plan(fixture)
+    catalog_path = tmp_path / "worker.sqlite"
+    cas_root = tmp_path / "cas"
+    provider = LocalWorkspaceProvider(fixture.workspace)
+    try:
+        try:
+            provider.require_support()
+        except UnsupportedWorkspaceCreation as exc:
+            pytest.skip(str(exc))
+        with LocalCAS.provision(cas_root):
+            pass
+        with SQLiteCatalog(catalog_path) as catalog:
+            repository_id, source_revision_id, profile_id = _register_bm25_job_subject(
+                catalog,
+                fixture,
+                plan,
+            )
+            queued = _create_bm25_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+            )
+        args = cli_module.build_parser().parse_args(
+            [
+                "jobs",
+                "run-once",
+                str(fixture.repository),
+                "--cache-dir",
+                str(fixture.cache),
+                "--catalog",
+                str(catalog_path),
+                "--cas-root",
+                str(cas_root),
+                "--workspace-root",
+                str(fixture.workspace),
+                "--repository",
+                _REPOSITORY_KEY,
+                "--lease-duration-ms",
+                "60000",
+                "--heartbeat-interval-ms",
+                "5",
+                "--json",
+            ]
+        )
+
+        assert args.handler is cli_module._run_jobs_run_once
+        assert cli_module._run_jobs_run_once(args) == 0
+
+        assert json.loads(capsys.readouterr().out) == {
+            "attempt_count": 1,
+            "disposition": "succeeded",
+            "job_id": queued.job_id,
+        }
+        assert not tuple(fixture.workspace.glob(".codenib-cache-job-*"))
+        assert len(tuple(fixture.workspace.glob(".*.discarded-*"))) == 2
+        with SQLiteCatalog(catalog_path, create=False) as catalog:
+            completed = catalog.get_job(queued.job_id)
+            assert completed.status is IndexJobStatus.SUCCEEDED
+            assert completed.result_snapshot_id is not None
     finally:
         fixture.close()
 

--- a/test/storage/test_job_worker.py
+++ b/test/storage/test_job_worker.py
@@ -1491,6 +1491,7 @@ def _worker(
     backend: _Backend,
     resolver: _Resolver,
     *,
+    candidate_filter: Callable[[IndexJobRecord], bool] | None = None,
     owner_id_factory: Callable[[], str] = lambda: "worker-default",
     lease_duration_ms: int = 300,
     heartbeat_interval_ms: int = 50,
@@ -1505,6 +1506,7 @@ def _worker(
         lease_duration_ms=lease_duration_ms,
         heartbeat_interval_ms=heartbeat_interval_ms,
         scan_limit=scan_limit,
+        candidate_filter=candidate_filter,
         owner_id_factory=owner_id_factory,
         monotonic=lambda: 0.0,
     )
@@ -1585,6 +1587,20 @@ def test_worker_constructor_rejects_a_different_bound_resolver_store() -> None:
         )
 
 
+def test_worker_constructor_requires_callable_candidate_filter() -> None:
+    backend = _Backend()
+
+    with pytest.raises(TypeError, match="candidate filter must be callable"):
+        IndexJobWorker(
+            catalog_factory=_SessionFactory(backend),
+            object_store=_RetainingStore(),
+            resolver=_default_resolver(),
+            lease_duration_ms=300,
+            heartbeat_interval_ms=50,
+            candidate_filter=object(),  # type: ignore[arg-type]
+        )
+
+
 def test_empty_scan_returns_idle_without_creating_an_owner() -> None:
     backend = _Backend()
     owners: list[str] = []
@@ -1650,6 +1666,101 @@ def test_structurally_damaged_scan_candidate_fails_closed() -> None:
     assert backend.completion_calls == []
     assert backend.publication_calls == []
     assert store.retained == []
+
+
+def test_candidate_filter_skips_jobs_before_owner_or_claim() -> None:
+    backend = _Backend()
+    first = backend.add_job("unsupported-first")
+    second = backend.add_job("supported-second")
+    considered: list[str] = []
+    owners: list[str] = []
+
+    def accept(job: IndexJobRecord) -> bool:
+        considered.append(job.job_id)
+        return job.job_id == second.job_id
+
+    worker, _store, _factory = _worker(
+        backend,
+        _default_resolver(),
+        candidate_filter=accept,
+        owner_id_factory=lambda: owners.append("selected-owner") or "selected-owner",
+    )
+
+    result = worker.run_once()
+
+    assert result.disposition is IndexJobWorkerDisposition.SUCCEEDED
+    assert result.job_id == second.job_id
+    assert considered == [first.job_id, second.job_id]
+    assert owners == ["selected-owner"]
+    assert [call[1] for call in backend.acquire_calls] == [second.job_id]
+    assert backend.jobs[first.job_id].status is IndexJobStatus.QUEUED
+
+
+@pytest.mark.parametrize("decision", (None, 1, "true"))
+def test_candidate_filter_requires_an_exact_boolean_before_claim(
+    decision: object,
+) -> None:
+    backend = _Backend()
+    backend.add_job("invalid-filter-decision")
+    worker, store, _factory = _worker(
+        backend,
+        _default_resolver(),
+        candidate_filter=lambda _job: decision,  # type: ignore[return-value]
+    )
+
+    with pytest.raises(StorageIntegrityError, match="non-exact decision"):
+        worker.run_once()
+
+    assert backend.acquire_calls == []
+    assert backend.completion_calls == []
+    assert backend.publication_calls == []
+    assert store.retained == []
+
+
+def test_candidate_filter_failure_is_integrity_alarm_before_claim() -> None:
+    backend = _Backend()
+    backend.add_job("filter-failure")
+
+    def fail(_job: IndexJobRecord) -> bool:
+        raise RuntimeError("filter unavailable")
+
+    worker, store, _factory = _worker(
+        backend,
+        _default_resolver(),
+        candidate_filter=fail,
+    )
+
+    with pytest.raises(StorageIntegrityError, match="candidate filter failed"):
+        worker.run_once()
+
+    assert backend.acquire_calls == []
+    assert backend.completion_calls == []
+    assert backend.publication_calls == []
+    assert store.retained == []
+
+
+def test_candidate_filter_cannot_mutate_the_detached_candidate() -> None:
+    backend = _Backend()
+    queued = backend.add_job("filter-mutation")
+
+    def mutate(job: IndexJobRecord) -> bool:
+        object.__setattr__(job, "status", IndexJobStatus.FAILED)
+        return True
+
+    worker, store, _factory = _worker(
+        backend,
+        _default_resolver(),
+        candidate_filter=mutate,
+    )
+
+    with pytest.raises(StorageIntegrityError, match="damaged its candidate"):
+        worker.run_once()
+
+    assert backend.acquire_calls == []
+    assert backend.completion_calls == []
+    assert backend.publication_calls == []
+    assert store.retained == []
+    assert backend.jobs[queued.job_id].status is IndexJobStatus.QUEUED
 
 
 def test_claim_conflict_continues_with_a_fresh_owner_for_next_candidate() -> None:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -535,6 +535,56 @@ def test_artifact_import_cache_parser_exposes_existing_storage_inputs() -> None:
     assert overflow.value.code == 2
 
 
+def test_jobs_run_once_parser_exposes_bounded_worker_inputs() -> None:
+    base = [
+        "jobs",
+        "run-once",
+        "/src/repo",
+        "--cache-dir",
+        "/src/repo/.codenib_index",
+        "--catalog",
+        "/state/catalog.sqlite3",
+        "--cas-root",
+        "/state/cas",
+        "--workspace-root",
+        "/state/workspaces",
+        "--repository",
+        "owner/repo",
+    ]
+    defaults = cli.build_parser().parse_args(base)
+    configured = cli.build_parser().parse_args(
+        [
+            *base,
+            "--namespace",
+            "production",
+            "--lease-duration-ms",
+            "60000",
+            "--heartbeat-interval-ms",
+            "10000",
+            "--scan-limit",
+            "128",
+            "--json",
+        ]
+    )
+
+    assert defaults.handler is cli._run_jobs_run_once
+    assert defaults.jobs_command == "run-once"
+    assert defaults.namespace == "default"
+    assert defaults.lease_duration_ms == 30_000
+    assert defaults.heartbeat_interval_ms == 5_000
+    assert defaults.scan_limit == 64
+    assert defaults.json is False
+    assert configured.namespace == "production"
+    assert configured.lease_duration_ms == 60_000
+    assert configured.heartbeat_interval_ms == 10_000
+    assert configured.scan_limit == 128
+    assert configured.json is True
+
+    with pytest.raises(SystemExit) as invalid:
+        cli.build_parser().parse_args([*base, "--scan-limit", "0"])
+    assert invalid.value.code == 2
+
+
 def test_artifact_import_cache_freezes_missing_disjoint_topology(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Add one bounded production CLI pass for an explicitly trusted local compiler-cache target.

PRs #694, #696, and #697 are merged; this branch is restacked directly on main.

## Changes

- add an optional detached pre-claim candidate filter to the durable worker, with fail-closed validation before owner allocation or lease mutation
- limit the trusted local resource factory to exact one-view required full BM25/vector requests while leaving foreign and unsupported jobs untouched
- add existing-only catalog sessions, strict LocalCAS retention, and codenib jobs run-once for at most one eligible job from one bounded advisory page
- preserve the side-effect-free create-scope resolver contract introduced by #697
- document topology, cleanup, output, and scheduler boundaries and update the storage backend roadmap
- add parser, eligibility, isolation, and forced-native end-to-end coverage

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- focused candidate, resolver, cleanup, and CLI tests: 17 passed, 1 skipped
- full changed-file surface: 461 passed, 5 skipped, 1 known environment-only baseline test deselected
- the deselected no-extension failure reproduces unchanged on #697
- forced-native jobs run-once end-to-end test: 1 passed
- post-#697 restack range-diff: patch-equivalent
- mkdocs build --strict
- public docs boundary and namespace consistency checks
- pinned Black, isort, flake8, and pre-commit hooks

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
