### PR TITLE
feat(web): add RCU repository generations

### DIFF
--- a/codenib/index/embedding/vector_store.py
+++ b/codenib/index/embedding/vector_store.py
@@ -25,10 +25,7 @@ import faiss
 import numpy as np
 
 from ... import compat_pickle
-from ..._atomic_directory import (
-    PublicationDirectoryReader,
-    _annotate_secondary_error,
-)
+from ..._atomic_directory import PublicationDirectoryReader, _annotate_secondary_error
 from ..._bounded_json import canonical_json_array_chunks, iter_bounded_json_array
 from ..._captured_directory import AuthenticatedSnapshotReader
 from ...log_utils import get_logger
@@ -1053,6 +1050,24 @@ class CodeVectorStore:
             state = _LoadedVectorState(None, [], None, [], {}, None)
             self._loaded_state = state
         return state
+
+    @property
+    def closed(self) -> bool:
+        """Whether every resource owned by this store has been released."""
+
+        state = getattr(self, "_loaded_state", None)
+        if state is None:
+            return getattr(self, "embedding", None) is None
+        return bool(
+            state.l0_index is None
+            and state.l2_index is None
+            and not state.l0_documents
+            and not state.l2_documents
+            and getattr(self, "embedding", None) is None
+            and getattr(self, "_query_cache_depth", 0) == 0
+            and getattr(self, "_cached_query_text", None) is None
+            and getattr(self, "_cached_query_vector", None) is None
+        )
 
     @property
     def l0_index(self) -> Any:

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -22,7 +22,7 @@ import asyncio
 import hashlib
 import os
 from collections.abc import Mapping
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 from functools import partial
 from pathlib import Path, PurePosixPath
 from time import perf_counter
@@ -159,7 +159,13 @@ async def lifespan(app: FastAPI):
         logger.info("Ready: %d repo(s) available", len(registry.list_infos()))
         yield
     finally:
-        registry.close()
+        try:
+            registry.close()
+        finally:
+            for name in ("wiki_builders", "edge_labelers", "commit_windows"):
+                cache = getattr(app.state, name, None)
+                if isinstance(cache, dict):
+                    cache.clear()
 
 
 app = FastAPI(title="CodeNib Code QA", lifespan=lifespan)
@@ -178,7 +184,10 @@ async def add_request_timing(request: Request, call_next):
     """Expose backend time and log slow API paths without query contents."""
 
     started_at = perf_counter()
-    response = await call_next(request)
+    try:
+        response = await call_next(request)
+    finally:
+        _prune_retired_generation_caches()
     duration_ms = (perf_counter() - started_at) * 1000
     response.headers.append("Server-Timing", f"codenib;dur={duration_ms:.1f}")
     if request.url.path.startswith("/api/") and duration_ms >= 2_000:
@@ -224,28 +233,150 @@ def _bundle(repo_id: str):
     return bundle
 
 
-def _wiki(repo_id: str):
+@contextmanager
+def _pinned_bundle(repo_id: str):
+    """Keep one repository generation alive for a complete Web operation."""
+
+    registry = getattr(app.state, "registry", None)
+    pin = getattr(registry, "pin", None)
+    if not callable(pin):
+        # Preserve the small injected registry contract used by offline tools;
+        # the production RepoRegistry always supplies generation pinning.
+        yield _bundle(repo_id)
+        return
+    with pin(repo_id) as bundle:
+        if bundle is None:
+            raise HTTPException(status_code=404, detail=f"Unknown repo: {repo_id!r}")
+        yield bundle
+
+
+_THREAD_CALL_SUCCEEDED = object()
+_THREAD_CALL_FAILED = object()
+
+
+def _capture_thread_outcome(function, args, kwargs):
+    """Keep control-flow exceptions out of asyncio Future transport."""
+
+    try:
+        return (_THREAD_CALL_SUCCEEDED, function(*args, **kwargs))
+    except BaseException as failure:  # noqa: B036 - preserve exact identity
+        return (_THREAD_CALL_FAILED, failure)
+
+
+async def _run_pinned_thread(function, /, *args, **kwargs):
+    """Keep the surrounding bundle lease until an offloaded call settles."""
+
+    worker = asyncio.create_task(
+        asyncio.to_thread(_capture_thread_outcome, function, args, kwargs)
+    )
+    try:
+        outcome = await asyncio.shield(worker)
+    except asyncio.CancelledError:
+        # Cancelling an asyncio.to_thread() awaiter cannot stop a thread that is
+        # already using the pinned generation.  Consume repeated cancellation
+        # requests until that worker settles, then let the original cancellation
+        # leave the surrounding pin context.  Any worker failure is secondary to
+        # the already-observed request cancellation and is consumed here so it
+        # cannot become an un-retrieved task exception.
+        while not worker.done():
+            try:
+                await asyncio.shield(worker)
+            except asyncio.CancelledError:
+                continue
+            except BaseException:  # noqa: B036 - cancellation stays primary
+                break
+        if worker.done() and not worker.cancelled():
+            try:
+                worker.result()
+            except BaseException:  # noqa: B036 - consume secondary worker failure
+                pass
+        raise
+    state, value = outcome
+    if state is _THREAD_CALL_FAILED:
+        if isinstance(value, (StopIteration, StopAsyncIteration)):
+            # Iteration sentinels cannot cross an async function boundary:
+            # PEP 479 would otherwise rewrite them implicitly. Make that
+            # unavoidable mapping explicit and retain the exact worker error.
+            raise RuntimeError("thread worker raised an iteration sentinel") from value
+        raise value
+    return value
+
+
+def _generation_cached(cache: dict, key: str, bundle, factory):
+    """Reuse a helper only while it is bound to the active bundle generation."""
+
+    repo_id = getattr(getattr(bundle, "entry", None), "instance_id", None)
+    if repo_id is not None:
+        for cached_key, cached_value in tuple(cache.items()):
+            if not (
+                isinstance(cached_value, tuple)
+                and len(cached_value) == 2
+                and cached_value[0] is not bundle
+                and getattr(
+                    getattr(cached_value[0], "entry", None),
+                    "instance_id",
+                    None,
+                )
+                == repo_id
+            ):
+                continue
+            cache.pop(cached_key, None)
+    cached = cache.get(key)
+    if isinstance(cached, tuple) and len(cached) == 2 and cached[0] is bundle:
+        return cached[1]
+    value = factory()
+    cache[key] = (bundle, value)
+    return value
+
+
+def _prune_retired_generation_caches(registry=None) -> None:
+    """Drop helpers whose bundle is no longer the published generation."""
+
+    if registry is None:
+        registry = getattr(app.state, "registry", None)
+    get_bundle = getattr(registry, "get", None)
+    if not callable(get_bundle):
+        return
+    for name in ("wiki_builders", "edge_labelers", "commit_windows"):
+        cache = getattr(app.state, name, None)
+        if not isinstance(cache, dict):
+            continue
+        for key, cached in tuple(cache.items()):
+            if not (isinstance(cached, tuple) and len(cached) == 2):
+                continue
+            bundle = cached[0]
+            repo_id = getattr(getattr(bundle, "entry", None), "instance_id", None)
+            try:
+                current = get_bundle(repo_id) if repo_id is not None else bundle
+            except BaseException:  # noqa: B036 - cache pruning is best effort
+                continue
+            if current is not bundle:
+                cache.pop(key, None)
+
+
+def _wiki(repo_id: str, bundle=None):
     """Lazily build + cache a wiki per repo (conceptual agent wiki by default)."""
+    if bundle is None:
+        bundle = _bundle(repo_id)
     cache = app.state.wiki_builders
-    if repo_id not in cache:
+
+    def build():
         config = load_config()
         if getattr(config, "wiki_agent", True):
             from ..wiki.agent_wiki import AgentWiki
 
             wiki_cache = os.path.join(os.path.abspath(config.data_dir), "wiki_cache")
-            cache[repo_id] = AgentWiki(
-                _bundle(repo_id),
+            return AgentWiki(
+                bundle,
                 config.wiki_generation_model,
                 cache_dir=wiki_cache,
                 llm=_wiki_llm(config),
                 api_base=config.wiki_generation_api_base,
                 api_key=config.wiki_generation_api_key,
             )
-        else:
-            cache[repo_id] = WikiBuilder(
-                _bundle(repo_id), narrator=getattr(app.state, "narrator", None)
-            )
-    return cache[repo_id]
+        return WikiBuilder(bundle, narrator=getattr(app.state, "narrator", None))
+
+    return _generation_cached(cache, repo_id, bundle, build)
 
 
 def _wiki_media_dir(config, repo_id: str, page_id: str) -> Path:
@@ -287,7 +418,12 @@ def _wiki_media_evidence_builder(bundle, page: Mapping):
     )
 
 
-def _materialize_wiki_media(repo_id: str, page_id: str, page: dict) -> dict:
+def _materialize_wiki_media(
+    repo_id: str,
+    page_id: str,
+    page: dict,
+    bundle=None,
+) -> dict:
     """Attach generated media assets when a wiki media provider is configured."""
 
     public_page = redact_media_evidence_packs(page)
@@ -305,7 +441,10 @@ def _materialize_wiki_media(repo_id: str, page_id: str, page: dict) -> dict:
             generator=generator,
             output_dir=_wiki_media_dir(config, repo_id, page_id),
             asset_base_path=asset_base,
-            evidence_builder=_wiki_media_evidence_builder(_bundle(repo_id), page),
+            evidence_builder=_wiki_media_evidence_builder(
+                bundle if bundle is not None else _bundle(repo_id),
+                page,
+            ),
         )
     except MemoryError:
         raise
@@ -339,15 +478,16 @@ def _safe_media_filename(value: str) -> str:
     return filename
 
 
-def _edge_labeler(repo_id: str, commit: str | None = None):
+def _edge_labeler(repo_id: str, commit: str | None = None, bundle=None):
     """Build a labeler whose source reader matches the requested graph commit."""
     cache = app.state.edge_labelers
-    bundle = _bundle(repo_id)
+    if bundle is None:
+        bundle = _bundle(repo_id)
     base_commit = str(bundle.entry.base_commit or "")
     source_fn = None
     source_commit = base_commit
     if commit:
-        window = _commit_window(repo_id)
+        window = _commit_window(repo_id, bundle)
         entry = window.resolve(commit) if window.available else None
         if entry is not None:
             source_commit = str(entry.get("sha") or "")
@@ -371,14 +511,15 @@ def _edge_labeler(repo_id: str, commit: str | None = None):
         )
 
     cache_key = f"{repo_id}@{source_commit}"
-    if cache_key not in cache:
+
+    def build():
         from .edge_label import EdgeLabeler
 
         config = load_config()
         wiki_cache = os.path.join(os.path.abspath(config.data_dir), "wiki_cache")
         namespace = f"{bundle.entry.instance_id}@{source_commit}"
         model = config.edge_label_model or config.wiki_generation_model
-        cache[cache_key] = EdgeLabeler(
+        return EdgeLabeler(
             source_fn=source_fn,
             model=model,
             cache_dir=wiki_cache,
@@ -387,28 +528,41 @@ def _edge_labeler(repo_id: str, commit: str | None = None):
             api_base=config.wiki_generation_api_base,
             api_key=config.wiki_generation_api_key,
         )
-    return cache[cache_key]
+
+    return _generation_cached(cache, cache_key, bundle, build)
 
 
-def _commit_window(repo_id: str):
+def _commit_window(repo_id: str, bundle=None):
     """Lazily build + cache this repo's per-commit graph window."""
+    if bundle is None:
+        bundle = _bundle(repo_id)
     cache = app.state.commit_windows
-    if repo_id not in cache:
+
+    def build():
         from .commit_window import CommitWindow
 
-        cache[repo_id] = CommitWindow(_bundle(repo_id).entry.repo_dir)
-    return cache[repo_id]
+        return CommitWindow(bundle.entry.repo_dir)
+
+    return _generation_cached(cache, repo_id, bundle, build)
 
 
-def _window_stats_for(repo_id: str):
-    """Commit-window cost figures for *repo_id*, or None when it has no window."""
+def _window_stats_for_bundle(repo_id: str, bundle):
+    """Commit-window cost figures bound to one already-pinned generation."""
+
     from .schemas import WindowStats
 
-    window = _commit_window(repo_id)
+    window = _commit_window(repo_id, bundle)
     if not window.available:
         return None
     stats = window.summary().get("stats")
     return WindowStats(**stats) if stats else None
+
+
+def _window_stats_for(repo_id: str):
+    """Commit-window cost figures for *repo_id*, or None when it has no window."""
+
+    with _pinned_bundle(repo_id) as bundle:
+        return _window_stats_for_bundle(repo_id, bundle)
 
 
 @app.get("/api/health")
@@ -422,39 +576,54 @@ async def health() -> dict:
 
 @app.get("/api/repos", response_model=list[RepoInfo])
 async def list_repos() -> list[RepoInfo]:
-    infos = _registry().list_infos()
-    # Surface the (global) edge-label toggle per repo so the UI can gate the
-    # feature. repo_registry.py is skip-worktree, so inject it here instead.
+    registry = _registry()
     edge_on = bool(getattr(load_config(), "edge_labels", False))
-    for info in infos:
+
+    async def decorate(info: RepoInfo, bundle=None) -> RepoInfo:
+        # Surface the global edge-label toggle per repo so the UI can gate the
+        # feature, then derive window figures from that same generation.
         info.capabilities = {**info.capabilities, "edge_labels": edge_on}
-        # Attach commit-window cost figures so the landing page can say what
-        # incremental maintenance bought, rather than only naming a commit.
-        # CommitWindow is lazy and cached per repo, and _bundle() is a registry
-        # lookup with no graph loading, so this stays one cheap request.
         try:
-            info.incremental = await asyncio.to_thread(_window_stats_for, info.id)
+            if bundle is None:
+                info.incremental = await asyncio.to_thread(
+                    _window_stats_for,
+                    info.id,
+                )
+            else:
+                info.incremental = await _run_pinned_thread(
+                    _window_stats_for_bundle,
+                    info.id,
+                    bundle,
+                )
         except HTTPException:
-            # Registry and bundle can disagree transiently; a missing bundle
-            # just means no window figures for that card.
             info.incremental = None
-    return infos
+        return info
+
+    pin_all = getattr(registry, "pin_all", None)
+    if callable(pin_all):
+        with pin_all() as bundles:
+            return [await decorate(bundle.info(), bundle) for bundle in bundles]
+
+    # Preserve the intentionally small injected registry contract used by
+    # offline tools and route tests. Production always takes the coherent path.
+    return [await decorate(info) for info in registry.list_infos()]
 
 
 @app.get("/api/repos/{repo_id}/wiki")
 async def wiki_tree(repo_id: str, cached_only: bool = False) -> dict:
-    builder = _wiki(repo_id)
-    if cached_only:
-        cached_page_tree = getattr(builder, "cached_page_tree", None)
-        pages = (
-            await asyncio.to_thread(cached_page_tree)
-            if callable(cached_page_tree)
-            else None
-        )
-        pages = pages or []
-    else:
-        pages = await asyncio.to_thread(builder.page_tree)
-    return {"repo": _bundle(repo_id).entry.repo, "pages": pages}
+    with _pinned_bundle(repo_id) as bundle:
+        builder = _wiki(repo_id, bundle)
+        if cached_only:
+            cached_page_tree = getattr(builder, "cached_page_tree", None)
+            pages = (
+                await _run_pinned_thread(cached_page_tree)
+                if callable(cached_page_tree)
+                else None
+            )
+            pages = pages or []
+        else:
+            pages = await _run_pinned_thread(builder.page_tree)
+        return {"repo": bundle.entry.repo, "pages": pages}
 
 
 @app.get("/api/repos/{repo_id}/wiki/{page_id}")
@@ -463,51 +632,63 @@ async def wiki_page(
     page_id: str,
     materialize_media: bool = True,
 ) -> dict:
-    page = await asyncio.to_thread(_wiki(repo_id).page, page_id)
-    if page is None:
-        raise HTTPException(status_code=404, detail=f"Unknown wiki page: {page_id!r}")
-    if "media_slots" not in page:
-        page = {**page, "media_slots": []}
-    if materialize_media and page.get("media_slots"):
-        page = await asyncio.to_thread(_materialize_wiki_media, repo_id, page_id, page)
-    if "generation" not in page:
-        page = {
-            **page,
-            "generation": {
-                "mode": "offline",
-                "model": None,
-                "repaired": False,
-            },
-            "grounding": {
-                "valid": True,
-                "citation_coverage": 1.0,
-                "cited_evidence": len(page.get("citations") or []),
-                "evidence_count": len(page.get("citations") or []),
-                "relation_count": 0,
-            },
-        }
-    return redact_media_evidence_packs(page)
+    with _pinned_bundle(repo_id) as bundle:
+        page = await _run_pinned_thread(_wiki(repo_id, bundle).page, page_id)
+        if page is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Unknown wiki page: {page_id!r}",
+            )
+        if "media_slots" not in page:
+            page = {**page, "media_slots": []}
+        if materialize_media and page.get("media_slots"):
+            page = await _run_pinned_thread(
+                _materialize_wiki_media,
+                repo_id,
+                page_id,
+                page,
+                bundle,
+            )
+        if "generation" not in page:
+            page = {
+                **page,
+                "generation": {
+                    "mode": "offline",
+                    "model": None,
+                    "repaired": False,
+                },
+                "grounding": {
+                    "valid": True,
+                    "citation_coverage": 1.0,
+                    "cited_evidence": len(page.get("citations") or []),
+                    "evidence_count": len(page.get("citations") or []),
+                    "relation_count": 0,
+                },
+            }
+        return redact_media_evidence_packs(page)
 
 
 @app.get("/api/repos/{repo_id}/wiki-media/{page_id}/{filename:path}")
 async def wiki_media_asset(repo_id: str, page_id: str, filename: str):
-    _bundle(repo_id)  # 404 on unknown repo
-    safe_filename = _safe_media_filename(filename)
-    payload = read_generated_media_asset(
-        _wiki_media_dir(load_config(), repo_id, page_id), safe_filename
-    )
-    if payload is None:
-        raise HTTPException(status_code=404, detail="media asset not found")
-    suffix = Path(safe_filename).suffix.lower()
-    headers = {
-        "Cache-Control": "private, no-store",
-        "X-Content-Type-Options": "nosniff",
-    }
-    if suffix == ".svg":
-        headers["Content-Security-Policy"] = "default-src 'none'; sandbox"
-    return Response(
-        content=payload, media_type=_WIKI_MEDIA_TYPES[suffix], headers=headers
-    )
+    with _pinned_bundle(repo_id):
+        safe_filename = _safe_media_filename(filename)
+        payload = read_generated_media_asset(
+            _wiki_media_dir(load_config(), repo_id, page_id), safe_filename
+        )
+        if payload is None:
+            raise HTTPException(status_code=404, detail="media asset not found")
+        suffix = Path(safe_filename).suffix.lower()
+        headers = {
+            "Cache-Control": "private, no-store",
+            "X-Content-Type-Options": "nosniff",
+        }
+        if suffix == ".svg":
+            headers["Content-Security-Policy"] = "default-src 'none'; sandbox"
+        return Response(
+            content=payload,
+            media_type=_WIKI_MEDIA_TYPES[suffix],
+            headers=headers,
+        )
 
 
 @app.get("/api/repos/{repo_id}/wiki/{page_id}/graph")
@@ -517,46 +698,46 @@ async def wiki_page_graph(repo_id: str, page_id: str) -> dict:
     Lets a wiki page render as a *view over the graph* (subsystem symbols + how
     they connect), using the same ``{nodes, edges}`` payload as ``/codemap``.
     """
-    builder = _wiki(repo_id)
-    page_citations = getattr(builder, "page_citations", None)
-    if callable(page_citations):
-        citations = await asyncio.to_thread(page_citations, page_id)
-        if citations is None:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Unknown wiki page: {page_id!r}",
-            )
-    else:
-        # The deterministic WikiBuilder does not make a model call, so its
-        # existing page contract remains a safe compatibility fallback.
-        page = await asyncio.to_thread(builder.page, page_id)
-        if page is None:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Unknown wiki page: {page_id!r}",
-            )
-        citations = page.get("citations", []) if isinstance(page, dict) else []
-    bundle = _bundle(repo_id)
-    graph = await asyncio.to_thread(bundle.code_graph)
-    if graph is None:
-        return {
-            "available": False,
-            "nodes": [],
-            "edges": [],
-            "mermaid": "",
-            "note": bundle.graph_unavailable_note(),
-        }
-    from .codemap import build_page_subgraph
+    with _pinned_bundle(repo_id) as bundle:
+        builder = _wiki(repo_id, bundle)
+        page_citations = getattr(builder, "page_citations", None)
+        if callable(page_citations):
+            citations = await _run_pinned_thread(page_citations, page_id)
+            if citations is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Unknown wiki page: {page_id!r}",
+                )
+        else:
+            # The deterministic WikiBuilder does not make a model call, so its
+            # existing page contract remains a safe compatibility fallback.
+            page = await _run_pinned_thread(builder.page, page_id)
+            if page is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Unknown wiki page: {page_id!r}",
+                )
+            citations = page.get("citations", []) if isinstance(page, dict) else []
+        graph = await _run_pinned_thread(bundle.code_graph)
+        if graph is None:
+            return {
+                "available": False,
+                "nodes": [],
+                "edges": [],
+                "mermaid": "",
+                "note": bundle.graph_unavailable_note(),
+            }
+        from .codemap import build_page_subgraph
 
-    hierarchy_graph = await asyncio.to_thread(bundle.hierarchical_graph)
-    return await asyncio.to_thread(
-        build_page_subgraph,
-        graph,
-        citations,
-        repo_dir=bundle.entry.repo_dir,
-        hierarchy_graph=hierarchy_graph,
-        source_reader=bundle.source_reader,
-    )
+        hierarchy_graph = await _run_pinned_thread(bundle.hierarchical_graph)
+        return await _run_pinned_thread(
+            build_page_subgraph,
+            graph,
+            citations,
+            repo_dir=bundle.entry.repo_dir,
+            hierarchy_graph=hierarchy_graph,
+            source_reader=bundle.source_reader,
+        )
 
 
 @app.get("/api/repos/{repo_id}/source")
@@ -568,43 +749,51 @@ async def source(
     commit: str | None = None,
 ) -> dict:
     """Read source from the commit that produced the active graph payload."""
-    bundle = _bundle(repo_id)
-    result = None
-    if commit:
-        window = _commit_window(repo_id)
-        entry = window.resolve(commit) if window.available else None
-        if entry is not None:
-            result = await asyncio.to_thread(
-                _historical_source_slice,
-                bundle,
-                window.source_for,
-                commit,
-                file,
-                start,
-                end,
-            )
-        else:
-            base = str(bundle.entry.base_commit or "")
-            requested = commit.strip().lower()
-            if requested not in {base.lower(), base[:8].lower()}:
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"Unknown commit for this repo: {commit!r}",
+    with _pinned_bundle(repo_id) as bundle:
+        result = None
+        if commit:
+            window = _commit_window(repo_id, bundle)
+            entry = window.resolve(commit) if window.available else None
+            if entry is not None:
+                result = await _run_pinned_thread(
+                    _historical_source_slice,
+                    bundle,
+                    window.source_for,
+                    commit,
+                    file,
+                    start,
+                    end,
                 )
+            else:
+                base = str(bundle.entry.base_commit or "")
+                requested = commit.strip().lower()
+                if requested not in {base.lower(), base[:8].lower()}:
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"Unknown commit for this repo: {commit!r}",
+                    )
+                source_reader = getattr(bundle, "source_reader", None)
+                if source_reader is not None:
+                    result = await _run_pinned_thread(
+                        bound_source_slice,
+                        source_reader,
+                        file,
+                        start,
+                        end,
+                    )
+        else:
             source_reader = getattr(bundle, "source_reader", None)
             if source_reader is not None:
-                result = await asyncio.to_thread(
-                    bound_source_slice, source_reader, file, start, end
+                result = await _run_pinned_thread(
+                    bound_source_slice,
+                    source_reader,
+                    file,
+                    start,
+                    end,
                 )
-    else:
-        source_reader = getattr(bundle, "source_reader", None)
-        if source_reader is not None:
-            result = await asyncio.to_thread(
-                bound_source_slice, source_reader, file, start, end
-            )
-    if result is None:
-        raise HTTPException(status_code=404, detail=f"File not found: {file!r}")
-    return result
+        if result is None:
+            raise HTTPException(status_code=404, detail=f"File not found: {file!r}")
+        return result
 
 
 @app.get("/api/repos/{repo_id}/commits")
@@ -614,9 +803,9 @@ async def commits(repo_id: str) -> dict:
     Backed by ``scripts/build_commit_window.py``. Repos without a prebuilt
     window return ``available=False`` and the UI keeps its single-commit label.
     """
-    _bundle(repo_id)  # 404 on unknown repo
-    window = _commit_window(repo_id)
-    return await asyncio.to_thread(window.summary)
+    with _pinned_bundle(repo_id) as bundle:
+        window = _commit_window(repo_id, bundle)
+        return await _run_pinned_thread(window.summary)
 
 
 @app.get("/api/repos/{repo_id}/codemap")
@@ -633,75 +822,80 @@ async def codemap(
     Returns ``{available, root, nodes, edges, mermaid, ...}``; the ``mermaid``
     field renders directly in the frontend's existing diagram component.
     """
-    bundle = _bundle(repo_id)
-    # Prefer a commit-window snapshot when one exists: an explicit ``commit``
-    # selects that point in history, and an absent one still defaults to the
-    # window's newest commit so the graph matches the selector's default.
-    window = _commit_window(repo_id)
-    graph = None
-    selected_commit = None
-    loaded_from_window = False
-    fell_back = False
-    if window.available:
-        entry = window.resolve(commit)
-        if entry is None and commit:
-            raise HTTPException(
-                status_code=404, detail=f"Unknown commit for this repo: {commit!r}"
-            )
-        graph = await asyncio.to_thread(window.graph_for, commit)
-        if entry is not None and graph is not None:
-            selected_commit = entry.get("sha")
-            loaded_from_window = True
-    if graph is None:
-        # The snapshot was absent or unloadable (e.g. a graph.pkl written under
-        # an older schema_version). Serving the repo's default graph is fine;
-        # reporting it as the requested commit is not -- the client would render
-        # one commit's graph under another commit's label.
-        graph = await asyncio.to_thread(bundle.code_graph)
-        selected_commit = bundle.entry.base_commit
-        fell_back = window.available
-    if graph is None:
-        return {
-            "available": False,
-            "nodes": [],
-            "edges": [],
-            "hierarchy": {"root": "hier::root", "nodes": [], "open_files": []},
-            "mermaid": "",
-            "note": bundle.graph_unavailable_note(),
-            "setup": bundle.graph_setup().to_dict(),
-        }
-    from .codemap import build_codemap
+    with _pinned_bundle(repo_id) as bundle:
+        # Prefer a commit-window snapshot when one exists: an explicit ``commit``
+        # selects that point in history, and an absent one still defaults to the
+        # window's newest commit so the graph matches the selector's default.
+        window = _commit_window(repo_id, bundle)
+        graph = None
+        selected_commit = None
+        loaded_from_window = False
+        fell_back = False
+        if window.available:
+            entry = window.resolve(commit)
+            if entry is None and commit:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Unknown commit for this repo: {commit!r}",
+                )
+            graph = await _run_pinned_thread(window.graph_for, commit)
+            if entry is not None and graph is not None:
+                selected_commit = entry.get("sha")
+                loaded_from_window = True
+        if graph is None:
+            # The snapshot was absent or unloadable (e.g. a graph.pkl written under
+            # an older schema_version). Serving the repo's default graph is fine;
+            # reporting it as the requested commit is not -- the client would render
+            # one commit's graph under another commit's label.
+            graph = await _run_pinned_thread(bundle.code_graph)
+            selected_commit = bundle.entry.base_commit
+            fell_back = window.available
+        if graph is None:
+            return {
+                "available": False,
+                "nodes": [],
+                "edges": [],
+                "hierarchy": {
+                    "root": "hier::root",
+                    "nodes": [],
+                    "open_files": [],
+                },
+                "mermaid": "",
+                "note": bundle.graph_unavailable_note(),
+                "setup": bundle.graph_setup().to_dict(),
+            }
+        from .codemap import build_codemap
 
-    hierarchy_graph = (
-        None
-        if loaded_from_window
-        else await asyncio.to_thread(bundle.hierarchical_graph)
-    )
-    result = await asyncio.to_thread(
-        build_codemap,
-        graph,
-        symbol,
-        direction,
-        depth,
-        max_nodes,
-        repo_dir=bundle.entry.repo_dir,
-        repo_commit=selected_commit if loaded_from_window else None,
-        hierarchy_graph=hierarchy_graph,
-        source_reader=(
-            None if loaded_from_window else getattr(bundle, "source_reader", None)
-        ),
-        source_selection=(
-            _manifest_source_selection(bundle) if loaded_from_window else None
-        ),
-    )
-    # Let the client confirm which snapshot it is looking at. ``fell_back``
-    # marks the case where a window exists but its snapshot could not be served,
-    # so the UI can say so instead of implying the selection took effect.
-    if isinstance(result, dict):
-        result["commit"] = selected_commit
-        if fell_back:
-            result["fell_back"] = True
-    return result
+        hierarchy_graph = (
+            None
+            if loaded_from_window
+            else await _run_pinned_thread(bundle.hierarchical_graph)
+        )
+        result = await _run_pinned_thread(
+            build_codemap,
+            graph,
+            symbol,
+            direction,
+            depth,
+            max_nodes,
+            repo_dir=bundle.entry.repo_dir,
+            repo_commit=selected_commit if loaded_from_window else None,
+            hierarchy_graph=hierarchy_graph,
+            source_reader=(
+                None if loaded_from_window else getattr(bundle, "source_reader", None)
+            ),
+            source_selection=(
+                _manifest_source_selection(bundle) if loaded_from_window else None
+            ),
+        )
+        # Let the client confirm which snapshot it is looking at. ``fell_back``
+        # marks the case where a window exists but its snapshot could not be served,
+        # so the UI can say so instead of implying the selection took effect.
+        if isinstance(result, dict):
+            result["commit"] = selected_commit
+            if fell_back:
+                result["fell_back"] = True
+        return result
 
 
 @app.get("/api/repos/{repo_id}/modulemap")
@@ -720,63 +914,68 @@ async def modulemap(
     symbol references — so this aggregates reference edges through each symbol's
     file. Same ``{nodes, edges, hierarchy, mermaid}`` shape as ``/codemap``.
     """
-    bundle = _bundle(repo_id)
-    window = _commit_window(repo_id)
-    graph = None
-    selected_commit = None
-    loaded_from_window = False
-    fell_back = False
-    if window.available:
-        entry = window.resolve(commit)
-        if entry is None and commit:
-            raise HTTPException(
-                status_code=404, detail=f"Unknown commit for this repo: {commit!r}"
-            )
-        graph = await asyncio.to_thread(window.graph_for, commit)
-        if entry is not None and graph is not None:
-            selected_commit = entry.get("sha")
-            loaded_from_window = True
-    if graph is None:
-        graph = await asyncio.to_thread(bundle.code_graph)
-        selected_commit = bundle.entry.base_commit
-        fell_back = window.available
-    if graph is None:
-        return {
-            "available": False,
-            "granularity": (
-                granularity if granularity in ("file", "directory") else "file"
-            ),
-            "nodes": [],
-            "edges": [],
-            "hierarchy": {"root": "hier::root", "nodes": [], "open_files": []},
-            "mermaid": "",
-            "note": bundle.graph_unavailable_note(),
-            "setup": bundle.graph_setup().to_dict(),
-        }
-    from .modulemap import build_modulemap
+    with _pinned_bundle(repo_id) as bundle:
+        window = _commit_window(repo_id, bundle)
+        graph = None
+        selected_commit = None
+        loaded_from_window = False
+        fell_back = False
+        if window.available:
+            entry = window.resolve(commit)
+            if entry is None and commit:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Unknown commit for this repo: {commit!r}",
+                )
+            graph = await _run_pinned_thread(window.graph_for, commit)
+            if entry is not None and graph is not None:
+                selected_commit = entry.get("sha")
+                loaded_from_window = True
+        if graph is None:
+            graph = await _run_pinned_thread(bundle.code_graph)
+            selected_commit = bundle.entry.base_commit
+            fell_back = window.available
+        if graph is None:
+            return {
+                "available": False,
+                "granularity": (
+                    granularity if granularity in ("file", "directory") else "file"
+                ),
+                "nodes": [],
+                "edges": [],
+                "hierarchy": {
+                    "root": "hier::root",
+                    "nodes": [],
+                    "open_files": [],
+                },
+                "mermaid": "",
+                "note": bundle.graph_unavailable_note(),
+                "setup": bundle.graph_setup().to_dict(),
+            }
+        from .modulemap import build_modulemap
 
-    result = await asyncio.to_thread(
-        build_modulemap,
-        graph,
-        focus,
-        granularity,
-        depth,
-        max_nodes,
-        repo_dir=bundle.entry.repo_dir,
-        include_tests=include_tests,
-        repo_commit=selected_commit if loaded_from_window else None,
-        source_reader=(
-            None if loaded_from_window else getattr(bundle, "source_reader", None)
-        ),
-        source_selection=(
-            _manifest_source_selection(bundle) if loaded_from_window else None
-        ),
-    )
-    if isinstance(result, dict):
-        result["commit"] = selected_commit
-        if fell_back:
-            result["fell_back"] = True
-    return result
+        result = await _run_pinned_thread(
+            build_modulemap,
+            graph,
+            focus,
+            granularity,
+            depth,
+            max_nodes,
+            repo_dir=bundle.entry.repo_dir,
+            include_tests=include_tests,
+            repo_commit=selected_commit if loaded_from_window else None,
+            source_reader=(
+                None if loaded_from_window else getattr(bundle, "source_reader", None)
+            ),
+            source_selection=(
+                _manifest_source_selection(bundle) if loaded_from_window else None
+            ),
+        )
+        if isinstance(result, dict):
+            result["commit"] = selected_commit
+            if fell_back:
+                result["fell_back"] = True
+        return result
 
 
 @app.post("/api/repos/{repo_id}/edge-label", response_model=EdgeLabelResponse)
@@ -789,25 +988,25 @@ async def edge_label(repo_id: str, req: EdgeLabelRequest) -> EdgeLabelResponse:
     """
     if not bool(getattr(load_config(), "edge_labels", False)):
         return EdgeLabelResponse(label="", disabled=True)
-    _bundle(repo_id)  # 404 on unknown repo
-    try:
-        labeler = _edge_labeler(repo_id, req.commit)
-    except ValueError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    anchors = [a.model_dump() for a in req.anchors]
-    label, cached = await asyncio.to_thread(
-        labeler.label,
-        req.source.file,
-        req.source.line,
-        req.source.end_line,
-        req.source.label,
-        req.target.file,
-        req.target.line,
-        req.target.end_line,
-        req.target.label,
-        anchors,
-    )
-    return EdgeLabelResponse(label=label, cached=cached)
+    with _pinned_bundle(repo_id) as bundle:
+        try:
+            labeler = _edge_labeler(repo_id, req.commit, bundle)
+        except ValueError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        anchors = [a.model_dump() for a in req.anchors]
+        label, cached = await _run_pinned_thread(
+            labeler.label,
+            req.source.file,
+            req.source.line,
+            req.source.end_line,
+            req.source.label,
+            req.target.file,
+            req.target.line,
+            req.target.end_line,
+            req.target.label,
+            anchors,
+        )
+        return EdgeLabelResponse(label=label, cached=cached)
 
 
 @app.post("/api/chat", response_model=ChatResponse)
@@ -820,37 +1019,45 @@ async def chat(req: ChatRequest) -> ChatResponse:
     if not query:
         raise HTTPException(status_code=400, detail="query must not be empty")
 
-    bundle = _registry().get(req.repo_id)
-    if bundle is None:
-        raise HTTPException(status_code=404, detail=f"Unknown repo: {req.repo_id!r}")
-    await asyncio.to_thread(bundle.ensure_runtime)
-    if bundle.runner is None:
-        raise HTTPException(status_code=503, detail="repo runtime is unavailable")
+    with _pinned_bundle(req.repo_id) as bundle:
+        await _run_pinned_thread(bundle.ensure_runtime)
+        if bundle.runner is None:
+            raise HTTPException(status_code=503, detail="repo runtime is unavailable")
 
-    # Earlier messages give the agent context so it can resolve follow-ups
-    # like "what calls it?".
-    chat_history = [{"role": m.role, "content": m.content} for m in req.messages[:-1]]
+        # Earlier messages give the agent context so it can resolve follow-ups
+        # like "what calls it?".
+        chat_history = [
+            {"role": message.role, "content": message.content}
+            for message in req.messages[:-1]
+        ]
 
-    try:
-        result = await asyncio.to_thread(
-            bundle.runner.run, query, chat_history=chat_history
+        try:
+            result = await _run_pinned_thread(
+                bundle.runner.run,
+                query,
+                chat_history=chat_history,
+            )
+        except Exception as exc:  # noqa: BLE001 - clean 500 without query content
+            logger.error(
+                "agent run failed for %r: %s",
+                req.repo_id,
+                exc,
+                exc_info=True,
+            )
+            raise HTTPException(status_code=500, detail="agent run failed") from exc
+
+        source_reader = getattr(bundle, "source_reader", None)
+        if source_reader is None:
+            raise HTTPException(
+                status_code=503,
+                detail="authenticated repository source is unavailable",
+            )
+        return await _run_pinned_thread(
+            agent_result_to_response,
+            result,
+            repo_path=getattr(bundle.entry, "repo_dir", ""),
+            source_reader=source_reader,
         )
-    except Exception as exc:  # noqa: BLE001 - surface a clean 500 to the client
-        logger.error("agent run failed for %r: %s", req.repo_id, exc, exc_info=True)
-        raise HTTPException(status_code=500, detail="agent run failed") from exc
-
-    source_reader = getattr(bundle, "source_reader", None)
-    if source_reader is None:
-        raise HTTPException(
-            status_code=503,
-            detail="authenticated repository source is unavailable",
-        )
-    return await asyncio.to_thread(
-        agent_result_to_response,
-        result,
-        repo_path=getattr(bundle.entry, "repo_dir", ""),
-        source_reader=source_reader,
-    )
 
 
 def _parse_args(

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -293,7 +293,7 @@ async def _run_pinned_thread(function, /, *args, **kwargs):
         raise
     state, value = outcome
     if state is _THREAD_CALL_FAILED:
-        if isinstance(value, (StopIteration, StopAsyncIteration)):
+        if issubclass(type(value), (StopIteration, StopAsyncIteration)):
             # Iteration sentinels cannot cross an async function boundary:
             # PEP 479 would otherwise rewrite them implicitly. Make that
             # unavoidable mapping explicit and retain the exact worker error.
@@ -302,30 +302,28 @@ async def _run_pinned_thread(function, /, *args, **kwargs):
     return value
 
 
-def _generation_cached(cache: dict, key: str, bundle, factory):
+def _generation_cached(cache: dict, key: str, repo_id: str, bundle, factory):
     """Reuse a helper only while it is bound to the active bundle generation."""
 
-    repo_id = getattr(getattr(bundle, "entry", None), "instance_id", None)
-    if repo_id is not None:
-        for cached_key, cached_value in tuple(cache.items()):
-            if not (
-                isinstance(cached_value, tuple)
-                and len(cached_value) == 2
-                and cached_value[0] is not bundle
-                and getattr(
-                    getattr(cached_value[0], "entry", None),
-                    "instance_id",
-                    None,
-                )
-                == repo_id
-            ):
-                continue
-            cache.pop(cached_key, None)
+    for cached_key, cached_value in tuple(cache.items()):
+        if not (
+            isinstance(cached_value, tuple)
+            and len(cached_value) == 3
+            and cached_value[0] == repo_id
+            and cached_value[1] is not bundle
+        ):
+            continue
+        cache.pop(cached_key, None)
     cached = cache.get(key)
-    if isinstance(cached, tuple) and len(cached) == 2 and cached[0] is bundle:
-        return cached[1]
+    if (
+        isinstance(cached, tuple)
+        and len(cached) == 3
+        and cached[0] == repo_id
+        and cached[1] is bundle
+    ):
+        return cached[2]
     value = factory()
-    cache[key] = (bundle, value)
+    cache[key] = (repo_id, bundle, value)
     return value
 
 
@@ -342,12 +340,11 @@ def _prune_retired_generation_caches(registry=None) -> None:
         if not isinstance(cache, dict):
             continue
         for key, cached in tuple(cache.items()):
-            if not (isinstance(cached, tuple) and len(cached) == 2):
+            if not (isinstance(cached, tuple) and len(cached) == 3):
                 continue
-            bundle = cached[0]
-            repo_id = getattr(getattr(bundle, "entry", None), "instance_id", None)
+            repo_id, bundle, _helper = cached
             try:
-                current = get_bundle(repo_id) if repo_id is not None else bundle
+                current = get_bundle(repo_id)
             except BaseException:  # noqa: B036 - cache pruning is best effort
                 continue
             if current is not bundle:
@@ -376,7 +373,7 @@ def _wiki(repo_id: str, bundle=None):
             )
         return WikiBuilder(bundle, narrator=getattr(app.state, "narrator", None))
 
-    return _generation_cached(cache, repo_id, bundle, build)
+    return _generation_cached(cache, repo_id, repo_id, bundle, build)
 
 
 def _wiki_media_dir(config, repo_id: str, page_id: str) -> Path:
@@ -517,7 +514,7 @@ def _edge_labeler(repo_id: str, commit: str | None = None, bundle=None):
 
         config = load_config()
         wiki_cache = os.path.join(os.path.abspath(config.data_dir), "wiki_cache")
-        namespace = f"{bundle.entry.instance_id}@{source_commit}"
+        namespace = f"{repo_id}@{source_commit}"
         model = config.edge_label_model or config.wiki_generation_model
         return EdgeLabeler(
             source_fn=source_fn,
@@ -529,7 +526,7 @@ def _edge_labeler(repo_id: str, commit: str | None = None, bundle=None):
             api_key=config.wiki_generation_api_key,
         )
 
-    return _generation_cached(cache, cache_key, bundle, build)
+    return _generation_cached(cache, cache_key, repo_id, bundle, build)
 
 
 def _commit_window(repo_id: str, bundle=None):
@@ -543,7 +540,7 @@ def _commit_window(repo_id: str, bundle=None):
 
         return CommitWindow(bundle.entry.repo_dir)
 
-    return _generation_cached(cache, repo_id, bundle, build)
+    return _generation_cached(cache, repo_id, repo_id, bundle, build)
 
 
 def _window_stats_for_bundle(repo_id: str, bundle):

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -560,6 +560,11 @@ class RepoRegistry:
         self._cleanup_in_progress: set[int] = set()
         self._orphan_cleanup_owners: List[Any] = []
         self._closed = False
+        # Serialize registry-file snapshots through publication and removal
+        # reconciliation. Without this boundary, an older load_all() could
+        # retire a generation that a concurrent refresh() just published from
+        # a newer snapshot.
+        self._registry_reload_lock = RLock()
         # One embedding model per model name, shared across repos: the GPU model
         # is loaded once instead of once per CodeVectorStore (one per repo).
         self._embeddings: Dict[Tuple[str, str, int, Optional[str], str], object] = {}
@@ -570,44 +575,46 @@ class RepoRegistry:
 
         A repeated load no longer tears down the serving generation first. Each
         replacement is authenticated independently and then published under the
-        generation lock. A failed replacement leaves the previous bundle live.
+        generation lock. A failed replacement leaves the previous bundle live,
+        while active repositories absent from the complete snapshot are retired.
         """
 
-        with self._generation_lock:
-            if self._closed:
-                raise RuntimeError("repository registry is closed")
-        entries = load_registry(self._config.registry_path)
-        if not entries:
-            logger.warning(
-                "No QA registry at %s — run scripts/build_qa_index.py first.",
-                self._config.registry_path,
-            )
-            return
-        seen: set[str] = set()
-        for entry in entries:
-            instance_id = entry.instance_id
-            if instance_id in seen:
-                logger.error("Skipping duplicate repository id %r", instance_id)
-                continue
-            seen.add(instance_id)
-            if not os.path.exists(entry.manifest_path):
+        with self._registry_reload_lock:
+            with self._generation_lock:
+                if self._closed:
+                    raise RuntimeError("repository registry is closed")
+            entries = load_registry(self._config.registry_path)
+            if not entries:
                 logger.warning(
-                    "Skipping %r: manifest not found at %s",
-                    instance_id,
-                    entry.manifest_path,
+                    "No QA registry at %s — run scripts/build_qa_index.py first.",
+                    self._config.registry_path,
                 )
-                continue
-            try:
-                self._replace_entry(entry, prepare_runtime=False)
-                logger.info("Registered %r (%s)", instance_id, entry.repo)
-            except Exception as exc:  # noqa: BLE001 - keep other repos alive
-                self._retain_exception_cleanup(instance_id, exc)
-                logger.error(
-                    "Failed to load %r: %s",
-                    instance_id,
-                    exc,
-                    exc_info=True,
-                )
+            seen: set[str] = set()
+            for entry in entries:
+                instance_id = entry.instance_id
+                if instance_id in seen:
+                    logger.error("Skipping duplicate repository id %r", instance_id)
+                    continue
+                seen.add(instance_id)
+                if not os.path.exists(entry.manifest_path):
+                    logger.warning(
+                        "Skipping %r: manifest not found at %s",
+                        instance_id,
+                        entry.manifest_path,
+                    )
+                    continue
+                try:
+                    self._replace_entry(entry, prepare_runtime=False)
+                    logger.info("Registered %r (%s)", instance_id, entry.repo)
+                except Exception as exc:  # noqa: BLE001 - keep other repos alive
+                    self._retain_exception_cleanup(instance_id, exc)
+                    logger.error(
+                        "Failed to load %r: %s",
+                        instance_id,
+                        exc,
+                        exc_info=True,
+                    )
+            self._retire_entries_absent_from(seen)
 
     def refresh(self, repo_id: str) -> None:
         """Prepare and atomically publish a complete new bundle generation.
@@ -618,22 +625,44 @@ class RepoRegistry:
         unleased bundle that another concurrent refresh could retire.
         """
 
+        with self._registry_reload_lock:
+            with self._generation_lock:
+                if self._closed:
+                    raise RuntimeError("repository registry is closed")
+            entries = [
+                entry
+                for entry in load_registry(self._config.registry_path)
+                if entry.instance_id == repo_id
+            ]
+            if len(entries) != 1:
+                raise ValueError(
+                    "repository registry must contain exactly one entry for "
+                    f"{repo_id!r}"
+                )
+            entry = entries[0]
+            if not os.path.exists(entry.manifest_path):
+                raise FileNotFoundError(entry.manifest_path)
+            self._replace_entry(entry, prepare_runtime=True)
+
+    def _retire_entries_absent_from(self, instance_ids: set[str]) -> None:
+        """Remove active generations missing from one complete registry snapshot."""
+
         with self._generation_lock:
             if self._closed:
-                raise RuntimeError("repository registry is closed")
-        entries = [
-            entry
-            for entry in load_registry(self._config.registry_path)
-            if entry.instance_id == repo_id
-        ]
-        if len(entries) != 1:
-            raise ValueError(
-                f"repository registry must contain exactly one entry for {repo_id!r}"
+                return
+            for instance_id in tuple(self._bundles):
+                if instance_id in instance_ids:
+                    continue
+                owned = self._retire_active_locked(instance_id)
+                if owned is not None:
+                    self._retired_bundles[id(owned.bundle)] = owned
+        failure = self._drain_retired()
+        if failure is not None:
+            logger.error(
+                "Removed repository cleanup remains pending: %s",
+                failure,
+                exc_info=(type(failure), failure, failure.__traceback__),
             )
-        entry = entries[0]
-        if not os.path.exists(entry.manifest_path):
-            raise FileNotFoundError(entry.manifest_path)
-        self._replace_entry(entry, prepare_runtime=True)
 
     def _replace_entry(
         self,

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import os
 import re
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import partial
 from importlib.util import find_spec
 from threading import Lock, RLock
@@ -523,7 +523,7 @@ def _retain_cleanup_failure(
 
     if current is None:
         return later
-    if isinstance(current, Exception) and not isinstance(later, Exception):
+    if issubclass(type(current), Exception) and not issubclass(type(later), Exception):
         preferred = later
         secondary = current
         label = "earlier repository cleanup also failed"
@@ -553,14 +553,25 @@ def _raise_with_cleanup_failure(
 
 
 def _plain_repo_instance_id(value: Any) -> str:
-    """Detach a registry key from caller-defined string subclass methods."""
+    """Validate and detach one persistent repository registry key."""
 
-    if not isinstance(value, str):
+    if not issubclass(type(value), str):
         raise ValueError("repository instance_id must be non-empty text")
     instance_id = str.__str__(value)
     if not instance_id:
         raise ValueError("repository instance_id must be non-empty text")
     return instance_id
+
+
+_REPO_LOOKUP_MISS = object()
+
+
+def _plain_repo_lookup_key(value: Any) -> Any:
+    """Detach real string keys and safely map other legacy misses to a sentinel."""
+
+    if issubclass(type(value), str):
+        return str.__str__(value)
+    return _REPO_LOOKUP_MISS
 
 
 def _log_cleanup_failure(message: str, failure: BaseException) -> None:
@@ -578,6 +589,37 @@ def _log_cleanup_failure(message: str, failure: BaseException) -> None:
         )
     except BaseException:  # noqa: B036 - diagnostics cannot replace cleanup
         pass
+
+
+def _close_orphan_cleanup_owner(owner: Any) -> Tuple[bool, Optional[BaseException]]:
+    """Attempt one orphan authority without letting failures escape its claim."""
+
+    failure: BaseException | None = None
+    try:
+        closed = bool(owner.closed)
+    except BaseException as exc:  # noqa: B036 - uncertain means pending
+        closed = False
+        failure = _retain_cleanup_failure(failure, exc)
+    if not closed:
+        try:
+            owner.close()
+        except BaseException as exc:  # noqa: B036 - caller retains retry ownership
+            failure = _retain_cleanup_failure(failure, exc)
+        try:
+            closed = bool(owner.closed)
+        except BaseException as exc:  # noqa: B036 - uncertain means pending
+            closed = False
+            failure = _retain_cleanup_failure(failure, exc)
+    return closed, failure
+
+
+def _vector_cleanup_is_complete(vector_store: Any) -> bool:
+    """Read the vector store's monotonic cleanup attestation when available."""
+
+    try:
+        return bool(vector_store.closed)
+    except AttributeError:
+        return False
 
 
 class RepoRegistry:
@@ -621,9 +663,13 @@ class RepoRegistry:
         # publish under this lock, while retired generations remain reachable
         # until their final request releases its lease.
         self._generation_lock = RLock()
-        self._bundle_leases: Dict[int, int] = {}
+        self._bundle_leases: Dict[object, Tuple[int, ...]] = {}
         self._retired_bundles: Dict[int, _OwnedRepoBundle] = {}
-        self._cleanup_in_progress: set[int] = set()
+        # One atomic mapping entry claims both a retired bundle and its source
+        # authority. This avoids coupled-set release gaps under asynchronous
+        # exceptions; orphan-only authorities use their own atomic claim set.
+        self._cleanup_in_progress: Dict[int, Optional[int]] = {}
+        self._orphan_cleanup_in_progress: set[int] = set()
         self._orphan_cleanup_owners: List[Any] = []
         # Cleanup mutates retryable owners outside the generation lock. Keep
         # every drain and close serialized so shutdown cannot return while a
@@ -649,7 +695,7 @@ class RepoRegistry:
         while active repositories absent from the complete snapshot are retired.
         """
 
-        with self._registry_reload_lock:
+        with self._cleanup_lock, self._registry_reload_lock:
             with self._generation_lock:
                 if self._closed:
                     raise RuntimeError("repository registry is closed")
@@ -660,6 +706,7 @@ class RepoRegistry:
                     self._config.registry_path,
                 )
             seen: set[str] = set()
+            shutdown_failure: Optional[BaseException] = None
             for entry in entries:
                 try:
                     instance_id = _plain_repo_instance_id(entry.instance_id)
@@ -689,14 +736,26 @@ class RepoRegistry:
                     )
                     logger.info("Registered %r (%s)", instance_id, entry.repo)
                 except Exception as exc:  # noqa: BLE001 - keep other repos alive
-                    self._retain_exception_cleanup(instance_id, exc)
+                    try:
+                        self._retain_exception_cleanup(instance_id, exc)
+                    except BaseException as cleanup_failure:  # noqa: B036
+                        _raise_with_cleanup_failure(exc, cleanup_failure)
+                    with self._generation_lock:
+                        closed = self._closed
+                    if closed and shutdown_failure is None:
+                        shutdown_failure = exc
                     logger.error(
                         "Failed to load %r: %s",
                         instance_id,
                         exc,
                         exc_info=True,
                     )
+                    if closed:
+                        break
             self._retire_entries_absent_from(seen)
+            if shutdown_failure is not None:
+                raise shutdown_failure
+            self._raise_if_closed_after_cleanup()
 
     def refresh(self, repo_id: str) -> None:
         """Prepare and atomically publish a complete new bundle generation.
@@ -707,11 +766,11 @@ class RepoRegistry:
         unleased bundle that another concurrent refresh could retire.
         """
 
-        repo_id = _plain_repo_instance_id(repo_id)
-        with self._registry_reload_lock:
+        with self._cleanup_lock, self._registry_reload_lock:
             with self._generation_lock:
                 if self._closed:
                     raise RuntimeError("repository registry is closed")
+            repo_id = _plain_repo_instance_id(repo_id)
             entries = [
                 entry
                 for entry in load_registry(self._config.registry_path)
@@ -727,6 +786,21 @@ class RepoRegistry:
                 raise FileNotFoundError(entry.manifest_path)
             self._replace_entry(entry, prepare_runtime=True)
 
+    def _raise_if_closed_after_cleanup(
+        self,
+        cleanup_failure: Optional[BaseException] = None,
+    ) -> None:
+        """Reject false success when cleanup reentrantly shuts the registry."""
+
+        with self._generation_lock:
+            closed = self._closed
+        if not closed:
+            return
+        error = RuntimeError("repository registry is closed")
+        if cleanup_failure is not None:
+            _raise_with_cleanup_failure(error, cleanup_failure)
+        raise error
+
     def _retire_entries_absent_from(self, instance_ids: set[str]) -> None:
         """Remove active generations missing from one complete registry snapshot."""
 
@@ -736,9 +810,7 @@ class RepoRegistry:
             for instance_id in tuple(self._bundles):
                 if instance_id in instance_ids:
                     continue
-                owned = self._retire_active_locked(instance_id)
-                if owned is not None:
-                    self._retired_bundles[id(owned.bundle)] = owned
+                self._retire_active_locked(instance_id)
             # A failed metadata capture has no bundle to retire, but its owner
             # is still part of this complete registry snapshot. Once the id is
             # absent, move that owner to the generic retry drain instead of
@@ -746,30 +818,41 @@ class RepoRegistry:
             for instance_id in tuple(self._source_cleanup_owners):
                 if instance_id in instance_ids or instance_id in self._bundles:
                     continue
-                owner = self._source_cleanup_owners.pop(instance_id, None)
-                binding = self._source_bindings.pop(instance_id, None)
+                owner = self._source_cleanup_owners.get(instance_id)
+                binding = self._source_bindings.get(instance_id)
                 cleanup_owner = owner if owner is not None else binding
                 if cleanup_owner is not None and not any(
                     candidate is cleanup_owner
                     for candidate in self._orphan_cleanup_owners
                 ):
                     self._orphan_cleanup_owners.append(cleanup_owner)
+                self._source_cleanup_owners.pop(instance_id, None)
+                self._source_bindings.pop(instance_id, None)
         failure = self._drain_retired()
         if failure is not None:
-            if not isinstance(failure, Exception):
+            if not issubclass(type(failure), Exception):
+                self._raise_if_closed_after_cleanup(failure)
                 raise failure
             _log_cleanup_failure(
                 "Removed repository cleanup remains pending: %s",
                 failure,
             )
         orphan_failure = self._drain_orphan_cleanup()
+        cleanup_failure = failure
         if orphan_failure is not None:
-            if not isinstance(orphan_failure, Exception):
+            cleanup_failure = (
+                orphan_failure
+                if cleanup_failure is None
+                else _retain_cleanup_failure(cleanup_failure, orphan_failure)
+            )
+            if not issubclass(type(orphan_failure), Exception):
+                self._raise_if_closed_after_cleanup(cleanup_failure)
                 raise orphan_failure
             _log_cleanup_failure(
                 "Removed repository cleanup remains pending: %s",
                 orphan_failure,
             )
+        self._raise_if_closed_after_cleanup(cleanup_failure)
 
     def _replace_entry(
         self,
@@ -781,7 +864,10 @@ class RepoRegistry:
         try:
             owned = self._build_repo_metadata(entry)
         except BaseException as primary:  # noqa: B036 - retain retry owner
-            self._retain_exception_cleanup(instance_id, primary)
+            try:
+                self._retain_exception_cleanup(instance_id, primary)
+            except BaseException as cleanup_failure:  # noqa: B036
+                _raise_with_cleanup_failure(primary, cleanup_failure)
             raise
         try:
             if prepare_runtime:
@@ -789,15 +875,23 @@ class RepoRegistry:
             self._publish_owned(instance_id, owned)
             return owned.bundle
         except BaseException as primary:  # noqa: B036 - retain candidate owner
-            # Cancellation may land immediately after the atomic publication.
-            # Inspect identity under the same lock instead of relying on a
-            # caller-side flag whose next bytecode may never run.
-            with self._generation_lock:
-                published = self._bundles.get(instance_id) is owned.bundle
-            if not published:
-                cleanup_failure = self._retire_unpublished(owned)
-                if cleanup_failure is not None:
-                    _raise_with_cleanup_failure(primary, cleanup_failure)
+            cleanup_failure: BaseException | None = None
+            try:
+                # Cancellation may land immediately after the atomic
+                # publication. Both active and retired identity prove that the
+                # registry accepted cleanup ownership for this generation.
+                with self._generation_lock:
+                    key = id(owned.bundle)
+                    ownership_transferred = (
+                        self._bundles.get(instance_id) is owned.bundle
+                        or key in self._retired_bundles
+                    )
+                if not ownership_transferred:
+                    cleanup_failure = self._retire_unpublished(owned)
+            except BaseException as settlement_failure:  # noqa: B036
+                _raise_with_cleanup_failure(primary, settlement_failure)
+            if cleanup_failure is not None:
+                _raise_with_cleanup_failure(primary, cleanup_failure)
             raise
 
     def _prepare_runtime_bundle(self, bundle: RepoBundle) -> None:
@@ -827,7 +921,9 @@ class RepoRegistry:
             require_manifest_source_identity,
         )
 
-        _plain_repo_instance_id(entry.instance_id)
+        instance_id = _plain_repo_instance_id(entry.instance_id)
+        if type(entry.instance_id) is not str:
+            entry = replace(entry, instance_id=instance_id)
 
         manifest = RepoManifest.load(entry.manifest_path)
         cleanup_owner = SourceBindingCleanupOwner()
@@ -880,7 +976,7 @@ class RepoRegistry:
     def _load_repo_metadata(self, entry: RepoEntry) -> RepoBundle:
         """Legacy metadata loader used by offline callers and focused tests."""
 
-        with self._registry_reload_lock:
+        with self._cleanup_lock, self._registry_reload_lock:
             with self._generation_lock:
                 if self._closed:
                     raise RuntimeError("repository registry is closed")
@@ -888,7 +984,10 @@ class RepoRegistry:
             try:
                 owned = self._build_repo_metadata(entry)
             except BaseException as primary:  # noqa: B036 - preserve retry owner
-                self._retain_exception_cleanup(instance_id, primary)
+                try:
+                    self._retain_exception_cleanup(instance_id, primary)
+                except BaseException as cleanup_failure:  # noqa: B036
+                    _raise_with_cleanup_failure(primary, cleanup_failure)
                 raise
             with self._generation_lock:
                 closed = self._closed
@@ -906,14 +1005,20 @@ class RepoRegistry:
                         owned.source_cleanup_owner
                     )
             if closed:
-                cleanup_failure = self._retire_unpublished(owned)
                 error = RuntimeError("repository registry is closed")
+                try:
+                    cleanup_failure = self._retire_unpublished(owned)
+                except BaseException as cleanup_failure:  # noqa: B036
+                    _raise_with_cleanup_failure(error, cleanup_failure)
                 if cleanup_failure is not None:
                     _raise_with_cleanup_failure(error, cleanup_failure)
                 raise error
             if duplicate:
-                cleanup_failure = self._retire_unpublished(owned)
                 error = ValueError(f"duplicate repository instance_id: {instance_id!r}")
+                try:
+                    cleanup_failure = self._retire_unpublished(owned)
+                except BaseException as cleanup_failure:  # noqa: B036
+                    _raise_with_cleanup_failure(error, cleanup_failure)
                 if cleanup_failure is not None:
                     _raise_with_cleanup_failure(error, cleanup_failure)
                 raise error
@@ -955,18 +1060,60 @@ class RepoRegistry:
         if closed:
             cleanup_failure = self._drain_orphan_cleanup()
             if cleanup_failure is not None:
-                if not isinstance(cleanup_failure, Exception):
+                if not issubclass(type(cleanup_failure), Exception):
                     _raise_with_cleanup_failure(error, cleanup_failure)
                 _log_cleanup_failure(
                     "Unpublished repository cleanup remains pending: %s",
                     cleanup_failure,
                 )
 
-    def _publish_owned(self, instance_id: str, owned: _OwnedRepoBundle) -> None:
+    def _publish_owned(
+        self,
+        instance_id: str,
+        owned: _OwnedRepoBundle,
+    ) -> None:
         instance_id = _plain_repo_instance_id(instance_id)
+        with self._cleanup_lock:
+            self._publish_owned_under_cleanup_lock(instance_id, owned)
+
+    def _publish_owned_under_cleanup_lock(
+        self,
+        instance_id: str,
+        owned: _OwnedRepoBundle,
+    ) -> None:
+        authority = (
+            owned.source_cleanup_owner
+            if owned.source_cleanup_owner is not None
+            else owned.source_binding
+        )
         with self._generation_lock:
             if self._closed:
                 raise RuntimeError("repository registry is closed")
+            if authority is not None and (
+                any(
+                    retired.source_cleanup_owner is authority
+                    or retired.source_binding is authority
+                    for retired in self._retired_bundles.values()
+                )
+                or any(
+                    candidate is authority for candidate in self._orphan_cleanup_owners
+                )
+                or self._authority_cleanup_in_progress_locked(id(authority))
+            ):
+                raise RuntimeError("repository source cleanup authority is pending")
+
+        # The caller owns the cleanup lock, but no generation lock, while this
+        # caller-defined descriptor runs. All reload paths take locks in the
+        # same cleanup -> reload order, so reentrant shutdown cannot deadlock.
+        authority_closed = authority is not None and bool(authority.closed)
+
+        with self._generation_lock:
+            if self._closed:
+                raise RuntimeError("repository registry is closed")
+            if authority_closed:
+                raise RuntimeError(
+                    "repository source cleanup authority is already closed"
+                )
             previous_bundle = self._bundles.get(instance_id)
             previous_binding = self._source_bindings.get(instance_id)
             previous_owner = self._source_cleanup_owners.get(instance_id)
@@ -981,27 +1128,29 @@ class RepoRegistry:
             )
             orphan_owner = None
             orphan_appended = False
-            if previous is not None:
-                self._retired_bundles[id(previous.bundle)] = previous
-            else:
-                # A failed metadata capture may leave a retryable owner without
-                # a published bundle. A later first publish must not overwrite
-                # the only reference that can finish that cleanup.
-                orphan_owner = (
-                    previous_owner if previous_owner is not None else previous_binding
-                )
-                if (
-                    orphan_owner is not None
-                    and orphan_owner is not owned.source_cleanup_owner
-                    and orphan_owner is not owned.source_binding
-                    and not any(
-                        candidate is orphan_owner
-                        for candidate in self._orphan_cleanup_owners
-                    )
-                ):
-                    self._orphan_cleanup_owners.append(orphan_owner)
-                    orphan_appended = True
             try:
+                if previous is not None:
+                    self._retired_bundles[id(previous.bundle)] = previous
+                else:
+                    # A failed metadata capture may leave a retryable owner
+                    # without a published bundle. A later first publish must
+                    # not overwrite the only reference that can finish it.
+                    orphan_owner = (
+                        previous_owner
+                        if previous_owner is not None
+                        else previous_binding
+                    )
+                    if (
+                        orphan_owner is not None
+                        and orphan_owner is not owned.source_cleanup_owner
+                        and orphan_owner is not owned.source_binding
+                        and not any(
+                            candidate is orphan_owner
+                            for candidate in self._orphan_cleanup_owners
+                        )
+                    ):
+                        orphan_appended = True
+                        self._orphan_cleanup_owners.append(orphan_owner)
                 # Publish the bundle pointer last. Readers take the same lock,
                 # so none can observe candidate metadata with the old bundle.
                 self._source_bindings[instance_id] = owned.source_binding
@@ -1033,42 +1182,73 @@ class RepoRegistry:
                 raise
         failure = self._drain_retired()
         if failure is not None:
-            if not isinstance(failure, Exception):
+            if not issubclass(type(failure), Exception):
+                self._raise_if_closed_after_cleanup(failure)
                 raise failure
             _log_cleanup_failure(
                 "Retired repository cleanup remains pending: %s",
                 failure,
             )
         orphan_failure = self._drain_orphan_cleanup()
+        cleanup_failure = failure
         if orphan_failure is not None:
-            if not isinstance(orphan_failure, Exception):
+            cleanup_failure = (
+                orphan_failure
+                if cleanup_failure is None
+                else _retain_cleanup_failure(cleanup_failure, orphan_failure)
+            )
+            if not issubclass(type(orphan_failure), Exception):
+                self._raise_if_closed_after_cleanup(cleanup_failure)
                 raise orphan_failure
             _log_cleanup_failure(
                 "Unpublished repository cleanup remains pending: %s",
                 orphan_failure,
             )
+        self._raise_if_closed_after_cleanup(cleanup_failure)
 
     def _retire_active_locked(
         self,
         instance_id: str,
     ) -> Optional[_OwnedRepoBundle]:
-        bundle = self._bundles.pop(instance_id, None)
-        source_binding = self._source_bindings.pop(instance_id, None)
-        cleanup_owner = self._source_cleanup_owners.pop(instance_id, None)
+        bundle = self._bundles.get(instance_id)
         if bundle is None:
             return None
-        return _OwnedRepoBundle(bundle, source_binding, cleanup_owner)
+        source_binding = self._source_bindings.get(instance_id)
+        cleanup_owner = self._source_cleanup_owners.get(instance_id)
+        owned = _OwnedRepoBundle(bundle, source_binding, cleanup_owner)
+        # Install durable retirement ownership before deleting any active-map
+        # reference. An asynchronous exception can then create only a harmless
+        # temporary alias, never an unreachable resource authority.
+        self._retired_bundles[id(bundle)] = owned
+        if self._bundles.get(instance_id) is bundle:
+            self._bundles.pop(instance_id, None)
+        if self._source_bindings.get(instance_id) is source_binding:
+            self._source_bindings.pop(instance_id, None)
+        if self._source_cleanup_owners.get(instance_id) is cleanup_owner:
+            self._source_cleanup_owners.pop(instance_id, None)
+        return owned
 
     def _retire_unpublished(
         self,
         owned: _OwnedRepoBundle,
     ) -> Optional[BaseException]:
+        key = id(owned.bundle)
         with self._generation_lock:
-            self._retired_bundles[id(owned.bundle)] = owned
-        return self._drain_retired()
+            if key in self._retired_bundles:
+                return None
+            self._retired_bundles[key] = owned
+        # This unwind owns only the rejected candidate. Retrying unrelated
+        # generations here can close the same failed owner twice within one
+        # publication attempt and can manufacture a new higher-priority
+        # cancellation while preserving the original error.
+        return self._drain_retired(only_keys={key})
 
     @staticmethod
-    def _close_owned(owned: _OwnedRepoBundle) -> bool:
+    def _close_owned(
+        owned: _OwnedRepoBundle,
+        *,
+        close_authority: bool = True,
+    ) -> bool:
         """Close one unpinned generation and report whether cleanup completed."""
 
         bundle = owned.bundle
@@ -1079,88 +1259,336 @@ class RepoRegistry:
         vector_store = bundle.vector_store
         if vector_store is not None:
             try:
-                vector_store.close()
+                if _vector_cleanup_is_complete(vector_store):
+                    bundle.vector_store = None
+                else:
+                    vector_store.close()
+                    bundle.vector_store = None
             except BaseException as exc:  # noqa: B036 - continue source cleanup
+                try:
+                    if _vector_cleanup_is_complete(vector_store):
+                        bundle.vector_store = None
+                except BaseException as inspection_failure:  # noqa: B036
+                    exc = _retain_cleanup_failure(exc, inspection_failure)
                 first_failure = _retain_cleanup_failure(first_failure, exc)
-            else:
-                bundle.vector_store = None
 
         owner = owned.source_cleanup_owner
         owner_closed = owner is None
-        if owner is not None:
-            try:
-                owner.close()
-            except BaseException as exc:  # noqa: B036 - retain retry owner
-                first_failure = _retain_cleanup_failure(first_failure, exc)
+        if owner is not None and close_authority:
             try:
                 owner_closed = bool(owner.closed)
             except BaseException as exc:  # noqa: B036 - uncertain means pending
                 owner_closed = False
                 first_failure = _retain_cleanup_failure(first_failure, exc)
-        elif owned.source_binding is not None:
-            try:
-                owned.source_binding.close()
-            except BaseException as exc:  # noqa: B036 - retain retry owner
-                first_failure = _retain_cleanup_failure(first_failure, exc)
+            if not owner_closed:
+                try:
+                    owner.close()
+                except BaseException as exc:  # noqa: B036 - retain retry owner
+                    first_failure = _retain_cleanup_failure(first_failure, exc)
+                try:
+                    owner_closed = bool(owner.closed)
+                except BaseException as exc:  # noqa: B036 - uncertain means pending
+                    owner_closed = False
+                    first_failure = _retain_cleanup_failure(first_failure, exc)
+            if owner_closed:
+                owned.source_cleanup_owner = None
+                owned.source_binding = None
+        elif owned.source_binding is not None and close_authority:
             try:
                 owner_closed = bool(owned.source_binding.closed)
             except BaseException as exc:  # noqa: B036 - uncertain means pending
                 owner_closed = False
                 first_failure = _retain_cleanup_failure(first_failure, exc)
+            if not owner_closed:
+                try:
+                    owned.source_binding.close()
+                except BaseException as exc:  # noqa: B036 - retain retry owner
+                    first_failure = _retain_cleanup_failure(first_failure, exc)
+                try:
+                    owner_closed = bool(owned.source_binding.closed)
+                except BaseException as exc:  # noqa: B036 - uncertain means pending
+                    owner_closed = False
+                    first_failure = _retain_cleanup_failure(first_failure, exc)
+            if owner_closed:
+                owned.source_binding = None
 
+        complete = (
+            bundle.vector_store is None
+            and owned.source_cleanup_owner is None
+            and owned.source_binding is None
+        )
         if first_failure is not None:
             raise first_failure
-        return bundle.vector_store is None and owner_closed
+        return complete
 
-    def _drain_retired(self) -> Optional[BaseException]:
+    def _authority_cleanup_in_progress_locked(self, authority_id: int) -> bool:
+        return authority_id in self._orphan_cleanup_in_progress or any(
+            candidate == authority_id
+            for candidate in self._cleanup_in_progress.values()
+        )
+
+    def _bundle_key_is_leased_locked(self, key: int) -> bool:
+        return any(key in keys for keys in self._bundle_leases.values())
+
+    def _release_retired_cleanup_claim(self, key: int) -> None:
+        """Idempotently release one atomic bundle/authority cleanup claim."""
+
+        try:
+            with self._generation_lock:
+                self._cleanup_in_progress.pop(key, None)
+        finally:
+            # A line-level asynchronous exception before the first pop still
+            # runs this idempotent fallback while the owner remains durable.
+            with self._generation_lock:
+                self._cleanup_in_progress.pop(key, None)
+
+    def _release_orphan_cleanup_claim(self, authority_id: int) -> None:
+        """Idempotently release one orphan-only cleanup claim."""
+
+        try:
+            with self._generation_lock:
+                self._orphan_cleanup_in_progress.discard(authority_id)
+        finally:
+            with self._generation_lock:
+                self._orphan_cleanup_in_progress.discard(authority_id)
+
+    def _settle_retired_cleanup_claim(
+        self,
+        key: int,
+        owned: _OwnedRepoBundle,
+        *,
+        owner: Any,
+        binding: Any,
+        authority: Any,
+        suppress_authority: bool,
+        complete: bool,
+    ) -> None:
+        self._release_retired_cleanup_claim(key)
+        with self._generation_lock:
+            complete = complete or (
+                owned.bundle.vector_store is None
+                and owned.source_cleanup_owner is None
+                and owned.source_binding is None
+            )
+            authority_settled = (
+                not suppress_authority
+                and authority is not None
+                and (
+                    (owner is not None and owned.source_cleanup_owner is None)
+                    or (owner is None and owned.source_binding is None)
+                )
+            )
+            if authority_settled:
+                for retired in self._retired_bundles.values():
+                    if retired.source_cleanup_owner is authority:
+                        retired.source_cleanup_owner = None
+                        retired.source_binding = None
+                    elif retired.source_binding is authority:
+                        retired.source_binding = None
+                aliases = tuple(
+                    candidate for candidate in (owner, binding) if candidate is not None
+                )
+                self._orphan_cleanup_owners[:] = [
+                    candidate
+                    for candidate in self._orphan_cleanup_owners
+                    if not any(candidate is alias for alias in aliases)
+                ]
+            if complete and self._retired_bundles.get(key) is owned:
+                self._retired_bundles.pop(key, None)
+
+    def _settle_orphan_cleanup_claim(
+        self,
+        authority_id: int,
+        owner: Any,
+        *,
+        closed: bool,
+    ) -> None:
+        self._release_orphan_cleanup_claim(authority_id)
+        if closed:
+            with self._generation_lock:
+                self._orphan_cleanup_owners[:] = [
+                    candidate
+                    for candidate in self._orphan_cleanup_owners
+                    if candidate is not owner
+                ]
+
+    def _drain_retired(
+        self,
+        *,
+        only_keys: Optional[set[int]] = None,
+    ) -> Optional[BaseException]:
         with self._cleanup_lock:
             first_failure: BaseException | None = None
             with self._generation_lock:
-                ready = [
+                candidates = [
                     (key, owned)
                     for key, owned in self._retired_bundles.items()
-                    if self._bundle_leases.get(key, 0) == 0
-                    and key not in self._cleanup_in_progress
+                    if only_keys is None or key in only_keys
                 ]
-                self._cleanup_in_progress.update(key for key, _owned in ready)
-            for key, owned in ready:
+            attempted_authority_ids: set[int] = set()
+            for key, owned in candidates:
                 complete = False
+                claimed_key = False
+                suppress_authority = False
+                owner = owned.source_cleanup_owner
+                binding = owned.source_binding
+                authority = owner if owner is not None else binding
                 try:
-                    complete = self._close_owned(owned)
+                    with self._generation_lock:
+                        authority_id = id(authority) if authority is not None else None
+                        suppress_authority = authority_id is not None and (
+                            authority_id in attempted_authority_ids
+                            or self._authority_cleanup_in_progress_locked(authority_id)
+                        )
+                        if authority is not None:
+                            active_authority_alias = any(
+                                candidate is authority
+                                for candidate in self._source_cleanup_owners.values()
+                            ) or any(
+                                candidate is authority
+                                for candidate in self._source_bindings.values()
+                            )
+                            leased_authority_alias = any(
+                                self._bundle_key_is_leased_locked(retired_key)
+                                and (
+                                    retired.source_cleanup_owner is authority
+                                    or retired.source_binding is authority
+                                )
+                                for retired_key, retired in self._retired_bundles.items()
+                                if retired_key != key
+                            )
+                            suppress_authority = suppress_authority or (
+                                active_authority_alias or leased_authority_alias
+                            )
+                        if (
+                            self._retired_bundles.get(key) is not owned
+                            or any(
+                                candidate is owned.bundle
+                                for candidate in self._bundles.values()
+                            )
+                            or self._bundle_key_is_leased_locked(key)
+                            or key in self._cleanup_in_progress
+                        ):
+                            continue
+                        if authority_id is not None and not suppress_authority:
+                            attempted_authority_ids.add(authority_id)
+                        claimed_key = True
+                        self._cleanup_in_progress[key] = (
+                            authority_id if not suppress_authority else None
+                        )
+                        if suppress_authority:
+                            if owner is not None:
+                                owned.source_cleanup_owner = None
+                                owned.source_binding = None
+                            elif binding is not None:
+                                owned.source_binding = None
+                    complete = self._close_owned(
+                        owned,
+                        close_authority=not suppress_authority,
+                    )
                 except BaseException as exc:  # noqa: B036 - visit every generation
                     first_failure = _retain_cleanup_failure(first_failure, exc)
                 finally:
-                    with self._generation_lock:
-                        self._cleanup_in_progress.discard(key)
-                        if complete:
-                            self._retired_bundles.pop(key, None)
+                    try:
+                        if claimed_key:
+                            try:
+                                self._settle_retired_cleanup_claim(
+                                    key,
+                                    owned,
+                                    owner=owner,
+                                    binding=binding,
+                                    authority=authority,
+                                    suppress_authority=suppress_authority,
+                                    complete=complete,
+                                )
+                            except BaseException as exc:  # noqa: B036
+                                first_failure = _retain_cleanup_failure(
+                                    first_failure,
+                                    exc,
+                                )
+                    finally:
+                        try:
+                            if claimed_key:
+                                self._release_retired_cleanup_claim(key)
+                        except BaseException as exc:  # noqa: B036 - claim is durable
+                            first_failure = _retain_cleanup_failure(first_failure, exc)
             return first_failure
 
     def _drain_orphan_cleanup(self) -> Optional[BaseException]:
         with self._cleanup_lock:
             first_failure: BaseException | None = None
-            pending: List[Any] = []
             with self._generation_lock:
-                owners = tuple(self._orphan_cleanup_owners)
-                self._orphan_cleanup_owners.clear()
+                owners: List[Any] = []
+                for owner in self._orphan_cleanup_owners:
+                    if not any(candidate is owner for candidate in owners):
+                        owners.append(owner)
+            attempted_authority_ids: set[int] = set()
             for owner in owners:
+                claimed = False
+                closed = False
+                authority_id = id(owner)
                 try:
-                    owner.close()
-                except BaseException as exc:  # noqa: B036 - visit every owner
+                    # A retained generation is the sole authority for retrying
+                    # its cleanup. Keep aliases queued until that generation
+                    # either settles or releases its final lease.
+                    with self._generation_lock:
+                        still_queued = any(
+                            candidate is owner
+                            for candidate in self._orphan_cleanup_owners
+                        )
+                        generation_owned = (
+                            any(
+                                candidate is owner
+                                for candidate in self._source_cleanup_owners.values()
+                            )
+                            or any(
+                                candidate is owner
+                                for candidate in self._source_bindings.values()
+                            )
+                            or any(
+                                retired.source_cleanup_owner is owner
+                                or retired.source_binding is owner
+                                for retired in self._retired_bundles.values()
+                            )
+                        )
+                        if (
+                            not still_queued
+                            or generation_owned
+                            or authority_id in attempted_authority_ids
+                            or self._authority_cleanup_in_progress_locked(authority_id)
+                        ):
+                            continue
+                        attempted_authority_ids.add(authority_id)
+                        claimed = True
+                        self._orphan_cleanup_in_progress.add(authority_id)
+                    closed, failure = _close_orphan_cleanup_owner(owner)
+                    if failure is not None:
+                        first_failure = _retain_cleanup_failure(
+                            first_failure,
+                            failure,
+                        )
+                except BaseException as exc:  # noqa: B036 - keep owner reachable
                     first_failure = _retain_cleanup_failure(first_failure, exc)
-                try:
-                    closed = bool(owner.closed)
-                except BaseException as exc:  # noqa: B036 - uncertain means pending
-                    closed = False
-                    first_failure = _retain_cleanup_failure(first_failure, exc)
-                if not closed:
-                    pending.append(owner)
-            with self._generation_lock:
-                for owner in pending:
-                    if not any(
-                        candidate is owner for candidate in self._orphan_cleanup_owners
-                    ):
-                        self._orphan_cleanup_owners.append(owner)
+                finally:
+                    try:
+                        if claimed:
+                            try:
+                                self._settle_orphan_cleanup_claim(
+                                    authority_id,
+                                    owner,
+                                    closed=closed,
+                                )
+                            except BaseException as exc:  # noqa: B036
+                                first_failure = _retain_cleanup_failure(
+                                    first_failure,
+                                    exc,
+                                )
+                    finally:
+                        try:
+                            if claimed:
+                                self._release_orphan_cleanup_claim(authority_id)
+                        except BaseException as exc:  # noqa: B036 - claim is durable
+                            first_failure = _retain_cleanup_failure(first_failure, exc)
             return first_failure
 
     def close(self) -> None:
@@ -1169,33 +1597,35 @@ class RepoRegistry:
         # A refresh that entered first either publishes or fully retires its
         # candidate before shutdown can report completion. The cleanup lock
         # also joins drains started by a final request lease release.
-        with self._registry_reload_lock, self._cleanup_lock:
+        with self._cleanup_lock, self._registry_reload_lock:
             with self._generation_lock:
                 self._closed = True
                 for instance_id in tuple(self._bundles):
-                    owned = self._retire_active_locked(instance_id)
-                    if owned is not None:
-                        self._retired_bundles[id(owned.bundle)] = owned
+                    self._retire_active_locked(instance_id)
+                # Claim owner-only failures before invoking any caller-owned
+                # close method. The orphan drain removes its queue before each
+                # callback, so a reentrant close cannot acquire the same owner.
+                owner_only_ids = tuple(self._source_cleanup_owners) + tuple(
+                    instance_id
+                    for instance_id in self._source_bindings
+                    if instance_id not in self._source_cleanup_owners
+                )
+                for instance_id in owner_only_ids:
+                    owner = self._source_cleanup_owners.get(instance_id)
+                    binding = self._source_bindings.get(instance_id)
+                    cleanup_owner = owner if owner is not None else binding
+                    if cleanup_owner is not None and not any(
+                        candidate is cleanup_owner
+                        for candidate in self._orphan_cleanup_owners
+                    ):
+                        # Publish retry ownership before removing either map
+                        # entry, so interruption at any following line leaves a
+                        # reachable authority for the next close attempt.
+                        self._orphan_cleanup_owners.append(cleanup_owner)
+                    self._source_cleanup_owners.pop(instance_id, None)
+                    self._source_bindings.pop(instance_id, None)
 
             first_failure = self._drain_retired()
-
-            # Owners left in these maps belong to metadata candidates that failed
-            # before a bundle was published. They remain retryable just like retired
-            # generations, but have no request lease to wait for.
-            for instance_id, owner in tuple(self._source_cleanup_owners.items()):
-                try:
-                    owner.close()
-                except BaseException as exc:  # noqa: B036 - finish every cleanup
-                    first_failure = _retain_cleanup_failure(first_failure, exc)
-                try:
-                    owner_closed = bool(owner.closed)
-                except BaseException as exc:  # noqa: B036 - uncertain means pending
-                    owner_closed = False
-                    first_failure = _retain_cleanup_failure(first_failure, exc)
-                if owner_closed:
-                    with self._generation_lock:
-                        self._source_cleanup_owners.pop(instance_id, None)
-                        self._source_bindings.pop(instance_id, None)
 
             orphan_failure = self._drain_orphan_cleanup()
             if orphan_failure is not None:
@@ -1530,50 +1960,99 @@ class RepoRegistry:
     def pin(self, repo_id: str) -> Iterator[Optional[RepoBundle]]:
         """Pin the current generation for the complete caller operation."""
 
-        repo_id = _plain_repo_instance_id(repo_id)
-        with self._generation_lock:
-            if self._closed:
-                raise RuntimeError("repository registry is closed")
-            bundle = self._bundles.get(repo_id)
-            key = id(bundle) if bundle is not None else None
-            if key is not None:
-                self._bundle_leases[key] = self._bundle_leases.get(key, 0) + 1
+        lease_token = object()
+        bundle: Optional[RepoBundle] = None
+        keys: Tuple[int, ...] = ()
+        primary: BaseException | None = None
+        cleanup_failure: BaseException | None = None
         try:
-            yield bundle
+            try:
+                with self._generation_lock:
+                    if self._closed:
+                        raise RuntimeError("repository registry is closed")
+                    repo_id = _plain_repo_lookup_key(repo_id)
+                    bundle = self._bundles.get(repo_id)
+                    keys = (id(bundle),) if bundle is not None else ()
+                    if keys:
+                        self._bundle_leases[lease_token] = keys
+                yield bundle
+            except BaseException as exc:  # noqa: B036 - settle lease cleanup
+                primary = exc
         finally:
-            if key is not None:
-                self._release_bundle_keys((key,))
+            try:
+                if keys:
+                    try:
+                        self._release_bundle_lease(lease_token)
+                    except BaseException as exc:  # noqa: B036
+                        cleanup_failure = exc
+            finally:
+                if keys:
+                    self._drop_bundle_lease(lease_token)
+        if primary is not None:
+            if cleanup_failure is not None:
+                _raise_with_cleanup_failure(primary, cleanup_failure)
+            raise primary
+        if cleanup_failure is not None:
+            raise cleanup_failure
 
     @contextmanager
     def pin_all(self) -> Iterator[Tuple[RepoBundle, ...]]:
         """Pin one coherent snapshot of every currently published bundle."""
 
-        with self._generation_lock:
-            active = not self._closed
-            if not active:
-                bundles: Tuple[RepoBundle, ...] = ()
-            else:
-                bundles = tuple(self._bundles.values())
-            keys = tuple(id(bundle) for bundle in bundles)
-            for key in keys:
-                self._bundle_leases[key] = self._bundle_leases.get(key, 0) + 1
+        lease_token = object()
+        active = False
+        bundles: Tuple[RepoBundle, ...] = ()
+        keys: Tuple[int, ...] = ()
+        primary: BaseException | None = None
+        cleanup_failure: BaseException | None = None
         try:
-            yield bundles
+            try:
+                with self._generation_lock:
+                    active = not self._closed
+                    if active:
+                        bundles = tuple(self._bundles.values())
+                        keys = tuple(id(bundle) for bundle in bundles)
+                        if keys:
+                            self._bundle_leases[lease_token] = keys
+                yield bundles
+            except BaseException as exc:  # noqa: B036 - settle lease cleanup
+                primary = exc
         finally:
-            if active:
-                self._release_bundle_keys(keys)
+            try:
+                if active and keys:
+                    try:
+                        self._release_bundle_lease(lease_token)
+                    except BaseException as exc:  # noqa: B036
+                        cleanup_failure = exc
+            finally:
+                if active and keys:
+                    self._drop_bundle_lease(lease_token)
+        if primary is not None:
+            if cleanup_failure is not None:
+                _raise_with_cleanup_failure(primary, cleanup_failure)
+            raise primary
+        if cleanup_failure is not None:
+            raise cleanup_failure
 
-    def _release_bundle_keys(self, keys: Tuple[int, ...]) -> None:
-        with self._generation_lock:
-            for key in keys:
-                leases = self._bundle_leases.get(key, 0)
-                if leases <= 1:
-                    self._bundle_leases.pop(key, None)
-                else:
-                    self._bundle_leases[key] = leases - 1
+    def _drop_bundle_lease(self, lease_token: object) -> Tuple[int, ...]:
+        keys: Tuple[int, ...] = ()
+        try:
+            with self._generation_lock:
+                keys = self._bundle_leases.pop(lease_token, ())
+        finally:
+            # A trace/signal exception before the first pop still reaches this
+            # idempotent fallback, so an exited pin can never remain leased.
+            with self._generation_lock:
+                fallback_keys = self._bundle_leases.pop(lease_token, ())
+                if not keys:
+                    keys = fallback_keys
+        return keys
+
+    def _release_bundle_lease(self, lease_token: object) -> None:
+        self._drop_bundle_lease(lease_token)
         failure = self._drain_retired()
         if failure is not None:
-            if not isinstance(failure, Exception):
+            if not issubclass(type(failure), Exception):
                 raise failure
             _log_cleanup_failure(
                 "Retired repository cleanup remains pending: %s",
@@ -1587,7 +2066,7 @@ class RepoRegistry:
     def get(self, repo_id: str) -> Optional[RepoBundle]:
         """Return a non-owning snapshot for offline, non-reloading callers."""
 
-        repo_id = _plain_repo_instance_id(repo_id)
+        repo_id = _plain_repo_lookup_key(repo_id)
         with self._generation_lock:
             return self._bundles.get(repo_id)
 

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -22,6 +22,7 @@ from importlib.util import find_spec
 from threading import Lock, RLock
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Tuple
 
+from .._atomic_directory import _annotate_secondary_error
 from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
 from ..compiler.manifest import IndexEntry, RepoManifest
 from ..index.embedding._lifecycle import close_vector_after_failure
@@ -514,6 +515,60 @@ class _OwnedRepoBundle:
     source_cleanup_owner: Any
 
 
+def _retain_cleanup_failure(
+    current: BaseException | None,
+    later: BaseException,
+) -> BaseException:
+    """Keep cleanup order without demoting cancellation-class failures."""
+
+    if current is None:
+        return later
+    if isinstance(current, Exception) and not isinstance(later, Exception):
+        preferred = later
+        secondary = current
+        label = "earlier repository cleanup also failed"
+    else:
+        preferred = current
+        secondary = later
+        label = "additional repository cleanup also failed"
+    try:
+        _annotate_secondary_error(preferred, label, secondary)
+    except BaseException:  # noqa: B036 - diagnostics cannot replace cleanup
+        pass
+    return preferred
+
+
+def _raise_with_cleanup_failure(
+    primary: BaseException,
+    cleanup_failure: BaseException,
+) -> None:
+    """Raise the preferred exact failure and retain the other as its cause."""
+
+    if primary is cleanup_failure:
+        raise primary
+    preferred = _retain_cleanup_failure(primary, cleanup_failure)
+    if preferred is cleanup_failure:
+        raise cleanup_failure from primary
+    raise primary from cleanup_failure
+
+
+def _log_cleanup_failure(message: str, failure: BaseException) -> None:
+    """Report retryable cleanup without invoking hostile exception accessors."""
+
+    try:
+        traceback = vars(BaseException)["__traceback__"].__get__(
+            failure,
+            type(failure),
+        )
+        logger.error(
+            message,
+            failure,
+            exc_info=(type(failure), failure, traceback),
+        )
+    except BaseException:  # noqa: B036 - diagnostics cannot replace cleanup
+        pass
+
+
 class RepoRegistry:
     """Holds the loaded :class:`RepoBundle` objects, keyed by instance id."""
 
@@ -559,6 +614,10 @@ class RepoRegistry:
         self._retired_bundles: Dict[int, _OwnedRepoBundle] = {}
         self._cleanup_in_progress: set[int] = set()
         self._orphan_cleanup_owners: List[Any] = []
+        # Cleanup mutates retryable owners outside the generation lock. Keep
+        # every drain and close serialized so shutdown cannot return while a
+        # different thread is still closing an unleased generation or owner.
+        self._cleanup_lock = RLock()
         self._closed = False
         # Serialize registry-file snapshots through publication and removal
         # reconciliation. Without this boundary, an older load_all() could
@@ -604,7 +663,15 @@ class RepoRegistry:
                     )
                     continue
                 try:
-                    self._replace_entry(entry, prepare_runtime=False)
+                    with self._generation_lock:
+                        replacing_active = instance_id in self._bundles
+                    # Preserve lazy first-start loading, but never replace a
+                    # healthy serving generation with a candidate whose views
+                    # and advertised runtime have not passed their full load.
+                    self._replace_entry(
+                        entry,
+                        prepare_runtime=replacing_active,
+                    )
                     logger.info("Registered %r (%s)", instance_id, entry.repo)
                 except Exception as exc:  # noqa: BLE001 - keep other repos alive
                     self._retain_exception_cleanup(instance_id, exc)
@@ -656,12 +723,36 @@ class RepoRegistry:
                 owned = self._retire_active_locked(instance_id)
                 if owned is not None:
                     self._retired_bundles[id(owned.bundle)] = owned
+            # A failed metadata capture has no bundle to retire, but its owner
+            # is still part of this complete registry snapshot. Once the id is
+            # absent, move that owner to the generic retry drain instead of
+            # retaining it indefinitely until process shutdown.
+            for instance_id in tuple(self._source_cleanup_owners):
+                if instance_id in instance_ids or instance_id in self._bundles:
+                    continue
+                owner = self._source_cleanup_owners.pop(instance_id, None)
+                binding = self._source_bindings.pop(instance_id, None)
+                cleanup_owner = owner if owner is not None else binding
+                if cleanup_owner is not None and not any(
+                    candidate is cleanup_owner
+                    for candidate in self._orphan_cleanup_owners
+                ):
+                    self._orphan_cleanup_owners.append(cleanup_owner)
         failure = self._drain_retired()
         if failure is not None:
-            logger.error(
+            if not isinstance(failure, Exception):
+                raise failure
+            _log_cleanup_failure(
                 "Removed repository cleanup remains pending: %s",
                 failure,
-                exc_info=(type(failure), failure, failure.__traceback__),
+            )
+        orphan_failure = self._drain_orphan_cleanup()
+        if orphan_failure is not None:
+            if not isinstance(orphan_failure, Exception):
+                raise orphan_failure
+            _log_cleanup_failure(
+                "Removed repository cleanup remains pending: %s",
+                orphan_failure,
             )
 
     def _replace_entry(
@@ -689,7 +780,7 @@ class RepoRegistry:
             if not published:
                 cleanup_failure = self._retire_unpublished(owned)
                 if cleanup_failure is not None:
-                    raise primary from cleanup_failure
+                    _raise_with_cleanup_failure(primary, cleanup_failure)
             raise
 
     def _prepare_runtime_bundle(self, bundle: RepoBundle) -> None:
@@ -774,31 +865,37 @@ class RepoRegistry:
     def _load_repo_metadata(self, entry: RepoEntry) -> RepoBundle:
         """Legacy metadata loader used by offline callers and focused tests."""
 
-        instance_id = entry.instance_id
-        if not isinstance(instance_id, str) or not instance_id:
-            raise ValueError("repository instance_id must be non-empty text")
-        try:
-            owned = self._build_repo_metadata(entry)
-        except BaseException as primary:  # noqa: B036 - preserve retry owner
-            self._retain_exception_cleanup(instance_id, primary)
-            raise
-        with self._generation_lock:
-            if (
-                instance_id in self._source_bindings
-                or instance_id in self._source_cleanup_owners
-            ):
-                duplicate = True
-            else:
-                duplicate = False
-                self._source_bindings[instance_id] = owned.source_binding
-                self._source_cleanup_owners[instance_id] = owned.source_cleanup_owner
-        if duplicate:
-            cleanup_failure = self._retire_unpublished(owned)
-            error = ValueError(f"duplicate repository instance_id: {instance_id!r}")
-            if cleanup_failure is not None:
-                raise error from cleanup_failure
-            raise error
-        return owned.bundle
+        with self._registry_reload_lock:
+            with self._generation_lock:
+                if self._closed:
+                    raise RuntimeError("repository registry is closed")
+            instance_id = entry.instance_id
+            if not isinstance(instance_id, str) or not instance_id:
+                raise ValueError("repository instance_id must be non-empty text")
+            try:
+                owned = self._build_repo_metadata(entry)
+            except BaseException as primary:  # noqa: B036 - preserve retry owner
+                self._retain_exception_cleanup(instance_id, primary)
+                raise
+            with self._generation_lock:
+                if (
+                    instance_id in self._source_bindings
+                    or instance_id in self._source_cleanup_owners
+                ):
+                    duplicate = True
+                else:
+                    duplicate = False
+                    self._source_bindings[instance_id] = owned.source_binding
+                    self._source_cleanup_owners[instance_id] = (
+                        owned.source_cleanup_owner
+                    )
+            if duplicate:
+                cleanup_failure = self._retire_unpublished(owned)
+                error = ValueError(f"duplicate repository instance_id: {instance_id!r}")
+                if cleanup_failure is not None:
+                    _raise_with_cleanup_failure(error, cleanup_failure)
+                raise error
+            return owned.bundle
 
     def _retain_exception_cleanup(
         self,
@@ -807,7 +904,15 @@ class RepoRegistry:
     ) -> None:
         from ..artifacts.runtime import _source_cleanup_owner_is_pending
 
-        owner = getattr(error, "source_cleanup_owner", None)
+        try:
+            attributes = BaseException.__getattribute__(error, "__dict__")
+            owner = (
+                dict.get(attributes, "source_cleanup_owner")
+                if type(attributes) is dict
+                else None
+            )
+        except BaseException:  # noqa: B036 - inspection cannot replace primary
+            owner = None
         if not _source_cleanup_owner_is_pending(owner):
             return
         with self._generation_lock:
@@ -828,14 +933,11 @@ class RepoRegistry:
         if closed:
             cleanup_failure = self._drain_orphan_cleanup()
             if cleanup_failure is not None:
-                logger.error(
+                if not isinstance(cleanup_failure, Exception):
+                    _raise_with_cleanup_failure(error, cleanup_failure)
+                _log_cleanup_failure(
                     "Unpublished repository cleanup remains pending: %s",
                     cleanup_failure,
-                    exc_info=(
-                        type(cleanup_failure),
-                        cleanup_failure,
-                        cleanup_failure.__traceback__,
-                    ),
                 )
 
     def _publish_owned(self, instance_id: str, owned: _OwnedRepoBundle) -> None:
@@ -843,17 +945,39 @@ class RepoRegistry:
             if self._closed:
                 raise RuntimeError("repository registry is closed")
             previous_bundle = self._bundles.get(instance_id)
+            previous_binding = self._source_bindings.get(instance_id)
+            previous_owner = self._source_cleanup_owners.get(instance_id)
             previous = (
                 _OwnedRepoBundle(
                     previous_bundle,
-                    self._source_bindings.get(instance_id),
-                    self._source_cleanup_owners.get(instance_id),
+                    previous_binding,
+                    previous_owner,
                 )
                 if previous_bundle is not None
                 else None
             )
+            orphan_owner = None
+            orphan_appended = False
             if previous is not None:
                 self._retired_bundles[id(previous.bundle)] = previous
+            else:
+                # A failed metadata capture may leave a retryable owner without
+                # a published bundle. A later first publish must not overwrite
+                # the only reference that can finish that cleanup.
+                orphan_owner = (
+                    previous_owner if previous_owner is not None else previous_binding
+                )
+                if (
+                    orphan_owner is not None
+                    and orphan_owner is not owned.source_cleanup_owner
+                    and orphan_owner is not owned.source_binding
+                    and not any(
+                        candidate is orphan_owner
+                        for candidate in self._orphan_cleanup_owners
+                    )
+                ):
+                    self._orphan_cleanup_owners.append(orphan_owner)
+                    orphan_appended = True
             try:
                 # Publish the bundle pointer last. Readers take the same lock,
                 # so none can observe candidate metadata with the old bundle.
@@ -863,8 +987,20 @@ class RepoRegistry:
             except BaseException:  # noqa: B036 - restore pre-publication owner
                 if self._bundles.get(instance_id) is not owned.bundle:
                     if previous is None:
-                        self._source_bindings.pop(instance_id, None)
-                        self._source_cleanup_owners.pop(instance_id, None)
+                        if previous_binding is None:
+                            self._source_bindings.pop(instance_id, None)
+                        else:
+                            self._source_bindings[instance_id] = previous_binding
+                        if previous_owner is None:
+                            self._source_cleanup_owners.pop(instance_id, None)
+                        else:
+                            self._source_cleanup_owners[instance_id] = previous_owner
+                        if orphan_appended:
+                            self._orphan_cleanup_owners[:] = [
+                                candidate
+                                for candidate in self._orphan_cleanup_owners
+                                if candidate is not orphan_owner
+                            ]
                     else:
                         self._source_bindings[instance_id] = previous.source_binding
                         self._source_cleanup_owners[instance_id] = (
@@ -874,10 +1010,19 @@ class RepoRegistry:
                 raise
         failure = self._drain_retired()
         if failure is not None:
-            logger.error(
+            if not isinstance(failure, Exception):
+                raise failure
+            _log_cleanup_failure(
                 "Retired repository cleanup remains pending: %s",
                 failure,
-                exc_info=(type(failure), failure, failure.__traceback__),
+            )
+        orphan_failure = self._drain_orphan_cleanup()
+        if orphan_failure is not None:
+            if not isinstance(orphan_failure, Exception):
+                raise orphan_failure
+            _log_cleanup_failure(
+                "Unpublished repository cleanup remains pending: %s",
+                orphan_failure,
             )
 
     def _retire_active_locked(
@@ -913,7 +1058,7 @@ class RepoRegistry:
             try:
                 vector_store.close()
             except BaseException as exc:  # noqa: B036 - continue source cleanup
-                first_failure = exc
+                first_failure = _retain_cleanup_failure(first_failure, exc)
             else:
                 bundle.vector_store = None
 
@@ -923,120 +1068,120 @@ class RepoRegistry:
             try:
                 owner.close()
             except BaseException as exc:  # noqa: B036 - retain retry owner
-                if first_failure is None:
-                    first_failure = exc
+                first_failure = _retain_cleanup_failure(first_failure, exc)
             try:
                 owner_closed = bool(owner.closed)
             except BaseException as exc:  # noqa: B036 - uncertain means pending
                 owner_closed = False
-                if first_failure is None:
-                    first_failure = exc
+                first_failure = _retain_cleanup_failure(first_failure, exc)
         elif owned.source_binding is not None:
             try:
                 owned.source_binding.close()
             except BaseException as exc:  # noqa: B036 - retain retry owner
-                if first_failure is None:
-                    first_failure = exc
+                first_failure = _retain_cleanup_failure(first_failure, exc)
             try:
                 owner_closed = bool(owned.source_binding.closed)
             except BaseException as exc:  # noqa: B036 - uncertain means pending
                 owner_closed = False
-                if first_failure is None:
-                    first_failure = exc
+                first_failure = _retain_cleanup_failure(first_failure, exc)
 
         if first_failure is not None:
             raise first_failure
         return bundle.vector_store is None and owner_closed
 
     def _drain_retired(self) -> Optional[BaseException]:
-        first_failure: BaseException | None = None
-        with self._generation_lock:
-            ready = [
-                (key, owned)
-                for key, owned in self._retired_bundles.items()
-                if self._bundle_leases.get(key, 0) == 0
-                and key not in self._cleanup_in_progress
-            ]
-            self._cleanup_in_progress.update(key for key, _owned in ready)
-        for key, owned in ready:
-            complete = False
-            try:
-                complete = self._close_owned(owned)
-            except BaseException as exc:  # noqa: B036 - visit every generation
-                if first_failure is None:
-                    first_failure = exc
-            finally:
-                with self._generation_lock:
-                    self._cleanup_in_progress.discard(key)
-                    if complete:
-                        self._retired_bundles.pop(key, None)
-        return first_failure
+        with self._cleanup_lock:
+            first_failure: BaseException | None = None
+            with self._generation_lock:
+                ready = [
+                    (key, owned)
+                    for key, owned in self._retired_bundles.items()
+                    if self._bundle_leases.get(key, 0) == 0
+                    and key not in self._cleanup_in_progress
+                ]
+                self._cleanup_in_progress.update(key for key, _owned in ready)
+            for key, owned in ready:
+                complete = False
+                try:
+                    complete = self._close_owned(owned)
+                except BaseException as exc:  # noqa: B036 - visit every generation
+                    first_failure = _retain_cleanup_failure(first_failure, exc)
+                finally:
+                    with self._generation_lock:
+                        self._cleanup_in_progress.discard(key)
+                        if complete:
+                            self._retired_bundles.pop(key, None)
+            return first_failure
 
     def _drain_orphan_cleanup(self) -> Optional[BaseException]:
-        first_failure: BaseException | None = None
-        pending: List[Any] = []
-        with self._generation_lock:
-            owners = tuple(self._orphan_cleanup_owners)
-            self._orphan_cleanup_owners.clear()
-        for owner in owners:
-            try:
-                owner.close()
-            except BaseException as exc:  # noqa: B036 - visit every owner
-                if first_failure is None:
-                    first_failure = exc
-            try:
-                closed = bool(owner.closed)
-            except BaseException as exc:  # noqa: B036 - uncertain means pending
-                closed = False
-                if first_failure is None:
-                    first_failure = exc
-            if not closed:
-                pending.append(owner)
-        with self._generation_lock:
-            for owner in pending:
-                if not any(
-                    candidate is owner for candidate in self._orphan_cleanup_owners
-                ):
-                    self._orphan_cleanup_owners.append(owner)
-        return first_failure
+        with self._cleanup_lock:
+            first_failure: BaseException | None = None
+            pending: List[Any] = []
+            with self._generation_lock:
+                owners = tuple(self._orphan_cleanup_owners)
+                self._orphan_cleanup_owners.clear()
+            for owner in owners:
+                try:
+                    owner.close()
+                except BaseException as exc:  # noqa: B036 - visit every owner
+                    first_failure = _retain_cleanup_failure(first_failure, exc)
+                try:
+                    closed = bool(owner.closed)
+                except BaseException as exc:  # noqa: B036 - uncertain means pending
+                    closed = False
+                    first_failure = _retain_cleanup_failure(first_failure, exc)
+                if not closed:
+                    pending.append(owner)
+            with self._generation_lock:
+                for owner in pending:
+                    if not any(
+                        candidate is owner for candidate in self._orphan_cleanup_owners
+                    ):
+                        self._orphan_cleanup_owners.append(owner)
+            return first_failure
 
     def close(self) -> None:
         """Retire active generations; pinned requests release them later."""
 
-        with self._generation_lock:
-            self._closed = True
-            for instance_id in tuple(self._bundles):
-                owned = self._retire_active_locked(instance_id)
-                if owned is not None:
-                    self._retired_bundles[id(owned.bundle)] = owned
+        # A refresh that entered first either publishes or fully retires its
+        # candidate before shutdown can report completion. The cleanup lock
+        # also joins drains started by a final request lease release.
+        with self._registry_reload_lock, self._cleanup_lock:
+            with self._generation_lock:
+                self._closed = True
+                for instance_id in tuple(self._bundles):
+                    owned = self._retire_active_locked(instance_id)
+                    if owned is not None:
+                        self._retired_bundles[id(owned.bundle)] = owned
 
-        first_failure = self._drain_retired()
+            first_failure = self._drain_retired()
 
-        # Owners left in these maps belong to metadata candidates that failed
-        # before a bundle was published. They remain retryable just like retired
-        # generations, but have no request lease to wait for.
-        for instance_id, owner in tuple(self._source_cleanup_owners.items()):
-            try:
-                owner.close()
-            except BaseException as exc:  # noqa: B036 - finish every cleanup
-                if first_failure is None:
-                    first_failure = exc
-            try:
-                owner_closed = bool(owner.closed)
-            except BaseException as exc:  # noqa: B036 - uncertain means pending
-                owner_closed = False
-                if first_failure is None:
-                    first_failure = exc
-            if owner_closed:
-                with self._generation_lock:
-                    self._source_cleanup_owners.pop(instance_id, None)
-                    self._source_bindings.pop(instance_id, None)
+            # Owners left in these maps belong to metadata candidates that failed
+            # before a bundle was published. They remain retryable just like retired
+            # generations, but have no request lease to wait for.
+            for instance_id, owner in tuple(self._source_cleanup_owners.items()):
+                try:
+                    owner.close()
+                except BaseException as exc:  # noqa: B036 - finish every cleanup
+                    first_failure = _retain_cleanup_failure(first_failure, exc)
+                try:
+                    owner_closed = bool(owner.closed)
+                except BaseException as exc:  # noqa: B036 - uncertain means pending
+                    owner_closed = False
+                    first_failure = _retain_cleanup_failure(first_failure, exc)
+                if owner_closed:
+                    with self._generation_lock:
+                        self._source_cleanup_owners.pop(instance_id, None)
+                        self._source_bindings.pop(instance_id, None)
 
-        orphan_failure = self._drain_orphan_cleanup()
-        if first_failure is None:
-            first_failure = orphan_failure
-        if first_failure is not None:
-            raise first_failure
+            orphan_failure = self._drain_orphan_cleanup()
+            if orphan_failure is not None:
+                first_failure = _retain_cleanup_failure(
+                    first_failure,
+                    orphan_failure,
+                )
+            if first_failure is not None:
+                raise first_failure
 
     def _load_vector_store(
         self,
@@ -1375,6 +1520,25 @@ class RepoRegistry:
             if key is not None:
                 self._release_bundle_keys((key,))
 
+    @contextmanager
+    def pin_all(self) -> Iterator[Tuple[RepoBundle, ...]]:
+        """Pin one coherent snapshot of every currently published bundle."""
+
+        with self._generation_lock:
+            active = not self._closed
+            if not active:
+                bundles: Tuple[RepoBundle, ...] = ()
+            else:
+                bundles = tuple(self._bundles.values())
+            keys = tuple(id(bundle) for bundle in bundles)
+            for key in keys:
+                self._bundle_leases[key] = self._bundle_leases.get(key, 0) + 1
+        try:
+            yield bundles
+        finally:
+            if active:
+                self._release_bundle_keys(keys)
+
     def _release_bundle_keys(self, keys: Tuple[int, ...]) -> None:
         with self._generation_lock:
             for key in keys:
@@ -1385,24 +1549,16 @@ class RepoRegistry:
                     self._bundle_leases[key] = leases - 1
         failure = self._drain_retired()
         if failure is not None:
-            logger.error(
+            if not isinstance(failure, Exception):
+                raise failure
+            _log_cleanup_failure(
                 "Retired repository cleanup remains pending: %s",
                 failure,
-                exc_info=(type(failure), failure, failure.__traceback__),
             )
 
     def list_infos(self) -> List[RepoInfo]:
-        with self._generation_lock:
-            if self._closed:
-                return []
-            bundles = tuple(self._bundles.values())
-            keys = tuple(id(bundle) for bundle in bundles)
-            for key in keys:
-                self._bundle_leases[key] = self._bundle_leases.get(key, 0) + 1
-        try:
+        with self.pin_all() as bundles:
             return [bundle.info() for bundle in bundles]
-        finally:
-            self._release_bundle_keys(keys)
 
     def get(self, repo_id: str) -> Optional[RepoBundle]:
         """Return a non-owning snapshot for offline, non-reloading callers."""

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -15,10 +15,12 @@ from __future__ import annotations
 
 import os
 import re
+from contextlib import contextmanager
 from dataclasses import dataclass
+from functools import partial
 from importlib.util import find_spec
 from threading import Lock, RLock
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
 from ..compiler.manifest import IndexEntry, RepoManifest
@@ -503,6 +505,15 @@ class RepoBundle:
         return desc
 
 
+@dataclass(slots=True)
+class _OwnedRepoBundle:
+    """One bundle generation plus every resource required to retire it."""
+
+    bundle: RepoBundle
+    source_binding: Optional["RepositorySourceBinding"]
+    source_cleanup_owner: Any
+
+
 class RepoRegistry:
     """Holds the loaded :class:`RepoBundle` objects, keyed by instance id."""
 
@@ -540,15 +551,31 @@ class RepoRegistry:
         self._bundles: Dict[str, RepoBundle] = {}
         self._source_bindings: Dict[str, "RepositorySourceBinding"] = {}
         self._source_cleanup_owners: Dict[str, Any] = {}
+        # Requests pin the exact bundle object they started with. Replacements
+        # publish under this lock, while retired generations remain reachable
+        # until their final request releases its lease.
+        self._generation_lock = RLock()
+        self._bundle_leases: Dict[int, int] = {}
+        self._retired_bundles: Dict[int, _OwnedRepoBundle] = {}
+        self._cleanup_in_progress: set[int] = set()
+        self._orphan_cleanup_owners: List[Any] = []
+        self._closed = False
         # One embedding model per model name, shared across repos: the GPU model
         # is loaded once instead of once per CodeVectorStore (one per repo).
         self._embeddings: Dict[Tuple[str, str, int, Optional[str], str], object] = {}
         self._embedding_load_lock = RLock()
 
     def load_all(self) -> None:
-        """Load every dataset repo in the registry whose manifest exists."""
-        if self._bundles or self._source_cleanup_owners:
-            self.close()
+        """Load registry metadata, atomically replacing matching generations.
+
+        A repeated load no longer tears down the serving generation first. Each
+        replacement is authenticated independently and then published under the
+        generation lock. A failed replacement leaves the previous bundle live.
+        """
+
+        with self._generation_lock:
+            if self._closed:
+                raise RuntimeError("repository registry is closed")
         entries = load_registry(self._config.registry_path)
         if not entries:
             logger.warning(
@@ -556,33 +583,101 @@ class RepoRegistry:
                 self._config.registry_path,
             )
             return
-        try:
-            for entry in entries:
-                if not os.path.exists(entry.manifest_path):
-                    logger.warning(
-                        "Skipping %r: manifest not found at %s",
-                        entry.instance_id,
-                        entry.manifest_path,
-                    )
-                    continue
-                try:
-                    self._bundles[entry.instance_id] = self._load_repo_metadata(entry)
-                    logger.info("Registered %r (%s)", entry.instance_id, entry.repo)
-                except Exception as exc:  # noqa: BLE001 - keep other repos alive
-                    logger.error(
-                        "Failed to load %r: %s",
-                        entry.instance_id,
-                        exc,
-                        exc_info=True,
-                    )
-        except BaseException as primary:  # noqa: B036 - cancellation cleanup
+        seen: set[str] = set()
+        for entry in entries:
+            instance_id = entry.instance_id
+            if instance_id in seen:
+                logger.error("Skipping duplicate repository id %r", instance_id)
+                continue
+            seen.add(instance_id)
+            if not os.path.exists(entry.manifest_path):
+                logger.warning(
+                    "Skipping %r: manifest not found at %s",
+                    instance_id,
+                    entry.manifest_path,
+                )
+                continue
             try:
-                self.close()
-            except BaseException as cleanup_failure:  # noqa: B036
-                raise primary from cleanup_failure
+                self._replace_entry(entry, prepare_runtime=False)
+                logger.info("Registered %r (%s)", instance_id, entry.repo)
+            except Exception as exc:  # noqa: BLE001 - keep other repos alive
+                self._retain_exception_cleanup(instance_id, exc)
+                logger.error(
+                    "Failed to load %r: %s",
+                    instance_id,
+                    exc,
+                    exc_info=True,
+                )
+
+    def refresh(self, repo_id: str) -> RepoBundle:
+        """Prepare and atomically publish a complete new bundle generation.
+
+        The active bundle remains untouched when metadata authentication, view
+        loading, graph loading, or Ask runtime construction fails.
+        """
+
+        with self._generation_lock:
+            if self._closed:
+                raise RuntimeError("repository registry is closed")
+        entries = [
+            entry
+            for entry in load_registry(self._config.registry_path)
+            if entry.instance_id == repo_id
+        ]
+        if len(entries) != 1:
+            raise ValueError(
+                f"repository registry must contain exactly one entry for {repo_id!r}"
+            )
+        entry = entries[0]
+        if not os.path.exists(entry.manifest_path):
+            raise FileNotFoundError(entry.manifest_path)
+        return self._replace_entry(entry, prepare_runtime=True)
+
+    def _replace_entry(
+        self,
+        entry: RepoEntry,
+        *,
+        prepare_runtime: bool,
+    ) -> RepoBundle:
+        try:
+            owned = self._build_repo_metadata(entry)
+        except BaseException as primary:  # noqa: B036 - retain retry owner
+            self._retain_exception_cleanup(entry.instance_id, primary)
+            raise
+        try:
+            if prepare_runtime:
+                self._prepare_runtime_bundle(owned.bundle)
+            self._publish_owned(entry.instance_id, owned)
+            return owned.bundle
+        except BaseException as primary:  # noqa: B036 - retain candidate owner
+            # Cancellation may land immediately after the atomic publication.
+            # Inspect identity under the same lock instead of relying on a
+            # caller-side flag whose next bytecode may never run.
+            with self._generation_lock:
+                published = self._bundles.get(entry.instance_id) is owned.bundle
+            if not published:
+                cleanup_failure = self._retire_unpublished(owned)
+                if cleanup_failure is not None:
+                    raise primary from cleanup_failure
             raise
 
-    def _load_repo_metadata(self, entry: RepoEntry) -> RepoBundle:
+    def _prepare_runtime_bundle(self, bundle: RepoBundle) -> None:
+        """Load every runtime surface the service advertises before publish."""
+
+        bundle.ensure_views()
+        if bundle.chat_available:
+            bundle.ensure_runtime()
+        if bundle.info().capabilities.get("codemap"):
+            if bundle.code_graph() is None:
+                raise RuntimeError(bundle.graph_unavailable_note())
+            # Hierarchy is an optional enhancement, but building it before the
+            # swap prevents the first post-refresh request from observing a
+            # partially initialized bundle.
+            bundle.hierarchical_graph()
+
+    def _build_repo_metadata(self, entry: RepoEntry) -> _OwnedRepoBundle:
+        """Authenticate an unpublished candidate and retain all cleanup owners."""
+
         from ..artifacts.runtime import (
             SourceBindingCleanupOwner,
             _raise_source_cleanup_failure,
@@ -596,11 +691,6 @@ class RepoRegistry:
         instance_id = entry.instance_id
         if not isinstance(instance_id, str) or not instance_id:
             raise ValueError("repository instance_id must be non-empty text")
-        if (
-            instance_id in self._source_bindings
-            or instance_id in self._source_cleanup_owners
-        ):
-            raise ValueError(f"duplicate repository instance_id: {instance_id!r}")
 
         manifest = RepoManifest.load(entry.manifest_path)
         cleanup_owner = SourceBindingCleanupOwner()
@@ -623,15 +713,15 @@ class RepoRegistry:
                 entry=entry,
                 manifest=manifest,
                 chat_available=find_spec("litellm") is not None,
-                view_loader=self._load_repo_views,
+                view_loader=partial(
+                    self._load_repo_views,
+                    source_binding=source_binding,
+                ),
                 runtime_loader=self._load_repo_runtime,
                 source_reader=source_binding.borrow_reader(),
             )
-            self._source_bindings[instance_id] = source_binding
-            self._source_cleanup_owners[instance_id] = cleanup_owner
+            return _OwnedRepoBundle(bundle, source_binding, cleanup_owner)
         except BaseException as primary:  # noqa: B036 - preserve + clean owner
-            self._source_bindings.pop(instance_id, None)
-            self._source_cleanup_owners.pop(instance_id, None)
             cleanup_failure: BaseException | None = None
             try:
                 cleanup_owner.close()
@@ -642,11 +732,6 @@ class RepoRegistry:
                 if _source_cleanup_owner_is_pending(cleanup_owner)
                 else None
             )
-            if pending_owner is not None:
-                # ``load_all`` intentionally degrades ordinary per-repository
-                # failures. Retain cleanup ownership on the registry before it
-                # catches this error so a failed close is still retryable.
-                self._source_cleanup_owners[instance_id] = pending_owner
             if cleanup_failure is not None or pending_owner is not None:
                 _raise_source_cleanup_failure(
                     primary,
@@ -655,40 +740,270 @@ class RepoRegistry:
                 )
             raise
 
-        return bundle
+    def _load_repo_metadata(self, entry: RepoEntry) -> RepoBundle:
+        """Legacy metadata loader used by offline callers and focused tests."""
+
+        instance_id = entry.instance_id
+        if not isinstance(instance_id, str) or not instance_id:
+            raise ValueError("repository instance_id must be non-empty text")
+        try:
+            owned = self._build_repo_metadata(entry)
+        except BaseException as primary:  # noqa: B036 - preserve retry owner
+            self._retain_exception_cleanup(instance_id, primary)
+            raise
+        with self._generation_lock:
+            if (
+                instance_id in self._source_bindings
+                or instance_id in self._source_cleanup_owners
+            ):
+                duplicate = True
+            else:
+                duplicate = False
+                self._source_bindings[instance_id] = owned.source_binding
+                self._source_cleanup_owners[instance_id] = owned.source_cleanup_owner
+        if duplicate:
+            cleanup_failure = self._retire_unpublished(owned)
+            error = ValueError(f"duplicate repository instance_id: {instance_id!r}")
+            if cleanup_failure is not None:
+                raise error from cleanup_failure
+            raise error
+        return owned.bundle
+
+    def _retain_exception_cleanup(
+        self,
+        instance_id: str,
+        error: BaseException,
+    ) -> None:
+        from ..artifacts.runtime import _source_cleanup_owner_is_pending
+
+        owner = getattr(error, "source_cleanup_owner", None)
+        if not _source_cleanup_owner_is_pending(owner):
+            return
+        with self._generation_lock:
+            if any(
+                candidate is owner for candidate in self._source_cleanup_owners.values()
+            ) or any(candidate is owner for candidate in self._orphan_cleanup_owners):
+                return
+            closed = self._closed
+            if closed:
+                self._orphan_cleanup_owners.append(owner)
+            elif (
+                instance_id not in self._source_cleanup_owners
+                and instance_id not in self._bundles
+            ):
+                self._source_cleanup_owners[instance_id] = owner
+            else:
+                self._orphan_cleanup_owners.append(owner)
+        if closed:
+            cleanup_failure = self._drain_orphan_cleanup()
+            if cleanup_failure is not None:
+                logger.error(
+                    "Unpublished repository cleanup remains pending: %s",
+                    cleanup_failure,
+                    exc_info=(
+                        type(cleanup_failure),
+                        cleanup_failure,
+                        cleanup_failure.__traceback__,
+                    ),
+                )
+
+    def _publish_owned(self, instance_id: str, owned: _OwnedRepoBundle) -> None:
+        with self._generation_lock:
+            if self._closed:
+                raise RuntimeError("repository registry is closed")
+            previous_bundle = self._bundles.get(instance_id)
+            previous = (
+                _OwnedRepoBundle(
+                    previous_bundle,
+                    self._source_bindings.get(instance_id),
+                    self._source_cleanup_owners.get(instance_id),
+                )
+                if previous_bundle is not None
+                else None
+            )
+            if previous is not None:
+                self._retired_bundles[id(previous.bundle)] = previous
+            try:
+                # Publish the bundle pointer last. Readers take the same lock,
+                # so none can observe candidate metadata with the old bundle.
+                self._source_bindings[instance_id] = owned.source_binding
+                self._source_cleanup_owners[instance_id] = owned.source_cleanup_owner
+                self._bundles[instance_id] = owned.bundle
+            except BaseException:  # noqa: B036 - restore pre-publication owner
+                if self._bundles.get(instance_id) is not owned.bundle:
+                    if previous is None:
+                        self._source_bindings.pop(instance_id, None)
+                        self._source_cleanup_owners.pop(instance_id, None)
+                    else:
+                        self._source_bindings[instance_id] = previous.source_binding
+                        self._source_cleanup_owners[instance_id] = (
+                            previous.source_cleanup_owner
+                        )
+                        self._retired_bundles.pop(id(previous.bundle), None)
+                raise
+        failure = self._drain_retired()
+        if failure is not None:
+            logger.error(
+                "Retired repository cleanup remains pending: %s",
+                failure,
+                exc_info=(type(failure), failure, failure.__traceback__),
+            )
+
+    def _retire_active_locked(
+        self,
+        instance_id: str,
+    ) -> Optional[_OwnedRepoBundle]:
+        bundle = self._bundles.pop(instance_id, None)
+        source_binding = self._source_bindings.pop(instance_id, None)
+        cleanup_owner = self._source_cleanup_owners.pop(instance_id, None)
+        if bundle is None:
+            return None
+        return _OwnedRepoBundle(bundle, source_binding, cleanup_owner)
+
+    def _retire_unpublished(
+        self,
+        owned: _OwnedRepoBundle,
+    ) -> Optional[BaseException]:
+        with self._generation_lock:
+            self._retired_bundles[id(owned.bundle)] = owned
+        return self._drain_retired()
+
+    @staticmethod
+    def _close_owned(owned: _OwnedRepoBundle) -> bool:
+        """Close one unpinned generation and report whether cleanup completed."""
+
+        bundle = owned.bundle
+        first_failure: BaseException | None = None
+        bundle.bm25 = None
+        bundle.runner = None
+        bundle.source_reader = None
+        vector_store = bundle.vector_store
+        if vector_store is not None:
+            try:
+                vector_store.close()
+            except BaseException as exc:  # noqa: B036 - continue source cleanup
+                first_failure = exc
+            else:
+                bundle.vector_store = None
+
+        owner = owned.source_cleanup_owner
+        owner_closed = owner is None
+        if owner is not None:
+            try:
+                owner.close()
+            except BaseException as exc:  # noqa: B036 - retain retry owner
+                if first_failure is None:
+                    first_failure = exc
+            try:
+                owner_closed = bool(owner.closed)
+            except BaseException as exc:  # noqa: B036 - uncertain means pending
+                owner_closed = False
+                if first_failure is None:
+                    first_failure = exc
+        elif owned.source_binding is not None:
+            try:
+                owned.source_binding.close()
+            except BaseException as exc:  # noqa: B036 - retain retry owner
+                if first_failure is None:
+                    first_failure = exc
+            try:
+                owner_closed = bool(owned.source_binding.closed)
+            except BaseException as exc:  # noqa: B036 - uncertain means pending
+                owner_closed = False
+                if first_failure is None:
+                    first_failure = exc
+
+        if first_failure is not None:
+            raise first_failure
+        return bundle.vector_store is None and owner_closed
+
+    def _drain_retired(self) -> Optional[BaseException]:
+        first_failure: BaseException | None = None
+        with self._generation_lock:
+            ready = [
+                (key, owned)
+                for key, owned in self._retired_bundles.items()
+                if self._bundle_leases.get(key, 0) == 0
+                and key not in self._cleanup_in_progress
+            ]
+            self._cleanup_in_progress.update(key for key, _owned in ready)
+        for key, owned in ready:
+            complete = False
+            try:
+                complete = self._close_owned(owned)
+            except BaseException as exc:  # noqa: B036 - visit every generation
+                if first_failure is None:
+                    first_failure = exc
+            finally:
+                with self._generation_lock:
+                    self._cleanup_in_progress.discard(key)
+                    if complete:
+                        self._retired_bundles.pop(key, None)
+        return first_failure
+
+    def _drain_orphan_cleanup(self) -> Optional[BaseException]:
+        first_failure: BaseException | None = None
+        pending: List[Any] = []
+        with self._generation_lock:
+            owners = tuple(self._orphan_cleanup_owners)
+            self._orphan_cleanup_owners.clear()
+        for owner in owners:
+            try:
+                owner.close()
+            except BaseException as exc:  # noqa: B036 - visit every owner
+                if first_failure is None:
+                    first_failure = exc
+            try:
+                closed = bool(owner.closed)
+            except BaseException as exc:  # noqa: B036 - uncertain means pending
+                closed = False
+                if first_failure is None:
+                    first_failure = exc
+            if not closed:
+                pending.append(owner)
+        with self._generation_lock:
+            for owner in pending:
+                if not any(
+                    candidate is owner for candidate in self._orphan_cleanup_owners
+                ):
+                    self._orphan_cleanup_owners.append(owner)
+        return first_failure
 
     def close(self) -> None:
-        """Release retrieval views, then every retained repository authority."""
+        """Retire active generations; pinned requests release them later."""
 
-        first_failure: BaseException | None = None
-        pending_vector_cleanup = False
-        for bundle in tuple(self._bundles.values()):
-            vector_store = bundle.vector_store
-            bundle.bm25 = None
-            bundle.runner = None
-            bundle.source_reader = None
-            if vector_store is not None:
-                try:
-                    vector_store.close()
-                except BaseException as exc:  # noqa: B036 - finish all cleanup
-                    pending_vector_cleanup = True
-                    if first_failure is None:
-                        first_failure = exc
-                else:
-                    bundle.vector_store = None
+        with self._generation_lock:
+            self._closed = True
+            for instance_id in tuple(self._bundles):
+                owned = self._retire_active_locked(instance_id)
+                if owned is not None:
+                    self._retired_bundles[id(owned.bundle)] = owned
 
+        first_failure = self._drain_retired()
+
+        # Owners left in these maps belong to metadata candidates that failed
+        # before a bundle was published. They remain retryable just like retired
+        # generations, but have no request lease to wait for.
         for instance_id, owner in tuple(self._source_cleanup_owners.items()):
             try:
                 owner.close()
-            except BaseException as exc:  # noqa: B036 - finish all cleanup
+            except BaseException as exc:  # noqa: B036 - finish every cleanup
                 if first_failure is None:
                     first_failure = exc
-            if getattr(owner, "closed", False):
-                self._source_cleanup_owners.pop(instance_id, None)
-                self._source_bindings.pop(instance_id, None)
+            try:
+                owner_closed = bool(owner.closed)
+            except BaseException as exc:  # noqa: B036 - uncertain means pending
+                owner_closed = False
+                if first_failure is None:
+                    first_failure = exc
+            if owner_closed:
+                with self._generation_lock:
+                    self._source_cleanup_owners.pop(instance_id, None)
+                    self._source_bindings.pop(instance_id, None)
 
-        if not self._source_cleanup_owners and not pending_vector_cleanup:
-            self._bundles.clear()
+        orphan_failure = self._drain_orphan_cleanup()
+        if first_failure is None:
+            first_failure = orphan_failure
         if first_failure is not None:
             raise first_failure
 
@@ -826,7 +1141,12 @@ class RepoRegistry:
             extra_kwargs=self._config.model_options,
         )
 
-    def _load_repo_views(self, bundle: RepoBundle) -> None:
+    def _load_repo_views(
+        self,
+        bundle: RepoBundle,
+        *,
+        source_binding: Optional["RepositorySourceBinding"] = None,
+    ) -> None:
         """Load only the persisted retrieval views needed by static Wiki pages."""
         from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 
@@ -836,10 +1156,11 @@ class RepoRegistry:
             raise RuntimeError(
                 "manifest-selected repository has no authenticated source reader"
             )
-        entry = getattr(bundle, "entry", None)
-        source_binding = getattr(self, "_source_bindings", {}).get(
-            getattr(entry, "instance_id", "")
-        )
+        if source_binding is None:
+            entry = getattr(bundle, "entry", None)
+            source_binding = getattr(self, "_source_bindings", {}).get(
+                getattr(entry, "instance_id", "")
+            )
 
         bm25_index: Optional["BM25CodeIndexer"] = None
         vector_store: Optional["CodeVectorStore"] = None
@@ -1006,8 +1327,61 @@ class RepoRegistry:
 
     # -- queries --
 
+    @contextmanager
+    def pin(self, repo_id: str) -> Iterator[Optional[RepoBundle]]:
+        """Pin the current generation for the complete caller operation."""
+
+        with self._generation_lock:
+            if self._closed:
+                raise RuntimeError("repository registry is closed")
+            bundle = self._bundles.get(repo_id)
+            key = id(bundle) if bundle is not None else None
+            if key is not None:
+                self._bundle_leases[key] = self._bundle_leases.get(key, 0) + 1
+        try:
+            yield bundle
+        finally:
+            if key is not None:
+                self._release_bundle_keys((key,))
+
+    def _release_bundle_keys(self, keys: Tuple[int, ...]) -> None:
+        with self._generation_lock:
+            for key in keys:
+                leases = self._bundle_leases.get(key, 0)
+                if leases <= 1:
+                    self._bundle_leases.pop(key, None)
+                else:
+                    self._bundle_leases[key] = leases - 1
+        failure = self._drain_retired()
+        if failure is not None:
+            logger.error(
+                "Retired repository cleanup remains pending: %s",
+                failure,
+                exc_info=(type(failure), failure, failure.__traceback__),
+            )
+
     def list_infos(self) -> List[RepoInfo]:
-        return [b.info() for b in self._bundles.values()]
+        with self._generation_lock:
+            if self._closed:
+                return []
+            bundles = tuple(self._bundles.values())
+            keys = tuple(id(bundle) for bundle in bundles)
+            for key in keys:
+                self._bundle_leases[key] = self._bundle_leases.get(key, 0) + 1
+        try:
+            return [bundle.info() for bundle in bundles]
+        finally:
+            self._release_bundle_keys(keys)
 
     def get(self, repo_id: str) -> Optional[RepoBundle]:
-        return self._bundles.get(repo_id)
+        """Return a non-owning snapshot for offline, non-reloading callers."""
+
+        with self._generation_lock:
+            return self._bundles.get(repo_id)
+
+    @property
+    def retired_generation_count(self) -> int:
+        """Number of old generations still leased or awaiting cleanup retry."""
+
+        with self._generation_lock:
+            return len(self._retired_bundles)

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -675,6 +675,11 @@ class RepoRegistry:
         # every drain and close serialized so shutdown cannot return while a
         # different thread is still closing an unleased generation or owner.
         self._cleanup_lock = RLock()
+        # A request that releases its generation while a reload owns the
+        # cleanup boundary must not wait for a potentially slow candidate
+        # build. Exact operation tokens make that deferral cancellation-safe;
+        # the outermost reload drops its token before one final drain.
+        self._reload_preparations: set[object] = set()
         self._closed = False
         # Serialize registry-file snapshots through publication and removal
         # reconciliation. Without this boundary, an older load_all() could
@@ -686,6 +691,52 @@ class RepoRegistry:
         self._embeddings: Dict[Tuple[str, str, int, Optional[str], str], object] = {}
         self._embedding_load_lock = RLock()
 
+    @contextmanager
+    def _reload_preparation_boundary(self) -> Iterator[None]:
+        """Serialize a reload and settle leases deferred during its build."""
+
+        token = object()
+        primary: BaseException | None = None
+        cleanup_failure: BaseException | None = None
+        with self._cleanup_lock, self._registry_reload_lock:
+            try:
+                with self._generation_lock:
+                    self._reload_preparations.add(token)
+                try:
+                    yield
+                except BaseException as exc:  # noqa: B036 - settle boundary first
+                    primary = exc
+            finally:
+                final_drain = False
+                try:
+                    try:
+                        with self._generation_lock:
+                            self._reload_preparations.discard(token)
+                    finally:
+                        # A trace/signal exception after the first discard
+                        # cannot leave every future lease release deferred.
+                        with self._generation_lock:
+                            self._reload_preparations.discard(token)
+                            final_drain = not self._reload_preparations
+                    if final_drain:
+                        cleanup_failure = self._drain_retired()
+                except BaseException as exc:  # noqa: B036 - preserve body failure
+                    cleanup_failure = _retain_cleanup_failure(
+                        cleanup_failure,
+                        exc,
+                    )
+        if primary is not None:
+            if cleanup_failure is not None:
+                _raise_with_cleanup_failure(primary, cleanup_failure)
+            raise primary
+        if cleanup_failure is not None:
+            if not issubclass(type(cleanup_failure), Exception):
+                raise cleanup_failure
+            _log_cleanup_failure(
+                "Deferred repository cleanup remains pending: %s",
+                cleanup_failure,
+            )
+
     def load_all(self) -> None:
         """Load registry metadata, atomically replacing matching generations.
 
@@ -695,7 +746,7 @@ class RepoRegistry:
         while active repositories absent from the complete snapshot are retired.
         """
 
-        with self._cleanup_lock, self._registry_reload_lock:
+        with self._reload_preparation_boundary():
             with self._generation_lock:
                 if self._closed:
                     raise RuntimeError("repository registry is closed")
@@ -766,16 +817,20 @@ class RepoRegistry:
         unleased bundle that another concurrent refresh could retire.
         """
 
-        with self._cleanup_lock, self._registry_reload_lock:
+        with self._reload_preparation_boundary():
             with self._generation_lock:
                 if self._closed:
                     raise RuntimeError("repository registry is closed")
             repo_id = _plain_repo_instance_id(repo_id)
-            entries = [
-                entry
-                for entry in load_registry(self._config.registry_path)
-                if _plain_repo_instance_id(entry.instance_id) == repo_id
-            ]
+            entries = []
+            for entry in load_registry(self._config.registry_path):
+                try:
+                    instance_id = _plain_repo_instance_id(entry.instance_id)
+                except ValueError as exc:
+                    logger.error("Skipping malformed repository entry: %s", exc)
+                    continue
+                if instance_id == repo_id:
+                    entries.append(entry)
             if len(entries) != 1:
                 raise ValueError(
                     "repository registry must contain exactly one entry for "
@@ -976,7 +1031,7 @@ class RepoRegistry:
     def _load_repo_metadata(self, entry: RepoEntry) -> RepoBundle:
         """Legacy metadata loader used by offline callers and focused tests."""
 
-        with self._cleanup_lock, self._registry_reload_lock:
+        with self._reload_preparation_boundary():
             with self._generation_lock:
                 if self._closed:
                     raise RuntimeError("repository registry is closed")
@@ -2050,6 +2105,16 @@ class RepoRegistry:
 
     def _release_bundle_lease(self, lease_token: object) -> None:
         self._drop_bundle_lease(lease_token)
+        with self._generation_lock:
+            closed = self._closed
+            preparing = bool(self._reload_preparations)
+        if not closed and preparing:
+            # The outermost reload performs a final drain after dropping its
+            # operation token. The lease itself is already gone, so this
+            # request need not wait for model/index candidate preparation.
+            return
+        # Shutdown and ordinary non-reload cleanup retain the blocking
+        # settlement contract: no other owner is responsible for a final drain.
         failure = self._drain_retired()
         if failure is not None:
             if not issubclass(type(failure), Exception):

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -552,6 +552,17 @@ def _raise_with_cleanup_failure(
     raise primary from cleanup_failure
 
 
+def _plain_repo_instance_id(value: Any) -> str:
+    """Detach a registry key from caller-defined string subclass methods."""
+
+    if not isinstance(value, str):
+        raise ValueError("repository instance_id must be non-empty text")
+    instance_id = str.__str__(value)
+    if not instance_id:
+        raise ValueError("repository instance_id must be non-empty text")
+    return instance_id
+
+
 def _log_cleanup_failure(message: str, failure: BaseException) -> None:
     """Report retryable cleanup without invoking hostile exception accessors."""
 
@@ -650,7 +661,11 @@ class RepoRegistry:
                 )
             seen: set[str] = set()
             for entry in entries:
-                instance_id = entry.instance_id
+                try:
+                    instance_id = _plain_repo_instance_id(entry.instance_id)
+                except ValueError as exc:
+                    logger.error("Failed to load repository entry: %s", exc)
+                    continue
                 if instance_id in seen:
                     logger.error("Skipping duplicate repository id %r", instance_id)
                     continue
@@ -692,6 +707,7 @@ class RepoRegistry:
         unleased bundle that another concurrent refresh could retire.
         """
 
+        repo_id = _plain_repo_instance_id(repo_id)
         with self._registry_reload_lock:
             with self._generation_lock:
                 if self._closed:
@@ -699,7 +715,7 @@ class RepoRegistry:
             entries = [
                 entry
                 for entry in load_registry(self._config.registry_path)
-                if entry.instance_id == repo_id
+                if _plain_repo_instance_id(entry.instance_id) == repo_id
             ]
             if len(entries) != 1:
                 raise ValueError(
@@ -761,22 +777,23 @@ class RepoRegistry:
         *,
         prepare_runtime: bool,
     ) -> RepoBundle:
+        instance_id = _plain_repo_instance_id(entry.instance_id)
         try:
             owned = self._build_repo_metadata(entry)
         except BaseException as primary:  # noqa: B036 - retain retry owner
-            self._retain_exception_cleanup(entry.instance_id, primary)
+            self._retain_exception_cleanup(instance_id, primary)
             raise
         try:
             if prepare_runtime:
                 self._prepare_runtime_bundle(owned.bundle)
-            self._publish_owned(entry.instance_id, owned)
+            self._publish_owned(instance_id, owned)
             return owned.bundle
         except BaseException as primary:  # noqa: B036 - retain candidate owner
             # Cancellation may land immediately after the atomic publication.
             # Inspect identity under the same lock instead of relying on a
             # caller-side flag whose next bytecode may never run.
             with self._generation_lock:
-                published = self._bundles.get(entry.instance_id) is owned.bundle
+                published = self._bundles.get(instance_id) is owned.bundle
             if not published:
                 cleanup_failure = self._retire_unpublished(owned)
                 if cleanup_failure is not None:
@@ -810,9 +827,7 @@ class RepoRegistry:
             require_manifest_source_identity,
         )
 
-        instance_id = entry.instance_id
-        if not isinstance(instance_id, str) or not instance_id:
-            raise ValueError("repository instance_id must be non-empty text")
+        _plain_repo_instance_id(entry.instance_id)
 
         manifest = RepoManifest.load(entry.manifest_path)
         cleanup_owner = SourceBindingCleanupOwner()
@@ -869,16 +884,17 @@ class RepoRegistry:
             with self._generation_lock:
                 if self._closed:
                     raise RuntimeError("repository registry is closed")
-            instance_id = entry.instance_id
-            if not isinstance(instance_id, str) or not instance_id:
-                raise ValueError("repository instance_id must be non-empty text")
+            instance_id = _plain_repo_instance_id(entry.instance_id)
             try:
                 owned = self._build_repo_metadata(entry)
             except BaseException as primary:  # noqa: B036 - preserve retry owner
                 self._retain_exception_cleanup(instance_id, primary)
                 raise
             with self._generation_lock:
-                if (
+                closed = self._closed
+                if closed:
+                    duplicate = False
+                elif (
                     instance_id in self._source_bindings
                     or instance_id in self._source_cleanup_owners
                 ):
@@ -889,6 +905,12 @@ class RepoRegistry:
                     self._source_cleanup_owners[instance_id] = (
                         owned.source_cleanup_owner
                     )
+            if closed:
+                cleanup_failure = self._retire_unpublished(owned)
+                error = RuntimeError("repository registry is closed")
+                if cleanup_failure is not None:
+                    _raise_with_cleanup_failure(error, cleanup_failure)
+                raise error
             if duplicate:
                 cleanup_failure = self._retire_unpublished(owned)
                 error = ValueError(f"duplicate repository instance_id: {instance_id!r}")
@@ -941,6 +963,7 @@ class RepoRegistry:
                 )
 
     def _publish_owned(self, instance_id: str, owned: _OwnedRepoBundle) -> None:
+        instance_id = _plain_repo_instance_id(instance_id)
         with self._generation_lock:
             if self._closed:
                 raise RuntimeError("repository registry is closed")
@@ -1507,6 +1530,7 @@ class RepoRegistry:
     def pin(self, repo_id: str) -> Iterator[Optional[RepoBundle]]:
         """Pin the current generation for the complete caller operation."""
 
+        repo_id = _plain_repo_instance_id(repo_id)
         with self._generation_lock:
             if self._closed:
                 raise RuntimeError("repository registry is closed")
@@ -1563,6 +1587,7 @@ class RepoRegistry:
     def get(self, repo_id: str) -> Optional[RepoBundle]:
         """Return a non-owning snapshot for offline, non-reloading callers."""
 
+        repo_id = _plain_repo_instance_id(repo_id)
         with self._generation_lock:
             return self._bundles.get(repo_id)
 

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -609,11 +609,13 @@ class RepoRegistry:
                     exc_info=True,
                 )
 
-    def refresh(self, repo_id: str) -> RepoBundle:
+    def refresh(self, repo_id: str) -> None:
         """Prepare and atomically publish a complete new bundle generation.
 
         The active bundle remains untouched when metadata authentication, view
-        loading, graph loading, or Ask runtime construction fails.
+        loading, graph loading, or Ask runtime construction fails. The caller
+        must use ``pin()`` for any subsequent access; a refresh never escapes an
+        unleased bundle that another concurrent refresh could retire.
         """
 
         with self._generation_lock:
@@ -631,7 +633,7 @@ class RepoRegistry:
         entry = entries[0]
         if not os.path.exists(entry.manifest_path):
             raise FileNotFoundError(entry.manifest_path)
-        return self._replace_entry(entry, prepare_runtime=True)
+        self._replace_entry(entry, prepare_runtime=True)
 
     def _replace_entry(
         self,

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1307,7 +1307,8 @@ allocates that watermark from an explicit immutable `AUTOINCREMENT` job
 sequence, validates a gap-free job-to-sequence closure, and backfills existing
 jobs in canonical creation order; it therefore remains stable across `VACUUM`
 instead of depending on mutable implicit rowids. Cache-building adapters,
-runtime registration, and default routing remain absent.
+job-triggered runtime registration, and default routing remain absent. The Web
+runtime now has the generation-safe refresh boundary described under M3.
 
 ### M2: Immutable generation publication
 
@@ -1342,8 +1343,9 @@ schema-8 vector artifacts without catalog authority. Its resource-scoped
 resolver and trusted local target factory guarantee attempt-local cleanup,
 same-store binding, and exact configured repository/source identity, while
 the explicit CLI can run one bounded pass or a cursor-fair continuous scheduler
-over the current cache. Source builders, runtime, Web, MCP, and default wiring
-remain absent.
+over the current cache. The Web registry now supports complete-candidate RCU
+replacement and request-lifetime generation leases. Source builders, the #266
+job/status handoff, MCP, and default routing remain absent.
 
 - The backend-neutral worker now owns advisory scan/claim, per-attempt task
   authority, independent heartbeat sessions, cancellation precedence, bounded
@@ -1398,8 +1400,22 @@ remain absent.
   paths and are never nested inside the worker.
 - Expose the #266 status and update APIs with accurate incremental versus
   rebuild behavior.
-- Load a complete new bundle and swap it RCU-style; pin old bundles for in-flight
-  requests.
+- `RepoRegistry.load_all()` now reconciles each complete registry snapshot,
+  retires repositories removed from that snapshot, and leaves a healthy
+  generation live when its still-declared replacement fails. First startup
+  remains lazy; any replacement of an active generation authenticates and
+  prepares its complete retrieval, Ask, and advertised graph surface before a
+  single lock-protected pointer swap. Snapshot reload, explicit refresh, and
+  shutdown are serialized. Web requests pin one coherent generation through
+  every offloaded operation and response construction, including cancellation
+  settlement; list metadata and incremental statistics use one pinned snapshot.
+  Old, removed, or unpublished generations retain vector/source cleanup
+  authority until the final lease and all retryable cleanup complete, with
+  cancellation-class cleanup failures never demoted behind ordinary errors.
+  Bundle-derived Wiki, edge-label, and commit-window helpers are generation
+  keyed and stale entries are pruned after replacement, removal, and shutdown.
+  The remaining #266 work is to invoke this refresh boundary only after an
+  attested update job succeeds and expose its status/results to the UI.
 - Keep read-only/prebuilt paths safe through copy-on-write or explicit refusal.
 
 ### M4: Cross-file reference de-materialization

--- a/test/index/test_vector_artifact_identity.py
+++ b/test/index/test_vector_artifact_identity.py
@@ -647,6 +647,22 @@ def test_close_visits_all_indices_and_retains_failed_index_for_retry(
     assert store.embedding is None
 
 
+def test_closed_attestation_includes_query_cache_state(tmp_path) -> None:
+    store = _store(tmp_path, fingerprint="sha256:expected")
+    store._loaded_state = _LoadedVectorState(None, [], None, [], {}, tmp_path)
+    store.embedding = None
+    store._query_cache_depth = 1
+    store._cached_query_text = "query"
+    store._cached_query_vector = object()
+
+    assert store.closed is False
+
+    store._query_cache_depth = 0
+    store._cached_query_text = None
+    store._cached_query_vector = None
+    assert store.closed is True
+
+
 def test_openai_wrapper_sends_vector_options_on_embedding_requests() -> None:
     client = MagicMock()
     client.embeddings.create.return_value = SimpleNamespace(

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -366,6 +366,31 @@ def test_pinned_thread_preserves_cancelled_error_identity():
     assert asyncio.run(observe()) is failure
 
 
+def test_pinned_thread_does_not_read_hostile_exception_class():
+    touched = []
+
+    class HostileFailure(BaseException):
+        @property
+        def __class__(self):
+            touched.append("class")
+            raise SystemExit("spoofed worker failure")
+
+    failure = HostileFailure()
+
+    def fail():
+        raise failure
+
+    async def observe():
+        try:
+            await web_app._run_pinned_thread(fail)
+        except BaseException as observed:  # noqa: B036 - assert exact carrier
+            return observed
+        raise AssertionError("thread failure did not propagate")
+
+    assert asyncio.run(observe()) is failure
+    assert touched == []
+
+
 def test_pinned_thread_maps_stop_iteration_without_losing_exact_cause():
     failure = StopIteration("thread stop")
 
@@ -432,15 +457,16 @@ def test_wiki_cache_rebuilds_when_bundle_generation_changes(monkeypatch):
     assert repeated is first
     assert refreshed is not first
     assert [builder.bundle for builder in created] == [old, new]
-    assert web_app.app.state.wiki_builders["repo"] == (new, refreshed)
+    assert web_app.app.state.wiki_builders["repo"] == ("repo", new, refreshed)
 
 
 def test_generation_cache_drops_helpers_bound_to_retired_bundle():
     old = SimpleNamespace(entry=SimpleNamespace(instance_id="repo"))
     new = SimpleNamespace(entry=SimpleNamespace(instance_id="repo"))
     cache = {
-        "repo@old": (old, object()),
+        "repo@old": ("repo", old, object()),
         "other@commit": (
+            "other",
             SimpleNamespace(entry=SimpleNamespace(instance_id="other")),
             object(),
         ),
@@ -449,13 +475,38 @@ def test_generation_cache_drops_helpers_bound_to_retired_bundle():
     current = web_app._generation_cached(
         cache,
         "repo@new",
+        "repo",
         new,
         object,
     )
 
-    assert cache["repo@new"] == (new, current)
+    assert cache["repo@new"] == ("repo", new, current)
     assert "repo@old" not in cache
     assert "other@commit" in cache
+
+
+def test_generation_cache_does_not_read_hostile_bundle_repo_id():
+    touched = []
+
+    class HostileId(str):
+        def __eq__(self, other):
+            touched.append(other)
+            return str.__eq__(self, other)
+
+    old = SimpleNamespace(entry=SimpleNamespace(instance_id="repo"))
+    new = SimpleNamespace(entry=SimpleNamespace(instance_id=HostileId("repo")))
+    cache = {"repo@old": ("repo", old, object())}
+
+    current = web_app._generation_cached(
+        cache,
+        "repo@new",
+        "repo",
+        new,
+        object,
+    )
+
+    assert touched == []
+    assert cache == {"repo@new": ("repo", new, current)}
 
 
 def test_retired_generation_caches_are_pruned_after_removal(monkeypatch):
@@ -463,8 +514,8 @@ def test_retired_generation_caches_are_pruned_after_removal(monkeypatch):
     current = SimpleNamespace(entry=SimpleNamespace(instance_id="current"))
     current_helper = object()
     cache = {
-        "removed@commit": (removed, object()),
-        "current@commit": (current, current_helper),
+        "removed@commit": ("removed", removed, object()),
+        "current@commit": ("current", current, current_helper),
     }
     registry = SimpleNamespace(
         get=lambda repo_id: current if repo_id == "current" else None
@@ -475,7 +526,7 @@ def test_retired_generation_caches_are_pruned_after_removal(monkeypatch):
 
     web_app._prune_retired_generation_caches(registry)
 
-    assert cache == {"current@commit": (current, current_helper)}
+    assert cache == {"current@commit": ("current", current, current_helper)}
 
 
 def test_list_repos_keeps_info_and_window_stats_on_one_generation(monkeypatch):

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
+from contextlib import contextmanager
 from types import SimpleNamespace
 
 import pytest
@@ -166,7 +168,8 @@ def test_chat_maps_citations_off_loop_from_the_served_checkout(monkeypatch):
         return ChatResponse(answer="answer")
 
     async def fake_to_thread(func, *args, **kwargs):
-        calls.append(func)
+        observed = args[0] if func is web_app._capture_thread_outcome else func
+        calls.append(observed)
         return func(*args, **kwargs)
 
     monkeypatch.setattr(web_app, "_registry", Registry)
@@ -184,6 +187,342 @@ def test_chat_maps_citations_off_loop_from_the_served_checkout(monkeypatch):
 
     assert response.answer == "answer"
     assert calls == [bundle.ensure_runtime, bundle.runner.run, fake_mapping]
+
+
+def test_chat_pins_one_bundle_generation_through_response_mapping(monkeypatch):
+    events = []
+    result = object()
+
+    class Runner:
+        def run(self, _query, *, chat_history):
+            assert chat_history == []
+            assert events == ["pin-enter", "runtime"]
+            events.append("run")
+            return result
+
+    def ensure_runtime():
+        assert events == ["pin-enter"]
+        events.append("runtime")
+
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(repo_dir="/served/checkout"),
+        runner=Runner(),
+        ensure_runtime=ensure_runtime,
+        source_reader=object(),
+    )
+
+    class Registry:
+        @contextmanager
+        def pin(self, repo_id):
+            assert repo_id == "repo"
+            events.append("pin-enter")
+            try:
+                yield bundle
+            finally:
+                events.append("pin-exit")
+
+    def map_response(observed, **_kwargs):
+        assert observed is result
+        assert events == ["pin-enter", "runtime", "run"]
+        events.append("map")
+        return ChatResponse(answer="answer")
+
+    async def inline(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(web_app.app.state, "registry", Registry(), raising=False)
+    monkeypatch.setattr(web_app, "agent_result_to_response", map_response)
+    monkeypatch.setattr(web_app.asyncio, "to_thread", inline)
+
+    response = asyncio.run(
+        web_app.chat(
+            ChatRequest(
+                repo_id="repo",
+                messages=[{"role": "user", "content": "Where is runtime?"}],
+            )
+        )
+    )
+
+    assert response.answer == "answer"
+    assert events == ["pin-enter", "runtime", "run", "map", "pin-exit"]
+
+
+def test_pinned_bundle_preserves_get_only_registry_fallback(monkeypatch):
+    bundle = object()
+    calls = []
+
+    class Registry:
+        def get(self, repo_id):
+            calls.append(repo_id)
+            return bundle if repo_id == "repo" else None
+
+    monkeypatch.setattr(web_app.app.state, "registry", Registry(), raising=False)
+
+    with web_app._pinned_bundle("repo") as observed:
+        assert observed is bundle
+
+    with pytest.raises(web_app.HTTPException) as error:
+        with web_app._pinned_bundle("missing"):
+            raise AssertionError("missing bundle context yielded")
+
+    assert error.value.status_code == 404
+    assert calls == ["repo", "missing"]
+
+
+def test_pinned_bundle_releases_on_exact_base_exception(monkeypatch):
+    stop = SystemExit("request stopped")
+    events = []
+
+    class Registry:
+        @contextmanager
+        def pin(self, _repo_id):
+            events.append("pin-enter")
+            try:
+                yield object()
+            finally:
+                events.append("pin-exit")
+
+    monkeypatch.setattr(web_app.app.state, "registry", Registry(), raising=False)
+
+    with pytest.raises(SystemExit) as observed:
+        with web_app._pinned_bundle("repo"):
+            raise stop
+
+    assert observed.value is stop
+    assert events == ["pin-enter", "pin-exit"]
+
+
+def test_chat_cancellation_keeps_bundle_pinned_until_worker_settles(monkeypatch):
+    events = []
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+
+    class Runner:
+        def run(self, _query, *, chat_history):
+            assert chat_history == []
+            events.append("worker-enter")
+            worker_started.set()
+            assert release_worker.wait(timeout=5)
+            events.append("worker-exit")
+            return object()
+
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(repo_dir="/served/checkout"),
+        runner=Runner(),
+        ensure_runtime=lambda: None,
+        source_reader=object(),
+    )
+
+    class Registry:
+        @contextmanager
+        def pin(self, repo_id):
+            assert repo_id == "repo"
+            events.append("pin-enter")
+            try:
+                yield bundle
+            finally:
+                events.append("pin-exit")
+
+    monkeypatch.setattr(web_app.app.state, "registry", Registry(), raising=False)
+
+    async def cancel_while_worker_is_blocked():
+        request = asyncio.create_task(
+            web_app.chat(
+                ChatRequest(
+                    repo_id="repo",
+                    messages=[{"role": "user", "content": "Where is runtime?"}],
+                )
+            )
+        )
+        started = await asyncio.to_thread(worker_started.wait, 5)
+        assert started
+        request.cancel()
+        for _ in range(3):
+            await asyncio.sleep(0)
+        assert not request.done()
+        assert events == ["pin-enter", "worker-enter"]
+        release_worker.set()
+        with pytest.raises(asyncio.CancelledError):
+            await request
+
+    asyncio.run(cancel_while_worker_is_blocked())
+
+    assert events == ["pin-enter", "worker-enter", "worker-exit", "pin-exit"]
+
+
+def test_pinned_thread_preserves_cancelled_error_identity():
+    failure = asyncio.CancelledError("thread cancelled")
+
+    def fail():
+        raise failure
+
+    async def observe():
+        try:
+            await web_app._run_pinned_thread(fail)
+        except BaseException as observed:  # noqa: B036 - assert exact carrier
+            return observed
+        raise AssertionError("thread failure did not propagate")
+
+    assert asyncio.run(observe()) is failure
+
+
+def test_pinned_thread_maps_stop_iteration_without_losing_exact_cause():
+    failure = StopIteration("thread stop")
+
+    def fail():
+        raise failure
+
+    async def observe():
+        with pytest.raises(RuntimeError) as observed:
+            await web_app._run_pinned_thread(fail)
+        return observed.value
+
+    observed = asyncio.run(observe())
+
+    assert str(observed) == "thread worker raised an iteration sentinel"
+    assert observed.__cause__ is failure
+
+
+def test_pinned_thread_outer_cancellation_precedes_worker_failure():
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    worker_finished = threading.Event()
+
+    def fail_after_release():
+        worker_started.set()
+        assert release_worker.wait(5)
+        worker_finished.set()
+        raise StopIteration("secondary worker stop")
+
+    async def cancel_worker():
+        request = asyncio.create_task(web_app._run_pinned_thread(fail_after_release))
+        assert await asyncio.to_thread(worker_started.wait, 5)
+        request.cancel()
+        await asyncio.sleep(0)
+        assert not request.done()
+        release_worker.set()
+        with pytest.raises(asyncio.CancelledError):
+            await request
+
+    asyncio.run(cancel_worker())
+
+    assert worker_finished.is_set()
+
+
+def test_wiki_cache_rebuilds_when_bundle_generation_changes(monkeypatch):
+    created = []
+    config = SimpleNamespace(wiki_agent=False)
+
+    def build(bundle, narrator=None):
+        builder = SimpleNamespace(bundle=bundle, narrator=narrator)
+        created.append(builder)
+        return builder
+
+    old = object()
+    new = object()
+    monkeypatch.setattr(web_app, "load_config", lambda: config)
+    monkeypatch.setattr(web_app, "WikiBuilder", build)
+    monkeypatch.setattr(web_app.app.state, "wiki_builders", {}, raising=False)
+    monkeypatch.setattr(web_app.app.state, "narrator", object(), raising=False)
+
+    first = web_app._wiki("repo", old)
+    repeated = web_app._wiki("repo", old)
+    refreshed = web_app._wiki("repo", new)
+
+    assert repeated is first
+    assert refreshed is not first
+    assert [builder.bundle for builder in created] == [old, new]
+    assert web_app.app.state.wiki_builders["repo"] == (new, refreshed)
+
+
+def test_generation_cache_drops_helpers_bound_to_retired_bundle():
+    old = SimpleNamespace(entry=SimpleNamespace(instance_id="repo"))
+    new = SimpleNamespace(entry=SimpleNamespace(instance_id="repo"))
+    cache = {
+        "repo@old": (old, object()),
+        "other@commit": (
+            SimpleNamespace(entry=SimpleNamespace(instance_id="other")),
+            object(),
+        ),
+    }
+
+    current = web_app._generation_cached(
+        cache,
+        "repo@new",
+        new,
+        object,
+    )
+
+    assert cache["repo@new"] == (new, current)
+    assert "repo@old" not in cache
+    assert "other@commit" in cache
+
+
+def test_retired_generation_caches_are_pruned_after_removal(monkeypatch):
+    removed = SimpleNamespace(entry=SimpleNamespace(instance_id="removed"))
+    current = SimpleNamespace(entry=SimpleNamespace(instance_id="current"))
+    current_helper = object()
+    cache = {
+        "removed@commit": (removed, object()),
+        "current@commit": (current, current_helper),
+    }
+    registry = SimpleNamespace(
+        get=lambda repo_id: current if repo_id == "current" else None
+    )
+    monkeypatch.setattr(web_app.app.state, "edge_labelers", cache, raising=False)
+    monkeypatch.setattr(web_app.app.state, "wiki_builders", {}, raising=False)
+    monkeypatch.setattr(web_app.app.state, "commit_windows", {}, raising=False)
+
+    web_app._prune_retired_generation_caches(registry)
+
+    assert cache == {"current@commit": (current, current_helper)}
+
+
+def test_list_repos_keeps_info_and_window_stats_on_one_generation(monkeypatch):
+    events = []
+    info = SimpleNamespace(
+        id="repo",
+        base_commit="old",
+        capabilities={},
+        incremental=None,
+    )
+    old = SimpleNamespace(
+        entry=SimpleNamespace(instance_id="repo", base_commit="old"),
+        info=lambda: info,
+    )
+    new = SimpleNamespace(entry=SimpleNamespace(instance_id="repo", base_commit="new"))
+
+    class Registry:
+        @contextmanager
+        def pin_all(self):
+            events.append("pin-enter")
+            try:
+                yield (old,)
+            finally:
+                events.append("pin-exit")
+
+        def get(self, _repo_id):
+            return new
+
+        def list_infos(self):
+            raise AssertionError("production listing must use the pinned snapshot")
+
+    def window_stats(repo_id, bundle):
+        assert repo_id == "repo"
+        events.append(f"stats-{bundle.entry.base_commit}")
+        return bundle.entry.base_commit
+
+    monkeypatch.setattr(web_app.app.state, "registry", Registry(), raising=False)
+    monkeypatch.setattr(
+        web_app, "load_config", lambda: SimpleNamespace(edge_labels=False)
+    )
+    monkeypatch.setattr(web_app, "_window_stats_for_bundle", window_stats)
+
+    observed = asyncio.run(web_app.list_repos())
+
+    assert observed[0].base_commit == "old"
+    assert observed[0].incremental == "old"
+    assert events == ["pin-enter", "stats-old", "pin-exit"]
 
 
 def test_chat_fails_closed_without_authenticated_source_reader(monkeypatch):
@@ -235,11 +574,17 @@ def test_wiki_generation_runs_off_event_loop(monkeypatch):
             return {"id": page_id}
 
     async def fake_to_thread(func, *args, **kwargs):
-        calls.append((func.__name__, args))
+        if func is web_app._capture_thread_outcome:
+            observed = args[0]
+            observed_args = args[1]
+        else:
+            observed = func
+            observed_args = args
+        calls.append((observed.__name__, observed_args))
         return func(*args, **kwargs)
 
     builder = Builder()
-    monkeypatch.setattr(web_app, "_wiki", lambda _repo_id: builder)
+    monkeypatch.setattr(web_app, "_wiki", lambda _repo_id, _bundle=None: builder)
     monkeypatch.setattr(
         web_app,
         "_bundle",
@@ -281,7 +626,7 @@ def test_cached_wiki_tree_does_not_generate_a_missing_outline(monkeypatch):
         def page_tree(self):
             raise AssertionError("cached-only Wiki lookup must not generate")
 
-    monkeypatch.setattr(web_app, "_wiki", lambda _repo_id: Builder())
+    monkeypatch.setattr(web_app, "_wiki", lambda _repo_id, _bundle=None: Builder())
     monkeypatch.setattr(
         web_app,
         "_bundle",
@@ -325,7 +670,7 @@ def test_wiki_page_materializes_local_svg_media(tmp_path, monkeypatch):
         wiki_media_api_key=None,
         wiki_media_options={},
     )
-    monkeypatch.setattr(web_app, "_wiki", lambda _repo_id: Builder())
+    monkeypatch.setattr(web_app, "_wiki", lambda _repo_id, _bundle=None: Builder())
     monkeypatch.setattr(web_app, "load_config", lambda: config)
     monkeypatch.setattr(
         web_app,
@@ -451,7 +796,12 @@ def test_wiki_page_can_skip_media_materialization_for_preload(monkeypatch):
                 "media_slots": [slot],
             }
 
-    monkeypatch.setattr(web_app, "_wiki", lambda _repo_id: Builder())
+    monkeypatch.setattr(web_app, "_wiki", lambda _repo_id, _bundle=None: Builder())
+    monkeypatch.setattr(
+        web_app,
+        "_bundle",
+        lambda _repo_id: SimpleNamespace(entry=SimpleNamespace(repo="org/repo")),
+    )
     monkeypatch.setattr(
         web_app,
         "_materialize_wiki_media",
@@ -590,7 +940,7 @@ def test_wiki_page_graph_reports_why_the_graph_is_unavailable(monkeypatch):
             "Dependency graph uses schema 4, but this server requires schema 5."
         ),
     )
-    monkeypatch.setattr(web_app, "_wiki", lambda _repo_id: Builder())
+    monkeypatch.setattr(web_app, "_wiki", lambda _repo_id, _bundle=None: Builder())
     monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
 
     result = asyncio.run(web_app.wiki_page_graph("repo", "overview"))
@@ -677,7 +1027,11 @@ def test_unavailable_codemap_returns_repository_setup_report(monkeypatch):
         graph_setup=lambda: Setup(),
     )
     monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
-    monkeypatch.setattr(web_app, "_commit_window", lambda _repo_id: Window())
+    monkeypatch.setattr(
+        web_app,
+        "_commit_window",
+        lambda _repo_id, _bundle=None: Window(),
+    )
 
     result = asyncio.run(web_app.codemap("repo"))
 
@@ -700,7 +1054,11 @@ def test_unavailable_modulemap_returns_repository_setup_report(monkeypatch):
         graph_setup=lambda: Setup(),
     )
     monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
-    monkeypatch.setattr(web_app, "_commit_window", lambda _repo_id: Window())
+    monkeypatch.setattr(
+        web_app,
+        "_commit_window",
+        lambda _repo_id, _bundle=None: Window(),
+    )
 
     result = asyncio.run(web_app.modulemap("repo"))
 
@@ -746,7 +1104,11 @@ def test_modulemap_endpoint_projects_the_graph_and_stamps_the_commit(monkeypatch
         graph_setup=lambda: None,
     )
     monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
-    monkeypatch.setattr(web_app, "_commit_window", lambda _repo_id: Window())
+    monkeypatch.setattr(
+        web_app,
+        "_commit_window",
+        lambda _repo_id, _bundle=None: Window(),
+    )
 
     result = asyncio.run(web_app.modulemap("repo", granularity="file"))
 
@@ -804,7 +1166,11 @@ def test_commit_window_maps_use_only_selected_snapshot_metadata(monkeypatch):
         }
 
     monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
-    monkeypatch.setattr(web_app, "_commit_window", lambda _repo_id: Window())
+    monkeypatch.setattr(
+        web_app,
+        "_commit_window",
+        lambda _repo_id, _bundle=None: Window(),
+    )
     monkeypatch.setattr(codemap_builder, "build_codemap", fake_codemap)
     monkeypatch.setattr(modulemap_builder, "build_modulemap", fake_modulemap)
 
@@ -848,7 +1214,11 @@ def test_current_codemap_uses_the_authenticated_source_reader(monkeypatch):
         return {"available": True, "nodes": [], "edges": []}
 
     monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
-    monkeypatch.setattr(web_app, "_commit_window", lambda _repo_id: Window())
+    monkeypatch.setattr(
+        web_app,
+        "_commit_window",
+        lambda _repo_id, _bundle=None: Window(),
+    )
     monkeypatch.setattr(codemap_builder, "build_codemap", fake_codemap)
 
     result = asyncio.run(web_app.codemap("repo"))
@@ -884,7 +1254,11 @@ def test_source_endpoint_reads_the_requested_window_commit(monkeypatch):
         ),
     )
     monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
-    monkeypatch.setattr(web_app, "_commit_window", lambda _repo_id: Window())
+    monkeypatch.setattr(
+        web_app,
+        "_commit_window",
+        lambda _repo_id, _bundle=None: Window(),
+    )
     monkeypatch.setattr(
         web_app,
         "_wiki",
@@ -920,7 +1294,11 @@ def test_source_endpoint_rejects_excluded_historical_source(monkeypatch):
         ),
     )
     monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
-    monkeypatch.setattr(web_app, "_commit_window", lambda _repo_id: Window())
+    monkeypatch.setattr(
+        web_app,
+        "_commit_window",
+        lambda _repo_id, _bundle=None: Window(),
+    )
 
     with pytest.raises(web_app.HTTPException) as error:
         asyncio.run(
@@ -944,7 +1322,7 @@ def test_edge_label_uses_the_graph_payload_commit(monkeypatch):
         def label(self, *args):
             return "calls", False
 
-    def labeler(repo_id, commit):
+    def labeler(repo_id, commit, _bundle=None):
         calls.append((repo_id, commit))
         return Labeler()
 
@@ -1003,7 +1381,11 @@ def test_historical_edge_labeler_gates_source_with_manifest_selection(monkeypatc
         wiki_generation_api_key=None,
     )
     monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
-    monkeypatch.setattr(web_app, "_commit_window", lambda _repo_id: Window())
+    monkeypatch.setattr(
+        web_app,
+        "_commit_window",
+        lambda _repo_id, _bundle=None: Window(),
+    )
     monkeypatch.setattr(web_app, "load_config", lambda: config)
     monkeypatch.setattr(web_app, "_wiki_llm", lambda *_args, **_kwargs: object())
     monkeypatch.setattr(edge_label_module, "EdgeLabeler", Labeler)
@@ -1033,7 +1415,11 @@ def test_source_endpoint_reads_the_live_checkout_without_building_the_wiki(
     binding = capture_repository_source(tmp_path)
     bundle.source_reader = binding.borrow_reader()
     monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
-    monkeypatch.setattr(web_app, "_commit_window", lambda _repo_id: Window())
+    monkeypatch.setattr(
+        web_app,
+        "_commit_window",
+        lambda _repo_id, _bundle=None: Window(),
+    )
     monkeypatch.setattr(
         web_app,
         "_wiki",

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -68,6 +68,31 @@ def _repo_entry(repo, manifest_path, *, instance_id="owner__repo-1"):
     )
 
 
+def _hostile_registry_id(registry, touched):
+    class HostileId(str):
+        def __hash__(self):
+            touched.append("hash")
+            registry.close()
+            return str.__hash__(self)
+
+        def __eq__(self, other):
+            touched.append("eq")
+            registry.close()
+            return str.__eq__(self, other)
+
+        def __str__(self):
+            touched.append("str")
+            registry.close()
+            return str.__str__(self)
+
+        def __bool__(self):
+            touched.append("bool")
+            registry.close()
+            return True
+
+    return HostileId("repo")
+
+
 def _legacy_view_manifest(
     index_type,
     path,
@@ -393,6 +418,35 @@ def test_registry_load_all_prepares_only_live_replacements(tmp_path, monkeypatch
     assert old_owner.closed is True
 
 
+def test_registry_load_all_detaches_hostile_entry_key(tmp_path, monkeypatch):
+    touched = []
+    registry = RepoRegistry(QAConfig())
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    entry = _repo_entry(
+        tmp_path,
+        manifest_path,
+        instance_id=_hostile_registry_id(registry, touched),
+    )
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: [entry],
+    )
+    monkeypatch.setattr(
+        registry,
+        "_build_repo_metadata",
+        lambda _entry: _OwnedRepoBundle(candidate, None, None),
+    )
+
+    registry.load_all()
+
+    assert touched == []
+    assert registry._closed is False
+    assert registry.get("repo") is candidate
+    registry.close()
+
+
 def test_registry_close_waits_for_inflight_candidate_build(tmp_path, monkeypatch):
     manifest_path = tmp_path / "repo_manifest.json"
     manifest_path.write_text("{}", encoding="utf-8")
@@ -497,6 +551,80 @@ def test_registry_close_waits_for_legacy_metadata_build(monkeypatch):
 
     assert owner.close_calls == 1
     assert registry._source_cleanup_owners == {}
+
+
+def test_registry_legacy_metadata_rejects_reentrant_close(monkeypatch):
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+
+    def build(_entry):
+        registry.close()
+        return _OwnedRepoBundle(candidate, None, owner)
+
+    monkeypatch.setattr(registry, "_build_repo_metadata", build)
+
+    with pytest.raises(RuntimeError, match="repository registry is closed"):
+        registry._load_repo_metadata(SimpleNamespace(instance_id="repo"))
+
+    assert owner.close_calls == 1
+    assert registry._source_bindings == {}
+    assert registry._source_cleanup_owners == {}
+    assert registry._retired_bundles == {}
+
+
+def test_registry_legacy_metadata_detaches_hostile_string_key(monkeypatch):
+    hash_calls = 0
+
+    class ReentrantId(str):
+        def __hash__(self):
+            nonlocal hash_calls
+            hash_calls += 1
+            registry.close()
+            return str.__hash__(self)
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    monkeypatch.setattr(
+        registry,
+        "_build_repo_metadata",
+        lambda _entry: _OwnedRepoBundle(candidate, None, owner),
+    )
+
+    result = registry._load_repo_metadata(
+        SimpleNamespace(instance_id=ReentrantId("repo"))
+    )
+
+    assert result is candidate
+    assert hash_calls == 0
+    assert registry._closed is False
+    assert registry._source_cleanup_owners == {"repo": owner}
+
+    registry.close()
+    assert owner.close_calls == 1
 
 
 def test_registry_concurrent_close_closes_owner_once():
@@ -1064,6 +1192,22 @@ def test_registry_swap_keeps_pinned_generation_alive_until_release():
     registry.close()
 
 
+def test_registry_queries_detach_hostile_lookup_key():
+    touched = []
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = bundle
+    key = _hostile_registry_id(registry, touched)
+
+    assert registry.get(key) is bundle
+    with registry.pin(key) as pinned:
+        assert pinned is bundle
+
+    assert touched == []
+    assert registry._closed is False
+    registry.close()
+
+
 def test_registry_refresh_publishes_without_escaping_unleased_bundle(
     tmp_path,
     monkeypatch,
@@ -1102,6 +1246,32 @@ def test_registry_refresh_publishes_without_escaping_unleased_bundle(
 
     registry.close()
     assert owner.closed is True
+
+
+def test_registry_refresh_detaches_hostile_lookup_key(tmp_path, monkeypatch):
+    touched = []
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    entry = _repo_entry(tmp_path, manifest_path, instance_id="repo")
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: [entry],
+    )
+    monkeypatch.setattr(
+        registry,
+        "_build_repo_metadata",
+        lambda _entry: _OwnedRepoBundle(candidate, None, None),
+    )
+    monkeypatch.setattr(registry, "_prepare_runtime_bundle", lambda _bundle: None)
+
+    registry.refresh(_hostile_registry_id(registry, touched))
+
+    assert touched == []
+    assert registry._closed is False
+    assert registry.get("repo") is candidate
+    registry.close()
 
 
 def test_registry_failed_refresh_keeps_active_generation(tmp_path, monkeypatch):

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -1076,7 +1076,8 @@ def test_registry_vector_close_settles_before_opcode_interruption():
     call_index = next(
         index
         for index in range(close_index + 1, len(instructions))
-        if "CALL" in instructions[index].opname
+        if instructions[index].opname != "PRECALL"
+        and "CALL" in instructions[index].opname
     )
     interrupt_offset = instructions[call_index + 1].offset
     triggered = False
@@ -2290,6 +2291,105 @@ def test_registry_refresh_publishes_without_escaping_unleased_bundle(
         assert pinned is candidate
     assert owner.closed is False
 
+    registry.close()
+    assert owner.closed is True
+
+
+def test_registry_pin_release_does_not_wait_for_refresh_candidate_build(
+    tmp_path,
+    monkeypatch,
+):
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    entry = _repo_entry(tmp_path, manifest_path, instance_id="repo")
+    old = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    build_started = Event()
+    release_build = Event()
+    lease_released = Event()
+
+    class Owner:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    old_owner = Owner()
+    candidate_owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = old
+    registry._source_cleanup_owners["repo"] = old_owner
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: [entry],
+    )
+
+    def build(_entry):
+        build_started.set()
+        assert release_build.wait(5)
+        return _OwnedRepoBundle(candidate, None, candidate_owner)
+
+    monkeypatch.setattr(registry, "_build_repo_metadata", build)
+    monkeypatch.setattr(registry, "_prepare_runtime_bundle", lambda _bundle: None)
+    pinned = registry.pin("repo")
+    assert pinned.__enter__() is old
+
+    def release_pin():
+        pinned.__exit__(None, None, None)
+        lease_released.set()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        refresh_future = pool.submit(registry.refresh, "repo")
+        assert build_started.wait(5)
+        release_future = pool.submit(release_pin)
+        assert lease_released.wait(1)
+        assert old_owner.closed is False
+        release_build.set()
+        release_future.result(timeout=5)
+        refresh_future.result(timeout=5)
+
+    assert registry.get("repo") is candidate
+    assert old_owner.closed is True
+    assert registry.retired_generation_count == 0
+    registry.close()
+    assert candidate_owner.closed is True
+
+
+def test_registry_refresh_skips_malformed_unrelated_entry(tmp_path, monkeypatch):
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    malformed = _repo_entry(tmp_path, manifest_path, instance_id="")
+    target = _repo_entry(tmp_path, manifest_path, instance_id="repo")
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+
+    class Owner:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: [malformed, target],
+    )
+    monkeypatch.setattr(
+        registry,
+        "_build_repo_metadata",
+        lambda entry: (
+            _OwnedRepoBundle(candidate, None, owner)
+            if entry is target
+            else pytest.fail("malformed unrelated entry reached the builder")
+        ),
+    )
+    monkeypatch.setattr(registry, "_prepare_runtime_bundle", lambda _bundle: None)
+
+    registry.refresh("repo")
+
+    assert registry.get("repo") is candidate
     registry.close()
     assert owner.closed is True
 

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -37,6 +37,7 @@ from codenib.web.repo_registry import (
     RepoBundle,
     RepoRegistry,
     _fresh_registry,
+    _OwnedRepoBundle,
 )
 
 
@@ -273,6 +274,32 @@ def test_registry_reload_closes_the_previous_source_authority(tmp_path):
     registry.close()
 
 
+def test_registry_reload_keeps_pinned_source_authority_until_release(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "runtime.py").write_text("runtime\n", encoding="utf-8")
+    manifest_path = tmp_path / "artifacts" / "repo_manifest.json"
+    _write_source_manifest(repo, manifest_path)
+    entry = _repo_entry(repo, manifest_path)
+    config = QAConfig(data_dir=str(tmp_path / "data"))
+    save_registry(config.registry_path, [entry])
+    registry = RepoRegistry(config)
+    registry.load_all()
+
+    with registry.pin(entry.instance_id) as first_bundle:
+        first_reader = first_bundle.source_reader
+        registry.load_all()
+
+        assert registry.get(entry.instance_id) is not first_bundle
+        assert first_reader.read_prefix("runtime.py", max_bytes=32) == b"runtime\n"
+        assert registry.retired_generation_count == 1
+
+    with pytest.raises(RuntimeError, match="source binding is"):
+        first_reader.read_prefix("runtime.py", max_bytes=32)
+    assert registry.retired_generation_count == 0
+    registry.close()
+
+
 def test_registry_rejects_duplicate_instance_ids_without_replacing_owner(tmp_path):
     entries = []
     for name in ("first", "second"):
@@ -316,13 +343,184 @@ def test_registry_retains_vector_cleanup_owner_for_retry():
     with pytest.raises(RuntimeError, match="retry cleanup"):
         registry.close()
 
-    assert registry._bundles == {"repo": bundle}
+    assert registry._bundles == {}
+    assert set(registry._retired_bundles) == {id(bundle)}
     assert bundle.vector_store is vector
 
     registry.close()
 
     assert vector.close_calls == 2
     assert registry._bundles == {}
+    assert registry._retired_bundles == {}
+
+
+def test_registry_swap_keeps_pinned_generation_alive_until_release():
+    events = []
+
+    class Vector:
+        def close(self):
+            events.append("old-vector-closed")
+
+    class Owner:
+        def __init__(self, label):
+            self.label = label
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+            events.append(f"{self.label}-source-closed")
+
+    old_vector = Vector()
+    old = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+        vector_store=old_vector,
+    )
+    new = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    old_owner = Owner("old")
+    new_owner = Owner("new")
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = old
+    registry._source_cleanup_owners["repo"] = old_owner
+
+    with registry.pin("repo") as pinned:
+        registry._publish_owned(
+            "repo",
+            _OwnedRepoBundle(new, None, new_owner),
+        )
+
+        assert pinned is old
+        assert registry.get("repo") is new
+        assert old.vector_store is old_vector
+        assert old_owner.closed is False
+        assert registry.retired_generation_count == 1
+        assert events == []
+
+    assert old.vector_store is None
+    assert old_owner.closed is True
+    assert registry.retired_generation_count == 0
+    assert events == ["old-vector-closed", "old-source-closed"]
+    registry.close()
+
+
+def test_registry_failed_refresh_keeps_active_generation(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    entry = _repo_entry(repo, manifest_path, instance_id="repo")
+    old = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+
+    class Owner:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    old_owner = Owner()
+    candidate_owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = old
+    registry._source_cleanup_owners["repo"] = old_owner
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: [entry],
+    )
+    monkeypatch.setattr(
+        registry,
+        "_build_repo_metadata",
+        lambda _entry: _OwnedRepoBundle(candidate, None, candidate_owner),
+    )
+
+    def reject(_bundle):
+        assert registry.get("repo") is old
+        raise ValueError("candidate is incomplete")
+
+    monkeypatch.setattr(registry, "_prepare_runtime_bundle", reject)
+
+    with pytest.raises(ValueError, match="candidate is incomplete"):
+        registry.refresh("repo")
+
+    assert registry.get("repo") is old
+    assert old_owner.closed is False
+    assert candidate_owner.closed is True
+    assert registry.retired_generation_count == 0
+    registry.close()
+
+
+def test_registry_failed_refresh_retains_unpublished_cleanup_owner(
+    tmp_path,
+    monkeypatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    entry = _repo_entry(repo, manifest_path, instance_id="repo")
+    old = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+
+    class Owner:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    old_owner = Owner()
+    candidate_owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = old
+    registry._source_cleanup_owners["repo"] = old_owner
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: [entry],
+    )
+
+    error = ValueError("candidate authentication failed")
+    error.source_cleanup_owner = candidate_owner
+
+    def fail_build(_entry):
+        raise error
+
+    monkeypatch.setattr(registry, "_build_repo_metadata", fail_build)
+
+    with pytest.raises(ValueError, match="candidate authentication failed"):
+        registry.refresh("repo")
+
+    assert registry.get("repo") is old
+    assert old_owner.closed is False
+    assert registry._orphan_cleanup_owners == [candidate_owner]
+    registry.close()
+    assert old_owner.closed is True
+    assert candidate_owner.closed is True
+
+
+def test_registry_close_defers_pinned_generation_cleanup():
+    class Owner:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = bundle
+    registry._source_cleanup_owners["repo"] = owner
+
+    with registry.pin("repo") as pinned:
+        registry.close()
+
+        assert pinned is bundle
+        assert owner.closed is False
+        assert registry.get("repo") is None
+        assert registry.retired_generation_count == 1
+
+    assert owner.closed is True
+    assert registry.retired_generation_count == 0
 
 
 def test_repo_views_reject_documents_outside_authenticated_selection(tmp_path):

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -251,6 +251,524 @@ def test_registry_retains_failed_source_cleanup_for_retry(tmp_path, monkeypatch)
     assert registry._source_cleanup_owners == {}
 
 
+def test_registry_later_publish_preserves_failed_owner_for_retry():
+    class Owner:
+        def __init__(self, *, fail_first=False):
+            self.close_calls = 0
+            self.fail_first = fail_first
+
+        @property
+        def closed(self):
+            return self.close_calls >= (2 if self.fail_first else 1)
+
+        def close(self):
+            self.close_calls += 1
+            if self.fail_first and self.close_calls == 1:
+                raise RuntimeError("retry old owner")
+
+    failed_owner = Owner(fail_first=True)
+    published_owner = Owner()
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    registry._source_cleanup_owners["repo"] = failed_owner
+
+    registry._publish_owned(
+        "repo",
+        _OwnedRepoBundle(bundle, None, published_owner),
+    )
+
+    assert registry.get("repo") is bundle
+    assert registry._source_cleanup_owners["repo"] is published_owner
+    assert registry._orphan_cleanup_owners == [failed_owner]
+    assert failed_owner.close_calls == 1
+
+    registry.close()
+
+    assert failed_owner.close_calls == 2
+    assert published_owner.close_calls == 1
+    assert registry._orphan_cleanup_owners == []
+
+
+def test_registry_complete_snapshot_retires_owner_without_bundle(monkeypatch):
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    registry._source_cleanup_owners["removed"] = owner
+    monkeypatch.setattr("codenib.web.repo_registry.load_registry", lambda _path: [])
+
+    registry.load_all()
+
+    assert owner.close_calls == 1
+    assert registry._source_cleanup_owners == {}
+    assert registry._orphan_cleanup_owners == []
+    registry.close()
+    assert owner.close_calls == 1
+
+
+def test_registry_complete_snapshot_retries_failed_owner_cleanup(monkeypatch):
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls >= 2
+
+        def close(self):
+            self.close_calls += 1
+            if self.close_calls == 1:
+                raise RuntimeError("retry removed owner")
+
+    owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    registry._source_cleanup_owners["removed"] = owner
+    monkeypatch.setattr("codenib.web.repo_registry.load_registry", lambda _path: [])
+
+    registry.load_all()
+    assert registry._source_cleanup_owners == {}
+    assert registry._orphan_cleanup_owners == [owner]
+
+    registry.load_all()
+    assert owner.close_calls == 2
+    assert registry._orphan_cleanup_owners == []
+
+
+def test_registry_load_all_prepares_only_live_replacements(tmp_path, monkeypatch):
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    entry = _repo_entry(tmp_path, manifest_path, instance_id="repo")
+
+    class Owner:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    old = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    old_owner = Owner()
+    candidate_owner = Owner()
+    built = iter(
+        (
+            _OwnedRepoBundle(old, None, old_owner),
+            _OwnedRepoBundle(candidate, None, candidate_owner),
+        )
+    )
+    prepared = []
+    registry = RepoRegistry(QAConfig())
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: [entry],
+    )
+    monkeypatch.setattr(registry, "_build_repo_metadata", lambda _entry: next(built))
+
+    def prepare(bundle):
+        prepared.append(bundle)
+        raise ValueError("candidate views are invalid")
+
+    monkeypatch.setattr(registry, "_prepare_runtime_bundle", prepare)
+
+    registry.load_all()
+    assert registry.get("repo") is old
+    assert prepared == []
+
+    registry.load_all()
+
+    assert prepared == [candidate]
+    assert registry.get("repo") is old
+    assert old_owner.closed is False
+    assert candidate_owner.closed is True
+    registry.close()
+    assert old_owner.closed is True
+
+
+def test_registry_close_waits_for_inflight_candidate_build(tmp_path, monkeypatch):
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    entry = _repo_entry(tmp_path, manifest_path, instance_id="repo")
+    build_started = Event()
+    release_build = Event()
+    close_started = Event()
+    close_finished = Event()
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: [entry],
+    )
+
+    def build(_entry):
+        build_started.set()
+        assert release_build.wait(5)
+        return _OwnedRepoBundle(candidate, None, owner)
+
+    def close_registry():
+        close_started.set()
+        try:
+            registry.close()
+        finally:
+            close_finished.set()
+
+    monkeypatch.setattr(registry, "_build_repo_metadata", build)
+    monkeypatch.setattr(registry, "_prepare_runtime_bundle", lambda _bundle: None)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        refresh_future = pool.submit(registry.refresh, "repo")
+        assert build_started.wait(5)
+        close_future = pool.submit(close_registry)
+        assert close_started.wait(5)
+        assert close_finished.wait(0.1) is False
+        release_build.set()
+        refresh_future.result(timeout=5)
+        close_future.result(timeout=5)
+
+    assert registry.get("repo") is None
+    assert owner.close_calls == 1
+
+
+def test_registry_close_waits_for_legacy_metadata_build(monkeypatch):
+    build_started = Event()
+    release_build = Event()
+    close_finished = Event()
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+
+    def build(_entry):
+        build_started.set()
+        assert release_build.wait(5)
+        return _OwnedRepoBundle(candidate, None, owner)
+
+    def close_registry():
+        try:
+            registry.close()
+        finally:
+            close_finished.set()
+
+    monkeypatch.setattr(registry, "_build_repo_metadata", build)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        load = pool.submit(
+            registry._load_repo_metadata,
+            SimpleNamespace(instance_id="repo"),
+        )
+        assert build_started.wait(5)
+        closing = pool.submit(close_registry)
+        assert close_finished.wait(0.1) is False
+        release_build.set()
+        assert load.result(timeout=5) is candidate
+        closing.result(timeout=5)
+
+    assert owner.close_calls == 1
+    assert registry._source_cleanup_owners == {}
+
+
+def test_registry_concurrent_close_closes_owner_once():
+    close_entered = Event()
+    release_close = Event()
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+            close_entered.set()
+            assert release_close.wait(5)
+
+    owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    registry._source_cleanup_owners["repo"] = owner
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(registry.close)
+        assert close_entered.wait(5)
+        second = pool.submit(registry.close)
+        assert second.done() is False
+        release_close.set()
+        first.result(timeout=5)
+        second.result(timeout=5)
+
+    assert owner.close_calls == 1
+
+
+def test_registry_close_waits_for_an_inflight_cleanup_drain():
+    cleanup_started = Event()
+    release_cleanup = Event()
+    close_finished = Event()
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+            cleanup_started.set()
+            assert release_cleanup.wait(5)
+
+    owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    registry._orphan_cleanup_owners.append(owner)
+
+    def close_registry():
+        try:
+            registry.close()
+        finally:
+            close_finished.set()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        drain = pool.submit(registry._drain_orphan_cleanup)
+        assert cleanup_started.wait(5)
+        closing = pool.submit(close_registry)
+        assert close_finished.wait(0.1) is False
+        release_cleanup.set()
+        assert drain.result(timeout=5) is None
+        closing.result(timeout=5)
+
+    assert owner.close_calls == 1
+
+
+def test_registry_cleanup_cancellation_precedes_ordinary_failure():
+    ordinary = RuntimeError("vector cleanup failed")
+    stop = SystemExit("source cleanup stopped")
+
+    class Vector:
+        def close(self):
+            raise ordinary
+
+    class Owner:
+        @property
+        def closed(self):
+            return False
+
+        def close(self):
+            raise stop
+
+    owned = _OwnedRepoBundle(
+        RepoBundle(
+            entry=SimpleNamespace(),
+            manifest=SimpleNamespace(),
+            vector_store=Vector(),
+        ),
+        None,
+        Owner(),
+    )
+
+    with pytest.raises(SystemExit) as observed:
+        RepoRegistry._close_owned(owned)
+
+    assert observed.value is stop
+    notes = getattr(stop, "__notes__", ()) or getattr(
+        stop,
+        "_codenib_cleanup_notes",
+        (),
+    )
+    assert any("earlier repository cleanup" in note for note in notes)
+
+
+def test_registry_unpublished_cleanup_cancellation_precedes_primary(monkeypatch):
+    primary = ValueError("candidate invalid")
+    stop = KeyboardInterrupt("cleanup stopped")
+
+    class Owner:
+        @property
+        def closed(self):
+            return False
+
+        def close(self):
+            raise stop
+
+    owned = _OwnedRepoBundle(
+        RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace()),
+        None,
+        Owner(),
+    )
+    registry = RepoRegistry(QAConfig())
+    monkeypatch.setattr(registry, "_build_repo_metadata", lambda _entry: owned)
+
+    def reject(_bundle):
+        raise primary
+
+    monkeypatch.setattr(registry, "_prepare_runtime_bundle", reject)
+
+    with pytest.raises(KeyboardInterrupt) as observed:
+        registry._replace_entry(
+            SimpleNamespace(instance_id="repo"), prepare_runtime=True
+        )
+
+    assert observed.value is stop
+    assert observed.value.__cause__ is primary
+    assert registry.retired_generation_count == 1
+
+
+def test_registry_primary_cancellation_precedes_ordinary_cleanup(monkeypatch):
+    primary = SystemExit("candidate stopped")
+    cleanup = RuntimeError("cleanup failed")
+
+    class Owner:
+        @property
+        def closed(self):
+            return False
+
+        def close(self):
+            raise cleanup
+
+    owned = _OwnedRepoBundle(
+        RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace()),
+        None,
+        Owner(),
+    )
+    registry = RepoRegistry(QAConfig())
+    monkeypatch.setattr(registry, "_build_repo_metadata", lambda _entry: owned)
+
+    def stop(_bundle):
+        raise primary
+
+    monkeypatch.setattr(registry, "_prepare_runtime_bundle", stop)
+
+    with pytest.raises(SystemExit) as observed:
+        registry._replace_entry(
+            SimpleNamespace(instance_id="repo"), prepare_runtime=True
+        )
+
+    assert observed.value is primary
+    assert observed.value.__cause__ is cleanup
+
+
+def test_registry_cleanup_does_not_create_self_cause(monkeypatch):
+    stop = SystemExit("shared cancellation")
+
+    class Owner:
+        @property
+        def closed(self):
+            return False
+
+        def close(self):
+            raise stop
+
+    owned = _OwnedRepoBundle(
+        RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace()),
+        None,
+        Owner(),
+    )
+    registry = RepoRegistry(QAConfig())
+    monkeypatch.setattr(registry, "_build_repo_metadata", lambda _entry: owned)
+    monkeypatch.setattr(
+        registry,
+        "_prepare_runtime_bundle",
+        lambda _bundle: (_ for _ in ()).throw(stop),
+    )
+
+    with pytest.raises(SystemExit) as observed:
+        registry._replace_entry(
+            SimpleNamespace(instance_id="repo"), prepare_runtime=True
+        )
+
+    assert observed.value is stop
+    assert observed.value.__cause__ is not stop
+
+
+def test_registry_hostile_cleanup_attribute_cannot_replace_primary(monkeypatch):
+    lookup = KeyboardInterrupt("hostile attribute lookup")
+
+    class HostileExit(SystemExit):
+        def __getattribute__(self, name):
+            if name == "source_cleanup_owner":
+                raise lookup
+            return super().__getattribute__(name)
+
+    primary = HostileExit("primary")
+    registry = RepoRegistry(QAConfig())
+    monkeypatch.setattr(
+        registry,
+        "_build_repo_metadata",
+        lambda _entry: (_ for _ in ()).throw(primary),
+    )
+
+    with pytest.raises(SystemExit) as observed:
+        registry._replace_entry(
+            SimpleNamespace(instance_id="repo"), prepare_runtime=False
+        )
+
+    assert observed.value is primary
+
+
+def test_registry_hostile_cleanup_traceback_cannot_replace_publication():
+    lookup = KeyboardInterrupt("hostile traceback lookup")
+
+    class HostileFailure(RuntimeError):
+        def __getattribute__(self, name):
+            if name == "__traceback__":
+                raise lookup
+            return super().__getattribute__(name)
+
+    failure = HostileFailure("cleanup remains pending")
+
+    class Owner:
+        @property
+        def closed(self):
+            return False
+
+        def close(self):
+            raise failure
+
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    registry._source_cleanup_owners["repo"] = Owner()
+
+    registry._publish_owned(
+        "repo",
+        _OwnedRepoBundle(candidate, None, None),
+    )
+
+    assert registry.get("repo") is candidate
+    assert len(registry._orphan_cleanup_owners) == 1
+
+
 def test_registry_reload_closes_the_previous_source_authority(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -364,7 +882,7 @@ def test_registry_reload_keeps_failed_declared_entry_and_retires_absent_entry(
     )
 
     def reject(_entry, *, prepare_runtime):
-        assert prepare_runtime is False
+        assert prepare_runtime is True
         raise ValueError("replacement rejected")
 
     monkeypatch.setattr(registry, "_replace_entry", reject)

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -300,6 +300,149 @@ def test_registry_reload_keeps_pinned_source_authority_until_release(tmp_path):
     registry.close()
 
 
+def test_registry_reload_retires_entry_removed_from_snapshot(monkeypatch):
+    class Owner:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["removed"] = bundle
+    registry._source_cleanup_owners["removed"] = owner
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: [],
+    )
+
+    with registry.pin("removed") as pinned:
+        registry.load_all()
+
+        assert pinned is bundle
+        assert registry.get("removed") is None
+        assert owner.closed is False
+        assert registry.retired_generation_count == 1
+
+    assert owner.closed is True
+    assert registry.retired_generation_count == 0
+    registry.close()
+
+
+def test_registry_reload_keeps_failed_declared_entry_and_retires_absent_entry(
+    tmp_path,
+    monkeypatch,
+):
+    class Owner:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    declared_manifest = tmp_path / "declared.json"
+    declared_manifest.write_text("{}", encoding="utf-8")
+    declared = _repo_entry(
+        tmp_path,
+        declared_manifest,
+        instance_id="declared",
+    )
+    owners = {}
+    registry = RepoRegistry(QAConfig())
+    for instance_id in ("declared", "absent"):
+        bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+        owner = Owner()
+        registry._bundles[instance_id] = bundle
+        registry._source_cleanup_owners[instance_id] = owner
+        owners[instance_id] = owner
+
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: [declared],
+    )
+
+    def reject(_entry, *, prepare_runtime):
+        assert prepare_runtime is False
+        raise ValueError("replacement rejected")
+
+    monkeypatch.setattr(registry, "_replace_entry", reject)
+
+    registry.load_all()
+
+    assert registry.get("declared") is not None
+    assert owners["declared"].closed is False
+    assert registry.get("absent") is None
+    assert owners["absent"].closed is True
+    registry.close()
+
+
+def test_registry_reload_serializes_refresh_after_snapshot_reconciliation(
+    tmp_path,
+    monkeypatch,
+):
+    class Owner:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    entry = _repo_entry(tmp_path, manifest_path, instance_id="repo")
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    owner = Owner()
+    first_snapshot_read = Event()
+    release_first_snapshot = Event()
+    refresh_started = Event()
+    second_snapshot_read = Event()
+    call_lock = Lock()
+    calls = 0
+
+    def load_rows(_path):
+        nonlocal calls
+        with call_lock:
+            calls += 1
+            call = calls
+        if call == 1:
+            first_snapshot_read.set()
+            assert release_first_snapshot.wait(5)
+            return []
+        assert call == 2
+        second_snapshot_read.set()
+        return [entry]
+
+    registry = RepoRegistry(QAConfig())
+    monkeypatch.setattr("codenib.web.repo_registry.load_registry", load_rows)
+    monkeypatch.setattr(
+        registry,
+        "_build_repo_metadata",
+        lambda _entry: _OwnedRepoBundle(candidate, None, owner),
+    )
+    monkeypatch.setattr(registry, "_prepare_runtime_bundle", lambda _bundle: None)
+
+    def refresh():
+        refresh_started.set()
+        registry.refresh("repo")
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        load_future = pool.submit(registry.load_all)
+        assert first_snapshot_read.wait(5)
+        refresh_future = pool.submit(refresh)
+        assert refresh_started.wait(5)
+        assert second_snapshot_read.wait(0.05) is False
+        release_first_snapshot.set()
+        load_future.result(timeout=5)
+        refresh_future.result(timeout=5)
+
+    assert second_snapshot_read.is_set()
+    assert registry.get("repo") is candidate
+    registry.close()
+    assert owner.closed is True
+
+
 def test_registry_rejects_duplicate_instance_ids_without_replacing_owner(tmp_path):
     entries = []
     for name in ("first", "second"):

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -4,7 +4,10 @@
 
 """Tests for per-repo skill-registry isolation, config, and the QA registry."""
 
+import dis
+import inspect
 import pickle
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from threading import Event, Lock
 from types import SimpleNamespace
@@ -368,6 +371,195 @@ def test_registry_complete_snapshot_retries_failed_owner_cleanup(monkeypatch):
     assert registry._orphan_cleanup_owners == []
 
 
+def test_registry_absent_owner_transfer_interruption_keeps_authority():
+    stop = KeyboardInterrupt("absent owner transfer interrupted")
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    registry._source_cleanup_owners["removed"] = owner
+    source, first_line = inspect.getsourcelines(
+        RepoRegistry._retire_entries_absent_from
+    )
+    transfer_line = first_line + next(
+        index
+        for index, line in enumerate(source)
+        if "self._orphan_cleanup_owners.append(cleanup_owner)" in line
+    )
+    triggered = False
+
+    def interrupt_after_transfer(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is RepoRegistry._retire_entries_absent_from.__code__
+            and frame.f_lineno > transfer_line
+        ):
+            triggered = True
+            sys.settrace(None)
+            raise stop
+        return interrupt_after_transfer
+
+    sys.settrace(interrupt_after_transfer)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            registry._retire_entries_absent_from(set())
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is stop
+    assert triggered is True
+    assert owner.close_calls == 0
+    assert owner in registry._orphan_cleanup_owners
+
+    registry._retire_entries_absent_from(set())
+    assert owner.close_calls == 1
+    assert registry._source_cleanup_owners == {}
+    assert registry._orphan_cleanup_owners == []
+
+
+def test_registry_complete_snapshot_reports_reentrant_cleanup_shutdown():
+    registry = RepoRegistry(QAConfig())
+
+    class Owner:
+        def __init__(self, *, close_registry=False):
+            self.close_calls = 0
+            self.close_registry = close_registry
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+            if self.close_registry:
+                registry.close()
+
+    keep = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    removed = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    keep_owner = Owner()
+    removed_owner = Owner(close_registry=True)
+    registry._bundles.update({"keep": keep, "removed": removed})
+    registry._source_cleanup_owners.update(
+        {"keep": keep_owner, "removed": removed_owner}
+    )
+
+    with pytest.raises(RuntimeError, match="repository registry is closed"):
+        registry._retire_entries_absent_from({"keep"})
+
+    assert registry._closed is True
+    assert registry.get("keep") is None
+    assert removed_owner.close_calls == 1
+    assert keep_owner.close_calls == 1
+    assert registry._source_cleanup_owners == {}
+    assert registry._retired_bundles == {}
+
+
+def test_registry_load_all_reports_reentrant_build_shutdown(tmp_path, monkeypatch):
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    entry = _repo_entry(tmp_path, manifest_path, instance_id="repo")
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: [entry],
+    )
+
+    def build(_entry):
+        registry.close()
+        return _OwnedRepoBundle(candidate, None, owner)
+
+    monkeypatch.setattr(registry, "_build_repo_metadata", build)
+
+    with pytest.raises(RuntimeError, match="repository registry is closed"):
+        registry.load_all()
+
+    assert registry._closed is True
+    assert owner.close_calls == 1
+    assert registry._bundles == {}
+    assert registry._source_cleanup_owners == {}
+    assert registry._retired_bundles == {}
+
+
+def test_registry_load_all_preserves_reentrant_cleanup_failure(
+    tmp_path,
+    monkeypatch,
+):
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    entry = _repo_entry(tmp_path, manifest_path, instance_id="repo")
+    cleanup_failure = RuntimeError("old generation cleanup failed")
+
+    class Owner:
+        def __init__(self, *, reentrant_failure=None):
+            self.close_calls = 0
+            self.reentrant_failure = reentrant_failure
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+            if self.reentrant_failure is not None:
+                registry.close()
+                raise self.reentrant_failure
+
+    old_owner = Owner(reentrant_failure=cleanup_failure)
+    candidate_owner = Owner()
+    old = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = old
+    registry._source_cleanup_owners["repo"] = old_owner
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: [entry],
+    )
+    monkeypatch.setattr(
+        registry,
+        "_build_repo_metadata",
+        lambda _entry: _OwnedRepoBundle(candidate, None, candidate_owner),
+    )
+    monkeypatch.setattr(registry, "_prepare_runtime_bundle", lambda _bundle: None)
+
+    with pytest.raises(RuntimeError, match="repository registry is closed") as caught:
+        registry.load_all()
+
+    assert caught.value.__cause__ is cleanup_failure
+    assert registry._closed is True
+    assert old_owner.close_calls == 1
+    assert candidate_owner.close_calls == 1
+    assert registry._bundles == {}
+    assert registry._source_cleanup_owners == {}
+    assert registry._retired_bundles == {}
+
+
 def test_registry_load_all_prepares_only_live_replacements(tmp_path, monkeypatch):
     manifest_path = tmp_path / "repo_manifest.json"
     manifest_path.write_text("{}", encoding="utf-8")
@@ -658,6 +850,636 @@ def test_registry_concurrent_close_closes_owner_once():
         second.result(timeout=5)
 
     assert owner.close_calls == 1
+
+
+def test_registry_reentrant_close_claims_owner_only_once():
+    stop = SystemExit("owner cleanup stopped")
+    registry = RepoRegistry(QAConfig())
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+            registry.close()
+            raise stop
+
+    owner = Owner()
+    registry._source_cleanup_owners["repo"] = owner
+
+    with pytest.raises(SystemExit) as caught:
+        registry.close()
+
+    assert caught.value is stop
+    assert owner.close_calls == 1
+    assert registry._source_cleanup_owners == {}
+    assert registry._orphan_cleanup_owners == []
+
+    registry.close()
+    assert owner.close_calls == 1
+
+
+def test_registry_close_owner_transfer_interruption_keeps_authority():
+    stop = KeyboardInterrupt("owner transfer interrupted")
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    registry._source_cleanup_owners["repo"] = owner
+    source, first_line = inspect.getsourcelines(RepoRegistry.close)
+    transfer_line = first_line + next(
+        index
+        for index, line in enumerate(source)
+        if "self._orphan_cleanup_owners.append(cleanup_owner)" in line
+    )
+    triggered = False
+
+    def interrupt_after_transfer(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is RepoRegistry.close.__code__
+            and frame.f_lineno > transfer_line
+        ):
+            triggered = True
+            sys.settrace(None)
+            raise stop
+        return interrupt_after_transfer
+
+    sys.settrace(interrupt_after_transfer)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            registry.close()
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is stop
+    assert triggered is True
+    assert owner.close_calls == 0
+    assert owner in registry._orphan_cleanup_owners
+
+    registry.close()
+    assert owner.close_calls == 1
+    assert registry._source_cleanup_owners == {}
+    assert registry._orphan_cleanup_owners == []
+
+
+def test_registry_cleanup_settles_closed_owner_before_raising():
+    stop = KeyboardInterrupt("owner cleanup stopped")
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+            raise stop
+
+    owner = Owner()
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = bundle
+    registry._source_cleanup_owners["repo"] = owner
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        registry.close()
+
+    assert caught.value is stop
+    assert owner.close_calls == 1
+    assert registry._retired_bundles == {}
+
+    registry.close()
+    assert owner.close_calls == 1
+
+
+def test_registry_refresh_cannot_deadlock_reentrant_retired_cleanup(monkeypatch):
+    cleanup_entered = Event()
+    refresh_started = Event()
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+            cleanup_entered.set()
+            assert refresh_started.wait(5)
+            registry.close()
+
+    owner = Owner()
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    registry._retired_bundles[id(bundle)] = _OwnedRepoBundle(
+        bundle,
+        None,
+        owner,
+    )
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: pytest.fail("closed refresh must not read the registry"),
+    )
+
+    def refresh():
+        refresh_started.set()
+        with pytest.raises(RuntimeError, match="repository registry is closed"):
+            registry.refresh("repo")
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        cleanup_future = pool.submit(registry._drain_retired)
+        assert cleanup_entered.wait(5)
+        refresh_future = pool.submit(refresh)
+        assert cleanup_future.result(timeout=5) is None
+        refresh_future.result(timeout=5)
+
+    assert owner.close_calls == 1
+    assert registry._closed is True
+    assert registry._retired_bundles == {}
+
+
+def test_registry_vector_close_settles_before_opcode_interruption():
+    opcode_events = []
+
+    def probe():
+        return None
+
+    def probe_trace(frame, event, _arg):
+        if frame.f_code is probe.__code__:
+            frame.f_trace_opcodes = True
+            if event == "opcode":
+                opcode_events.append(frame.f_lasti)
+        return probe_trace
+
+    sys.settrace(probe_trace)
+    try:
+        probe()
+    finally:
+        sys.settrace(None)
+    if not opcode_events:
+        pytest.skip("this interpreter does not emit opcode trace events")
+
+    stop = KeyboardInterrupt("vector settlement interrupted")
+
+    class Vector:
+        def __init__(self):
+            self.close_calls = 0
+            self.done = False
+
+        @property
+        def closed(self):
+            return self.done
+
+        def close(self):
+            self.close_calls += 1
+            if self.close_calls > 1:
+                raise RuntimeError("vector closed twice")
+            self.done = True
+
+    vector = Vector()
+    bundle = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+        vector_store=vector,
+    )
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = bundle
+    instructions = tuple(dis.get_instructions(RepoRegistry._close_owned))
+    close_index = next(
+        index
+        for index, instruction in enumerate(instructions)
+        if instruction.opname in {"LOAD_ATTR", "LOAD_METHOD"}
+        and instruction.argval == "close"
+    )
+    call_index = next(
+        index
+        for index in range(close_index + 1, len(instructions))
+        if "CALL" in instructions[index].opname
+    )
+    interrupt_offset = instructions[call_index + 1].offset
+    triggered = False
+
+    def interrupt_after_close(frame, event, _arg):
+        nonlocal triggered
+        if frame.f_code is RepoRegistry._close_owned.__code__:
+            frame.f_trace_opcodes = True
+            if (
+                not triggered
+                and event == "opcode"
+                and frame.f_lasti == interrupt_offset
+            ):
+                triggered = True
+                sys.settrace(None)
+                raise stop
+        return interrupt_after_close
+
+    sys.settrace(interrupt_after_close)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            registry.close()
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is stop
+    assert triggered is True
+    assert vector.close_calls == 1
+    assert bundle.vector_store is None
+    assert registry._retired_bundles == {}
+
+    registry.close()
+    assert vector.close_calls == 1
+
+
+def test_registry_vector_close_reconciles_completed_failure():
+    stop = KeyboardInterrupt("vector close completed while interrupted")
+
+    class Vector:
+        def __init__(self):
+            self.close_calls = 0
+            self.done = False
+
+        @property
+        def closed(self):
+            return self.done
+
+        def close(self):
+            self.close_calls += 1
+            self.done = True
+            raise stop
+
+    vector = Vector()
+    bundle = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+        vector_store=vector,
+    )
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = bundle
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        registry.close()
+
+    assert caught.value is stop
+    assert vector.close_calls == 1
+    assert bundle.vector_store is None
+    assert registry._retired_bundles == {}
+
+    registry.close()
+    assert vector.close_calls == 1
+
+
+def test_registry_cleanup_deduplicates_generation_and_orphan_owner():
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = bundle
+    registry._source_cleanup_owners["repo"] = owner
+    registry._orphan_cleanup_owners.append(owner)
+
+    registry.close()
+
+    assert owner.close_calls == 1
+    assert registry._retired_bundles == {}
+    assert registry._orphan_cleanup_owners == []
+
+
+def test_registry_final_lease_reconciles_orphan_owner_alias():
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = bundle
+    registry._source_cleanup_owners["repo"] = owner
+    registry._orphan_cleanup_owners.append(owner)
+
+    with registry.pin("repo"):
+        registry.close()
+        assert owner.close_calls == 0
+        assert registry.retired_generation_count == 1
+        assert registry._orphan_cleanup_owners == [owner]
+
+    assert owner.close_calls == 1
+    assert registry._retired_bundles == {}
+    assert registry._orphan_cleanup_owners == []
+
+
+def test_registry_shared_pending_owner_runs_once_per_cleanup_settlement():
+    first_failure = RuntimeError("first cleanup failed")
+    later_stop = SystemExit("later cleanup stopped")
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return False
+
+        def close(self):
+            self.close_calls += 1
+            if self.close_calls == 1:
+                raise first_failure
+            raise later_stop
+
+    owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    for repo_id in ("one", "two"):
+        registry._bundles[repo_id] = RepoBundle(
+            entry=SimpleNamespace(),
+            manifest=SimpleNamespace(),
+        )
+        registry._source_cleanup_owners[repo_id] = owner
+
+    with pytest.raises(RuntimeError) as caught:
+        registry.close()
+
+    assert caught.value is first_failure
+    assert owner.close_calls == 1
+    assert registry.retired_generation_count == 1
+
+    with pytest.raises(SystemExit) as caught:
+        registry.close()
+    assert caught.value is later_stop
+    assert owner.close_calls == 2
+
+
+def test_registry_shared_owner_still_closes_each_bundle_vector():
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    class Vector:
+        def __init__(self):
+            self.close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    vectors = [Vector(), Vector()]
+    registry = RepoRegistry(QAConfig())
+    for repo_id, vector in zip(("one", "two"), vectors, strict=True):
+        registry._bundles[repo_id] = RepoBundle(
+            entry=SimpleNamespace(),
+            manifest=SimpleNamespace(),
+            vector_store=vector,
+        )
+        registry._source_cleanup_owners[repo_id] = owner
+
+    registry.close()
+
+    assert owner.close_calls == 1
+    assert [vector.close_calls for vector in vectors] == [1, 1]
+    assert registry._retired_bundles == {}
+
+
+def test_registry_shared_owner_waits_for_every_leased_alias():
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    class Vector:
+        def __init__(self):
+            self.close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    vectors = [Vector(), Vector()]
+    bundles = [
+        RepoBundle(
+            entry=SimpleNamespace(),
+            manifest=SimpleNamespace(),
+            vector_store=vector,
+        )
+        for vector in vectors
+    ]
+    registry = RepoRegistry(QAConfig())
+    for repo_id, bundle in zip(("one", "two"), bundles, strict=True):
+        registry._bundles[repo_id] = bundle
+        registry._source_cleanup_owners[repo_id] = owner
+
+    with registry.pin("one") as pinned:
+        registry.close()
+        assert pinned is bundles[0]
+        assert owner.close_calls == 0
+        assert [vector.close_calls for vector in vectors] == [0, 1]
+        assert registry.retired_generation_count == 1
+
+    assert owner.close_calls == 1
+    assert [vector.close_calls for vector in vectors] == [1, 1]
+    assert registry._retired_bundles == {}
+
+
+def test_registry_publish_does_not_close_active_shared_owner():
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    class Vector:
+        def __init__(self):
+            self.close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    vector = Vector()
+    old = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+        vector_store=vector,
+    )
+    new = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = old
+    registry._source_cleanup_owners["repo"] = owner
+
+    registry._publish_owned("repo", _OwnedRepoBundle(new, None, owner))
+
+    assert registry.get("repo") is new
+    assert owner.close_calls == 0
+    assert vector.close_calls == 1
+    assert registry._retired_bundles == {}
+
+    registry.close()
+    assert owner.close_calls == 1
+
+
+def test_registry_retired_claim_interruption_keeps_retry_state():
+    stop = KeyboardInterrupt("retired claim interrupted")
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    key = id(bundle)
+    registry._retired_bundles[key] = _OwnedRepoBundle(bundle, None, owner)
+    source, first_line = inspect.getsourcelines(RepoRegistry._drain_retired)
+    claim_line = first_line + next(
+        index
+        for index, line in enumerate(source)
+        if "self._cleanup_in_progress[key] = (" in line
+    )
+    triggered = False
+
+    def interrupt_after_claim(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is RepoRegistry._drain_retired.__code__
+            and frame.f_lineno > claim_line
+        ):
+            triggered = True
+            sys.settrace(None)
+            raise stop
+        return interrupt_after_claim
+
+    sys.settrace(interrupt_after_claim)
+    try:
+        assert registry._drain_retired() is stop
+    finally:
+        sys.settrace(None)
+
+    assert triggered is True
+    assert owner.close_calls == 0
+    assert registry._cleanup_in_progress == {}
+    assert registry._orphan_cleanup_in_progress == set()
+    assert registry._retired_bundles[key].source_cleanup_owner is owner
+
+    assert registry._drain_retired() is None
+    assert owner.close_calls == 1
+    assert registry._retired_bundles == {}
+
+
+def test_registry_orphan_claim_interruption_keeps_retry_state():
+    stop = KeyboardInterrupt("orphan claim interrupted")
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    registry._orphan_cleanup_owners.append(owner)
+    source, first_line = inspect.getsourcelines(RepoRegistry._drain_orphan_cleanup)
+    claim_line = first_line + next(
+        index
+        for index, line in enumerate(source)
+        if "self._orphan_cleanup_in_progress.add(authority_id)" in line
+    )
+    triggered = False
+
+    def interrupt_after_claim(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is RepoRegistry._drain_orphan_cleanup.__code__
+            and frame.f_lineno > claim_line
+        ):
+            triggered = True
+            sys.settrace(None)
+            raise stop
+        return interrupt_after_claim
+
+    sys.settrace(interrupt_after_claim)
+    try:
+        assert registry._drain_orphan_cleanup() is stop
+    finally:
+        sys.settrace(None)
+
+    assert triggered is True
+    assert owner.close_calls == 0
+    assert registry._orphan_cleanup_in_progress == set()
+    assert registry._orphan_cleanup_owners == [owner]
+
+    assert registry._drain_orphan_cleanup() is None
+    assert owner.close_calls == 1
+    assert registry._orphan_cleanup_owners == []
 
 
 def test_registry_close_waits_for_an_inflight_cleanup_drain():
@@ -1208,6 +2030,230 @@ def test_registry_queries_detach_hostile_lookup_key():
     registry.close()
 
 
+@pytest.mark.parametrize("repo_id", ["", None])
+def test_registry_closed_state_precedes_invalid_lookup_key(repo_id):
+    registry = RepoRegistry(QAConfig())
+    registry.close()
+
+    with pytest.raises(RuntimeError, match="repository registry is closed"):
+        registry.refresh(repo_id)
+    with pytest.raises(RuntimeError, match="repository registry is closed"):
+        with registry.pin(repo_id):
+            pass
+
+
+@pytest.mark.parametrize("repo_id", ["", None, 17])
+def test_registry_open_lookup_preserves_legacy_miss_semantics(repo_id):
+    registry = RepoRegistry(QAConfig())
+
+    assert registry.get(repo_id) is None
+    with registry.pin(repo_id) as pinned:
+        assert pinned is None
+
+
+def test_registry_rejects_fake_string_without_descriptor_dispatch():
+    touched = []
+
+    class Masquerade:
+        @property
+        def __class__(self):
+            touched.append("class")
+            registry.close()
+            return str
+
+    registry = RepoRegistry(QAConfig())
+    key = Masquerade()
+
+    assert registry.get(key) is None
+    with registry.pin(key) as pinned:
+        assert pinned is None
+    with pytest.raises(ValueError, match="instance_id must be non-empty text"):
+        registry.refresh(key)
+
+    assert touched == []
+    assert registry._closed is False
+
+
+def test_registry_pin_acquisition_interruption_releases_lease():
+    stop = KeyboardInterrupt("pin acquisition interrupted")
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = bundle
+    registry._source_cleanup_owners["repo"] = owner
+    pin_impl = RepoRegistry.pin.__wrapped__
+    source, first_line = inspect.getsourcelines(pin_impl)
+    acquire_line = first_line + next(
+        index
+        for index, line in enumerate(source)
+        if "self._bundle_leases[lease_token] = keys" in line
+    )
+    triggered = False
+
+    def interrupt_after_acquire(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is pin_impl.__code__
+            and frame.f_lineno > acquire_line
+        ):
+            triggered = True
+            sys.settrace(None)
+            raise stop
+        return interrupt_after_acquire
+
+    context = registry.pin("repo")
+    sys.settrace(interrupt_after_acquire)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            context.__enter__()
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is stop
+    assert triggered is True
+    assert registry._bundle_leases == {}
+
+    registry.close()
+    assert owner.close_calls == 1
+    assert registry._retired_bundles == {}
+
+
+def test_registry_pin_all_acquisition_is_atomic_under_interruption():
+    stop = KeyboardInterrupt("pin-all acquisition interrupted")
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owners = [Owner(), Owner()]
+    registry = RepoRegistry(QAConfig())
+    for repo_id, owner in zip(("one", "two"), owners, strict=True):
+        registry._bundles[repo_id] = RepoBundle(
+            entry=SimpleNamespace(),
+            manifest=SimpleNamespace(),
+        )
+        registry._source_cleanup_owners[repo_id] = owner
+    pin_impl = RepoRegistry.pin_all.__wrapped__
+    source, first_line = inspect.getsourcelines(pin_impl)
+    acquire_line = first_line + next(
+        index
+        for index, line in enumerate(source)
+        if "self._bundle_leases[lease_token] = keys" in line
+    )
+    triggered = False
+
+    def interrupt_after_acquire(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is pin_impl.__code__
+            and frame.f_lineno > acquire_line
+        ):
+            triggered = True
+            sys.settrace(None)
+            raise stop
+        return interrupt_after_acquire
+
+    context = registry.pin_all()
+    sys.settrace(interrupt_after_acquire)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            context.__enter__()
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is stop
+    assert triggered is True
+    assert registry._bundle_leases == {}
+
+    registry.close()
+    assert [owner.close_calls for owner in owners] == [1, 1]
+    assert registry._retired_bundles == {}
+
+
+def test_registry_pin_release_interruption_cannot_leave_stale_lease():
+    stop = KeyboardInterrupt("pin release interrupted")
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = bundle
+    registry._source_cleanup_owners["repo"] = owner
+    context = registry.pin("repo")
+    assert context.__enter__() is bundle
+    registry.close()
+    source, first_line = inspect.getsourcelines(RepoRegistry._drop_bundle_lease)
+    release_line = first_line + next(
+        index
+        for index, line in enumerate(source)
+        if "keys = self._bundle_leases.pop(lease_token, ())" in line
+    )
+    triggered = False
+
+    def interrupt_after_release(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is RepoRegistry._drop_bundle_lease.__code__
+            and frame.f_lineno > release_line
+        ):
+            triggered = True
+            sys.settrace(None)
+            raise stop
+        return interrupt_after_release
+
+    sys.settrace(interrupt_after_release)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            context.__exit__(None, None, None)
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is stop
+    assert triggered is True
+    assert registry._bundle_leases == {}
+    assert owner.close_calls == 0
+    assert registry.retired_generation_count == 1
+
+    registry.close()
+    assert owner.close_calls == 1
+    assert registry._retired_bundles == {}
+
+
 def test_registry_refresh_publishes_without_escaping_unleased_bundle(
     tmp_path,
     monkeypatch,
@@ -1272,6 +2318,357 @@ def test_registry_refresh_detaches_hostile_lookup_key(tmp_path, monkeypatch):
     assert registry._closed is False
     assert registry.get("repo") is candidate
     registry.close()
+
+
+def test_registry_refresh_reports_reentrant_cleanup_shutdown(tmp_path, monkeypatch):
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    entry = _repo_entry(tmp_path, manifest_path, instance_id="repo")
+    old = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+
+    class Owner:
+        def __init__(self, *, close_registry=False):
+            self.close_calls = 0
+            self.close_registry = close_registry
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+            if self.close_registry:
+                registry.close()
+
+    old_owner = Owner(close_registry=True)
+    candidate_owner = Owner()
+    registry._bundles["repo"] = old
+    registry._source_cleanup_owners["repo"] = old_owner
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: [entry],
+    )
+    monkeypatch.setattr(
+        registry,
+        "_build_repo_metadata",
+        lambda _entry: _OwnedRepoBundle(candidate, None, candidate_owner),
+    )
+    monkeypatch.setattr(registry, "_prepare_runtime_bundle", lambda _bundle: None)
+
+    with pytest.raises(RuntimeError, match="repository registry is closed"):
+        registry.refresh("repo")
+
+    assert registry._closed is True
+    assert registry.get("repo") is None
+    assert old_owner.close_calls == 1
+    assert candidate_owner.close_calls == 1
+    assert registry._source_cleanup_owners == {}
+    assert registry._retired_bundles == {}
+
+
+def test_registry_publication_interrupt_closes_candidate_once(monkeypatch):
+    stop = KeyboardInterrupt("publication interrupted")
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    monkeypatch.setattr(
+        registry,
+        "_build_repo_metadata",
+        lambda _entry: _OwnedRepoBundle(candidate, None, owner),
+    )
+    publish_impl = RepoRegistry._publish_owned_under_cleanup_lock
+    source, first_line = inspect.getsourcelines(publish_impl)
+    assignment_line = first_line + next(
+        index
+        for index, line in enumerate(source)
+        if "self._bundles[instance_id] = owned.bundle" in line
+    )
+    triggered = False
+
+    def interrupt_after_publication(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is publish_impl.__code__
+            and frame.f_lineno > assignment_line
+        ):
+            triggered = True
+            sys.settrace(None)
+            registry.close()
+            raise stop
+        return interrupt_after_publication
+
+    sys.settrace(interrupt_after_publication)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            registry._replace_entry(
+                SimpleNamespace(instance_id="repo"),
+                prepare_runtime=False,
+            )
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is stop
+    assert triggered is True
+    assert registry._closed is True
+    assert owner.close_calls == 1
+    assert registry._bundles == {}
+    assert registry._source_cleanup_owners == {}
+    assert registry._retired_bundles == {}
+
+
+def test_registry_previous_retirement_interrupt_rolls_back_old_generation(
+    monkeypatch,
+):
+    stop = KeyboardInterrupt("previous retirement interrupted")
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    class Vector:
+        def __init__(self):
+            self.close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+
+    old_owner = Owner()
+    candidate_owner = Owner()
+    vector = Vector()
+    old = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+        vector_store=vector,
+    )
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = old
+    registry._source_cleanup_owners["repo"] = old_owner
+    monkeypatch.setattr(
+        registry,
+        "_build_repo_metadata",
+        lambda _entry: _OwnedRepoBundle(candidate, None, candidate_owner),
+    )
+    publish_impl = RepoRegistry._publish_owned_under_cleanup_lock
+    source, first_line = inspect.getsourcelines(publish_impl)
+    retirement_line = first_line + next(
+        index
+        for index, line in enumerate(source)
+        if "self._retired_bundles[id(previous.bundle)] = previous" in line
+    )
+    triggered = False
+
+    def interrupt_after_retirement(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is publish_impl.__code__
+            and frame.f_lineno > retirement_line
+        ):
+            triggered = True
+            sys.settrace(None)
+            raise stop
+        return interrupt_after_retirement
+
+    sys.settrace(interrupt_after_retirement)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            registry._replace_entry(
+                SimpleNamespace(instance_id="repo"),
+                prepare_runtime=False,
+            )
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is stop
+    assert triggered is True
+    assert registry.get("repo") is old
+    assert old_owner.close_calls == 0
+    assert vector.close_calls == 0
+    assert candidate_owner.close_calls == 1
+    assert registry._retired_bundles == {}
+
+    with registry.pin("repo") as pinned:
+        assert pinned is old
+    assert old_owner.close_calls == 0
+    assert vector.close_calls == 0
+
+    registry.close()
+    assert old_owner.close_calls == 1
+    assert vector.close_calls == 1
+
+
+def test_registry_active_alias_cannot_be_cleaned_after_retire_interrupt():
+    stop = KeyboardInterrupt("active retirement interrupted")
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    class Vector:
+        def __init__(self):
+            self.close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    vector = Vector()
+    bundle = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+        vector_store=vector,
+        bm25=object(),
+        runner=object(),
+    )
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = bundle
+    registry._source_cleanup_owners["repo"] = owner
+    source, first_line = inspect.getsourcelines(RepoRegistry._retire_active_locked)
+    retirement_line = first_line + next(
+        index
+        for index, line in enumerate(source)
+        if "self._retired_bundles[id(bundle)] = owned" in line
+    )
+    triggered = False
+
+    def interrupt_after_retirement(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is RepoRegistry._retire_active_locked.__code__
+            and frame.f_lineno > retirement_line
+        ):
+            triggered = True
+            sys.settrace(None)
+            raise stop
+        return interrupt_after_retirement
+
+    sys.settrace(interrupt_after_retirement)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            with registry._generation_lock:
+                registry._retire_active_locked("repo")
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is stop
+    assert registry.get("repo") is bundle
+    assert registry.retired_generation_count == 1
+
+    with registry.pin("repo") as pinned:
+        assert pinned is bundle
+
+    assert bundle.vector_store is vector
+    assert bundle.bm25 is not None
+    assert bundle.runner is not None
+    assert owner.close_calls == vector.close_calls == 0
+
+    registry.close()
+    assert owner.close_calls == vector.close_calls == 1
+    assert registry._retired_bundles == {}
+
+
+def test_registry_cleanup_claim_interruption_preserves_primary(monkeypatch):
+    primary = SystemExit("candidate preparation stopped")
+    later = KeyboardInterrupt("cleanup claim interrupted")
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    monkeypatch.setattr(
+        registry,
+        "_build_repo_metadata",
+        lambda _entry: _OwnedRepoBundle(candidate, None, owner),
+    )
+    monkeypatch.setattr(
+        registry,
+        "_prepare_runtime_bundle",
+        lambda _bundle: (_ for _ in ()).throw(primary),
+    )
+    source, first_line = inspect.getsourcelines(RepoRegistry._retire_unpublished)
+    claim_line = first_line + next(
+        index
+        for index, line in enumerate(source)
+        if "self._retired_bundles[key] = owned" in line
+    )
+    triggered = False
+
+    def interrupt_after_claim(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is RepoRegistry._retire_unpublished.__code__
+            and frame.f_lineno > claim_line
+        ):
+            triggered = True
+            sys.settrace(None)
+            raise later
+        return interrupt_after_claim
+
+    sys.settrace(interrupt_after_claim)
+    try:
+        with pytest.raises(SystemExit) as caught:
+            registry._replace_entry(
+                SimpleNamespace(instance_id="repo"),
+                prepare_runtime=True,
+            )
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is primary
+    assert caught.value.__cause__ is later
+    assert triggered is True
+    assert owner.close_calls == 0
+    assert registry.retired_generation_count == 1
+
+    registry.close()
+    assert owner.close_calls == 1
+    assert registry._retired_bundles == {}
 
 
 def test_registry_failed_refresh_keeps_active_generation(tmp_path, monkeypatch):
@@ -1391,6 +2788,65 @@ def test_registry_close_defers_pinned_generation_cleanup():
         assert registry.retired_generation_count == 1
 
     assert owner.closed is True
+    assert registry.retired_generation_count == 0
+
+
+@pytest.mark.parametrize("pin_all", [False, True])
+@pytest.mark.parametrize(
+    ("body_type", "cleanup_type", "cleanup_wins"),
+    [
+        (SystemExit, KeyboardInterrupt, False),
+        (RuntimeError, SystemExit, True),
+    ],
+)
+def test_registry_pin_cleanup_preserves_exception_priority(
+    pin_all,
+    body_type,
+    cleanup_type,
+    cleanup_wins,
+):
+    body_failure = body_type("body failure")
+    cleanup_failure = cleanup_type("cleanup failure")
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls >= 2
+
+        def close(self):
+            self.close_calls += 1
+            if self.close_calls == 1:
+                raise cleanup_failure
+
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = bundle
+    registry._source_cleanup_owners["repo"] = owner
+    pinned = registry.pin_all() if pin_all else registry.pin("repo")
+
+    caught = None
+    try:
+        with pinned:
+            registry.close()
+            raise body_failure
+    except BaseException as observed:  # noqa: B036 - assert exact priority
+        caught = observed
+    else:
+        raise AssertionError("pinned body failure did not propagate")
+
+    expected = cleanup_failure if cleanup_wins else body_failure
+    secondary = body_failure if cleanup_wins else cleanup_failure
+    assert caught is expected
+    assert caught.__cause__ is secondary
+    assert owner.close_calls == 1
+    assert registry.retired_generation_count == 1
+
+    registry.close()
+    assert owner.close_calls == 2
     assert registry.retired_generation_count == 0
 
 

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -403,6 +403,46 @@ def test_registry_swap_keeps_pinned_generation_alive_until_release():
     registry.close()
 
 
+def test_registry_refresh_publishes_without_escaping_unleased_bundle(
+    tmp_path,
+    monkeypatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    entry = _repo_entry(repo, manifest_path, instance_id="repo")
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+
+    class Owner:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: [entry],
+    )
+    monkeypatch.setattr(
+        registry,
+        "_build_repo_metadata",
+        lambda _entry: _OwnedRepoBundle(candidate, None, owner),
+    )
+    monkeypatch.setattr(registry, "_prepare_runtime_bundle", lambda _bundle: None)
+
+    assert registry.refresh("repo") is None
+    with registry.pin("repo") as pinned:
+        assert pinned is candidate
+    assert owner.closed is False
+
+    registry.close()
+    assert owner.closed is True
+
+
 def test_registry_failed_refresh_keeps_active_generation(tmp_path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary

Add the RCU-style repository generation core required for safe Web runtime refreshes, now restacked on the current `main` after #707.

## Changes

- build and fully validate live replacement bundles before atomically publishing them, while preserving lazy first-start loading
- pin exact bundle generations across complete async request and worker lifetimes; retire resources only after the final lease settles
- let lease release defer cleanup to the reload final drain so slow candidate preparation cannot hold completed requests
- bind wiki, commit-window, and edge-label caches to exact generations and evict stale commit-qualified entries
- treat each registry load as a complete snapshot and safely retire removed repositories without invalidating failed replacements
- skip malformed unrelated registry rows during targeted refresh while preserving exact target matching
- preserve and retry vector/source cleanup ownership across failures, removals, reentrant shutdown, and shared-authority aliases
- serialize cleanup, reload, publication, and shutdown with one lock order that remains safe under reentrant callbacks
- preserve exact cancellation priority and prevent duplicate close, stale claims, leaked leases, or active/retired use-after-close windows
- document the completed Web runtime RCU milestone in the storage roadmap

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Python 3.12 affected suites: 196 passed
- Python 3.12 complete Web surface: 415 passed
- Python 3.10 and 3.14 complete Web surface excluding the unavailable `datasets`-dependent module: 405 passed on each version
- Python 3.12 unit tier excluding the environment-blocked Docker test file: 8228 passed, 34 skipped, 190 deselected
- Python 3.11 registry suite after the final review fixes: 130 passed
- Python 3.11 complete Web surface after the final review fixes: 416 passed, with the known environment logging-capture baseline deselected
- Python 3.11 vector artifact identity suite after the final review fixes: 25 passed
- Black, isort (`--profile black --filter-files`), flake8, three-version `py_compile`, `git diff --check`, and pre-commit pass
- two independent hash-bound adversarial audits passed for lock ordering, request leases, cleanup ownership, cancellation identity, and vector settlement

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published