### PR TITLE
feat(web): expose durable index job status

### DIFF
--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -26,9 +26,10 @@ from contextlib import asynccontextmanager, contextmanager
 from functools import partial
 from pathlib import Path, PurePosixPath
 from time import perf_counter
+from typing import Annotated
 from urllib.parse import quote
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
@@ -47,6 +48,12 @@ from ..wiki.media_generation import (
 )
 from ..wiki.narrator import Narrator
 from .config import load_config
+from .index_jobs import (
+    IndexJobNotFoundError,
+    IndexJobReader,
+    IndexJobReadError,
+    overlay_active_job,
+)
 from .index_status import build_repo_index_status
 from .native_authority import authorize_local_manifest_vector
 from .ports import argparse_tcp_port
@@ -58,6 +65,7 @@ from .schemas import (
     ChatResponse,
     EdgeLabelRequest,
     EdgeLabelResponse,
+    IndexJobStatusResponse,
     RepoIndexStatus,
     RepoInfo,
     agent_result_to_response,
@@ -226,6 +234,16 @@ def _registry() -> RepoRegistry:
     if registry is None:
         raise HTTPException(status_code=503, detail="Server still starting up")
     return registry
+
+
+def _index_job_reader() -> IndexJobReader:
+    reader = getattr(app.state, "index_job_reader", None)
+    if not isinstance(reader, IndexJobReader):
+        raise HTTPException(
+            status_code=503,
+            detail="Durable index job status is not configured",
+        )
+    return reader
 
 
 def _bundle(repo_id: str):
@@ -626,11 +644,64 @@ async def index_status(repo_id: str) -> RepoIndexStatus:
         head_resolver = getattr(app.state, "index_head_resolver", None)
         if callable(head_resolver):
             kwargs["current_head_resolver"] = head_resolver
-        return await _run_pinned_thread(
+        status = await _run_pinned_thread(
             build_repo_index_status,
             bundle,
             **kwargs,
         )
+    reader = getattr(app.state, "index_job_reader", None)
+    if reader is None:
+        return status
+    if not isinstance(reader, IndexJobReader):
+        raise HTTPException(
+            status_code=503,
+            detail="Durable index job status is unavailable",
+        )
+    try:
+        active_job = await asyncio.to_thread(reader.active, repo_id)
+        return overlay_active_job(status, active_job)
+    except IndexJobNotFoundError:
+        return status
+    except (IndexJobReadError, ValueError) as exc:
+        logger.warning(
+            "Durable index job overlay unavailable: %s",
+            type(exc).__name__,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Durable index job status is unavailable",
+        ) from exc
+
+
+@app.get(
+    "/api/index-jobs/{job_id}",
+    response_model=IndexJobStatusResponse,
+)
+async def index_job_status(
+    job_id: str,
+    after_sequence: Annotated[int, Query(ge=0, lt=2**63)] = 0,
+    event_limit: Annotated[int, Query(ge=1, le=64)] = 64,
+) -> IndexJobStatusResponse:
+    """Return one authorized durable job and a bounded event page."""
+
+    try:
+        return await asyncio.to_thread(
+            _index_job_reader().get,
+            job_id,
+            after_sequence=after_sequence,
+            event_limit=event_limit,
+        )
+    except (IndexJobNotFoundError, TypeError, ValueError) as exc:
+        raise HTTPException(status_code=404, detail="Index job not found") from exc
+    except IndexJobReadError as exc:
+        logger.warning(
+            "Durable index job read unavailable: %s",
+            type(exc).__name__,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Durable index job status is unavailable",
+        ) from exc
 
 
 @app.get("/api/repos/{repo_id}/wiki")

--- a/codenib/web/index_jobs.py
+++ b/codenib/web/index_jobs.py
@@ -173,6 +173,34 @@ def _public_event_payload(event: IndexJobEventRecord) -> dict[str, object]:
     return result
 
 
+def _public_event_key(event: IndexJobEventRecord) -> str:
+    """Return a stable key without exposing executor-controlled text."""
+
+    return f"{event.kind.value.replace('_', '-')}-{event.sequence}"
+
+
+def _advance_job_projection(
+    earlier: IndexJobRecord,
+    later: IndexJobRecord,
+) -> IndexJobRecord:
+    """Attest a post-event job read as the same monotonically advancing record."""
+
+    if type(later) is not IndexJobRecord:
+        raise IndexJobReadError("catalog returned an invalid refreshed index job")
+    if (
+        later.job_id != earlier.job_id
+        or later.request_digest != earlier.request_digest
+        or later.created_at_ms != earlier.created_at_ms
+    ):
+        raise IndexJobReadError("catalog changed immutable index job identity")
+    if (
+        later.attempt_count < earlier.attempt_count
+        or later.updated_at_ms < earlier.updated_at_ms
+    ):
+        raise IndexJobReadError("catalog returned regressing index job state")
+    return later
+
+
 def _surface(view: IndexJobViewRecord) -> IndexJobSurface:
     if type(view) is not IndexJobViewRecord:
         raise IndexJobReadError("catalog returned an invalid index job view")
@@ -203,7 +231,7 @@ def _event(
     return IndexJobEvent(
         sequence=event.sequence,
         attempt_count=event.attempt_count,
-        event_key=event.event_key,
+        event_key=_public_event_key(event),
         kind=event.kind.value,
         index_type=event.view_type,
         effective_mode=(
@@ -254,6 +282,8 @@ def _project_job(
         raise IndexJobReadError("catalog returned an invalid index job event page")
     if len(raw_events) > event_limit:
         raise IndexJobReadError("catalog event page exceeds the requested limit")
+    if event_limit:
+        job = _advance_job_projection(job, catalog.get_job(job.job_id))
     events = [
         _event(
             event,

--- a/codenib/web/index_jobs.py
+++ b/codenib/web/index_jobs.py
@@ -1,0 +1,390 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Least-authority durable index-job reads for the Web control plane."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from typing import Callable, Protocol, runtime_checkable
+
+from ..storage import (
+    IndexJobEventRecord,
+    IndexJobRecord,
+    IndexJobStatus,
+    IndexJobViewRecord,
+    JobQueryCatalog,
+    StorageError,
+    StorageNotFound,
+)
+from .schemas import (
+    IndexJobEvent,
+    IndexJobStatusResponse,
+    IndexJobSurface,
+    RepoIndexStatus,
+)
+
+_PRIMARY_INDEX_ORDER = {"bm25": 0, "vector": 1, "symbol_graph": 2}
+_DEFAULT_EVENT_LIMIT = 64
+_MAX_EVENT_LIMIT = 64
+_FAILED_MESSAGES = {
+    "worker_resolver_failed": "The configured index worker could not accept this job.",
+    "worker_executor_failed": "The index worker failed while preparing artifacts.",
+    "worker_executor_incomplete": "The index worker returned an incomplete result.",
+    "worker_publication_conflict": "The indexed ref changed before publication completed.",
+}
+_GENERIC_FAILURE = "The index update failed. Use the job ID to inspect server logs."
+
+
+class IndexJobNotFoundError(LookupError):
+    """The requested Web repository or authorized durable job is absent."""
+
+
+class IndexJobReadError(RuntimeError):
+    """Durable job state could not be read or safely projected."""
+
+
+def _canonical_text(value: object, *, label: str, max_length: int) -> str:
+    if type(value) is not str:
+        raise TypeError(f"{label} must be exact text")
+    normalized = value.strip()
+    if not normalized or len(normalized) > max_length or "\x00" in normalized:
+        raise ValueError(f"{label} is invalid")
+    if normalized != value:
+        raise ValueError(f"{label} must be canonical")
+    return normalized
+
+
+@dataclass(frozen=True, slots=True)
+class IndexJobRepoBinding:
+    """Authorize one Web repository to read one durable repository/ref."""
+
+    repo_id: str
+    repository_id: str
+    ref_name: str = "main"
+
+    def __post_init__(self) -> None:
+        if type(self) is not IndexJobRepoBinding:
+            raise TypeError("index job repository binding must use the exact type")
+        object.__setattr__(
+            self,
+            "repo_id",
+            _canonical_text(self.repo_id, label="Web repository ID", max_length=512),
+        )
+        object.__setattr__(
+            self,
+            "repository_id",
+            _canonical_text(
+                self.repository_id,
+                label="storage repository ID",
+                max_length=96,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "ref_name",
+            _canonical_text(self.ref_name, label="storage ref name", max_length=512),
+        )
+
+
+@runtime_checkable
+class IndexJobReader(Protocol):
+    """Small Web-facing read contract suitable for dependency injection."""
+
+    def active(self, repo_id: str) -> IndexJobStatusResponse | None: ...
+
+    def get(
+        self,
+        job_id: str,
+        *,
+        after_sequence: int = 0,
+        event_limit: int = _DEFAULT_EVENT_LIMIT,
+    ) -> IndexJobStatusResponse: ...
+
+
+def _event_bounds(after_sequence: int, event_limit: int) -> tuple[int, int]:
+    if type(after_sequence) is not int or not 0 <= after_sequence < 2**63:
+        raise ValueError("index job event cursor is invalid")
+    if type(event_limit) is not int or not 0 <= event_limit <= _MAX_EVENT_LIMIT:
+        raise ValueError("index job event limit is invalid")
+    return after_sequence, event_limit
+
+
+def _safe_error_message(job: IndexJobRecord) -> str | None:
+    if job.status is IndexJobStatus.FAILED:
+        return _FAILED_MESSAGES.get(job.error_code or "", _GENERIC_FAILURE)
+    if job.status is IndexJobStatus.CANCELLED:
+        return "The index update was cancelled."
+    if job.status is IndexJobStatus.QUEUED and job.attempt_count > 0 and job.error_code:
+        return "A previous attempt failed; the index update is queued for retry."
+    return None
+
+
+def _safe_error_code(job: IndexJobRecord) -> str | None:
+    code = job.error_code
+    if code is None or code in _FAILED_MESSAGES:
+        return code
+    if job.status is IndexJobStatus.CANCELLED:
+        return "cancelled"
+    if job.status is IndexJobStatus.QUEUED:
+        return "index_update_retry"
+    return "index_update_failed"
+
+
+def _surface(view: IndexJobViewRecord) -> IndexJobSurface:
+    if type(view) is not IndexJobViewRecord:
+        raise IndexJobReadError("catalog returned an invalid index job view")
+    if view.view_type not in _PRIMARY_INDEX_ORDER:
+        raise IndexJobReadError("catalog job contains a non-Web index surface")
+    return IndexJobSurface(
+        index_type=view.view_type,
+        requested_mode=view.requested_mode.value,
+        required=view.required,
+    )
+
+
+def _event(event: IndexJobEventRecord) -> IndexJobEvent:
+    if type(event) is not IndexJobEventRecord:
+        raise IndexJobReadError("catalog returned an invalid index job event")
+    if event.view_type is not None and event.view_type not in _PRIMARY_INDEX_ORDER:
+        raise IndexJobReadError("catalog event contains a non-Web index surface")
+    return IndexJobEvent(
+        sequence=event.sequence,
+        attempt_count=event.attempt_count,
+        event_key=event.event_key,
+        kind=event.kind.value,
+        index_type=event.view_type,
+        effective_mode=(
+            None if event.effective_mode is None else event.effective_mode.value
+        ),
+        outcome=None if event.outcome is None else event.outcome.value,
+        payload=event.payload,
+        created_at_ms=event.created_at_ms,
+    )
+
+
+def _project_job(
+    catalog: JobQueryCatalog,
+    binding: IndexJobRepoBinding,
+    job: IndexJobRecord,
+    *,
+    after_sequence: int,
+    event_limit: int,
+) -> IndexJobStatusResponse:
+    if type(job) is not IndexJobRecord:
+        raise IndexJobReadError("catalog returned an invalid index job")
+    if (job.repository_id, job.ref_name) != (
+        binding.repository_id,
+        binding.ref_name,
+    ):
+        raise IndexJobReadError("catalog job escaped its Web repository binding")
+    views = catalog.get_job_views(job.job_id)
+    if type(views) is not tuple or any(view.job_id != job.job_id for view in views):
+        raise IndexJobReadError("catalog returned incoherent index job views")
+    surfaces = sorted(
+        (_surface(view) for view in views),
+        key=lambda item: _PRIMARY_INDEX_ORDER[item.index_type],
+    )
+    if not surfaces or len(surfaces) > len(_PRIMARY_INDEX_ORDER):
+        raise IndexJobReadError("catalog returned an invalid Web index job shape")
+
+    raw_events = (
+        ()
+        if event_limit == 0
+        else catalog.list_job_events(
+            job.job_id,
+            after_sequence=after_sequence,
+            limit=event_limit,
+        )
+    )
+    if type(raw_events) is not tuple:
+        raise IndexJobReadError("catalog returned an invalid index job event page")
+    events = [_event(event) for event in raw_events]
+    sequences = [event.sequence for event in events]
+    if sequences != sorted(set(sequences)) or any(
+        sequence <= after_sequence for sequence in sequences
+    ):
+        raise IndexJobReadError("catalog returned an incoherent index job event page")
+    next_sequence = sequences[-1] if sequences else after_sequence
+    return IndexJobStatusResponse(
+        job_id=job.job_id,
+        repo_id=binding.repo_id,
+        status=job.status.value,
+        cancel_requested=job.cancel_requested,
+        attempt_count=job.attempt_count,
+        max_attempts=job.max_attempts,
+        indexes=surfaces,
+        result_snapshot_id=job.result_snapshot_id,
+        error_code=_safe_error_code(job),
+        error_message=_safe_error_message(job),
+        created_at_ms=job.created_at_ms,
+        updated_at_ms=job.updated_at_ms,
+        started_at_ms=job.started_at_ms,
+        finished_at_ms=job.finished_at_ms,
+        events=events,
+        next_event_sequence=next_sequence,
+    )
+
+
+def _safe_project_job(
+    catalog: JobQueryCatalog,
+    binding: IndexJobRepoBinding,
+    job: IndexJobRecord,
+    *,
+    after_sequence: int,
+    event_limit: int,
+) -> IndexJobStatusResponse:
+    try:
+        return _project_job(
+            catalog,
+            binding,
+            job,
+            after_sequence=after_sequence,
+            event_limit=event_limit,
+        )
+    except IndexJobReadError:
+        raise
+    except (TypeError, ValueError) as exc:
+        raise IndexJobReadError("catalog job could not be safely projected") from exc
+
+
+class CatalogIndexJobReader:
+    """Open short, thread-confined read sessions for durable Web job status."""
+
+    def __init__(
+        self,
+        catalog_factory: Callable[[], AbstractContextManager[JobQueryCatalog]],
+        bindings: tuple[IndexJobRepoBinding, ...],
+    ) -> None:
+        if not callable(catalog_factory):
+            raise TypeError("index job catalog factory must be callable")
+        if type(bindings) is not tuple or not bindings:
+            raise ValueError("index job reader requires repository bindings")
+        if any(type(binding) is not IndexJobRepoBinding for binding in bindings):
+            raise TypeError("index job reader bindings must use exact values")
+        by_repo: dict[str, IndexJobRepoBinding] = {}
+        by_storage: dict[tuple[str, str], IndexJobRepoBinding] = {}
+        for binding in bindings:
+            storage_key = (binding.repository_id, binding.ref_name)
+            if binding.repo_id in by_repo or storage_key in by_storage:
+                raise ValueError("index job reader bindings must be unique")
+            by_repo[binding.repo_id] = binding
+            by_storage[storage_key] = binding
+        self._catalog_factory = catalog_factory
+        self._by_repo = by_repo
+        self._by_storage = by_storage
+
+    @staticmethod
+    def _require_catalog(value: object) -> JobQueryCatalog:
+        if not isinstance(value, JobQueryCatalog):
+            raise IndexJobReadError("catalog does not implement read-only job queries")
+        return value
+
+    def active(self, repo_id: str) -> IndexJobStatusResponse | None:
+        normalized = _canonical_text(
+            repo_id,
+            label="Web repository ID",
+            max_length=512,
+        )
+        binding = self._by_repo.get(normalized)
+        if binding is None:
+            raise IndexJobNotFoundError("Web repository has no durable job binding")
+        try:
+            with self._catalog_factory() as value:
+                catalog = self._require_catalog(value)
+                job = catalog.find_active_job(
+                    binding.repository_id,
+                    binding.ref_name,
+                )
+                if job is None:
+                    return None
+                return _safe_project_job(
+                    catalog,
+                    binding,
+                    job,
+                    after_sequence=0,
+                    event_limit=0,
+                )
+        except IndexJobReadError:
+            raise
+        except (OSError, sqlite3.Error, StorageError) as exc:
+            raise IndexJobReadError("durable index job status is unavailable") from exc
+
+    def get(
+        self,
+        job_id: str,
+        *,
+        after_sequence: int = 0,
+        event_limit: int = _DEFAULT_EVENT_LIMIT,
+    ) -> IndexJobStatusResponse:
+        normalized = _canonical_text(job_id, label="index job ID", max_length=80)
+        cursor, limit = _event_bounds(after_sequence, event_limit)
+        try:
+            with self._catalog_factory() as value:
+                catalog = self._require_catalog(value)
+                try:
+                    job = catalog.get_job(normalized)
+                except StorageNotFound as exc:
+                    raise IndexJobNotFoundError(
+                        "durable index job was not found"
+                    ) from exc
+                if type(job) is not IndexJobRecord:
+                    raise IndexJobReadError("catalog returned an invalid index job")
+                binding = self._by_storage.get((job.repository_id, job.ref_name))
+                if binding is None:
+                    raise IndexJobNotFoundError(
+                        "durable index job is outside the Web repository bindings"
+                    )
+                return _safe_project_job(
+                    catalog,
+                    binding,
+                    job,
+                    after_sequence=cursor,
+                    event_limit=limit,
+                )
+        except (IndexJobNotFoundError, IndexJobReadError):
+            raise
+        except (OSError, sqlite3.Error, StorageError) as exc:
+            raise IndexJobReadError("durable index job status is unavailable") from exc
+
+
+def overlay_active_job(
+    status: RepoIndexStatus,
+    active_job: IndexJobStatusResponse | None,
+) -> RepoIndexStatus:
+    """Mark requested primary surfaces updating without mutating the snapshot."""
+
+    if active_job is None:
+        return status
+    if active_job.repo_id != status.repo_id:
+        raise ValueError("active index job belongs to another Web repository")
+    if active_job.status not in {"queued", "running"}:
+        return status
+    requested = {surface.index_type for surface in active_job.indexes}
+    indexes = [
+        (
+            index.model_copy(
+                update={"state": "updating", "job_id": active_job.job_id},
+                deep=True,
+            )
+            if index.index_type in requested
+            else index.model_copy(deep=True)
+        )
+        for index in status.indexes
+    ]
+    return RepoIndexStatus.model_validate(
+        {**status.model_dump(), "indexes": [index.model_dump() for index in indexes]}
+    )
+
+
+__all__ = [
+    "CatalogIndexJobReader",
+    "IndexJobNotFoundError",
+    "IndexJobReadError",
+    "IndexJobReader",
+    "IndexJobRepoBinding",
+    "overlay_active_job",
+]

--- a/codenib/web/index_jobs.py
+++ b/codenib/web/index_jobs.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import math
 import sqlite3
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
@@ -30,6 +31,14 @@ from .schemas import (
 _PRIMARY_INDEX_ORDER = {"bm25": 0, "vector": 1, "symbol_graph": 2}
 _DEFAULT_EVENT_LIMIT = 64
 _MAX_EVENT_LIMIT = 64
+_MAX_PUBLIC_COUNT = 2**63 - 1
+_PUBLIC_COUNT_FIELDS = (
+    "changed_files",
+    "chunks_reembedded",
+    "chunks_from_cache",
+    "documents",
+)
+_COMMIT_CHARACTERS = frozenset("0123456789abcdef")
 _FAILED_MESSAGES = {
     "worker_resolver_failed": "The configured index worker could not accept this job.",
     "worker_executor_failed": "The index worker failed while preparing artifacts.",
@@ -134,6 +143,36 @@ def _safe_error_code(job: IndexJobRecord) -> str | None:
     return "index_update_failed"
 
 
+def _public_event_payload(event: IndexJobEventRecord) -> dict[str, object]:
+    """Project only explicitly public scalar metrics from an internal event."""
+
+    payload = event.payload
+    if type(payload) is not dict:
+        raise IndexJobReadError("catalog event returned an invalid payload")
+    result: dict[str, object] = {}
+    for field in _PUBLIC_COUNT_FIELDS:
+        value = payload.get(field)
+        if type(value) is int and 0 <= value <= _MAX_PUBLIC_COUNT:
+            result[field] = value
+    prepared = payload.get("prepared")
+    if type(prepared) is bool:
+        result["prepared"] = prepared
+    rate = payload.get("cache_hit_rate")
+    if type(rate) in {int, float}:
+        normalized_rate = float(rate)
+        if math.isfinite(normalized_rate) and 0.0 <= normalized_rate <= 1.0:
+            result["cache_hit_rate"] = normalized_rate
+    commit = payload.get("new_commit")
+    if type(commit) is str:
+        normalized_commit = commit.lower()
+        if (
+            7 <= len(normalized_commit) <= 64
+            and not set(normalized_commit) - _COMMIT_CHARACTERS
+        ):
+            result["new_commit"] = normalized_commit
+    return result
+
+
 def _surface(view: IndexJobViewRecord) -> IndexJobSurface:
     if type(view) is not IndexJobViewRecord:
         raise IndexJobReadError("catalog returned an invalid index job view")
@@ -146,11 +185,21 @@ def _surface(view: IndexJobViewRecord) -> IndexJobSurface:
     )
 
 
-def _event(event: IndexJobEventRecord) -> IndexJobEvent:
+def _event(
+    event: IndexJobEventRecord,
+    *,
+    job_id: str,
+    current_attempt_count: int,
+    requested_views: frozenset[str],
+) -> IndexJobEvent:
     if type(event) is not IndexJobEventRecord:
         raise IndexJobReadError("catalog returned an invalid index job event")
-    if event.view_type is not None and event.view_type not in _PRIMARY_INDEX_ORDER:
-        raise IndexJobReadError("catalog event contains a non-Web index surface")
+    if event.job_id != job_id:
+        raise IndexJobReadError("catalog event escaped its index job")
+    if event.attempt_count > current_attempt_count:
+        raise IndexJobReadError("catalog event names a future index job attempt")
+    if event.view_type is not None and event.view_type not in requested_views:
+        raise IndexJobReadError("catalog event names an unrequested index surface")
     return IndexJobEvent(
         sequence=event.sequence,
         attempt_count=event.attempt_count,
@@ -161,7 +210,7 @@ def _event(event: IndexJobEventRecord) -> IndexJobEvent:
             None if event.effective_mode is None else event.effective_mode.value
         ),
         outcome=None if event.outcome is None else event.outcome.value,
-        payload=event.payload,
+        payload=_public_event_payload(event),
         created_at_ms=event.created_at_ms,
     )
 
@@ -190,6 +239,7 @@ def _project_job(
     )
     if not surfaces or len(surfaces) > len(_PRIMARY_INDEX_ORDER):
         raise IndexJobReadError("catalog returned an invalid Web index job shape")
+    requested_views = frozenset(surface.index_type for surface in surfaces)
 
     raw_events = (
         ()
@@ -202,12 +252,25 @@ def _project_job(
     )
     if type(raw_events) is not tuple:
         raise IndexJobReadError("catalog returned an invalid index job event page")
-    events = [_event(event) for event in raw_events]
+    if len(raw_events) > event_limit:
+        raise IndexJobReadError("catalog event page exceeds the requested limit")
+    events = [
+        _event(
+            event,
+            job_id=job.job_id,
+            current_attempt_count=job.attempt_count,
+            requested_views=requested_views,
+        )
+        for event in raw_events
+    ]
     sequences = [event.sequence for event in events]
     if sequences != sorted(set(sequences)) or any(
         sequence <= after_sequence for sequence in sequences
     ):
         raise IndexJobReadError("catalog returned an incoherent index job event page")
+    attempts = [event.attempt_count for event in events]
+    if attempts != sorted(attempts):
+        raise IndexJobReadError("catalog returned regressing index job attempts")
     next_sequence = sequences[-1] if sequences else after_sequence
     return IndexJobStatusResponse(
         job_id=job.job_id,

--- a/codenib/web/schemas.py
+++ b/codenib/web/schemas.py
@@ -141,7 +141,7 @@ class IndexJobSurface(BaseModel):
 
 
 class IndexJobEvent(BaseModel):
-    """Bounded job progress without worker ownership or fencing authority."""
+    """Bounded progress with a Web-owned key and no worker/fencing authority."""
 
     sequence: int = Field(ge=1)
     attempt_count: int = Field(ge=1, le=1_000)

--- a/codenib/web/schemas.py
+++ b/codenib/web/schemas.py
@@ -132,6 +132,78 @@ class RepoIndexStatus(BaseModel):
         return self
 
 
+class IndexJobSurface(BaseModel):
+    """One primary index requested by a durable job."""
+
+    index_type: Literal["bm25", "vector", "symbol_graph"]
+    requested_mode: Literal["auto", "full", "incremental"]
+    required: bool
+
+
+class IndexJobEvent(BaseModel):
+    """Bounded job progress without worker ownership or fencing authority."""
+
+    sequence: int = Field(ge=1)
+    attempt_count: int = Field(ge=1, le=1_000)
+    event_key: str = Field(min_length=1, max_length=128)
+    kind: Literal["progress", "view_result"]
+    index_type: Optional[Literal["bm25", "vector", "symbol_graph"]] = None
+    effective_mode: Optional[
+        Literal["full", "incremental", "rebuild_fallback", "unavailable"]
+    ] = None
+    outcome: Optional[Literal["succeeded", "failed", "skipped"]] = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+    created_at_ms: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def _require_event_shape(self) -> "IndexJobEvent":
+        result_fields = (self.index_type, self.effective_mode, self.outcome)
+        if self.kind == "progress" and any(
+            value is not None for value in result_fields
+        ):
+            raise ValueError("progress events cannot carry a view result")
+        if self.kind == "view_result" and any(value is None for value in result_fields):
+            raise ValueError("view-result events require view, mode, and outcome")
+        return self
+
+
+class IndexJobStatusResponse(BaseModel):
+    """Detached, reader-facing durable index-job state."""
+
+    job_id: str = Field(min_length=1, max_length=80)
+    repo_id: str = Field(min_length=1, max_length=_MAX_REPO_ID_CHARS)
+    status: Literal["queued", "running", "succeeded", "failed", "cancelled"]
+    cancel_requested: bool
+    attempt_count: int = Field(ge=0, le=1_000)
+    max_attempts: int = Field(ge=1, le=1_000)
+    indexes: List[IndexJobSurface] = Field(min_length=1, max_length=3)
+    result_snapshot_id: Optional[str] = Field(default=None, max_length=96)
+    error_code: Optional[str] = Field(default=None, max_length=128)
+    error_message: Optional[str] = Field(default=None, max_length=512)
+    created_at_ms: int = Field(ge=0)
+    updated_at_ms: int = Field(ge=0)
+    started_at_ms: Optional[int] = Field(default=None, ge=0)
+    finished_at_ms: Optional[int] = Field(default=None, ge=0)
+    events: List[IndexJobEvent] = Field(default_factory=list, max_length=64)
+    next_event_sequence: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def _require_canonical_job_status(self) -> "IndexJobStatusResponse":
+        order = {"bm25": 0, "vector": 1, "symbol_graph": 2}
+        observed = [surface.index_type for surface in self.indexes]
+        if len(set(observed)) != len(observed) or observed != sorted(
+            observed,
+            key=order.__getitem__,
+        ):
+            raise ValueError("index job surfaces must be unique and canonical")
+        sequences = [event.sequence for event in self.events]
+        if sequences != sorted(set(sequences)):
+            raise ValueError("index job events must have increasing unique sequences")
+        if sequences and self.next_event_sequence != sequences[-1]:
+            raise ValueError("index job event cursor must match the final event")
+        return self
+
+
 class CallSite(BaseModel):
     """An exact call site (1-based line), mirroring the frontend ``CallSite``."""
 

--- a/codenib/web/schemas.py
+++ b/codenib/web/schemas.py
@@ -157,12 +157,15 @@ class IndexJobEvent(BaseModel):
 
     @model_validator(mode="after")
     def _require_event_shape(self) -> "IndexJobEvent":
-        result_fields = (self.index_type, self.effective_mode, self.outcome)
+        result_fields = (self.effective_mode, self.outcome)
         if self.kind == "progress" and any(
             value is not None for value in result_fields
         ):
             raise ValueError("progress events cannot carry a view result")
-        if self.kind == "view_result" and any(value is None for value in result_fields):
+        if self.kind == "view_result" and any(
+            value is None
+            for value in (self.index_type, self.effective_mode, self.outcome)
+        ):
             raise ValueError("view-result events require view, mode, and outcome")
         return self
 

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1428,6 +1428,12 @@ and default routing remain absent.
   returns the oldest queued job for the exact repository/ref, while terminal
   jobs and bounded events remain addressable by job ID. This avoids an
   in-memory repo-to-job map that would lose state across Web process restarts.
+- An explicitly injected Web reader can now project authorized durable jobs and
+  at most 64 events without exposing worker owner IDs, fencing tokens, or raw
+  executor errors. Repository status overlays queued/running jobs only after
+  releasing its RCU bundle pin. The default server still has no job reader or
+  writer, so this read API returns unavailable until production storage
+  bindings are configured.
 - Keep read-only/prebuilt paths safe through copy-on-write or explicit refusal.
 
 ### M4: Cross-file reference de-materialization

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1430,10 +1430,11 @@ and default routing remain absent.
   in-memory repo-to-job map that would lose state across Web process restarts.
 - An explicitly injected Web reader can now project authorized durable jobs and
   at most 64 events without exposing worker owner IDs, fencing tokens, or raw
-  executor errors. Repository status overlays queued/running jobs only after
-  releasing its RCU bundle pin. The default server still has no job reader or
-  writer, so this read API returns unavailable until production storage
-  bindings are configured.
+  executor errors. Each event is rebound to the exact job, visible attempt, and
+  requested view; only explicitly public scalar metrics cross the Web boundary.
+  Repository status overlays queued/running jobs only after releasing its RCU
+  bundle pin. The default server still has no job reader or writer, so this read
+  API returns unavailable until production storage bindings are configured.
 - Keep read-only/prebuilt paths safe through copy-on-write or explicit refusal.
 
 ### M4: Cross-file reference de-materialization

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1430,8 +1430,9 @@ and default routing remain absent.
   in-memory repo-to-job map that would lose state across Web process restarts.
 - An explicitly injected Web reader can now project authorized durable jobs and
   at most 64 events without exposing worker owner IDs, fencing tokens, or raw
-  executor errors. Each event is rebound to the exact job, visible attempt, and
-  requested view; only explicitly public scalar metrics cross the Web boundary.
+  executor errors or event keys. Each event is rebound to the exact job, a
+  causally later job-state read, and the requested view; only a Web-generated
+  event key and explicitly public scalar metrics cross the Web boundary.
   Repository status overlays queued/running jobs only after releasing its RCU
   bundle pin. The default server still has no job reader or writer, so this read
   API returns unavailable until production storage bindings are configured.

--- a/test/web/test_index_jobs.py
+++ b/test/web/test_index_jobs.py
@@ -1,0 +1,415 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+import codenib.web.app as web_app
+from codenib.storage import (
+    INDEX_JOB_REQUEST_CONTRACT,
+    IndexJobEffectiveMode,
+    IndexJobEventKind,
+    IndexJobEventRecord,
+    IndexJobRecord,
+    IndexJobRequest,
+    IndexJobStatus,
+    IndexJobViewOutcome,
+    StorageNotFound,
+)
+from codenib.web.index_jobs import (
+    CatalogIndexJobReader,
+    IndexJobNotFoundError,
+    IndexJobRepoBinding,
+    overlay_active_job,
+)
+from codenib.web.schemas import (
+    IndexJobStatusResponse,
+    IndexJobSurface,
+    IndexSurfaceStatus,
+    RepoIndexStatus,
+)
+
+_STORAGE_REPO = "repo_" + "a" * 64
+_OTHER_STORAGE_REPO = "repo_" + "b" * 64
+_SOURCE = "src_" + "c" * 64
+_PROFILE = "profile_" + "d" * 64
+_INDEXED = "e" * 40
+
+
+def _request(
+    *,
+    repository_id: str = _STORAGE_REPO,
+    idempotency_key: str = "request",
+) -> IndexJobRequest:
+    return IndexJobRequest.create(
+        repository_id,
+        _SOURCE,
+        idempotency_key,
+        {
+            "contract": INDEX_JOB_REQUEST_CONTRACT,
+            "views": {
+                "bm25": {
+                    "profile_id": _PROFILE,
+                    "requested_mode": "full",
+                    "required": True,
+                }
+            },
+        },
+    )
+
+
+def _job(
+    *,
+    status: IndexJobStatus = IndexJobStatus.RUNNING,
+    repository_id: str = _STORAGE_REPO,
+    idempotency_key: str = "request",
+    error_code: str | None = None,
+    error_message: str | None = None,
+) -> IndexJobRecord:
+    request = _request(
+        repository_id=repository_id,
+        idempotency_key=idempotency_key,
+    )
+    running = status is IndexJobStatus.RUNNING
+    terminal = status in {
+        IndexJobStatus.SUCCEEDED,
+        IndexJobStatus.FAILED,
+        IndexJobStatus.CANCELLED,
+    }
+    return IndexJobRecord(
+        job_id=request.job_id,
+        repository_id=request.repository_id,
+        source_revision_id=request.source_revision_id,
+        ref_name=request.ref_name,
+        idempotency_key=request.idempotency_key,
+        expected_ref_generation=request.expected_ref_generation,
+        max_attempts=request.max_attempts,
+        request_json=request.request_json,
+        request_digest=request.request_digest,
+        status=status,
+        cancel_requested=status is IndexJobStatus.CANCELLED,
+        attempt_count=0 if status is IndexJobStatus.QUEUED else 1,
+        result_snapshot_id=(
+            "snapshot_" + "f" * 64 if status is IndexJobStatus.SUCCEEDED else None
+        ),
+        error_code=error_code,
+        error_message=error_message,
+        created_at_ms=10,
+        updated_at_ms=12 if running or terminal else 10,
+        started_at_ms=11 if running or terminal else None,
+        finished_at_ms=12 if terminal else None,
+    )
+
+
+class _Catalog:
+    def __init__(
+        self,
+        jobs: tuple[IndexJobRecord, ...],
+        events: tuple[IndexJobEventRecord, ...] = (),
+        *,
+        active_job_id: str | None = None,
+    ) -> None:
+        self.jobs = {job.job_id: job for job in jobs}
+        self.views = {
+            job.job_id: _request(
+                repository_id=job.repository_id,
+                idempotency_key=job.idempotency_key,
+            ).view_requests
+            for job in jobs
+        }
+        self.events = events
+        self.active_job_id = active_job_id
+        self.event_calls: list[tuple[str, int, int]] = []
+
+    def get_job(self, job_id: str) -> IndexJobRecord:
+        try:
+            return self.jobs[job_id]
+        except KeyError as exc:
+            raise StorageNotFound("job not found") from exc
+
+    def get_job_views(self, job_id: str):
+        return self.views[job_id]
+
+    def find_active_job(self, repository_id: str, ref_name: str = "main"):
+        if self.active_job_id is None:
+            return None
+        job = self.jobs[self.active_job_id]
+        assert (job.repository_id, job.ref_name) == (repository_id, ref_name)
+        return job
+
+    def list_job_events(
+        self,
+        job_id: str,
+        *,
+        after_sequence: int = 0,
+        limit: int = 128,
+    ):
+        self.event_calls.append((job_id, after_sequence, limit))
+        return tuple(
+            event
+            for event in self.events
+            if event.job_id == job_id and event.sequence > after_sequence
+        )[:limit]
+
+
+def _reader(catalog: _Catalog) -> CatalogIndexJobReader:
+    @contextmanager
+    def factory():
+        yield catalog
+
+    return CatalogIndexJobReader(
+        factory,
+        (IndexJobRepoBinding("demo", _STORAGE_REPO),),
+    )
+
+
+def _events(job: IndexJobRecord) -> tuple[IndexJobEventRecord, ...]:
+    return (
+        IndexJobEventRecord.create(
+            sequence=1,
+            job_id=job.job_id,
+            attempt_count=1,
+            event_key="capture-started",
+            kind=IndexJobEventKind.PROGRESS,
+            owner_id="private-worker",
+            fencing_token=7,
+            payload={"phase": "capture"},
+            created_at_ms=11,
+        ),
+        IndexJobEventRecord.create(
+            sequence=2,
+            job_id=job.job_id,
+            attempt_count=1,
+            event_key="bm25-result",
+            kind=IndexJobEventKind.VIEW_RESULT,
+            owner_id="private-worker",
+            fencing_token=7,
+            view_type="bm25",
+            effective_mode=IndexJobEffectiveMode.FULL,
+            outcome=IndexJobViewOutcome.SUCCEEDED,
+            payload={"documents": 8},
+            created_at_ms=12,
+        ),
+    )
+
+
+def _active_response(job: IndexJobRecord) -> IndexJobStatusResponse:
+    return IndexJobStatusResponse(
+        job_id=job.job_id,
+        repo_id="repo",
+        status=job.status.value,
+        cancel_requested=job.cancel_requested,
+        attempt_count=job.attempt_count,
+        max_attempts=job.max_attempts,
+        indexes=[
+            IndexJobSurface(
+                index_type="bm25",
+                requested_mode="full",
+                required=True,
+            )
+        ],
+        created_at_ms=job.created_at_ms,
+        updated_at_ms=job.updated_at_ms,
+        started_at_ms=job.started_at_ms,
+        finished_at_ms=job.finished_at_ms,
+        next_event_sequence=0,
+    )
+
+
+def test_catalog_reader_projects_bounded_events_without_worker_authority() -> None:
+    job = _job()
+    catalog = _Catalog((job,), _events(job))
+
+    status = _reader(catalog).get(job.job_id, after_sequence=0, event_limit=2)
+
+    assert status.repo_id == "demo"
+    assert status.status == "running"
+    assert status.next_event_sequence == 2
+    assert [event.kind for event in status.events] == ["progress", "view_result"]
+    assert status.events[1].effective_mode == "full"
+    assert catalog.event_calls == [(job.job_id, 0, 2)]
+    serialized = status.model_dump_json()
+    assert "private-worker" not in serialized
+    assert "fencing" not in serialized
+
+
+def test_catalog_reader_hides_raw_executor_error_messages() -> None:
+    job = _job(
+        status=IndexJobStatus.FAILED,
+        error_code="worker_executor_failed",
+        error_message="credential-bearing internal detail",
+    )
+
+    status = _reader(_Catalog((job,))).get(job.job_id)
+
+    assert status.error_code == "worker_executor_failed"
+    assert status.error_message == "The index worker failed while preparing artifacts."
+    assert "credential-bearing" not in status.model_dump_json()
+
+
+def test_catalog_reader_masks_unknown_executor_error_codes() -> None:
+    job = _job(
+        status=IndexJobStatus.FAILED,
+        error_code="private-adapter-detail",
+        error_message="private failure",
+    )
+
+    status = _reader(_Catalog((job,))).get(job.job_id)
+
+    assert status.error_code == "index_update_failed"
+    assert status.error_message == (
+        "The index update failed. Use the job ID to inspect server logs."
+    )
+    assert "private-adapter" not in status.model_dump_json()
+
+
+def test_catalog_reader_authorizes_jobs_through_repository_bindings() -> None:
+    allowed = _job()
+    other = _job(
+        repository_id=_OTHER_STORAGE_REPO,
+        idempotency_key="other",
+    )
+    reader = _reader(_Catalog((allowed, other), active_job_id=allowed.job_id))
+
+    assert reader.active("demo").job_id == allowed.job_id
+    with pytest.raises(IndexJobNotFoundError):
+        reader.get(other.job_id)
+    with pytest.raises(IndexJobNotFoundError):
+        reader.get("job_" + "f" * 64)
+
+
+def test_overlay_marks_only_requested_surface_without_mutating_snapshot() -> None:
+    status = RepoIndexStatus(
+        repo_id="repo",
+        last_indexed_commit=_INDEXED,
+        current_head=_INDEXED,
+        indexes=[
+            IndexSurfaceStatus(
+                index_type=index_type,
+                state="stale" if index_type == "bm25" else "built",
+                stale=index_type == "bm25",
+                update_mode="rebuild",
+                updates_enabled=True,
+            )
+            for index_type in ("bm25", "vector", "symbol_graph")
+        ],
+    )
+    job = _job()
+
+    overlaid = overlay_active_job(status, _active_response(job))
+
+    assert status.indexes[0].state == "stale"
+    assert overlaid.indexes[0].state == "updating"
+    assert overlaid.indexes[0].stale is True
+    assert overlaid.indexes[0].job_id == job.job_id
+    assert [index.state for index in overlaid.indexes[1:]] == ["built", "built"]
+
+
+def test_index_job_endpoint_uses_injected_reader(monkeypatch) -> None:
+    job = _job()
+    expected = _reader(_Catalog((job,))).get(job.job_id)
+    calls: list[tuple[str, int, int]] = []
+
+    class Reader:
+        def active(self, repo_id: str):
+            return None
+
+        def get(
+            self,
+            job_id: str,
+            *,
+            after_sequence: int = 0,
+            event_limit: int = 64,
+        ):
+            calls.append((job_id, after_sequence, event_limit))
+            return expected
+
+    async def inline(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(web_app.app.state, "index_job_reader", Reader(), raising=False)
+    monkeypatch.setattr(web_app.asyncio, "to_thread", inline)
+
+    response = asyncio.run(web_app.index_job_status(job.job_id, 4, 7))
+
+    assert response == expected
+    assert calls == [(job.job_id, 4, 7)]
+
+
+def test_index_job_endpoint_is_unavailable_without_reader(monkeypatch) -> None:
+    monkeypatch.delattr(web_app.app.state, "index_job_reader", raising=False)
+
+    with pytest.raises(HTTPException) as raised:
+        asyncio.run(web_app.index_job_status("job_" + "f" * 64, 0, 64))
+
+    assert raised.value.status_code == 503
+
+
+def test_repo_status_releases_bundle_pin_before_active_job_read(monkeypatch) -> None:
+    events: list[str] = []
+    entry = SimpleNamespace(
+        status="fresh",
+        commit=_INDEXED,
+        built_at="2026-08-26T00:00:00+00:00",
+        metadata={},
+    )
+    manifest = SimpleNamespace(
+        indexes={"bm25": entry},
+        last_indexed_commit=_INDEXED,
+        commit=_INDEXED,
+        index_is_current=lambda index_type: index_type == "bm25",
+    )
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(instance_id="repo", repo_dir="/repo"),
+        manifest=manifest,
+    )
+    job = _job()
+
+    class Registry:
+        @contextmanager
+        def pin(self, repo_id: str):
+            events.append("pin-enter")
+            try:
+                yield bundle
+            finally:
+                events.append("pin-exit")
+
+    class Reader:
+        def active(self, repo_id: str):
+            events.append("active")
+            return _active_response(job)
+
+        def get(self, job_id: str, **kwargs):
+            raise AssertionError("not used")
+
+    def head(_path):
+        events.append("head")
+        return _INDEXED
+
+    async def inline(function, *args, **kwargs):
+        events.append("thread")
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(web_app.app.state, "registry", Registry(), raising=False)
+    monkeypatch.setattr(web_app.app.state, "index_job_reader", Reader(), raising=False)
+    monkeypatch.setattr(web_app.app.state, "index_head_resolver", head, raising=False)
+    monkeypatch.setattr(web_app.asyncio, "to_thread", inline)
+
+    response = asyncio.run(web_app.index_status("repo"))
+
+    assert response.indexes[0].state == "updating"
+    assert events == [
+        "pin-enter",
+        "thread",
+        "head",
+        "pin-exit",
+        "thread",
+        "active",
+    ]

--- a/test/web/test_index_jobs.py
+++ b/test/web/test_index_jobs.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import contextmanager
+from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
@@ -26,6 +27,7 @@ from codenib.storage import (
 from codenib.web.index_jobs import (
     CatalogIndexJobReader,
     IndexJobNotFoundError,
+    IndexJobReadError,
     IndexJobRepoBinding,
     overlay_active_job,
 )
@@ -159,6 +161,18 @@ class _Catalog:
         )[:limit]
 
 
+class _UnattestedEventCatalog(_Catalog):
+    def list_job_events(
+        self,
+        job_id: str,
+        *,
+        after_sequence: int = 0,
+        limit: int = 128,
+    ):
+        self.event_calls.append((job_id, after_sequence, limit))
+        return self.events
+
+
 def _reader(catalog: _Catalog) -> CatalogIndexJobReader:
     @contextmanager
     def factory():
@@ -180,7 +194,11 @@ def _events(job: IndexJobRecord) -> tuple[IndexJobEventRecord, ...]:
             kind=IndexJobEventKind.PROGRESS,
             owner_id="private-worker",
             fencing_token=7,
-            payload={"phase": "capture"},
+            view_type="bm25",
+            payload={
+                "changed_files": 2,
+                "phase": "credential-bearing internal detail",
+            },
             created_at_ms=11,
         ),
         IndexJobEventRecord.create(
@@ -233,11 +251,39 @@ def test_catalog_reader_projects_bounded_events_without_worker_authority() -> No
     assert status.status == "running"
     assert status.next_event_sequence == 2
     assert [event.kind for event in status.events] == ["progress", "view_result"]
+    assert status.events[0].index_type == "bm25"
+    assert status.events[0].payload == {"changed_files": 2}
     assert status.events[1].effective_mode == "full"
+    assert status.events[1].payload == {"documents": 8}
     assert catalog.event_calls == [(job.job_id, 0, 2)]
     serialized = status.model_dump_json()
     assert "private-worker" not in serialized
     assert "fencing" not in serialized
+    assert "credential-bearing" not in serialized
+
+
+def test_catalog_reader_rejects_events_outside_the_attested_job() -> None:
+    job = _job()
+    event = _events(job)[0]
+    other = _job(idempotency_key="other")
+    invalid = (
+        (replace(event, job_id=other.job_id), "escaped"),
+        (replace(event, attempt_count=2), "future"),
+        (replace(event, view_type="vector"), "unrequested"),
+    )
+
+    for candidate, message in invalid:
+        catalog = _UnattestedEventCatalog((job,), (candidate,))
+        with pytest.raises(IndexJobReadError, match=message):
+            _reader(catalog).get(job.job_id)
+
+
+def test_catalog_reader_rejects_an_event_page_over_its_requested_limit() -> None:
+    job = _job()
+    catalog = _UnattestedEventCatalog((job,), _events(job))
+
+    with pytest.raises(IndexJobReadError, match="exceeds"):
+        _reader(catalog).get(job.job_id, event_limit=1)
 
 
 def test_catalog_reader_hides_raw_executor_error_messages() -> None:

--- a/test/web/test_index_jobs.py
+++ b/test/web/test_index_jobs.py
@@ -251,6 +251,10 @@ def test_catalog_reader_projects_bounded_events_without_worker_authority() -> No
     assert status.status == "running"
     assert status.next_event_sequence == 2
     assert [event.kind for event in status.events] == ["progress", "view_result"]
+    assert [event.event_key for event in status.events] == [
+        "progress-1",
+        "view-result-2",
+    ]
     assert status.events[0].index_type == "bm25"
     assert status.events[0].payload == {"changed_files": 2}
     assert status.events[1].effective_mode == "full"
@@ -260,6 +264,38 @@ def test_catalog_reader_projects_bounded_events_without_worker_authority() -> No
     assert "private-worker" not in serialized
     assert "fencing" not in serialized
     assert "credential-bearing" not in serialized
+    assert "capture-started" not in serialized
+    assert "bm25-result" not in serialized
+
+
+def test_catalog_reader_rereads_job_after_events_that_advance_attempt() -> None:
+    first = _job()
+    second = replace(first, attempt_count=2, updated_at_ms=13)
+    event = replace(
+        _events(first)[0],
+        attempt_count=2,
+        event_key="private-attempt-two-phase",
+        created_at_ms=13,
+    )
+
+    class AdvancingCatalog(_Catalog):
+        def list_job_events(
+            self,
+            job_id: str,
+            *,
+            after_sequence: int = 0,
+            limit: int = 128,
+        ):
+            self.event_calls.append((job_id, after_sequence, limit))
+            self.jobs[job_id] = second
+            return (event,)
+
+    status = _reader(AdvancingCatalog((first,))).get(first.job_id)
+
+    assert status.attempt_count == 2
+    assert status.events[0].attempt_count == 2
+    assert status.events[0].event_key == "progress-1"
+    assert "private-attempt-two-phase" not in status.model_dump_json()
 
 
 def test_catalog_reader_rejects_events_outside_the_attested_job() -> None:


### PR DESCRIPTION
## Summary

Expose authorized durable index-job status and bounded event polling for issue #266. The Web boundary remains read-only and disabled by default until production catalog bindings are explicitly injected.

## Changes

- Add reader-facing schemas for queued, running, succeeded, failed, and cancelled jobs plus primary index surfaces and bounded events.
- Add a least-authority catalog reader with explicit Web-repo to storage-repo/ref bindings.
- Rebind every event to the exact requested job, a causally later monotonic job-state read, and the authorized primary index surface; reject oversized, regressing, or incoherent pages.
- Allow legitimate view-scoped progress events while reserving mode/outcome fields for completed view results.
- Replace executor-controlled event keys with stable Web-owned keys and expose only allowlisted public scalar metrics; omit worker owners, fencing tokens, raw executor messages, private error codes, and arbitrary payload detail.
- Add `GET /api/index-jobs/{job_id}` with generic not-found and unavailable boundaries.
- Overlay queued/running jobs onto repository index status only after the cancellation-safe RCU projection thread settles and releases its bundle pin.
- Keep the default server read/write-disabled until a production job reader is configured.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/web/test_index_jobs.py test/web/test_index_status.py test/web/test_schemas.py --tb=short` (45 passed)
- `pytest -q test/web -k 'not request_timing_header_and_slow_log_exclude_query' --tb=short` (436 passed, 1 known logging baseline deselected)
- `python -m mkdocs build --strict`
- `python scripts/check_public_docs.py`
- `pre-commit run --from-ref origin/main --to-ref HEAD`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
