### PR TITLE
feat(compiler): build BM25 from retained source

### DIFF
--- a/codenib/code_chunker.py
+++ b/codenib/code_chunker.py
@@ -373,6 +373,7 @@ class CodeChunker:
             if self._source_record_is_selected(
                 record,
                 extension_to_language=extension_to_language,
+                repository_root=source_identity.root,
                 source_selection=source_selection,
             )
         ]
@@ -535,6 +536,7 @@ class CodeChunker:
         record: RepositorySourceFileRecord,
         *,
         extension_to_language: Dict[str, str],
+        repository_root: Path,
         source_selection: RepositorySourceSelection,
     ) -> bool:
         """Apply repository discovery policy to one authenticated file record."""
@@ -560,7 +562,10 @@ class CodeChunker:
             for part in relative.parts[:-1]
         ):
             return False
-        if not self._should_process_file_path(relative, extension_to_language):
+        if not self._should_process_file_path(
+            repository_root / relative,
+            extension_to_language,
+        ):
             return False
         file_size_mb = record.size / (1024 * 1024)
         return file_size_mb <= self.repo_config.max_file_size_mb

--- a/codenib/code_chunker.py
+++ b/codenib/code_chunker.py
@@ -351,7 +351,9 @@ class CodeChunker:
 
         if check_cancelled is not None:
             check_cancelled()
-        source_identity = repository_source.authenticated_identity_snapshot()
+        source_identity = repository_source.authenticated_identity_snapshot(
+            check_cancelled=check_cancelled,
+        )
         if check_cancelled is not None:
             check_cancelled()
         source_selection = self._source_selection_snapshot()
@@ -380,7 +382,7 @@ class CodeChunker:
         logger.info("Found %d authenticated files to process", len(selected))
 
         chunks: List[CodeChunk] = []
-        with repository_source.read_session():
+        with repository_source.read_session(check_cancelled=check_cancelled):
             for record, language in selected:
                 if check_cancelled is not None:
                     check_cancelled()

--- a/codenib/code_chunker.py
+++ b/codenib/code_chunker.py
@@ -12,7 +12,7 @@ This file maintains backward compatibility with the old API and adds repository 
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set
 
 # Import from the new modular code chunking system
 from .code_chunking import CodeChunk, create_chunker
@@ -28,6 +28,7 @@ from .repository_source_selection import (
     RepositorySourceSelection,
     repository_relative_source_path,
 )
+from .source_fingerprint import RepositorySourceBinding, RepositorySourceFileRecord
 from .utils import is_test_file
 
 logger = get_logger(__name__)
@@ -327,6 +328,105 @@ class CodeChunker:
 
         return all_chunks
 
+    def chunk_repository_source(
+        self,
+        repository_source: RepositorySourceBinding,
+        *,
+        check_cancelled: Callable[[], None] | None = None,
+    ) -> List[CodeChunk]:
+        """Chunk one retained repository generation without path-based reads.
+
+        The binding supplies the complete authenticated file inventory and all
+        source bytes.  Discovery, filtering, decoding, and parsing therefore
+        operate on that fixed generation even when the repository is also
+        visible through a mutable public pathname.
+        """
+
+        if type(repository_source) is not RepositorySourceBinding:
+            raise TypeError(
+                "authenticated repository chunking requires an exact source binding"
+            )
+        if check_cancelled is not None and not callable(check_cancelled):
+            raise TypeError("authenticated repository cancellation must be callable")
+
+        if check_cancelled is not None:
+            check_cancelled()
+        source_identity = repository_source.authenticated_identity_snapshot()
+        if check_cancelled is not None:
+            check_cancelled()
+        source_selection = self._source_selection_snapshot()
+        if source_identity.source_selection != source_selection:
+            raise RuntimeError(
+                "authenticated repository selection differs from chunker policy"
+            )
+        records = tuple(source_identity.file_records)
+        languages = self.repo_config.languages or self._detect_source_languages(
+            records,
+            source_selection=source_selection,
+        )
+        extension_to_language = self._extension_language_map(languages)
+        selected = [
+            (record, extension_to_language[Path(record.path).suffix])
+            for record in records
+            if self._source_record_is_selected(
+                record,
+                extension_to_language=extension_to_language,
+                source_selection=source_selection,
+            )
+        ]
+
+        logger.info("Chunking authenticated repository: %s", source_identity.root)
+        logger.info("Target languages: %s", ", ".join(languages))
+        logger.info("Found %d authenticated files to process", len(selected))
+
+        chunks: List[CodeChunk] = []
+        with repository_source.read_session():
+            for record, language in selected:
+                if check_cancelled is not None:
+                    check_cancelled()
+                payload = repository_source.read_bytes(
+                    record.path,
+                    max_bytes=max(1, record.size),
+                )
+                if len(payload) != record.size:
+                    raise RuntimeError(
+                        "authenticated repository source returned the wrong byte count"
+                    )
+                source_text = (
+                    payload.decode("utf-8", errors="replace")
+                    .replace("\r\n", "\n")
+                    .replace("\r", "\n")
+                )
+                if self.repo_config.skip_minified and self._is_minified_source(
+                    source_text,
+                    path=record.path,
+                ):
+                    continue
+                try:
+                    chunks.extend(
+                        self._chunk_source_with_language(
+                            source_text,
+                            record.path,
+                            language,
+                        )
+                    )
+                except Exception as exc:
+                    raise RuntimeError(
+                        "Failed to chunk authenticated repository source "
+                        f"{record.path}: {exc}"
+                    ) from exc
+                if check_cancelled is not None:
+                    check_cancelled()
+
+        self._require_selected_chunks(
+            chunks,
+            source_selection,
+            repository_root=source_identity.root,
+        )
+        self._update_nodes_from_chunks(chunks)
+        logger.info("Generated %d authenticated source chunks", len(chunks))
+        return chunks
+
     def get_repository_stats(self, repo_path: str) -> Dict[str, Any]:
         """
         Get statistics about the repository without processing files.
@@ -415,6 +515,54 @@ class CodeChunker:
             rel_path = Path(file_path).name  # Just show filename for brevity
             logger.info(f"  {rel_path}: {len(file_chunks)} chunks")
 
+    def _extension_language_map(self, languages: List[str]) -> Dict[str, str]:
+        """Map configured extensions to normalized chunker languages."""
+
+        extension_to_language: Dict[str, str] = {}
+        for language in languages:
+            normalized = normalize_chunker_language(language)
+            if normalized is None:
+                logger.warning("Language %r not supported yet", language)
+                continue
+            for extension in self._extensions_for_chunker_language(normalized):
+                extension_to_language[extension] = normalized
+        return extension_to_language
+
+    def _source_record_is_selected(
+        self,
+        record: RepositorySourceFileRecord,
+        *,
+        extension_to_language: Dict[str, str],
+        source_selection: RepositorySourceSelection,
+    ) -> bool:
+        """Apply repository discovery policy to one authenticated file record."""
+
+        if type(record) is not RepositorySourceFileRecord:
+            raise TypeError("authenticated repository file record is invalid")
+        relative = Path(record.path)
+        if (
+            relative.is_absolute()
+            or not record.path
+            or relative.as_posix() != record.path
+            or any(part in {"", ".", ".."} for part in relative.parts)
+        ):
+            raise RuntimeError("authenticated repository file path is not canonical")
+        if not source_selection.allows(record.path) or not repository_path_is_visible(
+            relative
+        ):
+            raise RuntimeError(
+                "authenticated repository binding exposed an excluded source path"
+            )
+        if any(
+            not self._should_include_directory(Path(part))
+            for part in relative.parts[:-1]
+        ):
+            return False
+        if not self._should_process_file_path(relative, extension_to_language):
+            return False
+        file_size_mb = record.size / (1024 * 1024)
+        return file_size_mb <= self.repo_config.max_file_size_mb
+
     def _discover_files(
         self,
         repo_path: Path,
@@ -441,15 +589,7 @@ class CodeChunker:
         if type(selected) is not RepositorySourceSelection:
             raise TypeError("source_selection must be a RepositorySourceSelection")
 
-        extension_to_language: Dict[str, str] = {}
-        for language in languages:
-            normalized = normalize_chunker_language(language)
-            if normalized is None:
-                logger.warning("Language %r not supported yet", language)
-                continue
-            extensions = self._extensions_for_chunker_language(normalized)
-            for ext in extensions:
-                extension_to_language[ext] = normalized
+        extension_to_language = self._extension_language_map(languages)
 
         # Walk through repository
         for root, dirs, files in os.walk(repo_path):
@@ -556,23 +696,29 @@ class CodeChunker:
         during embedding (e.g. babel's Makefile.js: 131KB in 3 lines →
         ~480 duplicate chunks each hitting the 8192-token cap).
         """
-        threshold = self.repo_config.minified_line_threshold
         try:
             with open(file_path, "r", errors="replace") as f:
-                for line in f:
-                    if len(line) > threshold:
-                        logger.debug(
-                            "Skipping minified file (line > %d chars): %s",
-                            threshold,
-                            file_path,
-                        )
-                        return True
+                return self._is_minified_source(f.read(), path=str(file_path))
         except OSError as exc:
             logger.debug(
                 "Unable to inspect file for minification, treating as not minified: %s (%s)",
                 file_path,
                 exc,
             )
+        return False
+
+    def _is_minified_source(self, source: str, *, path: str) -> bool:
+        """Apply the shared long-line policy to already-read source text."""
+
+        threshold = self.repo_config.minified_line_threshold
+        for line in source.splitlines(keepends=True):
+            if len(line) > threshold:
+                logger.debug(
+                    "Skipping minified file (line > %d chars): %s",
+                    threshold,
+                    path,
+                )
+                return True
         return False
 
     def _chunk_file_with_language(
@@ -614,6 +760,31 @@ class CodeChunker:
             )
         else:
             return chunker.chunk_file(str(file_path), skeleton_mode=self.skeleton_mode)
+
+    def _chunk_source_with_language(
+        self,
+        source: str,
+        relative_path: str,
+        language: str,
+    ) -> List[CodeChunk]:
+        """Chunk authenticated text through the configured language parser."""
+
+        if language not in self._chunkers:
+            self._chunkers[language] = create_chunker(
+                language,
+                max_lines_per_chunk=self.max_lines_per_chunk,
+                chunk_depth=self.chunk_depth,
+                include_header_epilogue=self.include_header_epilogue,
+                l2_level_exclusive=self.l2_level_exclusive,
+                skeleton_mode=self.skeleton_mode,
+                include_l2_in_file_skeleton=self.include_l2_in_file_skeleton,
+            )
+        return self._chunkers[language].chunk_source(
+            source,
+            file_path=relative_path,
+            relative_path=relative_path,
+            skeleton_mode=self.skeleton_mode,
+        )
 
     def _extensions_for_chunker_language(self, language: str) -> Set[str]:
         """Return configured repository extensions for a chunker language."""
@@ -755,6 +926,47 @@ class CodeChunker:
 
         result = list(detected_languages)
         logger.info(f"Detected languages: {result}")
+        return result
+
+    def _detect_source_languages(
+        self,
+        records: tuple[RepositorySourceFileRecord, ...],
+        *,
+        source_selection: RepositorySourceSelection,
+    ) -> List[str]:
+        """Infer languages from one authenticated repository inventory."""
+
+        extension_counts: Dict[str, int] = {}
+        for record in records:
+            if type(record) is not RepositorySourceFileRecord:
+                raise TypeError("authenticated repository file record is invalid")
+            relative = Path(record.path)
+            if (
+                not source_selection.allows(record.path)
+                or not repository_path_is_visible(relative)
+                or any(
+                    not self._should_include_directory(Path(part))
+                    for part in relative.parts[:-1]
+                )
+            ):
+                continue
+            if relative.suffix:
+                extension_counts[relative.suffix] = (
+                    extension_counts.get(relative.suffix, 0) + 1
+                )
+
+        detected = {
+            language
+            for language in chunker_languages()
+            if any(
+                extension in extension_counts
+                for extension in self._extensions_for_chunker_language(language)
+            )
+        }
+        if not detected or "python" in detected:
+            detected.add("python")
+        result = sorted(detected)
+        logger.info("Detected authenticated source languages: %s", result)
         return result
 
     def _source_selection_snapshot(self) -> RepositorySourceSelection:

--- a/codenib/code_chunker.py
+++ b/codenib/code_chunker.py
@@ -12,7 +12,7 @@ This file maintains backward compatibility with the old API and adds repository 
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set
 
 # Import from the new modular code chunking system
 from .code_chunking import CodeChunk, create_chunker
@@ -700,7 +700,7 @@ class CodeChunker:
         """
         try:
             with open(file_path, "r", errors="replace") as f:
-                return self._is_minified_source(f.read(), path=str(file_path))
+                return self._has_minified_line(f, path=str(file_path))
         except OSError as exc:
             logger.debug(
                 "Unable to inspect file for minification, treating as not minified: %s (%s)",
@@ -712,8 +712,13 @@ class CodeChunker:
     def _is_minified_source(self, source: str, *, path: str) -> bool:
         """Apply the shared long-line policy to already-read source text."""
 
+        return self._has_minified_line(source.splitlines(keepends=True), path=path)
+
+    def _has_minified_line(self, lines: Iterable[str], *, path: str) -> bool:
+        """Return whether a streamed or retained source has an oversized line."""
+
         threshold = self.repo_config.minified_line_threshold
-        for line in source.splitlines(keepends=True):
+        for line in lines:
             if len(line) > threshold:
                 logger.debug(
                     "Skipping minified file (line > %d chars): %s",

--- a/codenib/code_chunking/base.py
+++ b/codenib/code_chunking/base.py
@@ -155,6 +155,39 @@ class BaseCodeChunker(ABC):
         # parser routes measure and decode the exact same source boundary.
         code_content = self._read_source(file_path)
 
+        return self.chunk_source(
+            code_content,
+            file_path=file_path,
+            relative_path=relative_path,
+            skeleton_mode=skeleton_mode,
+        )
+
+    def chunk_source(
+        self,
+        code_content: str,
+        *,
+        file_path: str,
+        relative_path: Optional[str] = None,
+        skeleton_mode: Optional[bool] = None,
+    ) -> List[CodeChunk]:
+        """Chunk already-authenticated source text without reopening a path.
+
+        ``file_path`` remains the value recorded on emitted chunks, while
+        ``relative_path`` controls their graph-compatible node IDs.  Callers
+        that obtained bytes through a retained source authority can therefore
+        reuse the exact parser/chunking contract without materializing a
+        replaceable public source path.
+        """
+
+        if type(code_content) is not str:
+            raise TypeError("chunk source content must be exact text")
+        if type(file_path) is not str or not file_path:
+            raise TypeError("chunk source file path must be non-empty exact text")
+        if relative_path is not None and (
+            type(relative_path) is not str or not relative_path
+        ):
+            raise TypeError("chunk source relative path must be non-empty exact text")
+
         # Parse the code
         code_bytes = code_content.encode("utf-8")
         tree = self.parser.parse(code_bytes)

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -389,9 +389,19 @@ class BM25IndexBuilder:
             )
         output = Path(os.path.abspath(os.path.expanduser(output_dir)))
         repository_root = identity.root
-        if output == repository_root or output in repository_root.parents:
+        resolved_output = output.resolve(strict=False)
+        resolved_repository_root = repository_root.resolve(strict=True)
+        if (
+            output == repository_root
+            or output in repository_root.parents
+            or resolved_output == resolved_repository_root
+            or resolved_output in resolved_repository_root.parents
+        ):
             raise ValueError("BM25 source build output cannot contain the repository")
-        if repository_root in output.parents:
+        if (
+            repository_root in output.parents
+            or resolved_repository_root in resolved_output.parents
+        ):
             raise ValueError("BM25 source build output cannot be inside the repository")
         if os.path.lexists(output):
             raise FileExistsError(

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -25,7 +25,8 @@ import stat
 import subprocess
 import time
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Protocol, runtime_checkable
 
 from ..index.embedding.model_policy import (
     DEFAULT_EMBEDDING_DIMENSION,
@@ -50,6 +51,7 @@ from ..repository_source_selection import (
     RepositorySourceSelection,
     repository_relative_source_path,
 )
+from ..source_fingerprint import RepositorySourceBinding
 from .resources import IndexState, IndexStatus
 from .verification import NullVerifier, UpdateVerifier, VerificationResult
 
@@ -315,7 +317,6 @@ class BM25IndexBuilder:
         artifact_identity = self._artifact_identity_for_selection(source_selection)
 
         from ..code_chunker import CodeChunker, RepoChunkingConfig
-        from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 
         primary = self.languages[0] if self.languages else "python"
         repo_config = RepoChunkingConfig(
@@ -337,6 +338,116 @@ class BM25IndexBuilder:
             subject="BM25 chunks",
         )
 
+        return self._build_chunks(
+            scope,
+            repo_path=repo_path,
+            output_dir=output_dir,
+            source_selection=source_selection,
+            artifact_identity=artifact_identity,
+            chunks=chunks,
+            require_missing_output=False,
+            check_cancelled=None,
+        )
+
+    def build_from_repository_source(
+        self,
+        scope: str,
+        *,
+        repository_source: RepositorySourceBinding,
+        output_dir: str,
+        source_selection: RepositorySourceSelection | None = None,
+        check_cancelled: Callable[[], None] | None = None,
+    ) -> IndexStatus:
+        """Build one private BM25 generation from retained source authority.
+
+        Unlike :meth:`build`, this path never discovers or opens repository
+        files by pathname and refuses to reuse an existing output directory.
+        It is intended for prepare-only durable job attempts whose caller owns
+        the unique generation root and final cleanup.
+        """
+
+        if type(repository_source) is not RepositorySourceBinding:
+            raise TypeError("BM25 source build requires an exact source binding")
+        if type(output_dir) is not str or not output_dir:
+            raise TypeError("BM25 source build output must be non-empty exact text")
+        if check_cancelled is not None and not callable(check_cancelled):
+            raise TypeError("BM25 source build cancellation must be callable")
+        selected = _source_selection_for_build(
+            self.source_selection,
+            source_selection,
+        )
+        if check_cancelled is not None:
+            check_cancelled()
+        identity = repository_source.authenticated_identity_snapshot()
+        if check_cancelled is not None:
+            check_cancelled()
+        if identity.source_selection != selected:
+            raise RuntimeError(
+                "BM25 source binding selection differs from builder policy"
+            )
+        output = Path(os.path.abspath(os.path.expanduser(output_dir)))
+        repository_root = identity.root
+        if output == repository_root or output in repository_root.parents:
+            raise ValueError("BM25 source build output cannot contain the repository")
+        if repository_root in output.parents:
+            raise ValueError("BM25 source build output cannot be inside the repository")
+        if os.path.lexists(output):
+            raise FileExistsError(
+                "BM25 source build requires a missing private generation"
+            )
+        from ..code_chunker import CodeChunker, RepoChunkingConfig
+
+        primary = self.languages[0] if self.languages else "python"
+        repo_config = RepoChunkingConfig(
+            languages=self.languages,
+            source_selection=selected,
+        )
+        repo_config.ignore_dirs.update(self.additional_ignore_dirs)
+        chunker = CodeChunker(
+            language=primary,
+            repo_config=repo_config,
+            max_lines_per_chunk=self.max_lines_per_chunk,
+            include_header_epilogue=True,
+        )
+        chunks = chunker.chunk_repository_source(
+            repository_source,
+            check_cancelled=check_cancelled,
+        )
+        _require_selected_paths(
+            selected,
+            (getattr(chunk, "file", None) for chunk in chunks),
+            repository_root=str(repository_root),
+            subject="BM25 chunks",
+        )
+        if check_cancelled is not None:
+            check_cancelled()
+        return self._build_chunks(
+            scope,
+            repo_path=str(repository_root),
+            output_dir=str(output),
+            source_selection=selected,
+            artifact_identity=self._artifact_identity_for_selection(selected),
+            chunks=chunks,
+            require_missing_output=True,
+            check_cancelled=check_cancelled,
+        )
+
+    def _build_chunks(
+        self,
+        scope: str,
+        *,
+        repo_path: str,
+        output_dir: str,
+        source_selection: RepositorySourceSelection,
+        artifact_identity: Dict[str, Any],
+        chunks: List[Any],
+        require_missing_output: bool,
+        check_cancelled: Callable[[], None] | None,
+    ) -> IndexStatus:
+        """Persist and attest one already-captured BM25 chunk generation."""
+
+        from ..index.sparse_idx.bm25_index import BM25CodeIndexer
+
         indexer = BM25CodeIndexer(
             chunks=chunks,
             max_k=self.max_k,
@@ -348,11 +459,18 @@ class BM25IndexBuilder:
             repository_root=repo_path,
             subject="BM25 documents",
         )
-        os.makedirs(output_dir, exist_ok=True)
+        if check_cancelled is not None:
+            check_cancelled()
+        if require_missing_output:
+            os.mkdir(output_dir, mode=0o700)
+        else:
+            os.makedirs(output_dir, exist_ok=True)
         indexer.save_index(output_dir)
         from .artifact_fingerprints import bm25_artifact_file_fingerprints
 
         artifact_files = bm25_artifact_file_fingerprints(output_dir)
+        if check_cancelled is not None:
+            check_cancelled()
 
         return IndexStatus(
             index_type="bm25",

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -378,7 +378,9 @@ class BM25IndexBuilder:
         )
         if check_cancelled is not None:
             check_cancelled()
-        identity = repository_source.authenticated_identity_snapshot()
+        identity = repository_source.authenticated_identity_snapshot(
+            check_cancelled=check_cancelled,
+        )
         if check_cancelled is not None:
             check_cancelled()
         if identity.source_selection != selected:

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1265,6 +1265,16 @@ win; the staged namespace transition through authenticated receipt creation
 remains an uninterruptible commit section, and an exact cooperative stop does
 not poison the retained repository source.
 
+The first retained-source cache-building primitive now covers BM25 without
+reopening repository files by pathname. A retained `RepositorySourceBinding`
+supplies the authenticated inventory and bytes to the existing tree-sitter
+chunkers, which preserve normal filtering, relative-path, line, and
+compatibility contracts while parsing already-captured text. The builder writes
+only to a missing caller-owned private generation and attests the resulting
+BM25 artifact fingerprints. Durable source-job adapters, attempt resource and
+cleanup ownership, CLI/Web binding, vector source building, and graph source
+building remain absent.
+
 The compiler-cache bridge now also has a resource-scoped resolver seam. It
 attests the canonical running request before opening attempt resources, accepts
 only one required `full` BM25 or vector view, binds the exact
@@ -1314,8 +1324,10 @@ runtime now has the generation-safe refresh boundary described under M3.
 
 Status: in progress. The receipt-retained, fenced SQLite publication primitive
 and the explicit BM25 and schema-8 vector compiler-cache adapters, including
-their prepare-only worker bridge, are implemented; graph, generic source
-builders, cache-building execution, and remaining runtime wiring remain.
+their prepare-only worker bridge, are implemented. The first caller-scoped
+retained-source BM25 builder now produces a unique private generation; durable
+source-job adapters, vector and graph source builders, generic builder routing,
+and remaining runtime wiring remain.
 
 - Make every builder write to a unique staging generation.
 - Add per-view profile adapters that fail closed on incomplete compatibility
@@ -1348,8 +1360,8 @@ bundle before atomically publishing it, pins the exact generation for each
 in-flight request, defers old vector/source cleanup until the final pin exits,
 and invalidates bundle-bound Wiki, edge-label, and commit-window caches by
 generation identity. The first #266 status, durable-read, and explicitly
-injected one-view write slices are present; source builders, a production Web
-planner/default binding, success-triggered refresh, MCP, UI controls, and
+injected one-view write slices are present; source-job adapters, a production
+Web planner/default binding, success-triggered refresh, MCP, UI controls, and
 default routing remain absent.
 
 - The backend-neutral worker now owns advisory scan/claim, per-attempt task

--- a/test/chunker/test_base_chunker.py
+++ b/test/chunker/test_base_chunker.py
@@ -119,6 +119,69 @@ def test_chunk_file_replaces_invalid_utf8_bytes(monkeypatch, tmp_path):
     assert "\ufffd" in chunks[0].content
 
 
+def test_chunk_source_reuses_parser_without_reopening_a_path(monkeypatch):
+    parser = SimpleNamespace(parse=lambda _code: SimpleNamespace(root_node=object()))
+    monkeypatch.setattr(
+        "codenib.code_chunking.base.get_language", lambda _lang: object()
+    )
+    monkeypatch.setattr(
+        BaseCodeChunker,
+        "_create_parser",
+        staticmethod(lambda _language: parser),
+    )
+    monkeypatch.setattr(
+        BaseCodeChunker,
+        "_read_source",
+        staticmethod(lambda _path: pytest.fail("chunk_source reopened a path")),
+    )
+
+    chunker = StubCodeChunker("python", chunk_depth=0)
+    chunks = chunker.chunk_source(
+        "value = 1\n",
+        file_path="src/app.py",
+        relative_path="src/app.py",
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0].file == "src/app.py"
+    assert chunks[0].node_id == "src/app.py"
+    assert chunks[0].content == "src/app.py\nvalue = 1\n"
+
+
+@pytest.mark.parametrize(
+    ("content", "file_path", "relative_path", "message"),
+    [
+        (b"value = 1", "src/app.py", "src/app.py", "exact text"),
+        ("value = 1", "", "src/app.py", "file path"),
+        ("value = 1", "src/app.py", "", "relative path"),
+    ],
+)
+def test_chunk_source_rejects_noncanonical_inputs(
+    monkeypatch,
+    content,
+    file_path,
+    relative_path,
+    message,
+):
+    parser = SimpleNamespace(parse=lambda _code: SimpleNamespace(root_node=object()))
+    monkeypatch.setattr(
+        "codenib.code_chunking.base.get_language", lambda _lang: object()
+    )
+    monkeypatch.setattr(
+        BaseCodeChunker,
+        "_create_parser",
+        staticmethod(lambda _language: parser),
+    )
+    chunker = StubCodeChunker("python", chunk_depth=0)
+
+    with pytest.raises(TypeError, match=message):
+        chunker.chunk_source(
+            content,
+            file_path=file_path,
+            relative_path=relative_path,
+        )
+
+
 def test_tree_walkers_handle_deeper_trees_than_python_recursion_limit():
     target = SimpleNamespace(type="target", children=[])
     branch = target

--- a/test/chunker/test_repo_chunking_config.py
+++ b/test/chunker/test_repo_chunking_config.py
@@ -12,6 +12,7 @@ import pytest
 from codenib.code_chunker import CodeChunker, RepoChunkingConfig
 from codenib.languages import extensions_for_language
 from codenib.repository_source_selection import RepositorySourceSelection
+from codenib.source_fingerprint import RepositoryChangedError, capture_repository_source
 
 
 def test_repo_chunking_config_defaults_come_from_language_registry():
@@ -159,6 +160,71 @@ def test_repository_chunking_rejects_an_excluded_chunk_result(
 
     with pytest.raises(RuntimeError, match="leaked excluded chunk"):
         chunker.chunk_repository(str(tmp_path), strict=True)
+
+
+def test_authenticated_repository_chunking_uses_retained_bytes_and_paths(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    (repo / "src" / "private").mkdir(parents=True)
+    (repo / "src" / "app.py").write_bytes(b"def app():\r\n    return 'retained'\r\n")
+    (repo / "src" / "private" / "secret.py").write_text(
+        "def secret():\n    return 1\n",
+        encoding="utf-8",
+    )
+    selection = RepositorySourceSelection(("src/private",))
+    config = RepoChunkingConfig(
+        languages=["python"],
+        filter_tests=False,
+        source_selection=selection,
+    )
+    chunker = CodeChunker(language="python", repo_config=config)
+
+    with capture_repository_source(repo, selection=selection) as source:
+        chunks = chunker.chunk_repository_source(source)
+
+    assert {chunk.file for chunk in chunks} == {"src/app.py"}
+    assert {chunk.node_id for chunk in chunks} == {"src/app.py:app()"}
+    assert all("\r" not in chunk.content for chunk in chunks)
+    assert "retained" in chunks[0].content
+
+
+def test_authenticated_repository_chunking_rejects_policy_mismatch_before_reads(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "app.py").write_text("def app():\n    return 1\n", encoding="utf-8")
+    chunker = CodeChunker(
+        language="python",
+        repo_config=RepoChunkingConfig(
+            languages=["python"],
+            source_selection=RepositorySourceSelection(("generated",)),
+        ),
+    )
+
+    with capture_repository_source(repo) as source:
+        with pytest.raises(RuntimeError, match="differs from chunker policy"):
+            chunker.chunk_repository_source(source)
+        assert source.usable
+
+
+def test_authenticated_repository_chunking_rejects_changed_source(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source_path = repo / "app.py"
+    source_path.write_text("def app():\n    return 1\n", encoding="utf-8")
+    chunker = CodeChunker(
+        language="python",
+        repo_config=RepoChunkingConfig(languages=["python"]),
+    )
+
+    with capture_repository_source(repo) as source:
+        source_path.write_text("def replaced():\n    return 2\n", encoding="utf-8")
+        with pytest.raises(RepositoryChangedError):
+            chunker.chunk_repository_source(source)
 
 
 def test_strict_repository_chunking_rejects_partial_results(tmp_path, monkeypatch):

--- a/test/chunker/test_repo_chunking_config.py
+++ b/test/chunker/test_repo_chunking_config.py
@@ -124,6 +124,33 @@ def test_repo_discovery_applies_exact_selection_before_file_reads(
     assert "src/private/secret.py" not in inspected
 
 
+def test_minified_file_scan_remains_streaming(monkeypatch):
+    chunker = CodeChunker(
+        language="javascript",
+        repo_config=RepoChunkingConfig(
+            languages=["javascript"],
+            minified_line_threshold=10,
+        ),
+    )
+
+    class StreamingSource:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, _exc_type, _exc, _traceback):
+            return False
+
+        def __iter__(self):
+            return iter(("short\n", "x" * 11))
+
+        def read(self):
+            pytest.fail("minified path scan read the complete file")
+
+    monkeypatch.setattr("builtins.open", lambda *_args, **_kwargs: StreamingSource())
+
+    assert chunker._is_minified_file(Path("bundle.js")) is True
+
+
 def test_repo_language_detection_ignores_excluded_subtrees(tmp_path: Path):
     excluded = tmp_path / "generated" / "main.go"
     excluded.parent.mkdir()

--- a/test/chunker/test_repo_chunking_config.py
+++ b/test/chunker/test_repo_chunking_config.py
@@ -12,7 +12,11 @@ import pytest
 from codenib.code_chunker import CodeChunker, RepoChunkingConfig
 from codenib.languages import extensions_for_language
 from codenib.repository_source_selection import RepositorySourceSelection
-from codenib.source_fingerprint import RepositoryChangedError, capture_repository_source
+from codenib.source_fingerprint import (
+    RepositoryChangedError,
+    RepositorySourceBinding,
+    capture_repository_source,
+)
 
 
 def test_repo_chunking_config_defaults_come_from_language_registry():
@@ -187,6 +191,48 @@ def test_authenticated_repository_chunking_uses_retained_bytes_and_paths(
     assert {chunk.node_id for chunk in chunks} == {"src/app.py:app()"}
     assert all("\r" not in chunk.content for chunk in chunks)
     assert "retained" in chunks[0].content
+
+
+def test_authenticated_repository_chunking_threads_cancellation_into_source_gates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "app.py").write_text("def app():\n    return 1\n", encoding="utf-8")
+    chunker = CodeChunker(
+        language="python",
+        repo_config=RepoChunkingConfig(languages=["python"]),
+    )
+    real_snapshot = RepositorySourceBinding.authenticated_identity_snapshot
+    real_session = RepositorySourceBinding.read_session
+    observed = []
+
+    def tracked_snapshot(binding, *args, **kwargs):
+        observed.append(("identity", kwargs.get("check_cancelled")))
+        return real_snapshot(binding, *args, **kwargs)
+
+    def tracked_session(binding, *args, **kwargs):
+        observed.append(("session", kwargs.get("check_cancelled")))
+        return real_session(binding, *args, **kwargs)
+
+    monkeypatch.setattr(
+        RepositorySourceBinding,
+        "authenticated_identity_snapshot",
+        tracked_snapshot,
+    )
+    monkeypatch.setattr(RepositorySourceBinding, "read_session", tracked_session)
+
+    def check_cancelled() -> None:
+        return None
+
+    with capture_repository_source(repo) as source:
+        chunker.chunk_repository_source(source, check_cancelled=check_cancelled)
+
+    assert observed == [
+        ("identity", check_cancelled),
+        ("session", check_cancelled),
+    ]
 
 
 def test_authenticated_repository_chunking_rejects_policy_mismatch_before_reads(

--- a/test/chunker/test_repo_chunking_config.py
+++ b/test/chunker/test_repo_chunking_config.py
@@ -220,6 +220,27 @@ def test_authenticated_repository_chunking_uses_retained_bytes_and_paths(
     assert "retained" in chunks[0].content
 
 
+def test_authenticated_repository_chunking_preserves_test_filter_path_context(
+    tmp_path: Path,
+):
+    repo = tmp_path / "tests" / "repo"
+    repo.mkdir(parents=True)
+    (repo / "app.py").write_text(
+        "def app():\n    return 1\n",
+        encoding="utf-8",
+    )
+    chunker = CodeChunker(
+        language="python",
+        repo_config=RepoChunkingConfig(languages=["python"]),
+    )
+
+    direct_chunks = chunker.chunk_repository(str(repo), strict=True)
+    with capture_repository_source(repo) as source:
+        retained_chunks = chunker.chunk_repository_source(source)
+
+    assert direct_chunks == retained_chunks == []
+
+
 def test_authenticated_repository_chunking_threads_cancellation_into_source_gates(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -76,6 +76,7 @@ from codenib.repository_filters import (
 from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.source_fingerprint import (
     RepositoryChangedError,
+    RepositorySourceBinding,
     capture_repository_source,
     is_secure_source_fingerprint_v2,
 )
@@ -459,6 +460,43 @@ class TestBM25IndexBuilder:
                 )
 
         assert not output.exists()
+
+    def test_build_from_repository_source_threads_cancellation_into_identity(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "app.py").write_text("def app():\n    return 1\n", encoding="utf-8")
+        private_root = tmp_path / "private"
+        private_root.mkdir()
+        output = private_root / "bm25"
+        real_snapshot = RepositorySourceBinding.authenticated_identity_snapshot
+        observed = []
+
+        def tracked_snapshot(binding, *args, **kwargs):
+            observed.append(kwargs.get("check_cancelled"))
+            return real_snapshot(binding, *args, **kwargs)
+
+        monkeypatch.setattr(
+            RepositorySourceBinding,
+            "authenticated_identity_snapshot",
+            tracked_snapshot,
+        )
+
+        def check_cancelled() -> None:
+            return None
+
+        with capture_repository_source(repo) as source:
+            BM25IndexBuilder().build_from_repository_source(
+                "current_repo",
+                repository_source=source,
+                output_dir=str(output),
+                check_cancelled=check_cancelled,
+            )
+
+        assert observed == [check_cancelled, check_cancelled]
 
     def test_build_from_repository_source_rejects_changed_authority(
         self,

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -436,6 +436,27 @@ class TestBM25IndexBuilder:
 
         assert marker.read_text(encoding="utf-8") == "keep"
 
+    def test_build_from_repository_source_rejects_output_symlinked_into_repository(
+        self,
+        tmp_path,
+    ):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "app.py").write_text("def app():\n    return 1\n", encoding="utf-8")
+        alias = tmp_path / "repository-alias"
+        alias.symlink_to(repo, target_is_directory=True)
+        output = alias / "bm25"
+
+        with capture_repository_source(repo) as source:
+            with pytest.raises(ValueError, match="inside the repository"):
+                BM25IndexBuilder().build_from_repository_source(
+                    "current_repo",
+                    repository_source=source,
+                    output_dir=str(output),
+                )
+
+        assert not output.exists()
+
     def test_build_from_repository_source_stops_before_output_mutation(
         self,
         tmp_path,

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -74,7 +74,11 @@ from codenib.repository_filters import (
     default_exclude_patterns,
 )
 from codenib.repository_source_selection import RepositorySourceSelection
-from codenib.source_fingerprint import is_secure_source_fingerprint_v2
+from codenib.source_fingerprint import (
+    RepositoryChangedError,
+    capture_repository_source,
+    is_secure_source_fingerprint_v2,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -365,6 +369,119 @@ class TestBM25IndexBuilder:
         results = index.search("safe_local", top_k=1)
         assert results
         assert results[0].file == "settings.py"
+
+    def test_build_from_repository_source_uses_retained_bytes(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        from codenib.code_chunker import CodeChunker
+        from codenib.index.sparse_idx.bm25_index import BM25CodeIndexer
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "settings.py").write_bytes(b"UNIQUE_RETAINED_MODE = 'safe_source'\r\n")
+        private_root = tmp_path / "private"
+        private_root.mkdir()
+        output = private_root / "bm25"
+        monkeypatch.setattr(
+            CodeChunker,
+            "chunk_repository",
+            lambda *_args, **_kwargs: pytest.fail(
+                "retained BM25 build used path discovery"
+            ),
+        )
+
+        with capture_repository_source(repo) as source:
+            status = BM25IndexBuilder(
+                languages=["python"]
+            ).build_from_repository_source(
+                "current_repo",
+                repository_source=source,
+                output_dir=str(output),
+            )
+
+        assert status.state is IndexState.FRESH
+        assert status.path == str(output)
+        assert status.metadata["source_file_count"] == 1
+        assert status.metadata["source_selection_digest"] == (
+            RepositorySourceSelection().digest
+        )
+        index = BM25CodeIndexer()
+        index.load_index(str(output))
+        results = index.search("safe_source", top_k=1)
+        assert results
+        assert results[0].file == "settings.py"
+
+    def test_build_from_repository_source_requires_a_missing_private_output(
+        self,
+        tmp_path,
+    ):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "app.py").write_text("def app():\n    return 1\n", encoding="utf-8")
+        output = tmp_path / "private" / "bm25"
+        output.mkdir(parents=True)
+        marker = output / "owned.txt"
+        marker.write_text("keep", encoding="utf-8")
+
+        with capture_repository_source(repo) as source:
+            with pytest.raises(FileExistsError, match="missing private generation"):
+                BM25IndexBuilder().build_from_repository_source(
+                    "current_repo",
+                    repository_source=source,
+                    output_dir=str(output),
+                )
+
+        assert marker.read_text(encoding="utf-8") == "keep"
+
+    def test_build_from_repository_source_stops_before_output_mutation(
+        self,
+        tmp_path,
+    ):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "app.py").write_text("def app():\n    return 1\n", encoding="utf-8")
+        private_root = tmp_path / "private"
+        private_root.mkdir()
+        output = private_root / "bm25"
+
+        def stop() -> None:
+            raise RuntimeError("stop requested")
+
+        with capture_repository_source(repo) as source:
+            with pytest.raises(RuntimeError, match="stop requested"):
+                BM25IndexBuilder().build_from_repository_source(
+                    "current_repo",
+                    repository_source=source,
+                    output_dir=str(output),
+                    check_cancelled=stop,
+                )
+
+        assert not output.exists()
+
+    def test_build_from_repository_source_rejects_changed_authority(
+        self,
+        tmp_path,
+    ):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        path = repo / "app.py"
+        path.write_text("def app():\n    return 1\n", encoding="utf-8")
+        private_root = tmp_path / "private"
+        private_root.mkdir()
+        output = private_root / "bm25"
+
+        with capture_repository_source(repo) as source:
+            path.write_text("def changed():\n    return 2\n", encoding="utf-8")
+            with pytest.raises(RepositoryChangedError):
+                BM25IndexBuilder().build_from_repository_source(
+                    "current_repo",
+                    repository_source=source,
+                    output_dir=str(output),
+                )
+
+        assert not output.exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add the first retained-source cache-building primitive for the durable storage program: BM25 can now be built from an authenticated `RepositorySourceBinding` without reopening mutable repository paths. The slice remains prepare-only and does not add durable job adapters, resolver/resource wiring, CLI/Web routing, or runtime activation.

## Changes

- Add chunking for already-authenticated source text and retained repository inventories while preserving parser, filtering, language, relative-path, newline, minified-file, and cancellation contracts.
- Add a BM25 builder entry point that accepts retained source authority, writes only to a missing caller-owned private generation, rejects lexical or symlink-resolved repository overlap, and fingerprints the completed artifacts.
- Preserve direct/retained test-file filter parity when repository ancestors affect the established path policy.
- Add failure, cancellation, source-drift, output-ownership, symlink-overlap, streaming, and compatibility regressions.
- Update `docs/storage_backend_roadmap.md` to record the implemented primitive and the remaining M2/M3 boundaries.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/chunker test/compiler test/test_source_fingerprint.py test/index/sparse_idx/test_bm25_safe_source.py --tb=short` (`1320 passed, 18 skipped`)
- `mkdocs build --strict`
- `python scripts/check_public_docs.py`
- `pre-commit run --from-ref origin/main --to-ref HEAD`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
