### PR TITLE
test(compiler): stabilize source inventory drift

### DIFF
--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -3842,9 +3842,21 @@ def test_compile_and_import_rejects_drift_or_failed_view_before_data_io(
 
     def fake_update(*args, **kwargs):
         if failure == "source":
-            (fixture.repository / "sample.py").write_text(
+            source_path = fixture.repository / "sample.py"
+            authenticated = source_path.stat()
+            source_path.write_text(
                 "VALUE = 2\n",
                 encoding="utf-8",
+            )
+            # Some test filesystems coalesce same-size rewrites within one
+            # timestamp tick. Keep that equal-size case while making the
+            # intended inventory-version drift deterministic.
+            os.utime(
+                source_path,
+                ns=(
+                    authenticated.st_atime_ns,
+                    authenticated.st_mtime_ns + 1_000_000_000,
+                ),
             )
         return returned_manifest
 

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -3851,13 +3851,20 @@ def test_compile_and_import_rejects_drift_or_failed_view_before_data_io(
             # Some test filesystems coalesce same-size rewrites within one
             # timestamp tick. Keep that equal-size case while making the
             # intended inventory-version drift deterministic.
-            os.utime(
-                source_path,
-                ns=(
-                    authenticated.st_atime_ns,
-                    authenticated.st_mtime_ns + 1_000_000_000,
-                ),
-            )
+            for seconds in (1, 2, 4, 8, 16):
+                os.utime(
+                    source_path,
+                    ns=(
+                        authenticated.st_atime_ns,
+                        authenticated.st_mtime_ns + seconds * 1_000_000_000,
+                    ),
+                )
+                if source_path.stat().st_mtime_ns != authenticated.st_mtime_ns:
+                    break
+            else:
+                pytest.fail(
+                    "test filesystem could not represent source inventory drift"
+                )
         return returned_manifest
 
     monkeypatch.setattr(compiler, "_update_repo_locked", fake_update)


### PR DESCRIPTION
## Summary
Make the equal-size source-drift regression deterministic on filesystems that coalesce metadata updates within one timestamp tick.

## Changes
- Preserve the equal-size source rewrite exercised by the compiler import safety test.
- Explicitly advance the test file mtime so the intended inventory-version drift is deterministic across filesystems.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- Ran the affected source-drift case 20 consecutive times.
- `pytest -q test/compiler/test_cache_import.py --tb=short` (111 passed, 7 skipped).
- Pre-commit passed for `test/compiler/test_cache_import.py`.

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published