### PR TITLE
feat(web): expose repository index status

### DIFF
--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -47,6 +47,7 @@ from ..wiki.media_generation import (
 )
 from ..wiki.narrator import Narrator
 from .config import load_config
+from .index_status import build_repo_index_status
 from .native_authority import authorize_local_manifest_vector
 from .ports import argparse_tcp_port
 from .repo_registry import RepoRegistry
@@ -57,6 +58,7 @@ from .schemas import (
     ChatResponse,
     EdgeLabelRequest,
     EdgeLabelResponse,
+    RepoIndexStatus,
     RepoInfo,
     agent_result_to_response,
 )
@@ -604,6 +606,31 @@ async def list_repos() -> list[RepoInfo]:
     # Preserve the intentionally small injected registry contract used by
     # offline tools and route tests. Production always takes the coherent path.
     return [await decorate(info) for info in registry.list_infos()]
+
+
+@app.get(
+    "/api/repos/{repo_id}/index-status",
+    response_model=RepoIndexStatus,
+)
+async def index_status(repo_id: str) -> RepoIndexStatus:
+    """Return a detached status snapshot for one pinned bundle generation."""
+
+    with _pinned_bundle(repo_id) as bundle:
+        kwargs = {
+            "update_capabilities": getattr(
+                app.state,
+                "index_update_capabilities",
+                None,
+            )
+        }
+        head_resolver = getattr(app.state, "index_head_resolver", None)
+        if callable(head_resolver):
+            kwargs["current_head_resolver"] = head_resolver
+        return await asyncio.to_thread(
+            build_repo_index_status,
+            bundle,
+            **kwargs,
+        )
 
 
 @app.get("/api/repos/{repo_id}/wiki")

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -626,7 +626,7 @@ async def index_status(repo_id: str) -> RepoIndexStatus:
         head_resolver = getattr(app.state, "index_head_resolver", None)
         if callable(head_resolver):
             kwargs["current_head_resolver"] = head_resolver
-        return await asyncio.to_thread(
+        return await _run_pinned_thread(
             build_repo_index_status,
             bundle,
             **kwargs,

--- a/codenib/web/index_status.py
+++ b/codenib/web/index_status.py
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure status projection for the three Web indexing surfaces."""
+
+from __future__ import annotations
+
+import math
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping
+
+from ..compiler.checkout_identity import checkout_commit
+from .schemas import IndexSurfaceStatus, IndexUpdateMetrics, RepoIndexStatus
+
+PRIMARY_INDEX_TYPES = ("bm25", "vector", "symbol_graph")
+_UPDATE_MODES = frozenset({"incremental", "patch", "rebuild", "unavailable"})
+_DEFAULT_UPDATE_REASON = "Web index updates are not configured for this server."
+
+
+@dataclass(frozen=True, slots=True)
+class IndexUpdateCapability:
+    """Effective writer capability supplied by the owning job service."""
+
+    mode: str = "unavailable"
+    enabled: bool = False
+    reason: str = _DEFAULT_UPDATE_REASON
+
+    def __post_init__(self) -> None:
+        if type(self.mode) is not str or self.mode not in _UPDATE_MODES:
+            raise ValueError("index update capability has an invalid mode")
+        if type(self.enabled) is not bool:
+            raise TypeError("index update capability enabled flag must be a boolean")
+        if self.enabled and self.mode == "unavailable":
+            raise ValueError("an unavailable index update cannot be enabled")
+        if type(self.reason) is not str or len(self.reason) > 512:
+            raise ValueError("index update capability reason is invalid")
+        if not self.enabled and not self.reason.strip():
+            raise ValueError("a disabled index update requires a reason")
+
+
+_UNAVAILABLE = IndexUpdateCapability()
+
+
+def _capability_snapshot(
+    capabilities: Mapping[str, IndexUpdateCapability] | None,
+) -> dict[str, IndexUpdateCapability]:
+    result = {index_type: _UNAVAILABLE for index_type in PRIMARY_INDEX_TYPES}
+    if capabilities is None:
+        return result
+    if not isinstance(capabilities, Mapping):
+        raise TypeError("index update capabilities must be a mapping")
+    unknown = set(capabilities) - set(PRIMARY_INDEX_TYPES)
+    if unknown:
+        raise ValueError(f"unsupported index update capability: {sorted(unknown)[0]!r}")
+    for index_type, capability in capabilities.items():
+        if type(capability) is not IndexUpdateCapability:
+            raise TypeError("index update capabilities require exact capability values")
+        result[index_type] = capability
+    return result
+
+
+def _bounded_text(value: object, *, max_length: int = 128) -> str | None:
+    if type(value) is not str:
+        return None
+    normalized = value.strip()
+    if not normalized or len(normalized) > max_length or "\x00" in normalized:
+        return None
+    return normalized
+
+
+def _nonnegative_integer(value: object) -> int | None:
+    return value if type(value) is int and value >= 0 else None
+
+
+def _rate(value: object) -> float | None:
+    if type(value) not in {int, float}:
+        return None
+    normalized = float(value)
+    return (
+        normalized if math.isfinite(normalized) and 0.0 <= normalized <= 1.0 else None
+    )
+
+
+def _same_commit(left: str | None, right: str | None) -> bool:
+    if not left or not right:
+        return False
+    normalized_left = left.lower()
+    normalized_right = right.lower()
+    hex_characters = frozenset("0123456789abcdef")
+    if (
+        min(len(normalized_left), len(normalized_right)) < 7
+        or set(normalized_left) - hex_characters
+        or set(normalized_right) - hex_characters
+    ):
+        return normalized_left == normalized_right
+    return normalized_left.startswith(normalized_right) or normalized_right.startswith(
+        normalized_left
+    )
+
+
+def _metrics(entry: object) -> IndexUpdateMetrics | None:
+    metadata = getattr(entry, "metadata", None)
+    if not isinstance(metadata, Mapping):
+        return None
+    values = {
+        "changed_files": _nonnegative_integer(metadata.get("changed_files")),
+        "chunks_reembedded": _nonnegative_integer(metadata.get("chunks_reembedded")),
+        "chunks_from_cache": _nonnegative_integer(metadata.get("chunks_from_cache")),
+        "cache_hit_rate": _rate(metadata.get("cache_hit_rate")),
+        "new_commit": _bounded_text(metadata.get("new_commit")),
+    }
+    if all(value is None for value in values.values()):
+        return None
+    return IndexUpdateMetrics(**values)
+
+
+def _current_head(
+    repo_dir: object,
+    resolver: Callable[[Path], str | None],
+) -> str | None:
+    if type(repo_dir) is not str or not repo_dir:
+        return None
+    try:
+        return _bounded_text(resolver(Path(repo_dir)))
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _surface_status(
+    manifest: object,
+    index_type: str,
+    *,
+    current_head: str | None,
+    capability: IndexUpdateCapability,
+) -> IndexSurfaceStatus:
+    indexes = getattr(manifest, "indexes", None)
+    entry = indexes.get(index_type) if isinstance(indexes, Mapping) else None
+    if entry is None:
+        state = "missing"
+        indexed_commit = None
+        built_at = None
+        metrics = None
+    else:
+        indexed_commit = _bounded_text(getattr(entry, "commit", None)) or _bounded_text(
+            getattr(manifest, "last_indexed_commit", None)
+        )
+        built_at = _bounded_text(getattr(entry, "built_at", None))
+        metrics = _metrics(entry)
+        entry_status = getattr(entry, "status", None)
+        if entry_status == "failed":
+            state = "failed"
+        else:
+            is_current = False
+            checker = getattr(manifest, "index_is_current", None)
+            if callable(checker):
+                is_current = bool(checker(index_type))
+            commit_changed = bool(
+                current_head
+                and indexed_commit
+                and not _same_commit(current_head, indexed_commit)
+            )
+            state = "built" if is_current and not commit_changed else "stale"
+    return IndexSurfaceStatus(
+        index_type=index_type,
+        state=state,
+        stale=state == "stale",
+        indexed_commit=indexed_commit,
+        built_at=built_at,
+        update_mode=capability.mode,
+        updates_enabled=capability.enabled,
+        update_reason=capability.reason,
+        metrics=metrics,
+    )
+
+
+def build_repo_index_status(
+    bundle: object,
+    *,
+    update_capabilities: Mapping[str, IndexUpdateCapability] | None = None,
+    current_head_resolver: Callable[[Path], str | None] = checkout_commit,
+) -> RepoIndexStatus:
+    """Project one pinned bundle into a detached reader-facing status value."""
+
+    entry = getattr(bundle, "entry", None)
+    manifest = getattr(bundle, "manifest", None)
+    repo_id = _bounded_text(getattr(entry, "instance_id", None), max_length=512)
+    if repo_id is None:
+        raise ValueError("index status requires a repository instance id")
+    current_head = _current_head(
+        getattr(entry, "repo_dir", None),
+        current_head_resolver,
+    )
+    capabilities = _capability_snapshot(update_capabilities)
+    indexes = [
+        _surface_status(
+            manifest,
+            index_type,
+            current_head=current_head,
+            capability=capabilities[index_type],
+        )
+        for index_type in PRIMARY_INDEX_TYPES
+    ]
+    last_indexed_commit = _bounded_text(
+        getattr(manifest, "last_indexed_commit", None)
+    ) or _bounded_text(getattr(manifest, "commit", None))
+    repo_stale = any(index.state == "stale" for index in indexes) or bool(
+        current_head
+        and last_indexed_commit
+        and not _same_commit(current_head, last_indexed_commit)
+    )
+    return RepoIndexStatus(
+        repo_id=repo_id,
+        last_indexed_commit=last_indexed_commit,
+        current_head=current_head,
+        stale=repo_stale,
+        indexes=indexes,
+    )
+
+
+__all__ = [
+    "IndexUpdateCapability",
+    "PRIMARY_INDEX_TYPES",
+    "build_repo_index_status",
+]

--- a/codenib/web/schemas.py
+++ b/codenib/web/schemas.py
@@ -89,6 +89,49 @@ class RepoInfo(BaseModel):
     incremental: WindowStats | None = None
 
 
+class IndexUpdateMetrics(BaseModel):
+    """Bounded metrics retained from the most recent index generation."""
+
+    changed_files: Optional[int] = Field(default=None, ge=0)
+    chunks_reembedded: Optional[int] = Field(default=None, ge=0)
+    chunks_from_cache: Optional[int] = Field(default=None, ge=0)
+    cache_hit_rate: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    new_commit: Optional[str] = Field(default=None, max_length=128)
+
+
+class IndexSurfaceStatus(BaseModel):
+    """Reader-facing state for one primary repository index surface."""
+
+    index_type: Literal["bm25", "vector", "symbol_graph"]
+    state: Literal["built", "missing", "stale", "updating", "failed"]
+    stale: bool = False
+    indexed_commit: Optional[str] = Field(default=None, max_length=128)
+    built_at: Optional[str] = Field(default=None, max_length=128)
+    update_mode: Literal["incremental", "patch", "rebuild", "unavailable"]
+    updates_enabled: bool = False
+    update_reason: str = Field(default="", max_length=512)
+    job_id: Optional[str] = Field(default=None, max_length=256)
+    metrics: Optional[IndexUpdateMetrics] = None
+
+
+class RepoIndexStatus(BaseModel):
+    """Exactly three primary index surfaces for one repository generation."""
+
+    repo_id: str = Field(min_length=1, max_length=_MAX_REPO_ID_CHARS)
+    last_indexed_commit: Optional[str] = Field(default=None, max_length=128)
+    current_head: Optional[str] = Field(default=None, max_length=128)
+    stale: bool = False
+    indexes: List[IndexSurfaceStatus] = Field(min_length=3, max_length=3)
+
+    @model_validator(mode="after")
+    def _require_primary_surfaces(self) -> "RepoIndexStatus":
+        observed = tuple(index.index_type for index in self.indexes)
+        expected = ("bm25", "vector", "symbol_graph")
+        if observed != expected:
+            raise ValueError("index status must contain the three primary surfaces")
+        return self
+
+
 class CallSite(BaseModel):
     """An exact call site (1-based line), mirroring the frontend ``CallSite``."""
 

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1345,7 +1345,8 @@ same-store binding, and exact configured repository/source identity, while
 the explicit CLI can run one bounded pass or a cursor-fair continuous scheduler
 over the current cache. The Web registry now supports complete-candidate RCU
 replacement and request-lifetime generation leases. Source builders, the #266
-job/status handoff, MCP, and default routing remain absent.
+job handoff and update path, success-triggered runtime refresh, MCP, UI controls,
+and default routing remain absent.
 
 - The backend-neutral worker now owns advisory scan/claim, per-attempt task
   authority, independent heartbeat sessions, cancellation precedence, bounded
@@ -1398,8 +1399,8 @@ job/status handoff, MCP, and default routing remain absent.
   recapture an already-current single BM25 or vector cache view under the
   worker, while the older self-publishing ingress APIs remain compatibility
   paths and are never nested inside the worker.
-- Expose the #266 status and update APIs with accurate incremental versus
-  rebuild behavior.
+- Complete the #266 job and update APIs with accurate incremental versus rebuild
+  behavior; the first read-only status slice is described below.
 - `RepoRegistry.load_all()` now reconciles each complete registry snapshot,
   retires repositories removed from that snapshot, and leaves a healthy
   generation live when its still-declared replacement fails. First startup
@@ -1416,6 +1417,12 @@ job/status handoff, MCP, and default routing remain absent.
   keyed and stale entries are pruned after replacement, removal, and shutdown.
   The remaining #266 work is to invoke this refresh boundary only after an
   attested update job succeeds and expose its status/results to the UI.
+- The first #266 read slice exposes one pinned, detached status snapshot for
+  exactly BM25, vector, and symbol-graph surfaces. It reports manifest/current
+  commit drift and retained incremental metrics without exposing mutable bundle
+  state. Update capability is explicit and defaults to `unavailable` until an
+  owning Web job service is configured, so the read API never implies that the
+  current server can write or incrementally patch an index.
 - Keep read-only/prebuilt paths safe through copy-on-write or explicit refusal.
 
 ### M4: Cross-file reference de-materialization

--- a/test/web/test_index_status.py
+++ b/test/web/test_index_status.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import codenib.web.app as web_app
+from codenib.compiler.manifest import LEGACY_MANIFEST_VERSION, IndexEntry, RepoManifest
+from codenib.web.index_status import IndexUpdateCapability, build_repo_index_status
+
+_INDEXED = "a" * 40
+_CURRENT = "b" * 40
+
+
+def _entry(
+    index_type: str,
+    *,
+    status: str = "fresh",
+    commit: str = _INDEXED,
+    metadata: dict | None = None,
+) -> IndexEntry:
+    return IndexEntry(
+        index_type=index_type,
+        path=f"/artifacts/{index_type}",
+        built_at="2026-08-26T00:00:00+00:00",
+        built_at_epoch=1.0,
+        status=status,
+        metadata=dict(metadata or {}),
+        commit=commit,
+    )
+
+
+def _bundle(indexes: dict[str, IndexEntry]):
+    manifest = RepoManifest(
+        version=LEGACY_MANIFEST_VERSION,
+        commit=_INDEXED,
+        last_indexed_commit=_INDEXED,
+        indexes=indexes,
+    )
+    return SimpleNamespace(
+        entry=SimpleNamespace(instance_id="repo", repo_dir="/repo"),
+        manifest=manifest,
+    )
+
+
+def test_status_returns_exact_primary_surfaces_with_safe_defaults() -> None:
+    status = build_repo_index_status(
+        _bundle(
+            {
+                "bm25": _entry("bm25"),
+                "symbol_graph": _entry("symbol_graph", status="failed"),
+            }
+        ),
+        current_head_resolver=lambda path: _INDEXED,
+    )
+
+    assert status.repo_id == "repo"
+    assert status.last_indexed_commit == _INDEXED
+    assert status.current_head == _INDEXED
+    assert status.stale is False
+    assert [index.index_type for index in status.indexes] == [
+        "bm25",
+        "vector",
+        "symbol_graph",
+    ]
+    assert [index.state for index in status.indexes] == [
+        "built",
+        "missing",
+        "failed",
+    ]
+    assert all(index.update_mode == "unavailable" for index in status.indexes)
+    assert all(index.updates_enabled is False for index in status.indexes)
+    assert all(index.update_reason for index in status.indexes)
+
+
+def test_status_marks_fresh_manifest_view_stale_when_head_moves() -> None:
+    status = build_repo_index_status(
+        _bundle({"bm25": _entry("bm25")}),
+        current_head_resolver=lambda path: _CURRENT,
+    )
+
+    assert status.current_head == _CURRENT
+    assert status.stale is True
+    assert status.indexes[0].state == "stale"
+    assert status.indexes[0].stale is True
+
+
+def test_status_accepts_an_indexed_commit_prefix() -> None:
+    bundle = _bundle({"bm25": _entry("bm25", commit=_INDEXED[:12])})
+    bundle.manifest.commit = _INDEXED[:12]
+    bundle.manifest.last_indexed_commit = _INDEXED[:12]
+    status = build_repo_index_status(
+        bundle,
+        current_head_resolver=lambda path: _INDEXED,
+    )
+
+    assert status.stale is False
+    assert status.indexes[0].state == "built"
+
+
+def test_status_projects_explicit_capabilities_and_valid_metrics() -> None:
+    status = build_repo_index_status(
+        _bundle(
+            {
+                "vector": _entry(
+                    "vector",
+                    metadata={
+                        "changed_files": 4,
+                        "chunks_reembedded": 3,
+                        "chunks_from_cache": 2,
+                        "cache_hit_rate": 0.4,
+                        "new_commit": _INDEXED,
+                    },
+                )
+            }
+        ),
+        update_capabilities={
+            "bm25": IndexUpdateCapability(mode="rebuild", enabled=True, reason=""),
+            "vector": IndexUpdateCapability(
+                mode="incremental",
+                enabled=True,
+                reason="",
+            ),
+            "symbol_graph": IndexUpdateCapability(
+                mode="patch",
+                enabled=False,
+                reason="No admitted verifier is configured.",
+            ),
+        },
+        current_head_resolver=lambda path: _INDEXED,
+    )
+
+    vector = status.indexes[1]
+    assert status.indexes[0].update_mode == "rebuild"
+    assert vector.update_mode == "incremental"
+    assert vector.updates_enabled is True
+    assert vector.metrics.model_dump() == {
+        "changed_files": 4,
+        "chunks_reembedded": 3,
+        "chunks_from_cache": 2,
+        "cache_hit_rate": 0.4,
+        "new_commit": _INDEXED,
+    }
+    assert status.indexes[2].update_mode == "patch"
+    assert status.indexes[2].updates_enabled is False
+
+
+def test_status_omits_malformed_optional_metrics() -> None:
+    status = build_repo_index_status(
+        _bundle(
+            {
+                "vector": _entry(
+                    "vector",
+                    metadata={
+                        "changed_files": True,
+                        "chunks_reembedded": -1,
+                        "chunks_from_cache": "2",
+                        "cache_hit_rate": float("nan"),
+                        "new_commit": "",
+                    },
+                )
+            }
+        ),
+        current_head_resolver=lambda path: _INDEXED,
+    )
+
+    assert status.indexes[1].metrics is None
+
+
+def test_status_rejects_unknown_or_incoherent_writer_capabilities() -> None:
+    with pytest.raises(ValueError, match="unsupported index update capability"):
+        build_repo_index_status(
+            _bundle({}),
+            update_capabilities={"zoekt": IndexUpdateCapability()},
+            current_head_resolver=lambda path: _INDEXED,
+        )
+    with pytest.raises(ValueError, match="cannot be enabled"):
+        IndexUpdateCapability(mode="unavailable", enabled=True, reason="")
+
+
+def test_status_passes_repository_path_to_head_resolver() -> None:
+    observed: list[Path] = []
+
+    def resolve(path: Path) -> str:
+        observed.append(path)
+        return _INDEXED
+
+    build_repo_index_status(_bundle({}), current_head_resolver=resolve)
+
+    assert observed == [Path("/repo")]
+
+
+def test_index_status_endpoint_pins_generation_through_projection(monkeypatch) -> None:
+    events: list[str] = []
+    bundle = _bundle({"bm25": _entry("bm25")})
+
+    class Registry:
+        @contextmanager
+        def pin(self, repo_id: str):
+            assert repo_id == "repo"
+            events.append("pin-enter")
+            try:
+                yield bundle
+            finally:
+                events.append("pin-exit")
+
+    def head(path: Path) -> str:
+        assert path == Path("/repo")
+        events.append("head")
+        return _INDEXED
+
+    async def inline(function, *args, **kwargs):
+        events.append("thread")
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(web_app.app.state, "registry", Registry(), raising=False)
+    monkeypatch.setattr(web_app.app.state, "index_head_resolver", head, raising=False)
+    monkeypatch.setattr(web_app.asyncio, "to_thread", inline)
+
+    status = asyncio.run(web_app.index_status("repo"))
+
+    assert status.indexes[0].state == "built"
+    assert events == ["pin-enter", "thread", "head", "pin-exit"]

--- a/test/web/test_index_status.py
+++ b/test/web/test_index_status.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import threading
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -220,9 +221,58 @@ def test_index_status_endpoint_pins_generation_through_projection(monkeypatch) -
 
     monkeypatch.setattr(web_app.app.state, "registry", Registry(), raising=False)
     monkeypatch.setattr(web_app.app.state, "index_head_resolver", head, raising=False)
-    monkeypatch.setattr(web_app.asyncio, "to_thread", inline)
+    monkeypatch.setattr(web_app, "_run_pinned_thread", inline)
 
     status = asyncio.run(web_app.index_status("repo"))
 
     assert status.indexes[0].state == "built"
     assert events == ["pin-enter", "thread", "head", "pin-exit"]
+
+
+def test_index_status_endpoint_retains_pin_until_cancelled_projection_settles(
+    monkeypatch,
+) -> None:
+    events: list[str] = []
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    worker_finished = threading.Event()
+    bundle = _bundle({"bm25": _entry("bm25")})
+
+    class Registry:
+        @contextmanager
+        def pin(self, repo_id: str):
+            assert repo_id == "repo"
+            events.append("pin-enter")
+            try:
+                yield bundle
+            finally:
+                assert worker_finished.is_set()
+                events.append("pin-exit")
+
+    def head(path: Path) -> str:
+        assert path == Path("/repo")
+        events.append("head-start")
+        worker_started.set()
+        assert release_worker.wait(5)
+        events.append("head-finish")
+        worker_finished.set()
+        return _INDEXED
+
+    monkeypatch.setattr(web_app.app.state, "registry", Registry(), raising=False)
+    monkeypatch.setattr(web_app.app.state, "index_head_resolver", head, raising=False)
+
+    async def cancel_projection() -> None:
+        request = asyncio.create_task(web_app.index_status("repo"))
+        try:
+            assert await asyncio.to_thread(worker_started.wait, 5)
+            request.cancel()
+            await asyncio.sleep(0)
+            assert not request.done()
+        finally:
+            release_worker.set()
+        with pytest.raises(asyncio.CancelledError):
+            await request
+
+    asyncio.run(cancel_projection())
+
+    assert events == ["pin-enter", "head-start", "head-finish", "pin-exit"]


### PR DESCRIPTION
## Summary

Expose a read-only repository index status contract for issue #266 on current main. The endpoint projects one pinned repository generation into a detached snapshot and never implies writer support unless an owning job service explicitly supplies it.

This PR is restacked directly on the RCU runtime merged in #700. Request cancellation now waits for the offloaded status projection to settle before releasing its generation lease.

## Changes

- Add status schemas for exactly BM25, vector, and symbol-graph surfaces.
- Report built, missing, stale, or failed state plus indexed commit, current HEAD, and bounded retained metrics.
- Add GET /api/repos/{repo_id}/index-status while holding one RCU bundle pin through projection and cancellation settlement.
- Require explicit update capability injection and default every writer mode to unavailable.
- Record the first issue #266 read slice and remaining job, update, refresh, MCP, UI, and routing work in the storage backend roadmap.
- Add endpoint ordering and cancellation regressions.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/web/test_index_status.py -x --tb=short` (9 passed)
- focused status, registry, and runtime tier (181 passed, 1 known environment baseline deselected)
- complete Web tier (425 passed, 1 known environment baseline deselected)
- `python -m mkdocs build --strict`
- `python scripts/check_public_docs.py`
- repository pre-commit hooks on both commits

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published