### PR TITLE
fix(web): prevent registry cleanup lock cycles

### DIFF
--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -21,6 +21,7 @@ from functools import partial
 from importlib.util import find_spec
 from threading import Lock, RLock, local
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Tuple
+from weakref import ReferenceType, ref
 
 from .._atomic_directory import _annotate_secondary_error
 from .._owned_file_publication import _CancellationSafeRLock
@@ -47,6 +48,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 _REGISTRY_CLEANUP_CONTEXT = local()
 _REGISTRY_RELOAD_CONTEXT = local()
+_REGISTRY_DEFERRED_DRAIN_CONTEXT = local()
 _REGISTRY_LOCK_RESULT_MISSING = object()
 
 
@@ -56,6 +58,16 @@ class _RegistryLockOutcome:
 
     value: Any = _REGISTRY_LOCK_RESULT_MISSING
     error: BaseException | None = None
+
+
+class _DeferredRegistryDrain:
+    """One strong cleanup wakeup that can be invalidated across threads."""
+
+    __slots__ = ("registry", "token", "__weakref__")
+
+    def __init__(self, registry: "RepoRegistry") -> None:
+        self.registry: RepoRegistry | None = registry
+        self.token = object()
 
 
 def _capture_registry_lock_outcome(
@@ -124,6 +136,64 @@ def _settle_registry_lock_outcome(outcome: _RegistryLockOutcome) -> Any:
         if outcome.error is not None and outcome.error is not unwrap_failure:
             _raise_with_cleanup_failure(outcome.error, unwrap_failure)
         raise
+
+
+def _deferred_registry_drain_entries() -> Tuple[_DeferredRegistryDrain, ...]:
+    """Return live cleanup tickets queued by this thread."""
+
+    entries = getattr(_REGISTRY_DEFERRED_DRAIN_CONTEXT, "entries", ())
+    live = tuple(entry for entry in entries if entry.registry is not None)
+    if len(live) != len(entries):
+        try:
+            _REGISTRY_DEFERRED_DRAIN_CONTEXT.entries = live
+        finally:
+            _REGISTRY_DEFERRED_DRAIN_CONTEXT.entries = live
+    return live
+
+
+def _defer_registry_retired_drain(registry: "RepoRegistry") -> None:
+    """Keep one identity-deduplicated retired drain reachable for settlement."""
+
+    pending = _deferred_registry_drain_entries()
+    with registry._generation_lock:
+        if not registry._retired_bundles:
+            registry._invalidate_deferred_drain_tickets_locked()
+            return
+        ticket = next(
+            (entry for entry in pending if entry.registry is registry),
+            None,
+        )
+        if ticket is None:
+            ticket = _DeferredRegistryDrain(registry)
+            pending = (*pending, ticket)
+            registry._deferred_drain_tickets[:] = [
+                ticket_ref
+                for ticket_ref in registry._deferred_drain_tickets
+                if ticket_ref() is not None
+            ]
+            registry._deferred_drain_tickets.append(ref(ticket))
+        else:
+            ticket.token = object()
+        try:
+            _REGISTRY_DEFERRED_DRAIN_CONTEXT.entries = pending
+        finally:
+            _REGISTRY_DEFERRED_DRAIN_CONTEXT.entries = pending
+
+
+def _remove_deferred_registry_retired_drain(registry: "RepoRegistry") -> None:
+    """Discard this thread's settled or lease-blocked tickets for a registry."""
+
+    pending = _deferred_registry_drain_entries()
+    removed = tuple(entry for entry in pending if entry.registry is registry)
+    if not removed:
+        return
+    for ticket in removed:
+        registry._discard_deferred_drain_ticket(ticket)
+    updated = tuple(entry for entry in pending if entry.registry is not None)
+    try:
+        _REGISTRY_DEFERRED_DRAIN_CONTEXT.entries = updated
+    finally:
+        _REGISTRY_DEFERRED_DRAIN_CONTEXT.entries = updated
 
 
 def _live_registry_thread_context(
@@ -878,6 +948,10 @@ class RepoRegistry:
         self._cleanup_in_progress: Dict[int, Optional[int]] = {}
         self._orphan_cleanup_in_progress: set[int] = set()
         self._orphan_cleanup_owners: List[Any] = []
+        # Deferred drain tickets strongly retain this registry only until a
+        # cleanup attempt settles. Keep weak back-references so another thread
+        # can invalidate stale thread-local tickets after a successful retry.
+        self._deferred_drain_tickets: List[ReferenceType[_DeferredRegistryDrain]] = []
         # Cleanup mutates retryable owners outside the generation lock. Keep
         # every drain and close serialized so shutdown cannot return while a
         # different thread is still closing an unleased generation or owner.
@@ -936,7 +1010,7 @@ class RepoRegistry:
             )
         )
 
-    def _run_registry_lock(
+    def _run_registry_lock_once(
         self,
         lock: _CancellationSafeRLock,
         operation: Callable[[], Any],
@@ -979,6 +1053,95 @@ class RepoRegistry:
             if outcome.error is not None and outcome.error is not settlement_failure:
                 _raise_with_cleanup_failure(outcome.error, settlement_failure)
             raise
+
+    def _flush_deferred_retired_drains(
+        self,
+        *,
+        attempted_tokens: Optional[set[object]] = None,
+    ) -> BaseException | None:
+        """Drain cross-registry lease releases after every lock edge is gone."""
+
+        first_failure: BaseException | None = None
+        attempted = set(attempted_tokens or ())
+        while True:
+            target_entry = None
+            for ticket in _deferred_registry_drain_entries():
+                target = ticket.registry
+                token = ticket.token
+                if target is not None and token not in attempted:
+                    target_entry = (ticket, target, token)
+                    break
+            if target_entry is None:
+                break
+            ticket, target, token = target_entry
+            attempted.add(token)
+            failure: BaseException | None = None
+            try:
+                failure = target._drain_retired(settle_deferred=False)
+            except BaseException as exc:  # noqa: B036 - settle after locks
+                failure = exc
+            try:
+                _, waits_for_lease = target._retired_drain_state()
+            except BaseException as exc:  # noqa: B036 - keep retry authority
+                waits_for_lease = False
+                failure = _retain_cleanup_failure(failure, exc)
+            if failure is None and waits_for_lease:
+                target._discard_deferred_drain_ticket(
+                    ticket,
+                    expected_token=token,
+                )
+            if failure is not None:
+                first_failure = _retain_cleanup_failure(
+                    first_failure,
+                    failure,
+                )
+        return first_failure
+
+    def _can_flush_deferred_retired_drains(self) -> bool:
+        """Whether this thread has released every registry lifecycle edge."""
+
+        return (
+            not self._cleanup_lock.held_by_current_thread()
+            and not self._registry_reload_lock.held_by_current_thread()
+            and not self._cleanup_callback_is_active()
+            and not self._reload_operation_is_active()
+        )
+
+    def _run_registry_lock(
+        self,
+        lock: _CancellationSafeRLock,
+        operation: Callable[[], Any],
+    ) -> Any:
+        """Run one nested lock scope and settle deferred drains at its edge."""
+
+        outcome = _RegistryLockOutcome()
+        deferred_failure: BaseException | None = None
+        try:
+            outcome.value = self._run_registry_lock_once(lock, operation)
+        except BaseException as exc:  # noqa: B036 - settle deferred work next
+            outcome.error = exc
+
+        if self._can_flush_deferred_retired_drains():
+            try:
+                deferred_failure = self._flush_deferred_retired_drains()
+            except BaseException as exc:  # noqa: B036 - retain durable queue
+                deferred_failure = exc
+
+        primary = outcome.error
+        if primary is not None:
+            if deferred_failure is not None:
+                _raise_with_cleanup_failure(primary, deferred_failure)
+            raise primary
+        if deferred_failure is not None:
+            if not issubclass(type(deferred_failure), Exception):
+                raise deferred_failure
+            _log_cleanup_failure(
+                "Deferred repository cleanup remains pending: %s",
+                deferred_failure,
+            )
+        if outcome.value is _REGISTRY_LOCK_RESULT_MISSING:
+            raise RuntimeError("registry lifecycle lock did not run its operation")
+        return outcome.value
 
     def _run_serialized_cleanup(self, operation: Callable[[], Any]) -> Any:
         """Serialize mutation of retryable cleanup authorities."""
@@ -1539,6 +1702,8 @@ class RepoRegistry:
                             previous.source_cleanup_owner
                         )
                         self._retired_bundles.pop(id(previous.bundle), None)
+                        if not self._retired_bundles:
+                            self._invalidate_deferred_drain_tickets_locked()
                 raise
         failure = self._drain_retired()
         if failure is not None:
@@ -1755,6 +1920,8 @@ class RepoRegistry:
                 ]
             if complete and self._retired_bundles.get(key) is owned:
                 self._retired_bundles.pop(key, None)
+            if not self._retired_bundles:
+                self._invalidate_deferred_drain_tickets_locked()
 
     def _settle_orphan_cleanup_claim(
         self,
@@ -1776,6 +1943,7 @@ class RepoRegistry:
         self,
         *,
         only_keys: Optional[set[int]] = None,
+        settle_deferred: bool = True,
     ) -> Optional[BaseException]:
         def operation() -> Optional[BaseException]:
             first_failure: BaseException | None = None
@@ -1875,9 +2043,14 @@ class RepoRegistry:
                                 self._release_retired_cleanup_claim(key)
                         except BaseException as exc:  # noqa: B036 - claim is durable
                             first_failure = _retain_cleanup_failure(first_failure, exc)
+            with self._generation_lock:
+                if not self._retired_bundles:
+                    self._invalidate_deferred_drain_tickets_locked()
             return first_failure
 
-        return self._run_serialized_cleanup(operation)
+        if settle_deferred:
+            return self._run_serialized_cleanup(operation)
+        return self._run_registry_lock_once(self._cleanup_lock, operation)
 
     def _drain_orphan_cleanup(self) -> Optional[BaseException]:
         def operation() -> Optional[BaseException]:
@@ -2461,6 +2634,47 @@ class RepoRegistry:
                     keys = fallback_keys
         return keys
 
+    def _discard_deferred_drain_ticket(
+        self,
+        ticket: _DeferredRegistryDrain,
+        *,
+        expected_token: object | None = None,
+    ) -> bool:
+        """Invalidate one exact deferred wakeup under generation ownership."""
+
+        with self._generation_lock:
+            if ticket.registry is not self or (
+                expected_token is not None and ticket.token is not expected_token
+            ):
+                return False
+            ticket.registry = None
+            self._deferred_drain_tickets[:] = [
+                ticket_ref
+                for ticket_ref in self._deferred_drain_tickets
+                if ticket_ref() is not None and ticket_ref() is not ticket
+            ]
+            return True
+
+    def _invalidate_deferred_drain_tickets_locked(self) -> None:
+        """Release every cross-thread ticket after all retired work settles."""
+
+        for ticket_ref in self._deferred_drain_tickets:
+            ticket = ticket_ref()
+            if ticket is not None and ticket.registry is self:
+                ticket.registry = None
+        self._deferred_drain_tickets.clear()
+
+    def _retired_drain_state(self) -> Tuple[bool, bool]:
+        """Return pending state and whether leases alone block its drain."""
+
+        with self._generation_lock:
+            pending = bool(self._retired_bundles)
+            if not pending:
+                self._invalidate_deferred_drain_tickets_locked()
+            return pending, pending and all(
+                self._bundle_key_is_leased_locked(key) for key in self._retired_bundles
+            )
+
     def _release_bundle_lease(self, lease_token: object) -> None:
         self._drop_bundle_lease(lease_token)
         cross_cleanup_callback = (
@@ -2475,10 +2689,45 @@ class RepoRegistry:
             # The pin may have been entered before this cross-registry cleanup
             # callback or reload began. Its lease must still be dropped, but
             # synchronously taking the other registry's cleanup lock would let
-            # reciprocal operations form an ABBA cycle. Leave the now-unleased
-            # generation durable for the next ordinary release or shutdown.
+            # reciprocal operations form an ABBA cycle. Queue the now-unleased
+            # generation for the current thread's outermost lifecycle-lock
+            # settlement, after every registry lock on that thread is gone.
+            _defer_registry_retired_drain(self)
             return
-        failure = self._drain_retired()
+        # This release is itself the wakeup for the target generation. Do not
+        # let the generic lock wrapper immediately retry an older deferred
+        # ticket before this first failure has been classified and retained.
+        failure = self._drain_retired(settle_deferred=False)
+        pending, waits_for_lease = self._retired_drain_state()
+        if pending and (failure is not None or not waits_for_lease):
+            _defer_registry_retired_drain(self)
+        else:
+            _remove_deferred_registry_retired_drain(self)
+        # Cleanup callbacks may have released another registry's final lease.
+        # Settle those tickets now that this cleanup lock is gone, but do not
+        # retry this registry's just-attempted owner in the same unwind epoch.
+        deferred_failure: BaseException | None = None
+        if self._can_flush_deferred_retired_drains():
+            attempted_tokens = {
+                ticket.token
+                for ticket in _deferred_registry_drain_entries()
+                if ticket.registry is self
+            }
+            try:
+                deferred_failure = self._flush_deferred_retired_drains(
+                    attempted_tokens=attempted_tokens,
+                )
+            except BaseException as exc:  # noqa: B036 - tickets retain retry state
+                deferred_failure = exc
+        if failure is not None and deferred_failure is not None:
+            if not issubclass(type(failure), Exception) or not issubclass(
+                type(deferred_failure),
+                Exception,
+            ):
+                _raise_with_cleanup_failure(failure, deferred_failure)
+            failure = _retain_cleanup_failure(failure, deferred_failure)
+        elif deferred_failure is not None:
+            failure = deferred_failure
         if failure is not None:
             if not issubclass(type(failure), Exception):
                 raise failure

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -19,10 +19,11 @@ from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from functools import partial
 from importlib.util import find_spec
-from threading import Lock, RLock
+from threading import Lock, RLock, local
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 from .._atomic_directory import _annotate_secondary_error
+from .._owned_file_publication import _CancellationSafeRLock
 from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
 from ..compiler.manifest import IndexEntry, RepoManifest
 from ..index.embedding._lifecycle import close_vector_after_failure
@@ -44,6 +45,212 @@ if TYPE_CHECKING:
     from ..source_fingerprint import RepositorySourceBinding, RepositorySourceReader
 
 logger = get_logger(__name__)
+_REGISTRY_CLEANUP_CONTEXT = local()
+_REGISTRY_RELOAD_CONTEXT = local()
+_REGISTRY_LOCK_RESULT_MISSING = object()
+
+
+@dataclass(slots=True)
+class _RegistryLockOutcome:
+    """One lock callback result carried across normal lock settlement."""
+
+    value: Any = _REGISTRY_LOCK_RESULT_MISSING
+    error: BaseException | None = None
+
+
+def _capture_registry_lock_outcome(
+    operation: Callable[[], Any],
+    captured: List[_RegistryLockOutcome],
+) -> _RegistryLockOutcome:
+    """Keep operation failures out of the lifecycle lock's unwind path."""
+
+    outcome = _RegistryLockOutcome()
+    captured.append(outcome)
+    try:
+        outcome.value = operation()
+    except BaseException as error:  # noqa: B036 - unwrap after lock release
+        outcome.error = error
+    return outcome
+
+
+def _base_exception_context(error: BaseException) -> BaseException | None:
+    """Read one operation-origin context without hostile attribute dispatch."""
+
+    try:
+        context = vars(BaseException)["__context__"].__get__(error, type(error))
+    except BaseException:  # noqa: B036 - inspection cannot replace failure
+        return None
+    if not issubclass(type(context), BaseException):
+        return None
+    try:
+        error_traceback = vars(BaseException)["__traceback__"].__get__(
+            error,
+            type(error),
+        )
+        capture_frames = []
+        while error_traceback is not None:
+            frame = error_traceback.tb_frame
+            if frame.f_code is _capture_registry_lock_outcome.__code__:
+                capture_frames.append(frame)
+            error_traceback = error_traceback.tb_next
+        context_traceback = vars(BaseException)["__traceback__"].__get__(
+            context,
+            type(context),
+        )
+        while context_traceback is not None:
+            frame = context_traceback.tb_frame
+            if any(frame is capture_frame for capture_frame in capture_frames):
+                return context
+            context_traceback = context_traceback.tb_next
+    except BaseException:  # noqa: B036 - inspection cannot replace failure
+        return None
+    return None
+
+
+def _unwrap_registry_lock_outcome(outcome: _RegistryLockOutcome) -> Any:
+    """Return or raise one durable result after its lock has settled."""
+
+    if outcome.error is not None:
+        raise outcome.error
+    return outcome.value
+
+
+def _settle_registry_lock_outcome(outcome: _RegistryLockOutcome) -> Any:
+    """Preserve a durable operation failure across an interrupted unwrap."""
+
+    try:
+        return _unwrap_registry_lock_outcome(outcome)
+    except BaseException as unwrap_failure:  # noqa: B036 - retain primary
+        if outcome.error is not None and outcome.error is not unwrap_failure:
+            _raise_with_cleanup_failure(outcome.error, unwrap_failure)
+        raise
+
+
+def _live_registry_thread_context(
+    context: Any,
+    lock_attribute: str,
+) -> Tuple["RepoRegistry", ...]:
+    """Return markers whose guarding lock is still owned by this thread.
+
+    An asynchronous exception can land after a context manager's ``__enter__``
+    has stored its thread-local marker but before the ``with`` statement has
+    installed ``__exit__``.  The surrounding registry operation still releases
+    its real RLock while unwinding.  Treat that lock as the durable authority
+    and prune any marker that outlives it, so one interrupted callback cannot
+    poison every later operation on the same thread.
+    """
+
+    registries = getattr(context, "registries", ())
+    active = []
+    for registry in registries:
+        lock = object.__getattribute__(registry, lock_attribute)
+        if lock.held_by_current_thread():
+            active.append(registry)
+    if len(active) != len(registries):
+        live = tuple(active)
+        try:
+            context.registries = live
+        finally:
+            context.registries = live
+        return live
+    return registries
+
+
+class _RegistryThreadContext:
+    """Track one registry lock context with interruption-safe settlement."""
+
+    __slots__ = ("_context", "_kind", "_previous_registries", "_registry")
+
+    def __init__(self, context: Any, registry: "RepoRegistry", kind: str) -> None:
+        self._context = context
+        self._registry = registry
+        self._kind = kind
+        self._previous_registries: Tuple["RepoRegistry", ...] = ()
+
+    def _activate(self) -> None:
+        self._previous_registries = getattr(
+            self._context,
+            "registries",
+            (),
+        )
+        try:
+            self._context.registries = (
+                *self._previous_registries,
+                self._registry,
+            )
+        except BaseException:  # noqa: B036 - never leave a partial marker
+            try:
+                self._context.registries = self._previous_registries
+            finally:
+                self._context.registries = self._previous_registries
+            raise
+
+    def _restore(self) -> BaseException | None:
+        failure: BaseException | None = None
+        try:
+            self._context.registries = self._previous_registries
+        except BaseException as exc:  # noqa: B036 - retry restoration below
+            failure = exc
+        finally:
+            try:
+                self._context.registries = self._previous_registries
+            except BaseException as exc:  # noqa: B036 - preserve both failures
+                failure = _retain_cleanup_failure(failure, exc)
+        return failure
+
+    def run(self, operation: Callable[[], Any]) -> Any:
+        """Run one callback after installing all marker-cleanup finalizers."""
+
+        missing = object()
+        result: Any = missing
+        primary: BaseException | None = None
+        restore_failure: BaseException | None = None
+        try:
+            try:
+                try:
+                    self._activate()
+                    result = operation()
+                except BaseException as exc:  # noqa: B036 - settle exact primary
+                    primary = exc
+                retry_failure = self._restore()
+                if retry_failure is not None:
+                    restore_failure = _retain_cleanup_failure(
+                        restore_failure,
+                        retry_failure,
+                    )
+            except BaseException as exc:  # noqa: B036 - retry below
+                restore_failure = _retain_cleanup_failure(
+                    restore_failure,
+                    exc,
+                )
+        finally:
+            # This outer settlement is installed before marker activation, so
+            # even an asynchronous exception at an inner-finally boundary gets
+            # a second idempotent restoration attempt.
+            try:
+                retry_failure = self._restore()
+            except BaseException as exc:  # noqa: B036 - retain exact failure
+                restore_failure = _retain_cleanup_failure(
+                    restore_failure,
+                    exc,
+                )
+            else:
+                if retry_failure is not None:
+                    restore_failure = _retain_cleanup_failure(
+                        restore_failure,
+                        retry_failure,
+                    )
+
+        if primary is not None:
+            if restore_failure is not None:
+                _raise_with_cleanup_failure(primary, restore_failure)
+            raise primary
+        if restore_failure is not None:
+            raise restore_failure
+        if result is missing:
+            raise RuntimeError("registry thread context did not run its operation")
+        return result
+
 
 _SKILLS_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
@@ -674,68 +881,152 @@ class RepoRegistry:
         # Cleanup mutates retryable owners outside the generation lock. Keep
         # every drain and close serialized so shutdown cannot return while a
         # different thread is still closing an unleased generation or owner.
-        self._cleanup_lock = RLock()
-        # A request that releases its generation while a reload owns the
-        # cleanup boundary must not wait for a potentially slow candidate
-        # build. Exact operation tokens make that deferral cancellation-safe;
-        # the outermost reload drops its token before one final drain.
-        self._reload_preparations: set[object] = set()
+        self._cleanup_lock = _CancellationSafeRLock()
         self._closed = False
         # Serialize registry-file snapshots through publication and removal
         # reconciliation. Without this boundary, an older load_all() could
         # retire a generation that a concurrent refresh() just published from
-        # a newer snapshot.
-        self._registry_reload_lock = RLock()
+        # a newer snapshot. External reload/shutdown paths take this before
+        # cleanup; cleanup callbacks never reenter it.
+        self._registry_reload_lock = _CancellationSafeRLock()
         # One embedding model per model name, shared across repos: the GPU model
         # is loaded once instead of once per CodeVectorStore (one per repo).
         self._embeddings: Dict[Tuple[str, str, int, Optional[str], str], object] = {}
         self._embedding_load_lock = RLock()
 
-    @contextmanager
-    def _reload_preparation_boundary(self) -> Iterator[None]:
-        """Serialize a reload and settle leases deferred during its build."""
+    def _cleanup_callback_is_active(self) -> bool:
+        """Whether this thread is executing any registry cleanup hook."""
 
-        token = object()
-        primary: BaseException | None = None
-        cleanup_failure: BaseException | None = None
-        with self._cleanup_lock, self._registry_reload_lock:
-            try:
-                with self._generation_lock:
-                    self._reload_preparations.add(token)
-                try:
-                    yield
-                except BaseException as exc:  # noqa: B036 - settle boundary first
-                    primary = exc
-            finally:
-                final_drain = False
-                try:
-                    try:
-                        with self._generation_lock:
-                            self._reload_preparations.discard(token)
-                    finally:
-                        # A trace/signal exception after the first discard
-                        # cannot leave every future lease release deferred.
-                        with self._generation_lock:
-                            self._reload_preparations.discard(token)
-                            final_drain = not self._reload_preparations
-                    if final_drain:
-                        cleanup_failure = self._drain_retired()
-                except BaseException as exc:  # noqa: B036 - preserve body failure
-                    cleanup_failure = _retain_cleanup_failure(
-                        cleanup_failure,
-                        exc,
-                    )
-        if primary is not None:
-            if cleanup_failure is not None:
-                _raise_with_cleanup_failure(primary, cleanup_failure)
-            raise primary
-        if cleanup_failure is not None:
-            if not issubclass(type(cleanup_failure), Exception):
-                raise cleanup_failure
-            _log_cleanup_failure(
-                "Deferred repository cleanup remains pending: %s",
-                cleanup_failure,
+        return bool(
+            _live_registry_thread_context(
+                _REGISTRY_CLEANUP_CONTEXT,
+                "_cleanup_lock",
             )
+        )
+
+    def _owns_current_cleanup_callback(self) -> bool:
+        """Whether this thread owns this registry through a cleanup hook."""
+
+        return any(
+            registry is self
+            for registry in _live_registry_thread_context(
+                _REGISTRY_CLEANUP_CONTEXT,
+                "_cleanup_lock",
+            )
+        )
+
+    def _reload_operation_is_active(self) -> bool:
+        """Whether this thread is inside any serialized registry reload."""
+
+        return bool(
+            _live_registry_thread_context(
+                _REGISTRY_RELOAD_CONTEXT,
+                "_registry_reload_lock",
+            )
+        )
+
+    def _owns_current_reload_operation(self) -> bool:
+        """Whether this thread owns this registry's reload operation."""
+
+        return any(
+            registry is self
+            for registry in _live_registry_thread_context(
+                _REGISTRY_RELOAD_CONTEXT,
+                "_registry_reload_lock",
+            )
+        )
+
+    def _run_registry_lock(
+        self,
+        lock: _CancellationSafeRLock,
+        operation: Callable[[], Any],
+    ) -> Any:
+        """Run one operation and unwrap its failure only after lock release."""
+
+        baseline = lock._logical_depth()
+        captured: List[_RegistryLockOutcome] = []
+        try:
+            outcome = lock.run(
+                partial(
+                    _capture_registry_lock_outcome,
+                    operation,
+                    captured,
+                )
+            )
+        except BaseException as lock_failure:  # noqa: B036 - reconcile first
+            # ``run`` normally reconciles both acquisition and release. This
+            # outer pass covers an asynchronous exception at its own handler or
+            # normal-settlement entry before that reconciliation call starts.
+            lock._release_preserving(baseline, lock_failure)
+            outcome = captured[-1] if captured else None
+            operation_failure = outcome.error if outcome is not None else None
+            if (
+                operation_failure is None
+                and outcome is not None
+                and outcome.value is _REGISTRY_LOCK_RESULT_MISSING
+            ):
+                # An asynchronous exception may land at the operation's except
+                # handler before its error can be stored in the durable slot.
+                # CPython retains that earlier exact object as the implicit
+                # context; inspect it without caller-defined dispatch.
+                operation_failure = _base_exception_context(lock_failure)
+            if operation_failure is not None:
+                _raise_with_cleanup_failure(operation_failure, lock_failure)
+            raise
+        try:
+            return _settle_registry_lock_outcome(outcome)
+        except BaseException as settlement_failure:  # noqa: B036 - retry once
+            if outcome.error is not None and outcome.error is not settlement_failure:
+                _raise_with_cleanup_failure(outcome.error, settlement_failure)
+            raise
+
+    def _run_serialized_cleanup(self, operation: Callable[[], Any]) -> Any:
+        """Serialize mutation of retryable cleanup authorities."""
+
+        return self._run_registry_lock(self._cleanup_lock, operation)
+
+    def _cleanup_callback(self) -> _RegistryThreadContext:
+        """Mark caller cleanup code so registry reentry cannot invert locks."""
+
+        return _RegistryThreadContext(
+            _REGISTRY_CLEANUP_CONTEXT,
+            self,
+            "cleanup",
+        )
+
+    def _run_cleanup_callback(self, operation: Callable[[], Any]) -> Any:
+        """Run caller cleanup code under an interruption-safe thread marker."""
+
+        return self._cleanup_callback().run(operation)
+
+    def _run_serialized_reload(self, operation: Callable[[], Any]) -> Any:
+        """Serialize one reload without holding cleanup across candidate builds."""
+
+        if self._cleanup_callback_is_active():
+            raise RuntimeError("repository reload cannot start during cleanup")
+        if self._reload_operation_is_active():
+            raise RuntimeError("repository reload cannot reenter another reload")
+
+        def reload_operation() -> Any:
+            # Join cleanup already in flight before the registry snapshot, but
+            # release cleanup while metadata and runtime views are prepared.
+            def require_open() -> None:
+                with self._generation_lock:
+                    if self._closed:
+                        raise RuntimeError("repository registry is closed")
+
+            self._run_serialized_cleanup(require_open)
+            marker = _RegistryThreadContext(
+                _REGISTRY_RELOAD_CONTEXT,
+                self,
+                "reload",
+            )
+            return marker.run(operation)
+
+        return self._run_registry_lock(
+            self._registry_reload_lock,
+            reload_operation,
+        )
 
     def load_all(self) -> None:
         """Load registry metadata, atomically replacing matching generations.
@@ -746,10 +1037,7 @@ class RepoRegistry:
         while active repositories absent from the complete snapshot are retired.
         """
 
-        with self._reload_preparation_boundary():
-            with self._generation_lock:
-                if self._closed:
-                    raise RuntimeError("repository registry is closed")
+        def operation() -> None:
             entries = load_registry(self._config.registry_path)
             if not entries:
                 logger.warning(
@@ -808,6 +1096,8 @@ class RepoRegistry:
                 raise shutdown_failure
             self._raise_if_closed_after_cleanup()
 
+        self._run_serialized_reload(operation)
+
     def refresh(self, repo_id: str) -> None:
         """Prepare and atomically publish a complete new bundle generation.
 
@@ -817,29 +1107,34 @@ class RepoRegistry:
         unleased bundle that another concurrent refresh could retire.
         """
 
-        with self._reload_preparation_boundary():
-            with self._generation_lock:
-                if self._closed:
-                    raise RuntimeError("repository registry is closed")
-            repo_id = _plain_repo_instance_id(repo_id)
+        requested_repo_id = repo_id
+
+        def operation() -> None:
+            plain_repo_id = _plain_repo_instance_id(requested_repo_id)
             entries = []
             for entry in load_registry(self._config.registry_path):
                 try:
                     instance_id = _plain_repo_instance_id(entry.instance_id)
                 except ValueError as exc:
-                    logger.error("Skipping malformed repository entry: %s", exc)
+                    logger.error(
+                        "Skipping invalid repository entry while refreshing %r: %s",
+                        plain_repo_id,
+                        exc,
+                    )
                     continue
-                if instance_id == repo_id:
+                if instance_id == plain_repo_id:
                     entries.append(entry)
             if len(entries) != 1:
                 raise ValueError(
                     "repository registry must contain exactly one entry for "
-                    f"{repo_id!r}"
+                    f"{plain_repo_id!r}"
                 )
             entry = entries[0]
             if not os.path.exists(entry.manifest_path):
                 raise FileNotFoundError(entry.manifest_path)
             self._replace_entry(entry, prepare_runtime=True)
+
+        self._run_serialized_reload(operation)
 
     def _raise_if_closed_after_cleanup(
         self,
@@ -1031,10 +1326,7 @@ class RepoRegistry:
     def _load_repo_metadata(self, entry: RepoEntry) -> RepoBundle:
         """Legacy metadata loader used by offline callers and focused tests."""
 
-        with self._reload_preparation_boundary():
-            with self._generation_lock:
-                if self._closed:
-                    raise RuntimeError("repository registry is closed")
+        def operation() -> RepoBundle:
             instance_id = _plain_repo_instance_id(entry.instance_id)
             try:
                 owned = self._build_repo_metadata(entry)
@@ -1078,6 +1370,8 @@ class RepoRegistry:
                     _raise_with_cleanup_failure(error, cleanup_failure)
                 raise error
             return owned.bundle
+
+        return self._run_serialized_reload(operation)
 
     def _retain_exception_cleanup(
         self,
@@ -1128,8 +1422,13 @@ class RepoRegistry:
         owned: _OwnedRepoBundle,
     ) -> None:
         instance_id = _plain_repo_instance_id(instance_id)
-        with self._cleanup_lock:
-            self._publish_owned_under_cleanup_lock(instance_id, owned)
+        self._run_serialized_cleanup(
+            partial(
+                self._publish_owned_under_cleanup_lock,
+                instance_id,
+                owned,
+            )
+        )
 
     def _publish_owned_under_cleanup_lock(
         self,
@@ -1158,9 +1457,15 @@ class RepoRegistry:
                 raise RuntimeError("repository source cleanup authority is pending")
 
         # The caller owns the cleanup lock, but no generation lock, while this
-        # caller-defined descriptor runs. All reload paths take locks in the
-        # same cleanup -> reload order, so reentrant shutdown cannot deadlock.
-        authority_closed = authority is not None and bool(authority.closed)
+        # caller-defined descriptor runs. Reload paths reject cleanup-callback
+        # reentry, while a reentrant shutdown marks the registry closed without
+        # waiting on the reload operation that is currently settling it.
+        if authority is None:
+            authority_closed = False
+        else:
+            authority_closed = self._run_cleanup_callback(
+                lambda: bool(authority.closed)
+            )
 
         with self._generation_lock:
             if self._closed:
@@ -1472,7 +1777,7 @@ class RepoRegistry:
         *,
         only_keys: Optional[set[int]] = None,
     ) -> Optional[BaseException]:
-        with self._cleanup_lock:
+        def operation() -> Optional[BaseException]:
             first_failure: BaseException | None = None
             with self._generation_lock:
                 candidates = [
@@ -1537,9 +1842,12 @@ class RepoRegistry:
                                 owned.source_binding = None
                             elif binding is not None:
                                 owned.source_binding = None
-                    complete = self._close_owned(
-                        owned,
-                        close_authority=not suppress_authority,
+                    complete = self._run_cleanup_callback(
+                        partial(
+                            self._close_owned,
+                            owned,
+                            close_authority=not suppress_authority,
+                        )
                     )
                 except BaseException as exc:  # noqa: B036 - visit every generation
                     first_failure = _retain_cleanup_failure(first_failure, exc)
@@ -1569,8 +1877,10 @@ class RepoRegistry:
                             first_failure = _retain_cleanup_failure(first_failure, exc)
             return first_failure
 
+        return self._run_serialized_cleanup(operation)
+
     def _drain_orphan_cleanup(self) -> Optional[BaseException]:
-        with self._cleanup_lock:
+        def operation() -> Optional[BaseException]:
             first_failure: BaseException | None = None
             with self._generation_lock:
                 owners: List[Any] = []
@@ -1616,7 +1926,9 @@ class RepoRegistry:
                         attempted_authority_ids.add(authority_id)
                         claimed = True
                         self._orphan_cleanup_in_progress.add(authority_id)
-                    closed, failure = _close_orphan_cleanup_owner(owner)
+                    closed, failure = self._run_cleanup_callback(
+                        partial(_close_orphan_cleanup_owner, owner)
+                    )
                     if failure is not None:
                         first_failure = _retain_cleanup_failure(
                             first_failure,
@@ -1646,50 +1958,78 @@ class RepoRegistry:
                             first_failure = _retain_cleanup_failure(first_failure, exc)
             return first_failure
 
+        return self._run_serialized_cleanup(operation)
+
     def close(self) -> None:
         """Retire active generations; pinned requests release them later."""
 
-        # A refresh that entered first either publishes or fully retires its
-        # candidate before shutdown can report completion. The cleanup lock
-        # also joins drains started by a final request lease release.
-        with self._cleanup_lock, self._registry_reload_lock:
-            with self._generation_lock:
-                self._closed = True
-                for instance_id in tuple(self._bundles):
-                    self._retire_active_locked(instance_id)
-                # Claim owner-only failures before invoking any caller-owned
-                # close method. The orphan drain removes its queue before each
-                # callback, so a reentrant close cannot acquire the same owner.
-                owner_only_ids = tuple(self._source_cleanup_owners) + tuple(
-                    instance_id
-                    for instance_id in self._source_bindings
-                    if instance_id not in self._source_cleanup_owners
-                )
-                for instance_id in owner_only_ids:
-                    owner = self._source_cleanup_owners.get(instance_id)
-                    binding = self._source_bindings.get(instance_id)
-                    cleanup_owner = owner if owner is not None else binding
-                    if cleanup_owner is not None and not any(
-                        candidate is cleanup_owner
-                        for candidate in self._orphan_cleanup_owners
-                    ):
-                        # Publish retry ownership before removing either map
-                        # entry, so interruption at any following line leaves a
-                        # reachable authority for the next close attempt.
-                        self._orphan_cleanup_owners.append(cleanup_owner)
-                    self._source_cleanup_owners.pop(instance_id, None)
-                    self._source_bindings.pop(instance_id, None)
+        # Cleanup callbacks may reenter shutdown while a reload thread owns the
+        # reload lock and is waiting to publish under this same cleanup lock.
+        # Waiting for that reload here would form a lock cycle, so the owning
+        # cleanup thread performs the idempotent shutdown transition directly;
+        # the outer reload observes ``_closed`` and settles its candidate.
+        if self._owns_current_cleanup_callback():
+            self._close_under_cleanup_lock()
+            return
+        if self._cleanup_callback_is_active():
+            raise RuntimeError(
+                "repository shutdown cannot cross a registry cleanup callback"
+            )
+        if (
+            self._reload_operation_is_active()
+            and not self._owns_current_reload_operation()
+        ):
+            raise RuntimeError(
+                "repository shutdown cannot cross a registry reload operation"
+            )
 
-            first_failure = self._drain_retired()
+        # An external shutdown joins the complete reload operation first, then
+        # joins any cleanup drain. Slow builds hold only the reload lock, so
+        # unrelated request lease releases remain free to finish.
+        self._run_registry_lock(
+            self._registry_reload_lock,
+            lambda: self._run_serialized_cleanup(self._close_under_cleanup_lock),
+        )
 
-            orphan_failure = self._drain_orphan_cleanup()
-            if orphan_failure is not None:
-                first_failure = _retain_cleanup_failure(
-                    first_failure,
-                    orphan_failure,
-                )
-            if first_failure is not None:
-                raise first_failure
+    def _close_under_cleanup_lock(self) -> None:
+        """Close registry state while the current thread owns cleanup."""
+
+        with self._generation_lock:
+            self._closed = True
+            for instance_id in tuple(self._bundles):
+                self._retire_active_locked(instance_id)
+            # Claim owner-only failures before invoking any caller-owned close
+            # method. The orphan drain removes its queue before each callback,
+            # so a reentrant close cannot acquire the same owner.
+            owner_only_ids = tuple(self._source_cleanup_owners) + tuple(
+                instance_id
+                for instance_id in self._source_bindings
+                if instance_id not in self._source_cleanup_owners
+            )
+            for instance_id in owner_only_ids:
+                owner = self._source_cleanup_owners.get(instance_id)
+                binding = self._source_bindings.get(instance_id)
+                cleanup_owner = owner if owner is not None else binding
+                if cleanup_owner is not None and not any(
+                    candidate is cleanup_owner
+                    for candidate in self._orphan_cleanup_owners
+                ):
+                    # Publish retry ownership before removing either map entry,
+                    # so interruption leaves a reachable authority for retry.
+                    self._orphan_cleanup_owners.append(cleanup_owner)
+                self._source_cleanup_owners.pop(instance_id, None)
+                self._source_bindings.pop(instance_id, None)
+
+        first_failure = self._drain_retired()
+
+        orphan_failure = self._drain_orphan_cleanup()
+        if orphan_failure is not None:
+            first_failure = _retain_cleanup_failure(
+                first_failure,
+                orphan_failure,
+            )
+        if first_failure is not None:
+            raise first_failure
 
     def _load_vector_store(
         self,
@@ -2015,6 +2355,15 @@ class RepoRegistry:
     def pin(self, repo_id: str) -> Iterator[Optional[RepoBundle]]:
         """Pin the current generation for the complete caller operation."""
 
+        if self._cleanup_callback_is_active():
+            raise RuntimeError("repository pin cannot start during cleanup")
+        if (
+            self._reload_operation_is_active()
+            and not self._owns_current_reload_operation()
+        ):
+            raise RuntimeError(
+                "repository pin cannot cross a registry reload operation"
+            )
         lease_token = object()
         bundle: Optional[RepoBundle] = None
         keys: Tuple[int, ...] = ()
@@ -2054,6 +2403,15 @@ class RepoRegistry:
     def pin_all(self) -> Iterator[Tuple[RepoBundle, ...]]:
         """Pin one coherent snapshot of every currently published bundle."""
 
+        if self._cleanup_callback_is_active():
+            raise RuntimeError("repository pin cannot start during cleanup")
+        if (
+            self._reload_operation_is_active()
+            and not self._owns_current_reload_operation()
+        ):
+            raise RuntimeError(
+                "repository pin cannot cross a registry reload operation"
+            )
         lease_token = object()
         active = False
         bundles: Tuple[RepoBundle, ...] = ()
@@ -2105,16 +2463,21 @@ class RepoRegistry:
 
     def _release_bundle_lease(self, lease_token: object) -> None:
         self._drop_bundle_lease(lease_token)
-        with self._generation_lock:
-            closed = self._closed
-            preparing = bool(self._reload_preparations)
-        if not closed and preparing:
-            # The outermost reload performs a final drain after dropping its
-            # operation token. The lease itself is already gone, so this
-            # request need not wait for model/index candidate preparation.
+        cross_cleanup_callback = (
+            self._cleanup_callback_is_active()
+            and not self._owns_current_cleanup_callback()
+        )
+        cross_reload_operation = (
+            self._reload_operation_is_active()
+            and not self._owns_current_reload_operation()
+        )
+        if cross_cleanup_callback or cross_reload_operation:
+            # The pin may have been entered before this cross-registry cleanup
+            # callback or reload began. Its lease must still be dropped, but
+            # synchronously taking the other registry's cleanup lock would let
+            # reciprocal operations form an ABBA cycle. Leave the now-unleased
+            # generation durable for the next ordinary release or shutdown.
             return
-        # Shutdown and ordinary non-reload cleanup retain the blocking
-        # settlement contract: no other owner is responsible for a final drain.
         failure = self._drain_retired()
         if failure is not None:
             if not issubclass(type(failure), Exception):

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -151,8 +151,8 @@ def _deferred_registry_drain_entries() -> Tuple[_DeferredRegistryDrain, ...]:
     return live
 
 
-def _defer_registry_retired_drain(registry: "RepoRegistry") -> None:
-    """Keep one identity-deduplicated retired drain reachable for settlement."""
+def _defer_registry_retired_drain_once(registry: "RepoRegistry") -> None:
+    """Publish one identity-deduplicated retired-drain wakeup."""
 
     pending = _deferred_registry_drain_entries()
     with registry._generation_lock:
@@ -178,6 +178,19 @@ def _defer_registry_retired_drain(registry: "RepoRegistry") -> None:
             _REGISTRY_DEFERRED_DRAIN_CONTEXT.entries = pending
         finally:
             _REGISTRY_DEFERRED_DRAIN_CONTEXT.entries = pending
+
+
+def _defer_registry_retired_drain(registry: "RepoRegistry") -> None:
+    """Keep one retired drain strongly reachable across interruption."""
+
+    try:
+        _defer_registry_retired_drain_once(registry)
+    finally:
+        # The first attempt can be interrupted after the caller drops the
+        # final lease but before its ticket reaches thread-local storage. The
+        # idempotent fallback either finishes that publication or observes
+        # that another thread already settled the retired generations.
+        _defer_registry_retired_drain_once(registry)
 
 
 def _remove_deferred_registry_retired_drain(registry: "RepoRegistry") -> None:

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -9,8 +9,8 @@ import inspect
 import pickle
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from threading import Event, Lock
-from types import SimpleNamespace
+from threading import Barrier, Event, Lock, Thread
+from types import CodeType, SimpleNamespace
 
 import pytest
 
@@ -37,10 +37,15 @@ from codenib.web.config import (
 )
 from codenib.web.repo_registry import (
     _DEMO_SYSTEM_PROMPT,
+    _REGISTRY_CLEANUP_CONTEXT,
+    _REGISTRY_RELOAD_CONTEXT,
     RepoBundle,
     RepoRegistry,
+    _capture_registry_lock_outcome,
     _fresh_registry,
     _OwnedRepoBundle,
+    _settle_registry_lock_outcome,
+    _unwrap_registry_lock_outcome,
 )
 
 
@@ -696,6 +701,165 @@ def test_registry_close_waits_for_inflight_candidate_build(tmp_path, monkeypatch
     assert owner.close_calls == 1
 
 
+def test_registry_slow_refresh_does_not_block_pinned_request_release(
+    tmp_path,
+    monkeypatch,
+):
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    entry = _repo_entry(tmp_path, manifest_path, instance_id="repo")
+    prepare_started = Event()
+    release_prepare = Event()
+    request_pinned = Event()
+    release_request = Event()
+    request_finished = Event()
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    old_owner = Owner()
+    current_owner = Owner()
+    candidate_owner = Owner()
+    old = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    current = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = old
+    registry._source_cleanup_owners["repo"] = old_owner
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: [entry],
+    )
+
+    builds = 0
+
+    def build(_entry):
+        nonlocal builds
+        builds += 1
+        if builds == 1:
+            return _OwnedRepoBundle(current, None, current_owner)
+        return _OwnedRepoBundle(candidate, None, candidate_owner)
+
+    def prepare(bundle):
+        if bundle is candidate:
+            prepare_started.set()
+            assert release_prepare.wait(5)
+
+    def request():
+        try:
+            with registry.pin("repo") as pinned:
+                assert pinned is old
+                request_pinned.set()
+                assert release_request.wait(5)
+        finally:
+            request_finished.set()
+
+    monkeypatch.setattr(registry, "_build_repo_metadata", build)
+    monkeypatch.setattr(registry, "_prepare_runtime_bundle", prepare)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        request_future = pool.submit(request)
+        assert request_pinned.wait(5)
+        registry.refresh("repo")
+        assert registry.get("repo") is current
+        assert registry.retired_generation_count == 1
+        assert old_owner.close_calls == 0
+        refresh_future = pool.submit(registry.refresh, "repo")
+        assert prepare_started.wait(5)
+        try:
+            release_request.set()
+            assert request_finished.wait(1)
+            assert old_owner.close_calls == 1
+            assert registry.retired_generation_count == 0
+        finally:
+            release_request.set()
+            release_prepare.set()
+        request_future.result(timeout=5)
+        refresh_future.result(timeout=5)
+
+    assert current_owner.close_calls == 1
+    assert candidate_owner.close_calls == 0
+    assert registry.get("repo") is candidate
+    registry.close()
+    assert candidate_owner.close_calls == 1
+
+
+@pytest.mark.parametrize("operation", ["load_all", "legacy"])
+def test_registry_slow_metadata_load_does_not_block_cleanup(
+    tmp_path,
+    monkeypatch,
+    operation,
+):
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    entry = _repo_entry(tmp_path, manifest_path, instance_id="repo")
+    build_started = Event()
+    release_build = Event()
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    retired_owner = Owner()
+    candidate_owner = Owner()
+    retired = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    registry._retired_bundles[id(retired)] = _OwnedRepoBundle(
+        retired,
+        None,
+        retired_owner,
+    )
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: [entry],
+    )
+
+    def build(_entry):
+        build_started.set()
+        assert release_build.wait(5)
+        return _OwnedRepoBundle(candidate, None, candidate_owner)
+
+    def load():
+        if operation == "load_all":
+            return registry.load_all()
+        return registry._load_repo_metadata(entry)
+
+    monkeypatch.setattr(registry, "_build_repo_metadata", build)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        load_future = pool.submit(load)
+        assert build_started.wait(5)
+        cleanup_future = pool.submit(registry._drain_retired)
+        try:
+            assert cleanup_future.result(timeout=1) is None
+            assert retired_owner.close_calls == 1
+        finally:
+            release_build.set()
+        result = load_future.result(timeout=5)
+
+    if operation == "legacy":
+        assert result is candidate
+    assert candidate_owner.close_calls == 0
+    registry.close()
+    assert candidate_owner.close_calls == 1
+
+
 def test_registry_close_waits_for_legacy_metadata_build(monkeypatch):
     build_started = Event()
     release_build = Event()
@@ -901,7 +1065,8 @@ def test_registry_close_owner_transfer_interruption_keeps_authority():
     owner = Owner()
     registry = RepoRegistry(QAConfig())
     registry._source_cleanup_owners["repo"] = owner
-    source, first_line = inspect.getsourcelines(RepoRegistry.close)
+    close_impl = RepoRegistry._close_under_cleanup_lock
+    source, first_line = inspect.getsourcelines(close_impl)
     transfer_line = first_line + next(
         index
         for index, line in enumerate(source)
@@ -914,7 +1079,7 @@ def test_registry_close_owner_transfer_interruption_keeps_authority():
         if (
             not triggered
             and event == "line"
-            and frame.f_code is RepoRegistry.close.__code__
+            and frame.f_code is close_impl.__code__
             and frame.f_lineno > transfer_line
         ):
             triggered = True
@@ -1018,6 +1183,1103 @@ def test_registry_refresh_cannot_deadlock_reentrant_retired_cleanup(monkeypatch)
     assert owner.close_calls == 1
     assert registry._closed is True
     assert registry._retired_bundles == {}
+
+
+def test_registry_reentrant_cleanup_close_does_not_wait_for_slow_refresh(
+    tmp_path,
+    monkeypatch,
+):
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    entry = _repo_entry(tmp_path, manifest_path, instance_id="repo")
+    build_started = Event()
+    release_build = Event()
+    close_returned = Event()
+
+    class Owner:
+        def __init__(self, *, reentrant_close=False):
+            self.close_calls = 0
+            self.reentrant_close = reentrant_close
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+            if self.reentrant_close:
+                try:
+                    registry.close()
+                finally:
+                    close_returned.set()
+
+    retired_owner = Owner(reentrant_close=True)
+    candidate_owner = Owner()
+    retired = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    registry._retired_bundles[id(retired)] = _OwnedRepoBundle(
+        retired,
+        None,
+        retired_owner,
+    )
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: [entry],
+    )
+
+    def build(_entry):
+        build_started.set()
+        assert release_build.wait(5)
+        return _OwnedRepoBundle(candidate, None, candidate_owner)
+
+    monkeypatch.setattr(registry, "_build_repo_metadata", build)
+    monkeypatch.setattr(registry, "_prepare_runtime_bundle", lambda _bundle: None)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        refresh = pool.submit(registry.refresh, "repo")
+        assert build_started.wait(5)
+        cleanup = pool.submit(registry._drain_retired)
+        try:
+            assert close_returned.wait(1)
+        finally:
+            release_build.set()
+        assert cleanup.result(timeout=5) is None
+        with pytest.raises(RuntimeError, match="repository registry is closed"):
+            refresh.result(timeout=5)
+
+    assert retired_owner.close_calls == 1
+    assert candidate_owner.close_calls == 1
+    assert registry._retired_bundles == {}
+
+
+@pytest.mark.parametrize("operation", ["load_all", "refresh", "legacy"])
+def test_registry_cleanup_callback_rejects_reentrant_reload(operation):
+    failures = []
+    registry = RepoRegistry(QAConfig())
+
+    class Owner:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            try:
+                if operation == "load_all":
+                    registry.load_all()
+                elif operation == "refresh":
+                    registry.refresh("repo")
+                else:
+                    registry._load_repo_metadata(SimpleNamespace(instance_id="repo"))
+            except BaseException as exc:  # noqa: B036 - assert exact boundary
+                failures.append(exc)
+            self.closed = True
+
+    owner = Owner()
+    registry._orphan_cleanup_owners.append(owner)
+
+    assert registry._drain_orphan_cleanup() is None
+
+    assert len(failures) == 1
+    assert type(failures[0]) is RuntimeError
+    assert str(failures[0]) == "repository reload cannot start during cleanup"
+    assert registry._orphan_cleanup_owners == []
+
+
+def test_registry_cleanup_callback_rejects_cross_registry_shutdown():
+    failures = []
+    first = RepoRegistry(QAConfig())
+    second = RepoRegistry(QAConfig())
+
+    class Owner:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            try:
+                second.close()
+            except BaseException as exc:  # noqa: B036 - assert lock boundary
+                failures.append(exc)
+            self.closed = True
+
+    owner = Owner()
+    first._orphan_cleanup_owners.append(owner)
+
+    assert first._drain_orphan_cleanup() is None
+
+    assert len(failures) == 1
+    assert type(failures[0]) is RuntimeError
+    assert str(failures[0]) == (
+        "repository shutdown cannot cross a registry cleanup callback"
+    )
+    assert first._orphan_cleanup_owners == []
+    assert second._closed is False
+    second.close()
+
+
+@pytest.mark.parametrize("pin_all", [False, True])
+def test_registry_cleanup_callbacks_reject_cross_registry_pins(pin_all):
+    barrier = Barrier(2)
+    failures = []
+    results = []
+    first = RepoRegistry(QAConfig())
+    second = RepoRegistry(QAConfig())
+    first._bundles["first"] = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+    )
+    second._bundles["second"] = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+    )
+
+    class Owner:
+        def __init__(self, other, repo_id):
+            self.other = other
+            self.repo_id = repo_id
+            self.closed = False
+
+        def close(self):
+            barrier.wait(timeout=2)
+            try:
+                context = (
+                    self.other.pin_all() if pin_all else self.other.pin(self.repo_id)
+                )
+                with context:
+                    pytest.fail("cleanup callback unexpectedly acquired a pin")
+            except BaseException as exc:  # noqa: B036 - assert lock boundary
+                failures.append(exc)
+            self.closed = True
+
+    first._orphan_cleanup_owners.append(Owner(second, "second"))
+    second._orphan_cleanup_owners.append(Owner(first, "first"))
+    threads = [
+        Thread(
+            target=lambda registry=registry: results.append(
+                registry._drain_orphan_cleanup()
+            ),
+            daemon=True,
+        )
+        for registry in (first, second)
+    ]
+
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert results == [None, None]
+    assert len(failures) == 2
+    assert all(type(failure) is RuntimeError for failure in failures)
+    assert all(
+        str(failure) == "repository pin cannot start during cleanup"
+        for failure in failures
+    )
+    first.close()
+    second.close()
+
+
+def test_registry_cleanup_callbacks_defer_preexisting_cross_registry_pin_release():
+    barrier = Barrier(2)
+    results = []
+    first = RepoRegistry(QAConfig())
+    second = RepoRegistry(QAConfig())
+
+    class GenerationOwner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    first_owner = GenerationOwner()
+    second_owner = GenerationOwner()
+    first._bundles["first"] = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+    )
+    first._source_cleanup_owners["first"] = first_owner
+    second._bundles["second"] = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+    )
+    second._source_cleanup_owners["second"] = second_owner
+    first_pin = first.pin("first")
+    second_pin = second.pin("second")
+    assert first_pin.__enter__() is first._bundles["first"]
+    assert second_pin.__enter__() is second._bundles["second"]
+    with first._generation_lock:
+        first._retire_active_locked("first")
+    with second._generation_lock:
+        second._retire_active_locked("second")
+
+    class CrossOwner:
+        def __init__(self, context):
+            self.context = context
+            self.closed = False
+
+        def close(self):
+            barrier.wait(timeout=2)
+            self.context.__exit__(None, None, None)
+            self.closed = True
+
+    first._orphan_cleanup_owners.append(CrossOwner(second_pin))
+    second._orphan_cleanup_owners.append(CrossOwner(first_pin))
+    threads = [
+        Thread(
+            target=lambda registry=registry: results.append(
+                registry._drain_orphan_cleanup()
+            ),
+            daemon=True,
+        )
+        for registry in (first, second)
+    ]
+
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert results == [None, None]
+    assert first._bundle_leases == {}
+    assert second._bundle_leases == {}
+    assert first.retired_generation_count == 1
+    assert second.retired_generation_count == 1
+    assert first_owner.close_calls == 0
+    assert second_owner.close_calls == 0
+    assert first._drain_retired() is None
+    assert second._drain_retired() is None
+    assert first_owner.close_calls == 1
+    assert second_owner.close_calls == 1
+    assert first.retired_generation_count == 0
+    assert second.retired_generation_count == 0
+    first.close()
+    second.close()
+
+
+def test_registry_cleanup_callback_restores_context_after_interruption():
+    stop = KeyboardInterrupt("cleanup context restoration interrupted")
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    registry._orphan_cleanup_owners.append(owner)
+    restore_impl = type(registry._cleanup_callback())._restore
+    source, first_line = inspect.getsourcelines(restore_impl)
+    restore_line = first_line + next(
+        index
+        for index, line in enumerate(source)
+        if "self._context.registries = self._previous_registries" in line
+    )
+    triggered = False
+
+    def interrupt_first_restore(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is restore_impl.__code__
+            and frame.f_locals["self"]._kind == "cleanup"
+            and frame.f_lineno == restore_line
+        ):
+            triggered = True
+            raise stop
+        return interrupt_first_restore
+
+    sys.settrace(interrupt_first_restore)
+    try:
+        assert registry._drain_orphan_cleanup() is stop
+    finally:
+        sys.settrace(None)
+
+    assert triggered is True
+    assert registry._cleanup_callback_is_active() is False
+    assert registry._owns_current_cleanup_callback() is False
+    registry._run_serialized_reload(lambda: None)
+    assert registry._drain_orphan_cleanup() is None
+    assert owner.close_calls == 1
+
+
+@pytest.mark.parametrize("operation", ["close", "load_all", "pin", "pin_all"])
+def test_registry_reload_callbacks_reject_cross_registry_operations(operation):
+    barrier = Barrier(2)
+    failures = []
+    first = RepoRegistry(QAConfig())
+    second = RepoRegistry(QAConfig())
+
+    def load(registry, other, repo_id):
+        def build(_entry):
+            barrier.wait(timeout=2)
+            if operation == "close":
+                other.close()
+            elif operation == "load_all":
+                other.load_all()
+            elif operation == "pin":
+                with other.pin(repo_id):
+                    pytest.fail("reload callback unexpectedly acquired a pin")
+            else:
+                with other.pin_all():
+                    pytest.fail("reload callback unexpectedly acquired all pins")
+
+        registry._build_repo_metadata = build
+        try:
+            registry._load_repo_metadata(SimpleNamespace(instance_id=repo_id))
+        except BaseException as exc:  # noqa: B036 - assert lock boundary
+            failures.append(exc)
+
+    threads = [
+        Thread(target=load, args=(first, second, "first"), daemon=True),
+        Thread(target=load, args=(second, first, "second"), daemon=True),
+    ]
+
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(failures) == 2
+    assert all(type(failure) is RuntimeError for failure in failures)
+    expected_message = {
+        "close": "repository shutdown cannot cross a registry reload operation",
+        "load_all": "repository reload cannot reenter another reload",
+        "pin": "repository pin cannot cross a registry reload operation",
+        "pin_all": "repository pin cannot cross a registry reload operation",
+    }[operation]
+    assert all(str(failure) == expected_message for failure in failures)
+    assert first._closed is False
+    assert second._closed is False
+    first.close()
+    second.close()
+
+
+def test_registry_capture_failure_cross_reload_is_fail_fast_and_retryable(
+    monkeypatch,
+):
+    barrier = Barrier(2)
+    first = RepoRegistry(QAConfig())
+    second = RepoRegistry(QAConfig())
+
+    class Source:
+        def __init__(self, other):
+            self.other = other
+            self.close_calls = 0
+            self.done = False
+            self.cross = True
+
+        @property
+        def closed(self):
+            return self.done
+
+        def close(self):
+            self.close_calls += 1
+            if self.cross:
+                barrier.wait(timeout=2)
+                self.other.close()
+            self.done = True
+
+    sources = {
+        "first": Source(second),
+        "second": Source(first),
+    }
+    primaries = {key: ValueError(f"capture {key}") for key in sources}
+
+    def capture(repo_dir, _manifest, **kwargs):
+        kwargs["_source_owner"](sources[repo_dir])
+        raise primaries[repo_dir]
+
+    monkeypatch.setattr(
+        RepoManifest,
+        "load",
+        classmethod(lambda _cls, _path: SimpleNamespace()),
+    )
+    monkeypatch.setattr(
+        "codenib.compiler.manifest_source.capture_repository_source_for_manifest",
+        capture,
+    )
+    entries = {
+        key: SimpleNamespace(
+            instance_id=key,
+            repo_dir=key,
+            manifest_path=f"{key}.json",
+        )
+        for key in sources
+    }
+    caught = {}
+
+    def load(registry, key):
+        try:
+            registry._load_repo_metadata(entries[key])
+        except BaseException as exc:  # noqa: B036 - assert exact settlement
+            caught[key] = exc
+
+    threads = [
+        Thread(target=load, args=(first, "first"), daemon=True),
+        Thread(target=load, args=(second, "second"), daemon=True),
+    ]
+
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert all(not thread.is_alive() for thread in threads)
+    for registry, key in ((first, "first"), (second, "second")):
+        assert caught[key] is primaries[key]
+        assert type(caught[key].__cause__) is RuntimeError
+        assert str(caught[key].__cause__) == (
+            "repository shutdown cannot cross a registry reload operation"
+        )
+        assert registry._source_cleanup_owners[key].pending_sources == (sources[key],)
+        assert sources[key].close_calls == 1
+
+    for source in sources.values():
+        source.cross = False
+    first.close()
+    second.close()
+    assert [source.close_calls for source in sources.values()] == [2, 2]
+    assert all(source.closed for source in sources.values())
+
+
+@pytest.mark.parametrize(
+    "error_type",
+    [KeyboardInterrupt, StopIteration, StopAsyncIteration],
+)
+def test_registry_reload_restores_context_after_interruption(error_type):
+    stop = error_type("reload context restoration interrupted")
+    registry = RepoRegistry(QAConfig())
+    restore_impl = type(registry._cleanup_callback())._restore
+    source, first_line = inspect.getsourcelines(restore_impl)
+    restore_line = first_line + next(
+        index
+        for index, line in enumerate(source)
+        if "self._context.registries = self._previous_registries" in line
+    )
+    triggered = False
+
+    def interrupt_first_restore(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is restore_impl.__code__
+            and frame.f_locals["self"]._kind == "reload"
+            and frame.f_lineno == restore_line
+        ):
+            triggered = True
+            raise stop
+        return interrupt_first_restore
+
+    sys.settrace(interrupt_first_restore)
+    try:
+        with pytest.raises(error_type) as caught:
+            registry._run_serialized_reload(lambda: None)
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is stop
+    assert triggered is True
+    assert registry._reload_operation_is_active() is False
+    assert registry._owns_current_reload_operation() is False
+    registry._run_serialized_reload(lambda: None)
+    registry.close()
+
+
+@pytest.mark.parametrize("context_kind", ["cleanup", "reload"])
+def test_registry_thread_context_activation_return_is_recoverable(context_kind):
+    stop = KeyboardInterrupt(f"{context_kind} context activation interrupted")
+    registry = RepoRegistry(QAConfig())
+    activate_impl = type(registry._cleanup_callback())._activate
+    triggered = False
+
+    def interrupt_activation_return(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "return"
+            and frame.f_code is activate_impl.__code__
+            and frame.f_locals["self"]._kind == context_kind
+        ):
+            triggered = True
+            raise stop
+        return interrupt_activation_return
+
+    sys.settrace(interrupt_activation_return)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            if context_kind == "cleanup":
+                registry._run_serialized_cleanup(
+                    lambda: registry._run_cleanup_callback(lambda: None)
+                )
+            else:
+                registry._run_serialized_reload(lambda: None)
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is stop
+    assert triggered is True
+    assert registry._cleanup_callback_is_active() is False
+    assert registry._reload_operation_is_active() is False
+    assert getattr(_REGISTRY_CLEANUP_CONTEXT, "registries", ()) == ()
+    assert getattr(_REGISTRY_RELOAD_CONTEXT, "registries", ()) == ()
+    assert registry._cleanup_lock.held_by_current_thread() is False
+    assert registry._registry_reload_lock.held_by_current_thread() is False
+    registry._run_serialized_reload(lambda: None)
+    registry.close()
+
+
+@pytest.mark.parametrize("lock_name", ["_cleanup_lock", "_registry_reload_lock"])
+@pytest.mark.parametrize(
+    ("primary_type", "expected"),
+    [
+        (None, "settlement"),
+        (ValueError, "settlement"),
+        (SystemExit, "primary"),
+    ],
+)
+def test_registry_lock_adapter_recovers_settlement_interruption(
+    lock_name,
+    primary_type,
+    expected,
+):
+    stop = KeyboardInterrupt("registry lock settlement interrupted")
+    registry = RepoRegistry(QAConfig())
+    lock = getattr(registry, lock_name)
+    lock_run = type(lock).run
+    source, first_line = inspect.getsourcelines(lock_run)
+    release_call_index = next(
+        index
+        for index, line in enumerate(source)
+        if "release_error = self._release_reconciled(baseline)" in line
+    )
+    settlement_entry_line = first_line + release_call_index - 1
+    assert source[release_call_index - 1].strip() == "try:"
+    triggered = False
+    primary = primary_type("registry operation failed") if primary_type else None
+
+    def operation():
+        if primary is not None:
+            raise primary
+        return "ok"
+
+    def interrupt_settlement(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is lock_run.__code__
+            and frame.f_lineno == settlement_entry_line
+        ):
+            triggered = True
+            raise stop
+        return interrupt_settlement
+
+    sys.settrace(interrupt_settlement)
+    try:
+        with pytest.raises(BaseException) as caught:
+            registry._run_registry_lock(lock, operation)
+    finally:
+        sys.settrace(None)
+
+    preferred = primary if expected == "primary" else stop
+    assert caught.value is preferred
+    if primary is not None:
+        secondary = stop if expected == "primary" else primary
+        assert caught.value.__cause__ is secondary
+    assert triggered is True
+    assert lock._logical_depth() == 0
+    assert lock._native_is_owned() is False
+    observed = []
+    thread = Thread(
+        target=lambda: observed.append(
+            registry._run_registry_lock(lock, lambda: "released")
+        ),
+        daemon=True,
+    )
+    thread.start()
+    thread.join(timeout=2)
+    assert not thread.is_alive()
+    assert observed == ["released"]
+    registry.close()
+
+
+@pytest.mark.parametrize(
+    "fault_line_text",
+    [
+        "except BaseException as error:",
+        "outcome.error = error",
+        "return outcome",
+    ],
+)
+@pytest.mark.parametrize(
+    ("primary_type", "expected"),
+    [
+        (ValueError, "settlement"),
+        (SystemExit, "primary"),
+    ],
+)
+def test_registry_lock_adapter_retains_operation_failure_across_capture_seam(
+    fault_line_text,
+    primary_type,
+    expected,
+):
+    primary = primary_type("registry operation failed")
+    stop = KeyboardInterrupt("registry outcome capture interrupted")
+    registry = RepoRegistry(QAConfig())
+    capture_impl = _capture_registry_lock_outcome
+    source, first_line = inspect.getsourcelines(capture_impl)
+    fault_line = first_line + next(
+        index for index, line in enumerate(source) if fault_line_text in line
+    )
+    triggered = False
+
+    def fail():
+        raise primary
+
+    def interrupt_capture(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is capture_impl.__code__
+            and frame.f_lineno == fault_line
+        ):
+            triggered = True
+            raise stop
+        return interrupt_capture
+
+    sys.settrace(interrupt_capture)
+    try:
+        with pytest.raises(BaseException) as caught:
+            registry._run_registry_lock(registry._cleanup_lock, fail)
+    finally:
+        sys.settrace(None)
+
+    preferred = primary if expected == "primary" else stop
+    secondary = stop if expected == "primary" else primary
+    assert caught.value is preferred
+    assert caught.value.__cause__ is secondary
+    assert triggered is True
+    assert registry._cleanup_lock._logical_depth() == 0
+    assert registry._cleanup_lock._native_is_owned() is False
+    registry.close()
+
+
+@pytest.mark.parametrize("lock_name", ["_cleanup_lock", "_registry_reload_lock"])
+@pytest.mark.parametrize(
+    "ambient_type",
+    [ValueError, SystemExit, KeyboardInterrupt, StopIteration],
+)
+def test_registry_lock_adapter_ignores_ambient_exception_context(
+    lock_name,
+    ambient_type,
+):
+    ambient = ambient_type("unrelated caller context")
+    stop = KeyboardInterrupt("registry lock settlement interrupted")
+    registry = RepoRegistry(QAConfig())
+    lock = getattr(registry, lock_name)
+    lock_run = type(lock).run
+    source, first_line = inspect.getsourcelines(lock_run)
+    release_call_index = next(
+        index
+        for index, line in enumerate(source)
+        if "release_error = self._release_reconciled(baseline)" in line
+    )
+    settlement_entry_line = first_line + release_call_index - 1
+    triggered = False
+
+    def interrupt_settlement(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is lock_run.__code__
+            and frame.f_lineno == settlement_entry_line
+        ):
+            triggered = True
+            raise stop
+        return interrupt_settlement
+
+    def invoke_with_ambient_context():
+        try:
+            raise ambient
+        except BaseException:  # noqa: B036 - keep ambient context active
+            return registry._run_registry_lock(lock, lambda: "ok")
+
+    sys.settrace(interrupt_settlement)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            invoke_with_ambient_context()
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is stop
+    assert caught.value.__cause__ is None
+    assert triggered is True
+    assert lock._logical_depth() == 0
+    assert lock._native_is_owned() is False
+    registry.close()
+
+
+@pytest.mark.parametrize(
+    ("primary_type", "expected"),
+    [
+        (ValueError, "settlement"),
+        (SystemExit, "primary"),
+    ],
+)
+@pytest.mark.parametrize(
+    "fault_line_text",
+    ["if outcome.error is not None:", "raise outcome.error"],
+)
+def test_registry_lock_adapter_retains_failure_across_outcome_unwrap(
+    primary_type,
+    expected,
+    fault_line_text,
+):
+    primary = primary_type("registry operation failed")
+    stop = KeyboardInterrupt("registry outcome unwrap interrupted")
+    registry = RepoRegistry(QAConfig())
+    unwrap_impl = _unwrap_registry_lock_outcome
+    source, first_line = inspect.getsourcelines(unwrap_impl)
+    fault_line = first_line + next(
+        index for index, line in enumerate(source) if fault_line_text in line
+    )
+    triggered = False
+
+    def fail():
+        raise primary
+
+    def interrupt_unwrap(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is unwrap_impl.__code__
+            and frame.f_lineno == fault_line
+        ):
+            triggered = True
+            raise stop
+        return interrupt_unwrap
+
+    sys.settrace(interrupt_unwrap)
+    try:
+        with pytest.raises(BaseException) as caught:
+            registry._run_registry_lock(registry._cleanup_lock, fail)
+    finally:
+        sys.settrace(None)
+
+    preferred = primary if expected == "primary" else stop
+    secondary = stop if expected == "primary" else primary
+    assert caught.value is preferred
+    assert caught.value.__cause__ is secondary
+    assert triggered is True
+    assert registry._cleanup_lock._logical_depth() == 0
+    assert registry._cleanup_lock._native_is_owned() is False
+    registry.close()
+
+
+@pytest.mark.parametrize(
+    ("primary_type", "expected"),
+    [
+        (ValueError, "settlement"),
+        (SystemExit, "primary"),
+    ],
+)
+@pytest.mark.parametrize(
+    "fault_line_text",
+    [
+        "except BaseException as unwrap_failure:",
+        "if outcome.error is not None and outcome.error is not unwrap_failure:",
+    ],
+)
+def test_registry_lock_adapter_retains_failure_across_unwrap_handler(
+    primary_type,
+    expected,
+    fault_line_text,
+):
+    primary = primary_type("registry operation failed")
+    stop = KeyboardInterrupt("registry outcome settlement interrupted")
+    registry = RepoRegistry(QAConfig())
+    settle_impl = _settle_registry_lock_outcome
+    source, first_line = inspect.getsourcelines(settle_impl)
+    fault_line = first_line + next(
+        index for index, line in enumerate(source) if fault_line_text in line
+    )
+    triggered = False
+
+    def fail():
+        raise primary
+
+    def interrupt_settlement(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is settle_impl.__code__
+            and frame.f_lineno == fault_line
+        ):
+            triggered = True
+            raise stop
+        return interrupt_settlement
+
+    sys.settrace(interrupt_settlement)
+    try:
+        with pytest.raises(BaseException) as caught:
+            registry._run_registry_lock(registry._cleanup_lock, fail)
+    finally:
+        sys.settrace(None)
+
+    preferred = primary if expected == "primary" else stop
+    secondary = stop if expected == "primary" else primary
+    assert caught.value is preferred
+    assert caught.value.__cause__ is secondary
+    assert triggered is True
+    assert registry._cleanup_lock._logical_depth() == 0
+    assert registry._cleanup_lock._native_is_owned() is False
+    registry.close()
+
+
+@pytest.mark.parametrize("ambient_type", [SystemExit, KeyboardInterrupt])
+def test_registry_lock_adapter_ignores_ambient_at_capture_entry(ambient_type):
+    ambient = ambient_type("unrelated caller context")
+    stop = KeyboardInterrupt("registry capture entry interrupted")
+    registry = RepoRegistry(QAConfig())
+    capture_impl = _capture_registry_lock_outcome
+    source, first_line = inspect.getsourcelines(capture_impl)
+    fault_line = first_line + next(
+        index for index, line in enumerate(source) if line.strip() == "try:"
+    )
+    triggered = False
+
+    def interrupt_capture(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is capture_impl.__code__
+            and frame.f_lineno == fault_line
+        ):
+            triggered = True
+            raise stop
+        return interrupt_capture
+
+    def invoke_with_ambient_context():
+        try:
+            raise ambient
+        except BaseException:  # noqa: B036 - keep ambient context active
+            return registry._run_registry_lock(
+                registry._cleanup_lock,
+                lambda: "ok",
+            )
+
+    sys.settrace(interrupt_capture)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            invoke_with_ambient_context()
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is stop
+    assert caught.value.__cause__ is None
+    assert triggered is True
+    assert registry._cleanup_lock._logical_depth() == 0
+    assert registry._cleanup_lock._native_is_owned() is False
+    registry.close()
+
+
+@pytest.mark.parametrize("ambient_type", [SystemExit, KeyboardInterrupt])
+def test_registry_lock_adapter_ignores_reused_ambient_at_capture_entry(
+    ambient_type,
+):
+    ambient = ambient_type("previous registry operation failed")
+    stop = KeyboardInterrupt("next registry capture entry interrupted")
+    registry = RepoRegistry(QAConfig())
+    capture_impl = _capture_registry_lock_outcome
+    source, first_line = inspect.getsourcelines(capture_impl)
+    fault_line = first_line + next(
+        index for index, line in enumerate(source) if line.strip() == "try:"
+    )
+    triggered = False
+
+    def fail_once():
+        raise ambient
+
+    def interrupt_capture(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is capture_impl.__code__
+            and frame.f_lineno == fault_line
+        ):
+            triggered = True
+            raise stop
+        return interrupt_capture
+
+    try:
+        registry._run_registry_lock(registry._cleanup_lock, fail_once)
+    except BaseException as caught:  # noqa: B036 - reuse exact ambient error
+        assert caught is ambient
+        sys.settrace(interrupt_capture)
+        try:
+            with pytest.raises(KeyboardInterrupt) as interrupted:
+                registry._run_registry_lock(
+                    registry._cleanup_lock,
+                    lambda: "ok",
+                )
+        finally:
+            sys.settrace(None)
+    else:  # pragma: no cover - the exact primary must escape
+        raise AssertionError("registry operation failure did not escape")
+
+    assert interrupted.value is stop
+    assert interrupted.value.__cause__ is None
+    assert triggered is True
+    assert registry._cleanup_lock._logical_depth() == 0
+    assert registry._cleanup_lock._native_is_owned() is False
+    registry.close()
+
+
+@pytest.mark.parametrize(
+    ("context_kind", "primary_type", "restore_type", "expected"),
+    [
+        ("cleanup", SystemExit, KeyboardInterrupt, "primary"),
+        ("cleanup", RuntimeError, SystemExit, "restore"),
+        ("reload", SystemExit, KeyboardInterrupt, "primary"),
+        ("reload", RuntimeError, SystemExit, "restore"),
+    ],
+)
+def test_registry_thread_context_preserves_exception_priority(
+    context_kind,
+    primary_type,
+    restore_type,
+    expected,
+):
+    primary = primary_type("body failed")
+    restore_failure = restore_type("context restoration interrupted")
+    registry = RepoRegistry(QAConfig())
+    restore_impl = type(registry._cleanup_callback())._restore
+    source, first_line = inspect.getsourcelines(restore_impl)
+    restore_line = first_line + next(
+        index
+        for index, line in enumerate(source)
+        if "self._context.registries = self._previous_registries" in line
+    )
+    triggered = False
+
+    def interrupt_first_restore(frame, event, _arg):
+        nonlocal triggered
+        if (
+            not triggered
+            and event == "line"
+            and frame.f_code is restore_impl.__code__
+            and frame.f_locals["self"]._kind == context_kind
+            and frame.f_lineno == restore_line
+        ):
+            triggered = True
+            raise restore_failure
+        return interrupt_first_restore
+
+    sys.settrace(interrupt_first_restore)
+    try:
+        if context_kind == "cleanup":
+
+            class Owner:
+                @property
+                def closed(self):
+                    return False
+
+                def close(self):
+                    raise primary
+
+            bundle = RepoBundle(
+                entry=SimpleNamespace(),
+                manifest=SimpleNamespace(),
+            )
+            registry._retired_bundles[id(bundle)] = _OwnedRepoBundle(
+                bundle,
+                None,
+                Owner(),
+            )
+            observed = registry._drain_retired()
+        else:
+
+            def fail_reload():
+                raise primary
+
+            try:
+                registry._run_serialized_reload(fail_reload)
+            except BaseException as exc:  # noqa: B036 - assert exact priority
+                observed = exc
+    finally:
+        sys.settrace(None)
+
+    assert triggered is True
+    preferred = primary if expected == "primary" else restore_failure
+    assert observed is preferred
+    if expected == "restore":
+        assert observed.__cause__ is primary
+    assert registry._cleanup_callback_is_active() is False
+    assert registry._reload_operation_is_active() is False
+
+
+@pytest.mark.parametrize("context_kind", ["cleanup", "reload"])
+@pytest.mark.parametrize("error_type", [StopIteration, StopAsyncIteration])
+def test_registry_thread_context_preserves_iteration_stop_identity(
+    context_kind,
+    error_type,
+):
+    stop = error_type("exact stop")
+    registry = RepoRegistry(QAConfig())
+    if context_kind == "cleanup":
+
+        class Owner:
+            @property
+            def closed(self):
+                return False
+
+            def close(self):
+                raise stop
+
+        bundle = RepoBundle(
+            entry=SimpleNamespace(),
+            manifest=SimpleNamespace(),
+        )
+        registry._retired_bundles[id(bundle)] = _OwnedRepoBundle(
+            bundle,
+            None,
+            Owner(),
+        )
+        observed = registry._drain_retired()
+    else:
+
+        def fail_reload():
+            raise stop
+
+        try:
+            registry._run_serialized_reload(fail_reload)
+        except BaseException as exc:  # noqa: B036 - assert exact identity
+            observed = exc
+
+    assert observed is stop
+    assert registry._cleanup_callback_is_active() is False
+    assert registry._reload_operation_is_active() is False
 
 
 def test_registry_vector_close_settles_before_opcode_interruption():
@@ -1392,6 +2654,11 @@ def test_registry_retired_claim_interruption_keeps_retry_state():
     key = id(bundle)
     registry._retired_bundles[key] = _OwnedRepoBundle(bundle, None, owner)
     source, first_line = inspect.getsourcelines(RepoRegistry._drain_retired)
+    operation_code = next(
+        constant
+        for constant in RepoRegistry._drain_retired.__code__.co_consts
+        if isinstance(constant, CodeType) and constant.co_name == "operation"
+    )
     claim_line = first_line + next(
         index
         for index, line in enumerate(source)
@@ -1404,7 +2671,7 @@ def test_registry_retired_claim_interruption_keeps_retry_state():
         if (
             not triggered
             and event == "line"
-            and frame.f_code is RepoRegistry._drain_retired.__code__
+            and frame.f_code is operation_code
             and frame.f_lineno > claim_line
         ):
             triggered = True
@@ -1447,6 +2714,11 @@ def test_registry_orphan_claim_interruption_keeps_retry_state():
     registry = RepoRegistry(QAConfig())
     registry._orphan_cleanup_owners.append(owner)
     source, first_line = inspect.getsourcelines(RepoRegistry._drain_orphan_cleanup)
+    operation_code = next(
+        constant
+        for constant in RepoRegistry._drain_orphan_cleanup.__code__.co_consts
+        if isinstance(constant, CodeType) and constant.co_name == "operation"
+    )
     claim_line = first_line + next(
         index
         for index, line in enumerate(source)
@@ -1459,7 +2731,7 @@ def test_registry_orphan_claim_interruption_keeps_retry_state():
         if (
             not triggered
             and event == "line"
-            and frame.f_code is RepoRegistry._drain_orphan_cleanup.__code__
+            and frame.f_code is operation_code
             and frame.f_lineno > claim_line
         ):
             triggered = True
@@ -2417,6 +3689,69 @@ def test_registry_refresh_detaches_hostile_lookup_key(tmp_path, monkeypatch):
     assert touched == []
     assert registry._closed is False
     assert registry.get("repo") is candidate
+    registry.close()
+
+
+@pytest.mark.parametrize(
+    ("invalid_id", "invalid_first"),
+    [("", True), (None, False), (17, True)],
+)
+def test_registry_refresh_skips_invalid_unrelated_entry(
+    tmp_path,
+    monkeypatch,
+    invalid_id,
+    invalid_first,
+):
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    invalid = SimpleNamespace(instance_id=invalid_id)
+    entry = _repo_entry(tmp_path, manifest_path, instance_id="repo")
+    candidate = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry = RepoRegistry(QAConfig())
+    entries = [invalid, entry] if invalid_first else [entry, invalid]
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: entries,
+    )
+    monkeypatch.setattr(
+        registry,
+        "_build_repo_metadata",
+        lambda selected: (
+            _OwnedRepoBundle(candidate, None, None)
+            if selected is entry
+            else pytest.fail("refresh selected an unrelated entry")
+        ),
+    )
+    monkeypatch.setattr(registry, "_prepare_runtime_bundle", lambda _bundle: None)
+
+    registry.refresh("repo")
+
+    assert registry.get("repo") is candidate
+    registry.close()
+
+
+def test_registry_refresh_rejects_duplicate_valid_target_entries(
+    tmp_path,
+    monkeypatch,
+):
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    first = _repo_entry(tmp_path, manifest_path, instance_id="repo")
+    second = _repo_entry(tmp_path, manifest_path, instance_id="repo")
+    registry = RepoRegistry(QAConfig())
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.load_registry",
+        lambda _path: [first, second],
+    )
+    monkeypatch.setattr(
+        registry,
+        "_build_repo_metadata",
+        lambda _entry: pytest.fail("duplicate targets must fail before build"),
+    )
+
+    with pytest.raises(ValueError, match="exactly one entry"):
+        registry.refresh("repo")
+
     registry.close()
 
 

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -45,6 +45,7 @@ from codenib.web.repo_registry import (
     RepoRegistry,
     _capture_registry_lock_outcome,
     _defer_registry_retired_drain,
+    _defer_registry_retired_drain_once,
     _deferred_registry_drain_entries,
     _fresh_registry,
     _OwnedRepoBundle,
@@ -1751,6 +1752,83 @@ def test_registry_deferred_ticket_retains_target_until_first_flush():
     assert owner.close_calls == 1
     gc.collect()
     assert target_ref() is None
+
+
+def test_registry_deferred_enqueue_interruption_keeps_last_ref_authority():
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    target = RepoRegistry(QAConfig())
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    target._bundles["target"] = bundle
+    target._source_cleanup_owners["target"] = owner
+    pinned = target.pin("target")
+    assert pinned.__enter__() is bundle
+    target.close()
+    target_ref = weakref_ref(target)
+    del target
+
+    class CrossOwner:
+        def __init__(self, context):
+            self.context = context
+            self.done = False
+
+        @property
+        def closed(self):
+            return self.done
+
+        def close(self):
+            context = self.context
+            self.context = None
+            context.__exit__(None, None, None)
+            self.done = True
+
+    source = RepoRegistry(QAConfig())
+    source._orphan_cleanup_owners.append(CrossOwner(pinned))
+    del pinned
+    lines, start_line = inspect.getsourcelines(_defer_registry_retired_drain_once)
+    interrupt_line = start_line + next(
+        offset
+        for offset, line in enumerate(lines)
+        if "pending = (*pending, ticket)" in line
+    )
+    interrupted = False
+
+    def interrupt_enqueue(frame, event, _arg):
+        nonlocal interrupted
+        if (
+            not interrupted
+            and event == "line"
+            and frame.f_code is _defer_registry_retired_drain_once.__code__
+            and frame.f_lineno == interrupt_line
+        ):
+            interrupted = True
+            sys.settrace(None)
+            raise KeyboardInterrupt("deferred drain enqueue interrupted")
+        return interrupt_enqueue
+
+    sys.settrace(interrupt_enqueue)
+    try:
+        with pytest.raises(KeyboardInterrupt):
+            source.close()
+    finally:
+        sys.settrace(None)
+
+    gc.collect()
+    gc.collect()
+    assert interrupted
+    assert owner.close_calls == 1
+    assert target_ref() is None
+    assert _deferred_registry_drain_entries() == ()
 
 
 def test_registry_successful_cross_thread_retry_invalidates_deferred_ticket():

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -5,12 +5,14 @@
 """Tests for per-repo skill-registry isolation, config, and the QA registry."""
 
 import dis
+import gc
 import inspect
 import pickle
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from threading import Barrier, Event, Lock, Thread
 from types import CodeType, SimpleNamespace
+from weakref import ref as weakref_ref
 
 import pytest
 
@@ -42,6 +44,8 @@ from codenib.web.repo_registry import (
     RepoBundle,
     RepoRegistry,
     _capture_registry_lock_outcome,
+    _defer_registry_retired_drain,
+    _deferred_registry_drain_entries,
     _fresh_registry,
     _OwnedRepoBundle,
     _settle_registry_lock_outcome,
@@ -1448,18 +1452,718 @@ def test_registry_cleanup_callbacks_defer_preexisting_cross_registry_pin_release
     assert results == [None, None]
     assert first._bundle_leases == {}
     assert second._bundle_leases == {}
-    assert first.retired_generation_count == 1
-    assert second.retired_generation_count == 1
-    assert first_owner.close_calls == 0
-    assert second_owner.close_calls == 0
-    assert first._drain_retired() is None
-    assert second._drain_retired() is None
-    assert first_owner.close_calls == 1
-    assert second_owner.close_calls == 1
     assert first.retired_generation_count == 0
     assert second.retired_generation_count == 0
+    assert first_owner.close_calls == 1
+    assert second_owner.close_calls == 1
     first.close()
     second.close()
+
+
+def test_registry_cross_cleanup_release_flushes_closed_target_after_outer_lock():
+    first = RepoRegistry(QAConfig())
+    second = RepoRegistry(QAConfig())
+    lock_observations = []
+
+    class GenerationOwner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            lock_observations.append(
+                (
+                    second._cleanup_lock.held_by_current_thread(),
+                    second._registry_reload_lock.held_by_current_thread(),
+                )
+            )
+            self.close_calls += 1
+
+    owner = GenerationOwner()
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    first._bundles["first"] = bundle
+    first._source_cleanup_owners["first"] = owner
+    pinned = first.pin("first")
+    assert pinned.__enter__() is bundle
+    first.close()
+    assert first.retired_generation_count == 1
+    assert owner.close_calls == 0
+
+    class CrossOwner:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            pinned.__exit__(None, None, None)
+            self.closed = True
+
+    second._orphan_cleanup_owners.append(CrossOwner())
+    second.close()
+
+    assert first._bundle_leases == {}
+    assert first.retired_generation_count == 0
+    assert owner.close_calls == 1
+    assert lock_observations == [(False, False)]
+
+
+def test_registry_cross_reload_release_flushes_after_reload_returns():
+    first = RepoRegistry(QAConfig())
+    second = RepoRegistry(QAConfig())
+    lock_observations = []
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            lock_observations.append(
+                second._registry_reload_lock.held_by_current_thread()
+            )
+            self.close_calls += 1
+
+    owner = Owner()
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    first._bundles["first"] = bundle
+    first._source_cleanup_owners["first"] = owner
+    pinned = first.pin("first")
+    assert pinned.__enter__() is bundle
+    first.close()
+
+    def release_during_reload():
+        pinned.__exit__(None, None, None)
+        assert owner.close_calls == 0
+
+    second._run_serialized_reload(release_during_reload)
+
+    assert first._bundle_leases == {}
+    assert first.retired_generation_count == 0
+    assert owner.close_calls == 1
+    assert lock_observations == [False]
+    second.close()
+
+
+def test_registry_cross_cleanup_deduplicates_two_final_pin_releases():
+    first = RepoRegistry(QAConfig())
+    second = RepoRegistry(QAConfig())
+
+    class GenerationOwner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = GenerationOwner()
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    first._bundles["first"] = bundle
+    first._source_cleanup_owners["first"] = owner
+    pins = (first.pin("first"), first.pin("first"))
+    assert [pin.__enter__() for pin in pins] == [bundle, bundle]
+    first.close()
+
+    class CrossOwner:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            for pin in pins:
+                pin.__exit__(None, None, None)
+            self.closed = True
+
+    second._orphan_cleanup_owners.append(CrossOwner())
+    second.close()
+
+    assert first._bundle_leases == {}
+    assert first.retired_generation_count == 0
+    assert owner.close_calls == 1
+
+
+def test_registry_deferred_drain_retries_after_later_release_in_same_flush():
+    first = RepoRegistry(QAConfig())
+    second = RepoRegistry(QAConfig())
+    third = RepoRegistry(QAConfig())
+
+    class Owner:
+        def __init__(self, callback=None):
+            self.callback = callback
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+            if self.callback is not None:
+                self.callback()
+
+    first_owner = Owner()
+    first_bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    first._bundles["first"] = first_bundle
+    first._source_cleanup_owners["first"] = first_owner
+    first_pins = (first.pin("first"), first.pin("first"))
+    assert [pin.__enter__() for pin in first_pins] == [first_bundle, first_bundle]
+    first.close()
+
+    third_bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    third_pin = third.pin("third")
+    third_owner = Owner(lambda: first_pins[1].__exit__(None, None, None))
+    third._bundles["third"] = third_bundle
+    third._source_cleanup_owners["third"] = third_owner
+    assert third_pin.__enter__() is third_bundle
+    third.close()
+
+    class CrossOwner:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            first_pins[0].__exit__(None, None, None)
+            third_pin.__exit__(None, None, None)
+            self.closed = True
+
+    second._orphan_cleanup_owners.append(CrossOwner())
+    second.close()
+
+    assert first._bundle_leases == {}
+    assert first.retired_generation_count == 0
+    assert first_owner.close_calls == 1
+    assert third._bundle_leases == {}
+    assert third.retired_generation_count == 0
+    assert third_owner.close_calls == 1
+
+
+def test_registry_deferred_drain_does_not_retain_lease_blocked_target():
+    first = RepoRegistry(QAConfig())
+    second = RepoRegistry(QAConfig())
+    worker_ready = Event()
+    release_worker = Event()
+    worker_queues = []
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    first._bundles["first"] = bundle
+    first._source_cleanup_owners["first"] = owner
+    pins = (first.pin("first"), first.pin("first"))
+    assert [pin.__enter__() for pin in pins] == [bundle, bundle]
+    first.close()
+
+    class CrossOwner:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            pins[0].__exit__(None, None, None)
+            self.closed = True
+
+    second._orphan_cleanup_owners.append(CrossOwner())
+
+    def release_first_pin():
+        assert second._drain_orphan_cleanup() is None
+        worker_queues.append(_deferred_registry_drain_entries())
+        worker_ready.set()
+        release_worker.wait(timeout=2)
+        worker_queues.append(_deferred_registry_drain_entries())
+
+    thread = Thread(target=release_first_pin, daemon=True)
+    thread.start()
+    assert worker_ready.wait(timeout=2)
+
+    assert worker_queues == [()]
+    assert first.retired_generation_count == 1
+    assert owner.close_calls == 0
+    pins[1].__exit__(None, None, None)
+    assert first.retired_generation_count == 0
+    assert owner.close_calls == 1
+
+    release_worker.set()
+    thread.join(timeout=2)
+    assert not thread.is_alive()
+    assert worker_queues == [(), ()]
+    second.close()
+
+
+def test_registry_deferred_ticket_retains_target_until_first_flush():
+    second = RepoRegistry(QAConfig())
+    alive_during_callback = []
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = Owner()
+    target = RepoRegistry(QAConfig())
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    target._bundles["target"] = bundle
+    target._source_cleanup_owners["target"] = owner
+    pinned = target.pin("target")
+    assert pinned.__enter__() is bundle
+    target.close()
+    target_ref = weakref_ref(target)
+    del target
+
+    class CrossOwner:
+        def __init__(self, context):
+            self.context = context
+            self.closed = False
+
+        def close(self):
+            self.context.__exit__(None, None, None)
+            self.context = None
+            gc.collect()
+            alive_during_callback.append(target_ref() is not None)
+            self.closed = True
+
+    second._orphan_cleanup_owners.append(CrossOwner(pinned))
+    del pinned
+    second.close()
+
+    assert alive_during_callback == [True]
+    assert owner.close_calls == 1
+    gc.collect()
+    assert target_ref() is None
+
+
+def test_registry_successful_cross_thread_retry_invalidates_deferred_ticket():
+    second = RepoRegistry(QAConfig())
+    worker_ready = Event()
+    release_worker = Event()
+    worker_queues = []
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+            self.done = False
+            self.fail = True
+
+        @property
+        def closed(self):
+            return self.done
+
+        def close(self):
+            self.close_calls += 1
+            if self.fail:
+                raise ValueError("first cleanup failed")
+            self.done = True
+
+    owner = Owner()
+    target = RepoRegistry(QAConfig())
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    target._bundles["target"] = bundle
+    target._source_cleanup_owners["target"] = owner
+    pinned = target.pin("target")
+    assert pinned.__enter__() is bundle
+    target.close()
+
+    class CrossOwner:
+        def __init__(self, context):
+            self.context = context
+            self.closed = False
+
+        def close(self):
+            self.context.__exit__(None, None, None)
+            self.context = None
+            self.closed = True
+
+    second._orphan_cleanup_owners.append(CrossOwner(pinned))
+    del pinned
+
+    def fail_first_cleanup():
+        second.close()
+        worker_queues.append(_deferred_registry_drain_entries())
+        worker_ready.set()
+        release_worker.wait(timeout=2)
+        worker_queues.append(_deferred_registry_drain_entries())
+
+    thread = Thread(target=fail_first_cleanup, daemon=True)
+    thread.start()
+    assert worker_ready.wait(timeout=2)
+
+    assert len(worker_queues[0]) == 1
+    ticket = worker_queues[0][0]
+    assert ticket.registry is target
+    assert target.retired_generation_count == 1
+    assert owner.close_calls == 1
+    owner.fail = False
+    target.close()
+    assert target.retired_generation_count == 0
+    assert owner.close_calls == 2
+    assert ticket.registry is None
+    del target
+
+    release_worker.set()
+    thread.join(timeout=2)
+    assert not thread.is_alive()
+    assert worker_queues[1] == ()
+
+
+def test_registry_direct_release_classifies_failure_before_deferred_retry():
+    early = SystemExit("first cleanup cancellation")
+    late = KeyboardInterrupt("later deferred retry cancellation")
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+            self.failures = [early, late]
+            self.done = False
+
+        @property
+        def closed(self):
+            return self.done
+
+        def close(self):
+            self.close_calls += 1
+            if self.failures:
+                raise self.failures.pop(0)
+            self.done = True
+
+    owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    registry._bundles["repo"] = bundle
+    registry._source_cleanup_owners["repo"] = owner
+    pinned = registry.pin("repo")
+    assert pinned.__enter__() is bundle
+    registry.close()
+    _defer_registry_retired_drain(registry)
+
+    with pytest.raises(SystemExit) as caught:
+        pinned.__exit__(None, None, None)
+
+    assert caught.value is early
+    assert owner.close_calls == 1
+    assert registry.retired_generation_count == 1
+
+    owner.failures.clear()
+    registry.close()
+    assert owner.close_calls == 2
+    assert registry.retired_generation_count == 0
+
+
+def test_registry_direct_release_flushes_cross_callback_target():
+    first = RepoRegistry(QAConfig())
+    second = RepoRegistry(QAConfig())
+
+    class Owner:
+        def __init__(self, callback=None):
+            self.callback = callback
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+            if self.callback is not None:
+                self.callback()
+
+    second_owner = Owner()
+    second_bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    second._bundles["second"] = second_bundle
+    second._source_cleanup_owners["second"] = second_owner
+    second_pin = second.pin("second")
+    assert second_pin.__enter__() is second_bundle
+    second.close()
+
+    first_owner = Owner(lambda: second_pin.__exit__(None, None, None))
+    first_bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    first._bundles["first"] = first_bundle
+    first._source_cleanup_owners["first"] = first_owner
+    first_pin = first.pin("first")
+    assert first_pin.__enter__() is first_bundle
+    first.close()
+
+    first_pin.__exit__(None, None, None)
+
+    assert first._bundle_leases == {}
+    assert first.retired_generation_count == 0
+    assert first_owner.close_calls == 1
+    assert second._bundle_leases == {}
+    assert second.retired_generation_count == 0
+    assert second_owner.close_calls == 1
+
+
+def test_registry_nested_direct_release_waits_for_outer_lifecycle_edge():
+    first = RepoRegistry(QAConfig())
+    second = RepoRegistry(QAConfig())
+    lock_observations = []
+
+    class Owner:
+        def __init__(self, callback=None):
+            self.callback = callback
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+            if self.callback is not None:
+                self.callback()
+
+    second_owner = Owner(
+        lambda: lock_observations.append(
+            (
+                first._cleanup_lock.held_by_current_thread(),
+                first._registry_reload_lock.held_by_current_thread(),
+            )
+        )
+    )
+    second_bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    second._bundles["second"] = second_bundle
+    second._source_cleanup_owners["second"] = second_owner
+    second_pin = second.pin("second")
+    assert second_pin.__enter__() is second_bundle
+    second.close()
+
+    first_owner = Owner()
+    first_bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    first._bundles["first"] = first_bundle
+    first._source_cleanup_owners["first"] = first_owner
+    first_pin = first.pin("first")
+    assert first_pin.__enter__() is first_bundle
+
+    class CrossOwner:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            second_pin.__exit__(None, None, None)
+            first_pin.__exit__(None, None, None)
+            self.closed = True
+
+    first._orphan_cleanup_owners.append(CrossOwner())
+    first.close()
+
+    assert first_owner.close_calls == 1
+    assert second_owner.close_calls == 1
+    assert lock_observations == [(False, False)]
+    assert first.retired_generation_count == 0
+    assert second.retired_generation_count == 0
+
+
+def test_registry_direct_release_flushes_new_same_target_token():
+    first = RepoRegistry(QAConfig())
+    second = RepoRegistry(QAConfig())
+
+    class Owner:
+        def __init__(self, callback=None):
+            self.callback = callback
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+            if self.callback is not None:
+                self.callback()
+
+    second_bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    second_pin = second.pin("second")
+    first_second_pin = first.pin("first-two")
+    second_owner = Owner(lambda: first_second_pin.__exit__(None, None, None))
+    second._bundles["second"] = second_bundle
+    second._source_cleanup_owners["second"] = second_owner
+    assert second_pin.__enter__() is second_bundle
+
+    first_one = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    first_two = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    first_one_owner = Owner(lambda: second_pin.__exit__(None, None, None))
+    first_two_owner = Owner()
+    first._bundles.update({"first-one": first_one, "first-two": first_two})
+    first._source_cleanup_owners.update(
+        {"first-one": first_one_owner, "first-two": first_two_owner}
+    )
+    first_one_pin = first.pin("first-one")
+    assert first_one_pin.__enter__() is first_one
+    assert first_second_pin.__enter__() is first_two
+    first.close()
+    second.close()
+
+    first_one_pin.__exit__(None, None, None)
+
+    assert first._bundle_leases == {}
+    assert first.retired_generation_count == 0
+    assert first_one_owner.close_calls == 1
+    assert first_two_owner.close_calls == 1
+    assert second._bundle_leases == {}
+    assert second.retired_generation_count == 0
+    assert second_owner.close_calls == 1
+
+
+def test_registry_direct_release_precedes_cross_target_cleanup_failure():
+    early = SystemExit("direct cleanup cancellation")
+    late = KeyboardInterrupt("cross-target cleanup cancellation")
+    first = RepoRegistry(QAConfig())
+    second = RepoRegistry(QAConfig())
+
+    class Owner:
+        def __init__(self, failure, callback=None):
+            self.failure = failure
+            self.callback = callback
+            self.close_calls = 0
+            self.done = False
+
+        @property
+        def closed(self):
+            return self.done
+
+        def close(self):
+            self.close_calls += 1
+            if self.callback is not None:
+                self.callback()
+                self.callback = None
+            if self.failure is not None:
+                raise self.failure
+            self.done = True
+
+    second_owner = Owner(late)
+    second_bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    second._bundles["second"] = second_bundle
+    second._source_cleanup_owners["second"] = second_owner
+    second_pin = second.pin("second")
+    assert second_pin.__enter__() is second_bundle
+    second.close()
+
+    first_owner = Owner(early, lambda: second_pin.__exit__(None, None, None))
+    first_bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    first._bundles["first"] = first_bundle
+    first._source_cleanup_owners["first"] = first_owner
+    first_pin = first.pin("first")
+    assert first_pin.__enter__() is first_bundle
+    first.close()
+
+    with pytest.raises(SystemExit) as caught:
+        first_pin.__exit__(None, None, None)
+
+    assert caught.value is early
+    assert caught.value.__cause__ is late
+    assert first_owner.close_calls == 1
+    assert second_owner.close_calls == 1
+    assert first.retired_generation_count == 1
+    assert second.retired_generation_count == 1
+
+    first_owner.failure = None
+    second_owner.failure = None
+    first.close()
+    second.close()
+    assert first_owner.close_calls == 2
+    assert second_owner.close_calls == 2
+
+
+@pytest.mark.parametrize(
+    ("body_type", "deferred_type", "deferred_wins"),
+    [
+        (SystemExit, KeyboardInterrupt, False),
+        (RuntimeError, SystemExit, True),
+    ],
+)
+def test_registry_deferred_cleanup_preserves_exception_priority(
+    body_type,
+    deferred_type,
+    deferred_wins,
+):
+    body_failure = body_type("source cleanup failed")
+    deferred_failure = deferred_type("deferred generation cleanup failed")
+    first = RepoRegistry(QAConfig())
+    second = RepoRegistry(QAConfig())
+
+    class GenerationOwner:
+        def __init__(self):
+            self.failure = deferred_failure
+            self.close_calls = 0
+            self.done = False
+
+        @property
+        def closed(self):
+            return self.done
+
+        def close(self):
+            self.close_calls += 1
+            if self.failure is not None:
+                raise self.failure
+            self.done = True
+
+    generation_owner = GenerationOwner()
+    bundle = RepoBundle(entry=SimpleNamespace(), manifest=SimpleNamespace())
+    first._bundles["first"] = bundle
+    first._source_cleanup_owners["first"] = generation_owner
+    pinned = first.pin("first")
+    assert pinned.__enter__() is bundle
+    first.close()
+
+    class CrossOwner:
+        def __init__(self):
+            self.failure = body_failure
+            self.close_calls = 0
+            self.done = False
+
+        @property
+        def closed(self):
+            return self.done
+
+        def close(self):
+            self.close_calls += 1
+            if self.close_calls == 1:
+                pinned.__exit__(None, None, None)
+            if self.failure is not None:
+                raise self.failure
+            self.done = True
+
+    cross_owner = CrossOwner()
+    second._orphan_cleanup_owners.append(cross_owner)
+
+    with pytest.raises(BaseException) as caught:
+        second.close()
+
+    preferred = deferred_failure if deferred_wins else body_failure
+    secondary = body_failure if deferred_wins else deferred_failure
+    assert caught.value is preferred
+    assert caught.value.__cause__ is secondary
+    assert generation_owner.close_calls == 1
+    assert cross_owner.close_calls == 1
+    assert first.retired_generation_count == 1
+
+    generation_owner.failure = None
+    cross_owner.failure = None
+    first.close()
+    second.close()
+    assert generation_owner.close_calls == 2
+    assert cross_owner.close_calls == 2
+    assert first.retired_generation_count == 0
 
 
 def test_registry_cleanup_callback_restores_context_after_interruption():


### PR DESCRIPTION
## Summary
Follow-up to #700. Replace the merged reload-token workaround with a cancellation-safe lock protocol that keeps slow metadata/runtime preparation outside the cleanup lock, while preserving shutdown and retry ownership.

## Changes
- Hold the reload boundary across candidate preparation but take cleanup only for short open, publication, retirement, and shutdown transitions.
- Reject same-thread and cross-registry cleanup/reload cycles, and defer cross-registry lease drains without leaking lease ownership.
- Reconcile interrupted lock/TLS settlement while retaining exact cleanup authority for retries.
- Skip invalid unrelated repository IDs during targeted refresh while still requiring exactly one valid target.
- Add deterministic slow-build, reciprocal-lock, reentrant cleanup, exception-priority, and malformed-entry regressions; retain the Python PRECALL portability fix from #700.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- Python 3.10: 239 affected Web tests passed.
- Python 3.12: 238 passed, 1 interpreter-capability skip.
- Python 3.14: 239 passed.
- Python 3.12 full `test/web`: 482 passed, 1 skipped.
- Black, isort (`--profile black`), flake8, three-version `py_compile`, and `git diff --check` passed.
- 75 deterministic concurrency tests and a 305-trigger line-injection resource-settlement matrix passed; a 2,804-case targeted-refresh oracle passed.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
