### PR TITLE
fix(storage): retain BM25 attempt authority

### DIFF
--- a/codenib/artifacts/strict_bm25.py
+++ b/codenib/artifacts/strict_bm25.py
@@ -1226,6 +1226,59 @@ def _planned_view_from_publication(
     return result
 
 
+def _plan_retained_bm25_publication_view(
+    publication: PublicationDirectoryReader,
+    *,
+    repository_source: RepositorySourceBinding,
+    repository_identity: RepositorySourceIdentitySnapshot,
+    view_config: Mapping[str, Any],
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
+    check_cancelled: Callable[[], None] | None = None,
+) -> PlannedBm25View:
+    """Plan from a reader whose parent authority remains active for replay."""
+
+    if type(publication) is not PublicationDirectoryReader:
+        raise TypeError("retained BM25 source must be an exact publication reader")
+    repository_identity = _detach_repository_identity_snapshot(
+        repository_identity,
+        check_cancelled=check_cancelled,
+    )
+    retained_identity = repository_source.authenticated_identity_snapshot(
+        check_cancelled=check_cancelled,
+    )
+    _require_repository_identity_matches(
+        repository_identity,
+        retained_identity,
+        check_cancelled=check_cancelled,
+    )
+    config_digest, forbidden, authenticated_files = _policy(
+        repository_identity,
+        view_config,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
+        check_cancelled=check_cancelled,
+    )
+    source_session = repository_source.read_session(
+        check_cancelled=check_cancelled,
+    )
+    with source_session:
+        return _planned_view_from_publication(
+            publication,
+            publication.capture_ownership(
+                entry_policy=_entry_policy,
+                check_cancelled=check_cancelled,
+            ),
+            repository_identity=repository_identity,
+            config_digest=config_digest,
+            forbidden_paths=forbidden,
+            environ=environ,
+            authenticated_source_files=authenticated_files,
+            source_label="retained compiler-cache BM25 source",
+            check_cancelled=check_cancelled,
+        )
+
+
 def _plan_bm25_view_with_identity(
     source_generation: PublishedWorkspaceReceiptOwner,
     *,
@@ -1905,6 +1958,184 @@ def _publish_recaptured_bm25_view_with_identity(
         raise RuntimeError("strict BM25 publication returned the wrong receipt")
     if check_cancelled is not None:
         check_cancelled()
+    return planned.adjustments
+
+
+def _publish_retained_bm25_publication_view(
+    publication: PublicationDirectoryReader,
+    destination: Path,
+    *,
+    planned: PlannedBm25View,
+    repository_source: RepositorySourceBinding,
+    repository_identity: RepositorySourceIdentitySnapshot,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+    view_config: Mapping[str, Any],
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
+    check_cancelled: Callable[[], None] | None = None,
+) -> dict[str, Any]:
+    """Replay one BM25 subtree without reopening its diagnostic pathname."""
+
+    if type(publication) is not PublicationDirectoryReader:
+        raise TypeError("retained BM25 source must be an exact publication reader")
+    _preflight_recapture_publication_authorities(
+        repository_source=repository_source,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+    repository_identity = _detach_repository_identity_snapshot(
+        repository_identity,
+        check_cancelled=check_cancelled,
+    )
+    retained_identity = repository_source.authenticated_identity_snapshot(
+        check_cancelled=check_cancelled,
+    )
+    _require_repository_identity_matches(
+        repository_identity,
+        retained_identity,
+        check_cancelled=check_cancelled,
+    )
+    config_digest, forbidden, authenticated_files = _policy(
+        repository_identity,
+        view_config,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
+        check_cancelled=check_cancelled,
+    )
+    observed_source_ownership = publication.capture_ownership(
+        entry_policy=_entry_policy,
+        check_cancelled=check_cancelled,
+    )
+    _require_plan_for_ownership(
+        planned,
+        source_ownership=observed_source_ownership,
+        repository_identity=repository_identity,
+        view_config_digest=config_digest,
+    )
+    lexical_destination = _require_disjoint_view_path(
+        destination,
+        repository_identity.root,
+    )
+    request = StrictWorkspaceRequest(
+        purpose="portable-bm25-retained-recapture",
+        destination=lexical_destination,
+        plan=planned.plan,
+        destination_binding=None,
+    )
+
+    def operation(session: StrictWorkspaceSession) -> None:
+        if session.request != request:
+            raise RuntimeError("strict BM25 provider changed its request")
+        if check_cancelled is not None:
+            check_cancelled()
+
+        def replay_source() -> None:
+            ownership, source_records, reader = _captured_source_view(
+                planned.source_ownership,
+                publication,
+                label="retained compiler-cache BM25 source",
+                check_cancelled=check_cancelled,
+            )
+            if (
+                ownership != planned.source_ownership
+                or source_records != planned.source_records
+            ):
+                raise ValueError("retained BM25 source changed after planning")
+            metadata_bytes, document_chunks = _payloads(
+                reader,
+                repository_identity.root,
+                forbidden_paths=forbidden,
+                environ=environ,
+                authenticated_source_files=authenticated_files,
+                check_cancelled=check_cancelled,
+            )
+            written = tuple(
+                sorted(
+                    (
+                        session.write_file(
+                            "documents.json",
+                            _interruptible_chunks(
+                                document_chunks,
+                                check_cancelled,
+                            ),
+                        ),
+                        session.write_file("bm25_metadata.json", (metadata_bytes,)),
+                    ),
+                    key=lambda item: item.path,
+                )
+            )
+            if written != planned.output_records:
+                raise RuntimeError("strict BM25 replay differs from its exact plan")
+            reader.verify_root()
+
+        def validate_candidate_with_check(
+            candidate: PublicationDirectoryReader,
+            validation_check: Callable[[], None] | None,
+        ) -> None:
+            source_session = repository_source.read_session(
+                check_cancelled=validation_check,
+            )
+            with source_session:
+                if (
+                    _candidate_records(
+                        candidate,
+                        planned=planned,
+                        repository_identity=repository_identity,
+                        forbidden_paths=forbidden,
+                        environ=environ,
+                        authenticated_source_files=authenticated_files,
+                        check_cancelled=validation_check,
+                    )
+                    != planned.output_records
+                ):
+                    raise RuntimeError("strict BM25 candidate is not canonical")
+
+        source_session = repository_source.read_session(
+            check_cancelled=check_cancelled,
+        )
+        with source_session:
+            replay_source()
+        if check_cancelled is not None:
+            check_cancelled()
+        session.publish_validated(
+            lambda candidate: validate_candidate_with_check(
+                candidate,
+                check_cancelled,
+            ),
+            validate_published_destination=lambda candidate: (
+                validate_candidate_with_check(candidate, None)
+            ),
+        )
+
+    _preflight_recapture_publication_authorities(
+        repository_source=repository_source,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+    if check_cancelled is not None:
+        check_cancelled()
+    _require_missing_recapture_destination(lexical_destination)
+    run_strict_workspace(
+        workspace_provider,
+        request,
+        receipt_owner=output_receipt_owner,
+        operation=operation,
+        check_cancelled=check_cancelled,
+    )
+    if not output_receipt_owner.active:
+        raise RuntimeError("strict BM25 publication returned without a receipt")
+    receipt = output_receipt_owner.receipt
+    if receipt.path != lexical_destination or receipt.plan != planned.plan:
+        raise RuntimeError("strict BM25 publication returned the wrong receipt")
+    if (
+        publication.capture_ownership(
+            entry_policy=_entry_policy,
+            check_cancelled=check_cancelled,
+        )
+        != planned.source_ownership
+    ):
+        raise RuntimeError("retained BM25 source changed during publication")
     return planned.adjustments
 
 

--- a/codenib/compiler/__init__.py
+++ b/codenib/compiler/__init__.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
         import_compiler_cache,
         import_compiler_cache_bm25,
         prepare_compiler_cache_job_view,
+        prepare_compiler_cache_job_view_from_generation,
         publish_compiler_cache_bm25_job,
         publish_compiler_cache_vector_job,
     )
@@ -154,6 +155,10 @@ _EXPORTS = {
     "prepare_compiler_cache_job_view": (
         "codenib.compiler.cache_import",
         "prepare_compiler_cache_job_view",
+    ),
+    "prepare_compiler_cache_job_view_from_generation": (
+        "codenib.compiler.cache_import",
+        "prepare_compiler_cache_job_view_from_generation",
     ),
     "publish_compiler_cache_bm25_job": (
         "codenib.compiler.cache_import",
@@ -309,6 +314,7 @@ __all__ = [
     "import_compiler_cache",
     "import_compiler_cache_bm25",
     "prepare_compiler_cache_job_view",
+    "prepare_compiler_cache_job_view_from_generation",
     "publish_compiler_cache_bm25_job",
     "publish_compiler_cache_vector_job",
     "IndexCompiler",

--- a/codenib/compiler/cache_import.py
+++ b/codenib/compiler/cache_import.py
@@ -2426,14 +2426,13 @@ def _prepare_retained_bm25_cache_generation(
     source_view = _view_source(cache, entry, view="bm25")
     if source_view != operation.fixed_source_views["bm25"]:
         raise AssertionError("compiler cache fixed BM25 source changed")
-    for output in (*operation.view_outputs.values(), operation.context_output):
-        if any(
-            _path_relation(output, boundary) != "disjoint"
-            for boundary in (cache, source_view, repository)
-        ):
-            raise ValueError(
-                "compiler cache output overlaps a retained input authority"
-            )
+    _destination_topology(
+        tuple(operation.view_outputs.values()),
+        operation.context_output,
+        cache=cache,
+        repository=repository,
+        source_views=(source_view,),
+    )
     if check_cancelled is not None:
         check_cancelled()
 

--- a/codenib/compiler/cache_import.py
+++ b/codenib/compiler/cache_import.py
@@ -39,7 +39,9 @@ from ..artifacts.portable_views import _read_bounded_json
 from ..artifacts.strict_bm25 import (
     PlannedBm25View,
     _plan_recaptured_bm25_view,
+    _plan_retained_bm25_publication_view,
     _publish_recaptured_bm25_view,
+    _publish_retained_bm25_publication_view,
 )
 from ..artifacts.strict_context import (
     _canonical_json_bytes,
@@ -95,7 +97,7 @@ from ..storage.view_bundle import (
     DEFAULT_MAX_BUNDLE_METADATA_BYTES,
     VIEW_BUNDLE_SCHEMA,
 )
-from .cache_lock import compiler_cache_lock
+from .cache_lock import COMPILER_CACHE_LOCK_FILENAME, compiler_cache_lock
 from .index_compiler import IndexCompiler
 from .manifest import MANIFEST_FILENAME, MANIFEST_VERSION, IndexEntry, RepoManifest
 from .manifest_import import (
@@ -2337,6 +2339,344 @@ def import_compiler_cache(
     )
 
 
+def _retained_cache_manifest_bytes(
+    publication: PublicationDirectoryReader,
+    *,
+    max_manifest_bytes: int,
+    check_cancelled: Callable[[], None] | None,
+) -> bytes:
+    before = publication.capture_ownership(check_cancelled=check_cancelled)
+    with publication.open_authenticated_file(
+        MANIFEST_FILENAME,
+        max_bytes=max_manifest_bytes,
+    ) as source:
+        payload = b"".join(_interruptible_chunks(source.iter_bytes(), check_cancelled))
+    if publication.capture_ownership(check_cancelled=check_cancelled) != before:
+        raise StorageIntegrityError(
+            "retained compiler cache changed while reading its manifest"
+        )
+    return payload
+
+
+def _prepare_retained_bm25_cache_generation(
+    operation: _ImportOperation,
+    binding: _CompilerCacheJobBinding,
+    receipt: PublishedWorkspaceReceipt,
+    publication: PublicationDirectoryReader,
+    *,
+    expected_manifest: RepoManifest,
+    repository_source: RepositorySourceBinding,
+    context_output_owner: PublishedWorkspaceReceiptOwner,
+    workspace_provider: StrictWorkspaceProvider,
+    check_cancelled: Callable[[], None] | None,
+) -> _PreparedCompilerCacheImport:
+    """Prepare BM25 while one exact cache-generation authority stays active."""
+
+    cache = operation.cache
+    inputs = operation.inputs
+    if receipt.path != cache:
+        raise StorageIntegrityError(
+            "retained compiler cache receipt belongs to another destination"
+        )
+    initial_ownership = publication.capture_ownership(
+        check_cancelled=check_cancelled,
+    )
+    expected_inventory = {
+        (COMPILER_CACHE_LOCK_FILENAME, "file"),
+        ("bm25", "directory"),
+        ("bm25/bm25_metadata.json", "file"),
+        ("bm25/documents.json", "file"),
+        (MANIFEST_FILENAME, "file"),
+    }
+    if set(publication.inventory()) != expected_inventory:
+        raise StorageIntegrityError(
+            "retained compiler cache generation has an unexpected layout"
+        )
+    source_manifest_bytes = _retained_cache_manifest_bytes(
+        publication,
+        max_manifest_bytes=inputs.max_manifest_bytes,
+        check_cancelled=check_cancelled,
+    )
+    manifest = _parse_exact_manifest(
+        source_manifest_bytes,
+        max_manifest_bytes=inputs.max_manifest_bytes,
+    )
+    if (
+        type(expected_manifest) is not RepoManifest
+        or expected_manifest.to_dict() != manifest.to_dict()
+    ):
+        raise StorageIntegrityError(
+            "retained compiler cache differs from its prepared manifest"
+        )
+    if _COMMIT_RE.fullmatch(manifest.commit) is None:
+        raise ValueError(
+            "compiler cache repository manifest commit must be a full "
+            "lowercase Git SHA"
+        )
+    identity = repository_source.authenticated_identity_snapshot(
+        check_cancelled=check_cancelled,
+    )
+    if type(identity) is not RepositorySourceIdentitySnapshot:
+        raise TypeError("compiler cache repository identity has an invalid type")
+    repository = lexical_directory_path(identity.root)
+    if _path_relation(cache, repository) != "disjoint":
+        raise ValueError("retained compiler cache overlaps its repository")
+    _require_manifest_source(manifest, identity)
+    entry = _require_current_view(manifest, view="bm25")
+    source_view = _view_source(cache, entry, view="bm25")
+    if source_view != operation.fixed_source_views["bm25"]:
+        raise AssertionError("compiler cache fixed BM25 source changed")
+    for output in (*operation.view_outputs.values(), operation.context_output):
+        if any(
+            _path_relation(output, boundary) != "disjoint"
+            for boundary in (cache, source_view, repository)
+        ):
+            raise ValueError(
+                "compiler cache output overlaps a retained input authority"
+            )
+    if check_cancelled is not None:
+        check_cancelled()
+
+    source_publication = publication.subtree("bm25")
+    planned = _plan_retained_bm25_publication_view(
+        source_publication,
+        repository_source=repository_source,
+        repository_identity=identity,
+        view_config=entry.config,
+        forbidden_paths=operation.policy_forbidden,
+        environ=inputs.environment,
+        check_cancelled=check_cancelled,
+    )
+    _require_source_fingerprints(entry, planned)
+    _planned_adjustments("bm25", planned)
+    portable_manifest, canonical_manifest_bytes = _portable_manifest(
+        manifest,
+        views=("bm25",),
+        planned_views={"bm25": planned},
+    )
+    import_plan = plan_repo_manifest_import_bytes(
+        canonical_manifest_bytes,
+        views=("bm25",),
+        max_manifest_bytes=inputs.max_manifest_bytes,
+    )
+    if (
+        import_plan.selection.selected_views != ("bm25",)
+        or import_plan.manifest.to_dict() != portable_manifest.to_dict()
+    ):
+        raise StorageIntegrityError(
+            "compiler cache portable manifest changed during import planning"
+        )
+    _require_compiler_cache_job_profile(
+        binding,
+        import_plan,
+        view_type="bm25",
+    )
+    if check_cancelled is not None:
+        check_cancelled()
+
+    adjustments = _publish_retained_bm25_publication_view(
+        source_publication,
+        operation.view_outputs["bm25"],
+        planned=planned,
+        repository_source=repository_source,
+        repository_identity=identity,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=operation.view_owners["bm25"],
+        view_config=entry.config,
+        forbidden_paths=operation.policy_forbidden,
+        environ=inputs.environment,
+        check_cancelled=check_cancelled,
+    )
+    if adjustments != _planned_adjustments("bm25", planned):
+        raise StorageIntegrityError(
+            "compiler cache BM25 publication differs from its exact plan"
+        )
+    recapture = CompilerCacheViewRecaptureResult(
+        view_type="bm25",
+        source_view=source_view,
+        output_view=operation.view_outputs["bm25"],
+        source_records=planned.source_records,
+        output_records=planned.output_records,
+    )
+    if check_cancelled is not None:
+        check_cancelled()
+
+    planned_context = plan_context_artifact_strict(
+        portable_manifest,
+        repository=inputs.repository_key,
+        repository_source=repository_source,
+        view_generations=operation.view_owners,
+        environ=inputs.environment,
+        check_cancelled=check_cancelled,
+    )
+    if (
+        planned_context.views != ("bm25",)
+        or planned_context.manifest_payload != canonical_manifest_bytes
+    ):
+        raise StorageIntegrityError(
+            "compiler cache context plan differs from its portable manifest"
+        )
+    context_artifact = publish_planned_context_artifact_strict(
+        operation.context_output,
+        planned=planned_context,
+        manifest=portable_manifest,
+        repository=inputs.repository_key,
+        repository_source=repository_source,
+        view_generations=operation.view_owners,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=context_output_owner,
+        environ=inputs.environment,
+        check_cancelled=check_cancelled,
+    )
+    if (
+        _read_context_manifest(
+            context_output_owner,
+            max_manifest_bytes=inputs.max_manifest_bytes,
+            check_cancelled=check_cancelled,
+        )
+        != canonical_manifest_bytes
+    ):
+        raise StorageIntegrityError(
+            "compiler cache context manifest differs from its preplanned bytes"
+        )
+    final_identity = repository_source.authenticated_identity_snapshot(
+        check_cancelled=check_cancelled,
+    )
+    if final_identity != identity:
+        raise StorageIntegrityError(
+            "compiler cache repository source changed during recapture"
+        )
+    if (
+        _retained_cache_manifest_bytes(
+            publication,
+            max_manifest_bytes=inputs.max_manifest_bytes,
+            check_cancelled=check_cancelled,
+        )
+        != source_manifest_bytes
+        or publication.capture_ownership(check_cancelled=check_cancelled)
+        != initial_ownership
+    ):
+        raise StorageIntegrityError("retained compiler cache changed during recapture")
+    return _PreparedCompilerCacheImport(
+        manifest=manifest,
+        recaptures=(recapture,),
+        canonical_manifest_bytes=canonical_manifest_bytes,
+        import_plan=import_plan,
+        context_artifact=context_artifact,
+    )
+
+
+def prepare_compiler_cache_job_view_from_generation(
+    cache_generation: PublishedWorkspaceReceiptOwner,
+    *,
+    expected_manifest: RepoManifest,
+    job: IndexJobRecord,
+    views: tuple[IndexJobViewRecord, ...],
+    repository_source: RepositorySourceBinding,
+    view_output_owner: PublishedWorkspaceReceiptOwner,
+    context_output_owner: PublishedWorkspaceReceiptOwner,
+    view_destination: Path,
+    context_destination: Path,
+    workspace_provider: StrictWorkspaceProvider,
+    repository_key: str,
+    object_store: RetainedImportObjectStore,
+    namespace_name: str = DEFAULT_NAMESPACE_NAME,
+    stop_token: IndexJobStopToken | None = None,
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+    max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
+    max_context_bytes: int = DEFAULT_MAX_CONTEXT_BYTES,
+    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
+    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
+    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> CompilerCacheJobPreparationResult:
+    """Prepare BM25 from one retained cache generation without path reopening."""
+
+    if type(cache_generation) is not PublishedWorkspaceReceiptOwner:
+        raise TypeError("compiler cache generation must be an exact receipt owner")
+    if not cache_generation.active:
+        raise RuntimeError("compiler cache generation must be active")
+    if (
+        cache_generation is view_output_owner
+        or cache_generation is context_output_owner
+    ):
+        raise ValueError("compiler cache generation must use a distinct receipt owner")
+    check_cancelled = _compiler_cache_job_stop_check(stop_token)
+    if check_cancelled is not None:
+        check_cancelled()
+    cache = cache_generation.receipt.path
+    operation, binding = _preflight_cache_job_preparation_operation(
+        cache,
+        view_type="bm25",
+        job=job,
+        views=views,
+        repository_source=repository_source,
+        view_output_owner=view_output_owner,
+        context_output_owner=context_output_owner,
+        view_destination=view_destination,
+        context_destination=context_destination,
+        workspace_provider=workspace_provider,
+        repository_key=repository_key,
+        object_store=object_store,
+        namespace_name=namespace_name,
+        max_manifest_bytes=max_manifest_bytes,
+        max_context_files=max_context_files,
+        max_context_bytes=max_context_bytes,
+        max_bundle_files=max_bundle_files,
+        max_bundle_bytes=max_bundle_bytes,
+        max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
+        check_cancelled=check_cancelled,
+    )
+
+    def prepare(
+        receipt: PublishedWorkspaceReceipt,
+        publication: PublicationDirectoryReader,
+    ) -> _PreparedCompilerCacheImport:
+        return _prepare_retained_bm25_cache_generation(
+            operation,
+            binding,
+            receipt,
+            publication,
+            expected_manifest=expected_manifest,
+            repository_source=repository_source,
+            context_output_owner=context_output_owner,
+            workspace_provider=workspace_provider,
+            check_cancelled=check_cancelled,
+        )
+
+    preparation = cache_generation.consume(
+        prepare,
+        check_cancelled=check_cancelled,
+    )
+    if check_cancelled is not None:
+        check_cancelled()
+    artifact = _ingest_prepared_compiler_cache_job(
+        preparation,
+        operation,
+        binding,
+        view_type="bm25",
+        repository_source=repository_source,
+        context_output_owner=context_output_owner,
+        object_store=object_store,
+        check_cancelled=check_cancelled,
+    )
+    result = CompilerCacheJobPreparationResult(
+        job=binding.job,
+        view=binding.view,
+        manifest=preparation.import_plan.manifest,
+        import_plan=preparation.import_plan,
+        recapture=preparation.recaptures[0],
+        context_artifact=preparation.context_artifact,
+        artifact=artifact,
+    )
+    if check_cancelled is not None:
+        check_cancelled()
+    return result
+
+
 def prepare_compiler_cache_job_view(
     cache_dir: str | Path,
     *,
@@ -2550,32 +2890,36 @@ def _publish_compiler_cache_job(
 ) -> tuple[_PreparedCompilerCacheImport, IndexJobRecord]:
     """Recapture and atomically publish one exact compiler-cache job view."""
 
-    operation, binding, normalized_job_id, normalized_owner_id, token = (
-        _preflight_cache_job_operation(
-            cache_dir,
-            view_type=view_type,
-            job_id=job_id,
-            owner_id=owner_id,
-            fencing_token=fencing_token,
-            repository_source=repository_source,
-            view_output_owner=view_output_owner,
-            context_output_owner=context_output_owner,
-            view_destination=view_destination,
-            context_destination=context_destination,
-            workspace_provider=workspace_provider,
-            repository_key=repository_key,
-            catalog=catalog,
-            object_store=object_store,
-            namespace_name=namespace_name,
-            max_manifest_bytes=max_manifest_bytes,
-            max_context_files=max_context_files,
-            max_context_bytes=max_context_bytes,
-            max_bundle_files=max_bundle_files,
-            max_bundle_bytes=max_bundle_bytes,
-            max_bundle_metadata_bytes=max_bundle_metadata_bytes,
-            forbidden_paths=forbidden_paths,
-            environ=environ,
-        )
+    (
+        operation,
+        binding,
+        normalized_job_id,
+        normalized_owner_id,
+        token,
+    ) = _preflight_cache_job_operation(
+        cache_dir,
+        view_type=view_type,
+        job_id=job_id,
+        owner_id=owner_id,
+        fencing_token=fencing_token,
+        repository_source=repository_source,
+        view_output_owner=view_output_owner,
+        context_output_owner=context_output_owner,
+        view_destination=view_destination,
+        context_destination=context_destination,
+        workspace_provider=workspace_provider,
+        repository_key=repository_key,
+        catalog=catalog,
+        object_store=object_store,
+        namespace_name=namespace_name,
+        max_manifest_bytes=max_manifest_bytes,
+        max_context_files=max_context_files,
+        max_context_bytes=max_context_bytes,
+        max_bundle_files=max_bundle_files,
+        max_bundle_bytes=max_bundle_bytes,
+        max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
     )
     with compiler_cache_lock(operation.cache, create=False):
         preparation = _prepare_compiler_cache_import_locked(
@@ -3036,6 +3380,7 @@ __all__ = [
     "import_compiler_cache",
     "import_compiler_cache_bm25",
     "prepare_compiler_cache_job_view",
+    "prepare_compiler_cache_job_view_from_generation",
     "publish_compiler_cache_bm25_job",
     "publish_compiler_cache_vector_job",
 ]

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -51,7 +51,10 @@ from ..repository_source_selection import (
     RepositorySourceSelection,
     repository_relative_source_path,
 )
-from ..source_fingerprint import RepositorySourceBinding
+from ..source_fingerprint import (
+    RepositorySourceBinding,
+    RepositorySourceIdentitySnapshot,
+)
 from .resources import IndexState, IndexStatus
 from .verification import NullVerifier, UpdateVerifier, VerificationResult
 
@@ -274,6 +277,18 @@ class IndexBuilderRegistry:
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True, slots=True)
+class PreparedBm25Build:
+    """Canonical in-memory BM25 documents ready for bound persistence."""
+
+    scope: str
+    repository_root: str
+    indexer: Any = field(repr=False, compare=False)
+    artifact_identity: Dict[str, Any]
+    chunk_count: int
+    source_file_count: int
+
+
 @dataclass
 class BM25IndexBuilder:
     """Build a BM25 sparse index by wrapping ``BM25CodeIndexer``."""
@@ -380,21 +395,11 @@ class BM25IndexBuilder:
             raise TypeError("BM25 source build output must be non-empty exact text")
         if check_cancelled is not None and not callable(check_cancelled):
             raise TypeError("BM25 source build cancellation must be callable")
-        selected = _source_selection_for_build(
-            self.source_selection,
-            source_selection,
-        )
-        if check_cancelled is not None:
-            check_cancelled()
-        identity = repository_source.authenticated_identity_snapshot(
+        selected, identity = self._source_build_identity(
+            repository_source,
+            source_selection=source_selection,
             check_cancelled=check_cancelled,
         )
-        if check_cancelled is not None:
-            check_cancelled()
-        if identity.source_selection != selected:
-            raise RuntimeError(
-                "BM25 source binding selection differs from builder policy"
-            )
         output = Path(os.path.abspath(os.path.expanduser(output_dir)))
         repository_root = identity.root
         resolved_output = output.resolve(strict=False)
@@ -415,12 +420,86 @@ class BM25IndexBuilder:
             raise FileExistsError(
                 "BM25 source build requires a missing private generation"
             )
+        prepared = self._prepare_authenticated_repository_source(
+            scope,
+            repository_source=repository_source,
+            repository_root=str(repository_root),
+            source_selection=selected,
+            check_cancelled=check_cancelled,
+        )
+        return self._persist_prepared_chunks(
+            prepared,
+            output_dir=str(output),
+            require_missing_output=True,
+            check_cancelled=check_cancelled,
+        )
+
+    def prepare_from_repository_source(
+        self,
+        scope: str,
+        *,
+        repository_source: RepositorySourceBinding,
+        source_selection: RepositorySourceSelection | None = None,
+        check_cancelled: Callable[[], None] | None = None,
+    ) -> PreparedBm25Build:
+        """Prepare canonical BM25 documents without filesystem mutation."""
+
+        if type(repository_source) is not RepositorySourceBinding:
+            raise TypeError("BM25 source build requires an exact source binding")
+        if check_cancelled is not None and not callable(check_cancelled):
+            raise TypeError("BM25 source build cancellation must be callable")
+        selected, identity = self._source_build_identity(
+            repository_source,
+            source_selection=source_selection,
+            check_cancelled=check_cancelled,
+        )
+        return self._prepare_authenticated_repository_source(
+            scope,
+            repository_source=repository_source,
+            repository_root=str(identity.root),
+            source_selection=selected,
+            check_cancelled=check_cancelled,
+        )
+
+    def _source_build_identity(
+        self,
+        repository_source: RepositorySourceBinding,
+        *,
+        source_selection: RepositorySourceSelection | None,
+        check_cancelled: Callable[[], None] | None,
+    ) -> tuple[RepositorySourceSelection, RepositorySourceIdentitySnapshot]:
+        selected = _source_selection_for_build(
+            self.source_selection,
+            source_selection,
+        )
+        if check_cancelled is not None:
+            check_cancelled()
+        identity = repository_source.authenticated_identity_snapshot(
+            check_cancelled=check_cancelled,
+        )
+        if check_cancelled is not None:
+            check_cancelled()
+        if identity.source_selection != selected:
+            raise RuntimeError(
+                "BM25 source binding selection differs from builder policy"
+            )
+        return selected, identity
+
+    def _prepare_authenticated_repository_source(
+        self,
+        scope: str,
+        *,
+        repository_source: RepositorySourceBinding,
+        repository_root: str,
+        source_selection: RepositorySourceSelection,
+        check_cancelled: Callable[[], None] | None,
+    ) -> PreparedBm25Build:
         from ..code_chunker import CodeChunker, RepoChunkingConfig
 
         primary = self.languages[0] if self.languages else "python"
         repo_config = RepoChunkingConfig(
             languages=self.languages,
-            source_selection=selected,
+            source_selection=source_selection,
         )
         repo_config.ignore_dirs.update(self.additional_ignore_dirs)
         chunker = CodeChunker(
@@ -434,23 +513,20 @@ class BM25IndexBuilder:
             check_cancelled=check_cancelled,
         )
         _require_selected_paths(
-            selected,
+            source_selection,
             (getattr(chunk, "file", None) for chunk in chunks),
-            repository_root=str(repository_root),
+            repository_root=repository_root,
             subject="BM25 chunks",
             check_cancelled=check_cancelled,
         )
         if check_cancelled is not None:
             check_cancelled()
-        return self._build_chunks(
+        return self._prepare_chunks(
             scope,
-            repo_path=str(repository_root),
-            output_dir=str(output),
-            source_selection=selected,
-            artifact_identity=self._artifact_identity_for_selection(selected),
+            repo_path=repository_root,
+            source_selection=source_selection,
+            artifact_identity=self._artifact_identity_for_selection(source_selection),
             chunks=chunks,
-            prepare_only=True,
-            require_missing_output=True,
             check_cancelled=check_cancelled,
         )
 
@@ -468,6 +544,35 @@ class BM25IndexBuilder:
         check_cancelled: Callable[[], None] | None,
     ) -> IndexStatus:
         """Persist and attest one already-captured BM25 chunk generation."""
+
+        prepared = self._prepare_chunks(
+            scope,
+            repo_path=repo_path,
+            source_selection=source_selection,
+            artifact_identity=artifact_identity,
+            chunks=chunks,
+            prepare_only=prepare_only,
+            check_cancelled=check_cancelled,
+        )
+        return self._persist_prepared_chunks(
+            prepared,
+            output_dir=output_dir,
+            require_missing_output=require_missing_output,
+            check_cancelled=check_cancelled,
+        )
+
+    def _prepare_chunks(
+        self,
+        scope: str,
+        *,
+        repo_path: str,
+        source_selection: RepositorySourceSelection,
+        artifact_identity: Dict[str, Any],
+        chunks: List[Any],
+        check_cancelled: Callable[[], None] | None,
+        prepare_only: bool = True,
+    ) -> PreparedBm25Build:
+        """Construct canonical BM25 documents entirely in memory."""
 
         from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 
@@ -495,6 +600,33 @@ class BM25IndexBuilder:
         )
         if check_cancelled is not None:
             check_cancelled()
+        source_files: set[str] = set()
+        for chunk in chunks:
+            if check_cancelled is not None:
+                check_cancelled()
+            source_path = getattr(chunk, "file", "")
+            if source_path:
+                source_files.add(source_path)
+        return PreparedBm25Build(
+            scope=scope,
+            repository_root=repo_path,
+            indexer=indexer,
+            artifact_identity=artifact_identity,
+            chunk_count=len(chunks),
+            source_file_count=len(source_files),
+        )
+
+    def _persist_prepared_chunks(
+        self,
+        prepared: PreparedBm25Build,
+        *,
+        output_dir: str,
+        require_missing_output: bool,
+        check_cancelled: Callable[[], None] | None,
+    ) -> IndexStatus:
+        """Persist and attest one prepared BM25 document generation."""
+
+        indexer = prepared.indexer
         if require_missing_output:
             os.mkdir(output_dir, mode=0o700)
         else:
@@ -519,28 +651,20 @@ class BM25IndexBuilder:
         if check_cancelled is not None:
             check_cancelled()
 
-        source_files: set[str] = set()
-        for chunk in chunks:
-            if check_cancelled is not None:
-                check_cancelled()
-            source_path = getattr(chunk, "file", "")
-            if source_path:
-                source_files.add(source_path)
-
         return IndexStatus(
             index_type="bm25",
             state=IndexState.FRESH,
             last_built=time.time(),
             age_seconds=0.0,
-            scope=scope,
+            scope=prepared.scope,
             path=output_dir,
             metadata={
-                **artifact_identity,
+                **prepared.artifact_identity,
                 "artifact_file_fingerprints": artifact_files,
-                "chunk_count": len(chunks),
-                "source_file_count": len(source_files),
+                "chunk_count": prepared.chunk_count,
+                "source_file_count": prepared.source_file_count,
                 # Retain the legacy field for existing manifest consumers.
-                "file_count": len(chunks),
+                "file_count": prepared.chunk_count,
             },
         )
 

--- a/codenib/compiler/source_job.py
+++ b/codenib/compiler/source_job.py
@@ -41,6 +41,7 @@ from .._captured_directory import (
     WorkspaceFile,
     WorkspacePlan,
 )
+from .._local_workspace_provider import LocalWorkspaceProvider
 from .._workspace_provider import (
     StrictWorkspaceProvider,
     StrictWorkspaceRequest,
@@ -76,9 +77,11 @@ from ..storage.view_bundle import (
 )
 from .cache_import import (
     _compiler_cache_job_stop_check,
+    _path_relation,
     _preflight_cache_job_preparation_operation,
     _preflight_workspace_provider,
     _require_missing,
+    _resolved_path,
     prepare_compiler_cache_job_view_from_generation,
 )
 from .cache_lock import COMPILER_CACHE_LOCK_FILENAME
@@ -198,7 +201,7 @@ def _validate_private_cache_generation(
 class _RetainedCacheWorkspaceProvider:
     """Bind one provider call to the exact parent opened before cache checks."""
 
-    delegate: StrictWorkspaceProvider
+    delegate: LocalWorkspaceProvider
     parent_authority: _PublicationAuthority = field(repr=False, compare=False)
     parent_identity: tuple[int, ...]
 
@@ -361,39 +364,93 @@ def _exact_attempt_generation(value: object) -> Path:
     return generation
 
 
-def _require_disjoint_attempt_generation(
+def _preflight_source_job_topology(
     generation: Path,
     source: RepositorySourceIdentitySnapshot,
     *,
-    boundaries: tuple[Path, ...],
+    view_destination: Path,
+    context_destination: Path,
+    forbidden_paths: tuple[Path, ...],
 ) -> None:
     repository = lexical_directory_path(source.root)
-    try:
-        physical_generation = generation.resolve(strict=False)
-        physical_repository = repository.resolve(strict=True)
-    except (OSError, RuntimeError) as exc:
-        raise ValueError(
-            "BM25 source job attempt topology cannot be authenticated"
-        ) from exc
-    inputs = ((repository, physical_repository, "repository"),)
-    outputs = tuple(
-        (
-            lexical_directory_path(boundary),
-            lexical_directory_path(boundary).resolve(strict=False),
-            "output or forbidden boundary",
-        )
-        for boundary in boundaries
+    source_view = lexical_directory_path(generation / _BM25_VIEW)
+    outputs = (
+        lexical_directory_path(view_destination),
+        lexical_directory_path(context_destination),
     )
-    for lexical, physical, label in (*inputs, *outputs):
+    forbidden = tuple(lexical_directory_path(boundary) for boundary in forbidden_paths)
+    physical_repository = _resolved_path(
+        repository,
+        strict=True,
+        label="BM25 source job repository",
+    )
+    physical_generation = _resolved_path(
+        generation,
+        strict=False,
+        label="BM25 source job attempt generation",
+    )
+    physical_source_view = _resolved_path(
+        source_view,
+        strict=False,
+        label="BM25 source job cache view",
+    )
+    physical_outputs = tuple(
+        _resolved_path(
+            output,
+            strict=False,
+            label="BM25 source job destination",
+        )
+        for output in outputs
+    )
+    physical_forbidden = tuple(
+        _resolved_path(
+            boundary,
+            strict=False,
+            label="BM25 source job forbidden boundary",
+        )
+        for boundary in forbidden
+    )
+    if (
+        _path_relation(generation, repository) != "disjoint"
+        or _path_relation(physical_generation, physical_repository) != "disjoint"
+    ):
+        raise ValueError("BM25 source job attempt generation overlaps repository")
+    for lexical, physical in zip(
+        (*outputs, *forbidden),
+        (*physical_outputs, *physical_forbidden),
+        strict=True,
+    ):
         if (
-            generation == lexical
-            or generation in lexical.parents
-            or lexical in generation.parents
-            or physical_generation == physical
-            or physical_generation in physical.parents
-            or physical in physical_generation.parents
+            _path_relation(generation, lexical) != "disjoint"
+            or _path_relation(physical_generation, physical) != "disjoint"
         ):
-            raise ValueError("BM25 source job attempt generation overlaps " + label)
+            raise ValueError(
+                "BM25 source job attempt generation overlaps output or "
+                "forbidden boundary"
+            )
+
+    lexical_inputs = (repository, generation, source_view, *forbidden)
+    physical_inputs = (
+        physical_repository,
+        physical_generation,
+        physical_source_view,
+        *physical_forbidden,
+    )
+    for output, physical_output in zip(outputs, physical_outputs, strict=True):
+        if any(
+            _path_relation(output, boundary) != "disjoint"
+            for boundary in lexical_inputs
+        ) or any(
+            _path_relation(physical_output, boundary) != "disjoint"
+            for boundary in physical_inputs
+        ):
+            raise ValueError("BM25 source job destination overlaps an input authority")
+        _require_missing(output, label="BM25 source job destination")
+    if (
+        _path_relation(outputs[0], outputs[1]) != "disjoint"
+        or _path_relation(physical_outputs[0], physical_outputs[1]) != "disjoint"
+    ):
+        raise ValueError("BM25 source job output destinations overlap")
 
 
 def _built_at(status: IndexStatus) -> tuple[str, float]:
@@ -750,7 +807,7 @@ class BM25SourceJobExecutor:
     display_commit: str
     builder: InitVar[BM25IndexBuilder]
     attempt_output_owner: PublishedWorkspaceReceiptOwner
-    attempt_workspace_provider: StrictWorkspaceProvider
+    attempt_workspace_provider: LocalWorkspaceProvider
     repository_source: RepositorySourceBinding
     view_output_owner: PublishedWorkspaceReceiptOwner
     context_output_owner: PublishedWorkspaceReceiptOwner
@@ -812,6 +869,10 @@ class BM25SourceJobExecutor:
             raise ValueError("BM25 source job receipt owners must be distinct")
         if self.attempt_output_owner.state != "empty":
             raise RuntimeError("BM25 source job attempt owner must be empty")
+        if type(self.attempt_workspace_provider) is not LocalWorkspaceProvider:
+            raise TypeError(
+                "BM25 source job attempt requires an exact local workspace provider"
+            )
         _preflight_workspace_provider(self.attempt_workspace_provider)
         object.__setattr__(self, "_builder", configuration)
         object.__setattr__(self, "_profile", configuration.profile())
@@ -866,14 +927,12 @@ class BM25SourceJobExecutor:
             raise StorageValidationError(
                 "BM25 source job selection does not match the retained source"
             )
-        _require_disjoint_attempt_generation(
+        _preflight_source_job_topology(
             self.attempt_generation,
             binding.source_snapshot,
-            boundaries=(
-                *operation.view_outputs.values(),
-                operation.context_output,
-                *operation.inputs.forbidden_paths,
-            ),
+            view_destination=operation.view_outputs[_BM25_VIEW],
+            context_destination=operation.context_output,
+            forbidden_paths=operation.inputs.forbidden_paths,
         )
         check_cancelled()
         with _PublicationAuthorityOwner() as parent_owner:
@@ -890,14 +949,12 @@ class BM25SourceJobExecutor:
                 parent_identity=parent_identity,
             )
             parent_authority.verify_path_binding()
-            _require_disjoint_attempt_generation(
+            _preflight_source_job_topology(
                 self.attempt_generation,
                 binding.source_snapshot,
-                boundaries=(
-                    *operation.view_outputs.values(),
-                    operation.context_output,
-                    *operation.inputs.forbidden_paths,
-                ),
+                view_destination=operation.view_outputs[_BM25_VIEW],
+                context_destination=operation.context_output,
+                forbidden_paths=operation.inputs.forbidden_paths,
             )
             parent_authority.verify_path_binding()
             check_cancelled()

--- a/codenib/compiler/source_job.py
+++ b/codenib/compiler/source_job.py
@@ -453,6 +453,30 @@ def _preflight_source_job_topology(
         raise ValueError("BM25 source job output destinations overlap")
 
 
+def _require_attempt_provider_destination(
+    generation: Path,
+    provider: LocalWorkspaceProvider,
+) -> None:
+    root = lexical_directory_path(provider.allowed_root)
+    physical_root = _resolved_path(
+        root,
+        strict=True,
+        label="BM25 source job attempt provider root",
+    )
+    physical_generation = _resolved_path(
+        generation,
+        strict=False,
+        label="BM25 source job attempt generation",
+    )
+    if (
+        root not in generation.parents
+        or physical_root not in physical_generation.parents
+    ):
+        raise ValueError(
+            "BM25 source job attempt must be strictly below its local provider root"
+        )
+
+
 def _built_at(status: IndexStatus) -> tuple[str, float]:
     value = status.last_built
     if type(value) not in {int, float} or not math.isfinite(value) or value < 0:
@@ -874,6 +898,10 @@ class BM25SourceJobExecutor:
                 "BM25 source job attempt requires an exact local workspace provider"
             )
         _preflight_workspace_provider(self.attempt_workspace_provider)
+        _require_attempt_provider_destination(
+            self.attempt_generation,
+            self.attempt_workspace_provider,
+        )
         object.__setattr__(self, "_builder", configuration)
         object.__setattr__(self, "_profile", configuration.profile())
 
@@ -891,6 +919,10 @@ class BM25SourceJobExecutor:
         check_cancelled()
         if self.attempt_output_owner.state != "empty":
             raise RuntimeError("BM25 source job attempt owner must be empty")
+        _require_attempt_provider_destination(
+            self.attempt_generation,
+            self.attempt_workspace_provider,
+        )
         _require_missing(
             self.attempt_generation,
             label="BM25 source job attempt generation",

--- a/codenib/compiler/source_job.py
+++ b/codenib/compiler/source_job.py
@@ -14,17 +14,39 @@ ref mutation authority; the durable worker remains the only publisher.
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 import math
 import re
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import InitVar, dataclass, field
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+from typing import Iterator
 
-from .._atomic_directory import lexical_directory_path
-from .._captured_directory import PublishedWorkspaceReceiptOwner
-from .._workspace_provider import StrictWorkspaceProvider
+from .._atomic_directory import (
+    PublicationDirectoryReader,
+    TreeFileRecord,
+    _open_publication_authority,
+    _PublicationAuthority,
+    _PublicationAuthorityOwner,
+    directory_ownership_file_records,
+    directory_ownership_inventory,
+    lexical_directory_path,
+    publication_parent_identity,
+)
+from .._captured_directory import (
+    PublishedWorkspaceReceiptOwner,
+    WorkspaceDirectory,
+    WorkspaceFile,
+    WorkspacePlan,
+)
+from .._workspace_provider import (
+    StrictWorkspaceProvider,
+    StrictWorkspaceRequest,
+    StrictWorkspaceSession,
+    run_strict_workspace,
+)
 from ..repository_source_selection import RepositorySourceSelection
 from ..source_fingerprint import (
     RepositorySourceBinding,
@@ -55,11 +77,12 @@ from ..storage.view_bundle import (
 from .cache_import import (
     _compiler_cache_job_stop_check,
     _preflight_cache_job_preparation_operation,
+    _preflight_workspace_provider,
     _require_missing,
-    prepare_compiler_cache_job_view,
+    prepare_compiler_cache_job_view_from_generation,
 )
-from .cache_lock import compiler_cache_lock
-from .index_builders import BM25IndexBuilder
+from .cache_lock import COMPILER_CACHE_LOCK_FILENAME
+from .index_builders import BM25IndexBuilder, PreparedBm25Build
 from .manifest import MANIFEST_FILENAME, MANIFEST_VERSION, IndexEntry, RepoManifest
 from .manifest_import import (
     DEFAULT_MAX_CONTEXT_BYTES,
@@ -77,6 +100,146 @@ from .resources import IndexState, IndexStatus
 _DISPLAY_COMMIT_RE = re.compile(r"[0-9a-f]{40}\Z", re.ASCII)
 _BM25_VIEW = "bm25"
 _BM25_SCOPE = "current_repo"
+_CACHE_JSON_CHARS = 1024 * 1024
+_PRIVATE_CACHE_PLAN_DOMAIN = b"codenib-private-bm25-cache-generation-v1"
+
+
+def _json_byte_chunks(
+    value: object,
+    check_cancelled: Callable[[], None] | None,
+) -> Iterator[bytes]:
+    """Encode replayable indented JSON with bounded cancellation intervals."""
+
+    encoder = json.JSONEncoder(indent=2, allow_nan=False)
+    if check_cancelled is not None:
+        check_cancelled()
+    for fragment in encoder.iterencode(value):
+        for offset in range(0, len(fragment), _CACHE_JSON_CHARS):
+            if check_cancelled is not None:
+                check_cancelled()
+            yield fragment[offset : offset + _CACHE_JSON_CHARS].encode("utf-8")
+        if check_cancelled is not None:
+            check_cancelled()
+
+
+def _payload_record(
+    relative: str,
+    chunks: Iterable[bytes],
+    check_cancelled: Callable[[], None] | None,
+) -> TreeFileRecord:
+    digest = hashlib.sha256()
+    size = 0
+    for chunk in chunks:
+        if check_cancelled is not None:
+            check_cancelled()
+        if type(chunk) is not bytes:
+            raise TypeError("private BM25 cache payload chunks must be exact bytes")
+        digest.update(chunk)
+        size += len(chunk)
+    if check_cancelled is not None:
+        check_cancelled()
+    return TreeFileRecord(
+        path=relative,
+        mode=0o600,
+        size=size,
+        sha256=digest.hexdigest(),
+    )
+
+
+def _private_cache_subject(records: tuple[TreeFileRecord, ...]) -> str:
+    digest = hashlib.sha256(_PRIVATE_CACHE_PLAN_DOMAIN)
+    for record in records:
+        encoded = record.path.encode("utf-8")
+        digest.update(len(encoded).to_bytes(4, "big"))
+        digest.update(encoded)
+        digest.update(record.mode.to_bytes(4, "big"))
+        digest.update(record.size.to_bytes(8, "big"))
+        digest.update(bytes.fromhex(record.sha256))
+    return digest.hexdigest()
+
+
+def _validate_private_cache_generation(
+    publication: PublicationDirectoryReader,
+    *,
+    expected_records: tuple[TreeFileRecord, ...],
+    expected_manifest_bytes: bytes,
+    check_cancelled: Callable[[], None] | None,
+) -> None:
+    ownership = publication.capture_ownership(check_cancelled=check_cancelled)
+    expected_inventory = {
+        (COMPILER_CACHE_LOCK_FILENAME, "file"),
+        (_BM25_VIEW, "directory"),
+        (f"{_BM25_VIEW}/bm25_metadata.json", "file"),
+        (f"{_BM25_VIEW}/documents.json", "file"),
+        (MANIFEST_FILENAME, "file"),
+    }
+    if (
+        set(directory_ownership_inventory(ownership)) != expected_inventory
+        or tuple(directory_ownership_file_records(ownership)) != expected_records
+    ):
+        raise StorageIntegrityError(
+            "private BM25 cache generation differs from its exact plan"
+        )
+    observed_manifest = publication.read_bytes(
+        MANIFEST_FILENAME,
+        max_bytes=len(expected_manifest_bytes),
+    )
+    if observed_manifest != expected_manifest_bytes:
+        raise StorageIntegrityError(
+            "private BM25 cache manifest differs from its exact plan"
+        )
+    if publication.capture_ownership(check_cancelled=check_cancelled) != ownership:
+        raise StorageIntegrityError(
+            "private BM25 cache generation changed during validation"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _RetainedCacheWorkspaceProvider:
+    """Bind one provider call to the exact parent opened before cache checks."""
+
+    delegate: StrictWorkspaceProvider
+    parent_authority: _PublicationAuthority = field(repr=False, compare=False)
+    parent_identity: tuple[int, ...]
+
+    def _verify_parent(self) -> None:
+        self.parent_authority.verify_path_binding()
+        observed = publication_parent_identity(self.parent_authority.resource)
+        if observed != self.parent_identity:
+            raise RuntimeError("BM25 source cache parent authority changed")
+
+    def require_support(self) -> None:
+        self._verify_parent()
+        self.delegate.require_support()
+        self._verify_parent()
+
+    def run_workspace(
+        self,
+        request: StrictWorkspaceRequest,
+        *,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        operation: Callable[[StrictWorkspaceSession], object],
+        check_cancelled: Callable[[], None] | None = None,
+    ) -> object:
+        self._verify_parent()
+        arguments = {
+            "receipt_owner": receipt_owner,
+            "operation": operation,
+            "_expected_parent_identity": self.parent_identity,
+        }
+        if check_cancelled is None:
+            result = self.delegate.run_workspace(  # type: ignore[call-arg]
+                request,
+                **arguments,
+            )
+        else:
+            result = self.delegate.run_workspace(  # type: ignore[call-arg]
+                request,
+                **arguments,
+                check_cancelled=check_cancelled,
+            )
+        self._verify_parent()
+        return result
 
 
 @dataclass(frozen=True, slots=True)
@@ -326,20 +489,268 @@ def _source_manifest(
     return RepoManifest.from_dict(manifest.to_dict())
 
 
+def _paths_overlap(first: Path, second: Path) -> bool:
+    return first == second or first in second.parents or second in first.parents
+
+
+def _publish_private_bm25_cache_generation(
+    generation: Path,
+    *,
+    display_commit: str,
+    builder: _BM25BuilderConfiguration,
+    repository_source: RepositorySourceBinding,
+    expected_source: RepositorySourceIdentitySnapshot,
+    output_owner: PublishedWorkspaceReceiptOwner,
+    workspace_provider: _RetainedCacheWorkspaceProvider,
+    parent_authority: _PublicationAuthority,
+    check_cancelled: Callable[[], None],
+) -> RepoManifest:
+    """Prepare in memory and publish under one retained parent authority."""
+
+    _preflight_workspace_provider(workspace_provider)
+    if type(output_owner) is not PublishedWorkspaceReceiptOwner:
+        raise TypeError("BM25 source job attempt owner must be exact")
+    if output_owner.state != "empty":
+        raise RuntimeError("BM25 source job attempt owner must be empty")
+    check_cancelled()
+    parent_authority.verify_path_binding()
+    resolved_generation = generation.resolve(strict=False)
+    resolved_repository = expected_source.root.resolve(strict=True)
+    if _paths_overlap(generation, expected_source.root) or _paths_overlap(
+        resolved_generation,
+        resolved_repository,
+    ):
+        raise ValueError("BM25 source job attempt overlaps the repository")
+    if (
+        parent_authority.child_metadata(
+            generation.name,
+            path=generation,
+            label="BM25 source job attempt generation",
+        )
+        is not None
+    ):
+        raise FileExistsError("BM25 source job attempt generation must be missing")
+    parent_authority.verify_path_binding()
+
+    source_builder = builder.builder()
+    expected_identity = source_builder.artifact_identity()
+    prepared = source_builder.prepare_from_repository_source(
+        _BM25_SCOPE,
+        repository_source=repository_source,
+        source_selection=builder.source_selection,
+        check_cancelled=check_cancelled,
+    )
+    if type(prepared) is not PreparedBm25Build:
+        raise StorageIntegrityError("BM25 source builder returned an invalid build")
+    if (
+        prepared.scope != _BM25_SCOPE
+        or prepared.repository_root != str(expected_source.root)
+        or prepared.artifact_identity != expected_identity
+    ):
+        raise StorageIntegrityError(
+            "BM25 source builder returned a different generation"
+        )
+
+    indexer = prepared.indexer
+    documents: list[dict[str, object]] = []
+    index_documents = getattr(indexer, "documents", None)
+    if type(index_documents) is not list:
+        raise StorageIntegrityError("BM25 source builder documents are invalid")
+    for document in index_documents:
+        check_cancelled()
+        page_content = getattr(document, "page_content", None)
+        document_metadata = getattr(document, "metadata", None)
+        if type(page_content) is not str or type(document_metadata) is not dict:
+            raise StorageIntegrityError("BM25 source builder document is invalid")
+        try:
+            detached_metadata = copy.deepcopy(document_metadata)
+        except Exception as exc:
+            raise StorageIntegrityError(
+                "BM25 source builder document metadata cannot be detached"
+            ) from exc
+        documents.append(
+            {
+                "page_content": page_content,
+                "metadata": detached_metadata,
+            }
+        )
+    metadata_payload = {
+        "project_root": (
+            str(indexer.project_root) if indexer.project_root is not None else None
+        ),
+        "max_k": indexer.max_k,
+        "language": indexer.language,
+    }
+    documents_record = _payload_record(
+        f"{_BM25_VIEW}/documents.json",
+        _json_byte_chunks(documents, check_cancelled),
+        check_cancelled,
+    )
+    metadata_record = _payload_record(
+        f"{_BM25_VIEW}/bm25_metadata.json",
+        _json_byte_chunks(metadata_payload, check_cancelled),
+        check_cancelled,
+    )
+    artifact_fingerprints = {
+        record.path.removeprefix(f"{_BM25_VIEW}/"): {
+            "size": record.size,
+            "sha256": record.sha256,
+        }
+        for record in (documents_record, metadata_record)
+    }
+    status = IndexStatus(
+        index_type=_BM25_VIEW,
+        state=IndexState.FRESH,
+        last_built=datetime.now(timezone.utc).timestamp(),
+        age_seconds=0.0,
+        scope=_BM25_SCOPE,
+        path=str(generation / _BM25_VIEW),
+        metadata={
+            **copy.deepcopy(expected_identity),
+            "artifact_file_fingerprints": artifact_fingerprints,
+            "chunk_count": prepared.chunk_count,
+            "source_file_count": prepared.source_file_count,
+            "file_count": prepared.chunk_count,
+        },
+    )
+    manifest = _source_manifest(
+        status,
+        output=generation / _BM25_VIEW,
+        display_commit=display_commit,
+        repository_source=repository_source,
+        expected_source=expected_source,
+        builder=builder,
+        check_cancelled=check_cancelled,
+    )
+    if (
+        bm25_source_job_profile(source_builder).profile_id
+        != builder.profile().profile_id
+    ):
+        raise StorageIntegrityError(
+            "BM25 source builder profile changed during execution"
+        )
+    manifest_bytes = json.dumps(
+        manifest.to_dict(),
+        indent=2,
+        allow_nan=False,
+    ).encode("utf-8")
+    manifest_record = _payload_record(
+        MANIFEST_FILENAME,
+        (manifest_bytes,),
+        check_cancelled,
+    )
+    lock_record = _payload_record(
+        COMPILER_CACHE_LOCK_FILENAME,
+        (),
+        check_cancelled,
+    )
+    expected_records = tuple(
+        sorted(
+            (lock_record, documents_record, metadata_record, manifest_record),
+            key=lambda record: record.path,
+        )
+    )
+    payloads = {
+        COMPILER_CACHE_LOCK_FILENAME: lambda: iter(()),
+        f"{_BM25_VIEW}/documents.json": lambda: _json_byte_chunks(
+            documents,
+            check_cancelled,
+        ),
+        f"{_BM25_VIEW}/bm25_metadata.json": lambda: _json_byte_chunks(
+            metadata_payload,
+            check_cancelled,
+        ),
+        MANIFEST_FILENAME: lambda: iter((manifest_bytes,)),
+    }
+    plan = WorkspacePlan(
+        subject_digest=_private_cache_subject(expected_records),
+        directories=(WorkspaceDirectory(PurePosixPath(_BM25_VIEW), mode=0o700),),
+        files=tuple(
+            WorkspaceFile(
+                PurePosixPath(record.path),
+                mode=record.mode,
+                max_bytes=record.size,
+            )
+            for record in expected_records
+        ),
+        root_mode=0o700,
+        check_cancelled=check_cancelled,
+    )
+    request = StrictWorkspaceRequest(
+        purpose="private-bm25-compiler-cache",
+        destination=generation,
+        plan=plan,
+        destination_binding=None,
+    )
+
+    def operation(session: StrictWorkspaceSession) -> None:
+        if session.request != request:
+            raise RuntimeError("BM25 cache provider changed its request")
+        written = tuple(
+            sorted(
+                (
+                    session.write_file(record.path, payloads[record.path]())
+                    for record in expected_records
+                ),
+                key=lambda record: record.path,
+            )
+        )
+        if written != expected_records:
+            raise StorageIntegrityError(
+                "private BM25 cache write differs from its exact plan"
+            )
+        session.publish_validated(
+            lambda publication: _validate_private_cache_generation(
+                publication,
+                expected_records=expected_records,
+                expected_manifest_bytes=manifest_bytes,
+                check_cancelled=check_cancelled,
+            ),
+            validate_published_destination=lambda publication: (
+                _validate_private_cache_generation(
+                    publication,
+                    expected_records=expected_records,
+                    expected_manifest_bytes=manifest_bytes,
+                    check_cancelled=None,
+                )
+            ),
+        )
+
+    run_strict_workspace(
+        workspace_provider,
+        request,
+        receipt_owner=output_owner,
+        operation=operation,
+        check_cancelled=check_cancelled,
+    )
+    if (
+        not output_owner.active
+        or output_owner.receipt.path != generation
+        or output_owner.receipt.plan != plan
+    ):
+        raise StorageIntegrityError(
+            "private BM25 cache provider returned a different generation"
+        )
+    return manifest
+
+
 @dataclass(frozen=True, slots=True)
 class BM25SourceJobExecutor:
     """Prepare exactly one required FULL BM25 job from retained source bytes.
 
-    ``attempt_generation`` is a unique missing cache root owned by the caller.
-    The executor never removes it, including after cancellation or failure;
-    retries must supply another missing root. ``display_commit`` is provenance
-    for the strict portable context only. It is never derived from a lexical
-    repository read and does not alter the fingerprint-bound durable source ID.
+    ``attempt_generation`` is a unique missing cache root whose exact published
+    generation remains retained by ``attempt_output_owner``. The executor never
+    removes it, including after cancellation or failure; retries must supply
+    another missing root and owner. ``display_commit`` is provenance for the
+    strict portable context only. It is never derived from a lexical repository
+    read and does not alter the fingerprint-bound durable source ID.
     """
 
     attempt_generation: Path
     display_commit: str
     builder: InitVar[BM25IndexBuilder]
+    attempt_output_owner: PublishedWorkspaceReceiptOwner
+    attempt_workspace_provider: StrictWorkspaceProvider
     repository_source: RepositorySourceBinding
     view_output_owner: PublishedWorkspaceReceiptOwner
     context_output_owner: PublishedWorkspaceReceiptOwner
@@ -382,6 +793,26 @@ class BM25SourceJobExecutor:
             _snapshot_forbidden_paths(self.forbidden_paths),
         )
         object.__setattr__(self, "environ", _snapshot_environment(self.environ))
+        if (
+            type(self.attempt_output_owner) is not PublishedWorkspaceReceiptOwner
+            or type(self.view_output_owner) is not PublishedWorkspaceReceiptOwner
+            or type(self.context_output_owner) is not PublishedWorkspaceReceiptOwner
+        ):
+            raise TypeError("BM25 source job requires exact receipt owners")
+        if (
+            len(
+                {
+                    id(self.attempt_output_owner),
+                    id(self.view_output_owner),
+                    id(self.context_output_owner),
+                }
+            )
+            != 3
+        ):
+            raise ValueError("BM25 source job receipt owners must be distinct")
+        if self.attempt_output_owner.state != "empty":
+            raise RuntimeError("BM25 source job attempt owner must be empty")
+        _preflight_workspace_provider(self.attempt_workspace_provider)
         object.__setattr__(self, "_builder", configuration)
         object.__setattr__(self, "_profile", configuration.profile())
 
@@ -397,6 +828,8 @@ class BM25SourceJobExecutor:
         if check_cancelled is None:  # pragma: no cover - execution context invariant
             raise AssertionError("BM25 source job context has no stop check")
         check_cancelled()
+        if self.attempt_output_owner.state != "empty":
+            raise RuntimeError("BM25 source job attempt owner must be empty")
         _require_missing(
             self.attempt_generation,
             label="BM25 source job attempt generation",
@@ -443,46 +876,47 @@ class BM25SourceJobExecutor:
             ),
         )
         check_cancelled()
-        # Prove that all job/view/profile/source preflight remained read-only.
-        _require_missing(
-            self.attempt_generation,
-            label="BM25 source job attempt generation",
-        )
-
-        self.attempt_generation.mkdir(mode=0o700)
-        output = self.attempt_generation / _BM25_VIEW
-        builder = self._builder.builder()
-        with compiler_cache_lock(
-            self.attempt_generation,
-            check_cancelled=check_cancelled,
-        ):
-            status = builder.build_from_repository_source(
-                _BM25_SCOPE,
-                repository_source=self.repository_source,
-                output_dir=str(output),
-                source_selection=self._builder.source_selection,
-                check_cancelled=check_cancelled,
+        with _PublicationAuthorityOwner() as parent_owner:
+            parent_authority = _open_publication_authority(
+                self.attempt_generation.parent,
+                parent_resource=None,
+                expected_parent_identity=None,
+                authority_owner=parent_owner,
             )
+            parent_identity = publication_parent_identity(parent_authority.resource)
+            retained_provider = _RetainedCacheWorkspaceProvider(
+                delegate=self.attempt_workspace_provider,
+                parent_authority=parent_authority,
+                parent_identity=parent_identity,
+            )
+            parent_authority.verify_path_binding()
+            _require_disjoint_attempt_generation(
+                self.attempt_generation,
+                binding.source_snapshot,
+                boundaries=(
+                    *operation.view_outputs.values(),
+                    operation.context_output,
+                    *operation.inputs.forbidden_paths,
+                ),
+            )
+            parent_authority.verify_path_binding()
             check_cancelled()
-            manifest = _source_manifest(
-                status,
-                output=output,
+            manifest = _publish_private_bm25_cache_generation(
+                self.attempt_generation,
                 display_commit=self.display_commit,
+                builder=self._builder,
                 repository_source=self.repository_source,
                 expected_source=binding.source_snapshot,
-                builder=self._builder,
+                output_owner=self.attempt_output_owner,
+                workspace_provider=retained_provider,
+                parent_authority=parent_authority,
                 check_cancelled=check_cancelled,
             )
-            if bm25_source_job_profile(builder).profile_id != self._profile.profile_id:
-                raise StorageIntegrityError(
-                    "BM25 source builder profile changed during execution"
-                )
-            manifest.save(self.attempt_generation / MANIFEST_FILENAME)
         check_cancelled()
 
-        prepared = prepare_compiler_cache_job_view(
-            self.attempt_generation,
-            view_type=_BM25_VIEW,
+        prepared = prepare_compiler_cache_job_view_from_generation(
+            self.attempt_output_owner,
+            expected_manifest=manifest,
             job=context.job,
             views=context.views,
             repository_source=self.repository_source,

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1277,8 +1277,10 @@ exactly one active required `full` BM25 request and its dirty fingerprint source
 revision before creating output, and serializes the documents, metadata,
 fingerprints, lock file, and exact single-view manifest into one immutable
 workspace plan. A retained no-follow authority pins the attempt parent before
-the source build, an exact local provider publishes only against that parent
-identity, and a caller-owned receipt retains the exact resulting
+the source build, and the generation is first verified as a lexical and
+physical strict descendant of its exact local provider root. That provider
+publishes only against the retained parent identity, and a caller-owned receipt
+retains the exact resulting
 generation through recapture and CAS ingestion. Preparation consumes the
 receipt's callback-scoped directory reader and BM25 subtree directly; it never
 reopens the diagnostic cache pathname, so parent retargeting or a renamed

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1269,21 +1269,26 @@ The first retained-source cache-building primitive now covers BM25 without
 reopening repository files by pathname. A retained `RepositorySourceBinding`
 supplies the authenticated inventory and bytes to the existing tree-sitter
 chunkers, which preserve normal filtering, relative-path, line, and
-compatibility contracts while parsing already-captured text. The builder writes
-only to a missing caller-owned private generation and attests the resulting
-BM25 artifact fingerprints. The first durable source-job adapter now snapshots
-that builder's complete portable profile, authenticates exactly one active
-required `full` BM25 request and its dirty fingerprint source revision before
-creating output, and builds a caller-owned missing attempt root. It wraps the
-new BM25 generation in an exact single-view manifest, using a separately
-supplied full Git SHA only as display provenance, then delegates strict
-recapture, context evidence, and bundle/member CAS ingestion to the existing
-public prepare-only compiler-cache bridge. The returned
-`IndexJobExecutionResult` carries no catalog, lease, fencing, ref, or generation
-publication authority; the worker remains the sole publisher and the caller
-retains cleanup ownership for every attempt. Source-job resource factories and
-resolver/CLI/Web binding, vector source building, and graph source building
-remain absent.
+compatibility contracts while parsing already-captured text. Durable
+preparation stops after canonical BM25 documents are built in memory; it does
+not construct the serving-time `BM25Okapi` ranker. The first durable source-job
+adapter snapshots that builder's complete portable profile, authenticates
+exactly one active required `full` BM25 request and its dirty fingerprint source
+revision before creating output, and serializes the documents, metadata,
+fingerprints, lock file, and exact single-view manifest into one immutable
+workspace plan. A retained no-follow authority pins the attempt parent before
+the source build, the caller's strict provider publishes only against that
+parent identity, and a caller-owned receipt retains the exact resulting
+generation through recapture and CAS ingestion. Preparation consumes the
+receipt's callback-scoped directory reader and BM25 subtree directly; it never
+reopens the diagnostic cache pathname, so parent retargeting or a renamed
+generation plus pathname decoy fails before any output or CAS mutation. The
+separately supplied full Git SHA remains display provenance only. The returned
+`IndexJobExecutionResult` carries no catalog, lease, fencing, ref, or final
+generation publication authority; the worker remains the sole publisher and
+the caller retains cleanup ownership for every attempt. Source-job resource
+factories and resolver/CLI/Web binding, vector source building, and graph source
+building remain absent.
 
 The compiler-cache bridge now also has a resource-scoped resolver seam. It
 attests the canonical running request before opening attempt resources, accepts
@@ -1335,10 +1340,11 @@ runtime now has the generation-safe refresh boundary described under M3.
 Status: in progress. The receipt-retained, fenced SQLite publication primitive
 and the explicit BM25 and schema-8 vector compiler-cache adapters, including
 their prepare-only worker bridge, are implemented. The first caller-scoped
-retained-source BM25 builder and its prepare-only source-job adapter now produce
-and ingest a unique private generation without publication authority; vector
-and graph source builders, generic builder routing, source-job resource wiring,
-and remaining runtime wiring remain.
+retained-source BM25 builder and its prepare-only source-job adapter now publish
+and ingest a unique private generation under an exact retained parent and
+generation receipt, without final publication authority or a cache-path reopen;
+vector and graph source builders, generic builder routing, source-job resource
+wiring, and remaining runtime wiring remain.
 
 - Make every builder write to a unique staging generation.
 - Add per-view profile adapters that fail closed on incomplete compatibility

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1277,8 +1277,8 @@ exactly one active required `full` BM25 request and its dirty fingerprint source
 revision before creating output, and serializes the documents, metadata,
 fingerprints, lock file, and exact single-view manifest into one immutable
 workspace plan. A retained no-follow authority pins the attempt parent before
-the source build, the caller's strict provider publishes only against that
-parent identity, and a caller-owned receipt retains the exact resulting
+the source build, an exact local provider publishes only against that parent
+identity, and a caller-owned receipt retains the exact resulting
 generation through recapture and CAS ingestion. Preparation consumes the
 receipt's callback-scoped directory reader and BM25 subtree directly; it never
 reopens the diagnostic cache pathname, so parent retargeting or a renamed

--- a/test/compiler/test_source_job.py
+++ b/test/compiler/test_source_job.py
@@ -1222,7 +1222,7 @@ def test_bm25_source_executor_repr_does_not_expose_environment(
     context_owner = PublishedWorkspaceReceiptOwner()
     try:
         executor = BM25SourceJobExecutor(
-            attempt_generation=tmp_path / "attempt",
+            attempt_generation=attempt_workspace / "attempt",
             display_commit=_COMMIT,
             builder=BM25IndexBuilder(),
             attempt_output_owner=attempt_owner,
@@ -1279,6 +1279,56 @@ def test_bm25_source_executor_rejects_protocol_only_attempt_provider(
         context_owner.close()
         view_owner.close()
         attempt_owner.close()
+
+
+@pytest.mark.parametrize("case", ["equal", "outside", "physical-escape"])
+def test_bm25_source_executor_rejects_attempt_outside_provider_root(
+    tmp_path: Path,
+    case: str,
+) -> None:
+    fixture = _source_fixture(tmp_path)
+    view_owner = PublishedWorkspaceReceiptOwner()
+    context_owner = PublishedWorkspaceReceiptOwner()
+    attempt_root = tmp_path / "attempt-root"
+    attempt_root.mkdir(mode=0o700)
+    attempt_provider = LocalWorkspaceProvider(attempt_root)
+    if case == "equal":
+        attempt = attempt_root
+    elif case == "outside":
+        attempt = tmp_path / "outside-attempt"
+    elif case == "physical-escape":
+        outside_parent = tmp_path / "outside-parent"
+        outside_parent.mkdir(mode=0o700)
+        alias = attempt_root / "alias"
+        alias.symlink_to(outside_parent, target_is_directory=True)
+        attempt = alias / "attempt"
+    else:  # pragma: no cover - parameter invariant
+        raise AssertionError(f"unknown provider-root case: {case}")
+
+    try:
+        with LocalCAS(tmp_path / "cas") as cas:
+            with pytest.raises(ValueError, match="strictly below"):
+                _executor(
+                    fixture,
+                    cas,
+                    BM25IndexBuilder(),
+                    attempt_generation=attempt,
+                    view_owner=view_owner,
+                    context_owner=context_owner,
+                    attempt_provider=attempt_provider,
+                )
+
+            if case == "equal":
+                assert attempt.is_dir()
+                assert not tuple(attempt.iterdir())
+            else:
+                assert not attempt.exists()
+            assert view_owner.state == "empty"
+            assert context_owner.state == "empty"
+    finally:
+        context_owner.close()
+        view_owner.close()
+        fixture.close()
 
 
 def test_bm25_source_job_profile_covers_builder_schema_axes() -> None:

--- a/test/compiler/test_source_job.py
+++ b/test/compiler/test_source_job.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 
 import codenib.compiler as compiler_module
+import codenib.compiler.cache_import as cache_import_module
 import codenib.compiler.source_job as source_job_module
 from codenib import LocalWorkspaceProvider
 from codenib._captured_directory import PublishedWorkspaceReceiptOwner
@@ -193,7 +194,9 @@ def _executor(
     view_owner: PublishedWorkspaceReceiptOwner,
     context_owner: PublishedWorkspaceReceiptOwner,
     attempt_owner: PublishedWorkspaceReceiptOwner | None = None,
-    attempt_provider=None,
+    attempt_provider: LocalWorkspaceProvider | None = None,
+    view_destination: Path | None = None,
+    context_destination: Path | None = None,
     forbidden_paths=(),
     environ=None,
 ) -> BM25SourceJobExecutor:
@@ -201,13 +204,25 @@ def _executor(
         attempt_generation=attempt_generation,
         display_commit=_COMMIT,
         builder=builder,
-        attempt_output_owner=attempt_owner or fixture.owner(),
-        attempt_workspace_provider=attempt_provider or fixture.attempt_provider,
+        attempt_output_owner=(
+            fixture.owner() if attempt_owner is None else attempt_owner
+        ),
+        attempt_workspace_provider=(
+            fixture.attempt_provider if attempt_provider is None else attempt_provider
+        ),
         repository_source=fixture.source,
         view_output_owner=view_owner,
         context_output_owner=context_owner,
-        view_destination=fixture.workspace / "published-bm25",
-        context_destination=fixture.workspace / "published-context",
+        view_destination=(
+            fixture.workspace / "published-bm25"
+            if view_destination is None
+            else view_destination
+        ),
+        context_destination=(
+            fixture.workspace / "published-context"
+            if context_destination is None
+            else context_destination
+        ),
         workspace_provider=fixture.provider,
         repository_key=_REPOSITORY_KEY,
         object_store=cas,
@@ -570,19 +585,19 @@ def test_bm25_source_executor_threads_stop_check_into_attempt_workspace(
     def expected_check() -> None:
         return None
 
-    class TrackingAttemptProvider:
-        def require_support(self) -> None:
-            fixture.attempt_provider.require_support()
+    real_run_workspace = LocalWorkspaceProvider.run_workspace
 
-        def run_workspace(
-            self,
-            request,
-            *,
-            receipt_owner,
-            operation,
-            check_cancelled=None,
-            _expected_parent_identity=None,
-        ):
+    def tracking_run_workspace(
+        self,
+        request,
+        *,
+        receipt_owner,
+        operation,
+        check_cancelled=None,
+        _expected_parent_identity=None,
+        _replacement_source=None,
+    ):
+        if self is fixture.attempt_provider:
             observed.append(
                 (
                     request.purpose,
@@ -590,15 +605,15 @@ def test_bm25_source_executor_threads_stop_check_into_attempt_workspace(
                     _expected_parent_identity,
                 )
             )
-            return fixture.attempt_provider.run_workspace(
-                request,
-                receipt_owner=receipt_owner,
-                operation=operation,
-                check_cancelled=check_cancelled,
-                _expected_parent_identity=_expected_parent_identity,
-            )
-
-    attempt_provider = TrackingAttemptProvider()
+        return real_run_workspace(
+            self,
+            request,
+            receipt_owner=receipt_owner,
+            operation=operation,
+            check_cancelled=check_cancelled,
+            _expected_parent_identity=_expected_parent_identity,
+            _replacement_source=_replacement_source,
+        )
 
     try:
         with (
@@ -617,7 +632,11 @@ def test_bm25_source_executor_threads_stop_check_into_attempt_workspace(
                 attempt_generation=tmp_path / "attempt-generation",
                 view_owner=view_owner,
                 context_owner=context_owner,
-                attempt_provider=attempt_provider,
+            )
+            monkeypatch.setattr(
+                LocalWorkspaceProvider,
+                "run_workspace",
+                tracking_run_workspace,
             )
             monkeypatch.setattr(
                 source_job_module,
@@ -750,6 +769,196 @@ def test_bm25_source_executor_rejects_symlinked_attempt_inside_repository(
     finally:
         context_owner.close()
         view_owner.close()
+        fixture.close()
+
+
+@pytest.mark.parametrize(
+    ("case", "error", "message"),
+    [
+        ("same", ValueError, "output destinations overlap"),
+        ("nested", ValueError, "output destinations overlap"),
+        ("physical-alias", ValueError, "output destinations overlap"),
+        ("existing-view", FileExistsError, "destination must be missing"),
+        ("existing-context", FileExistsError, "destination must be missing"),
+        ("repository", ValueError, "destination overlaps an input authority"),
+        ("forbidden", ValueError, "destination overlaps an input authority"),
+    ],
+)
+def test_bm25_source_executor_rejects_invalid_output_topology_before_build(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+    error: type[Exception],
+    message: str,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    view_owner = PublishedWorkspaceReceiptOwner()
+    context_owner = PublishedWorkspaceReceiptOwner()
+    attempt = tmp_path / "attempt-generation"
+    output_root = fixture.workspace / "outputs"
+    output_root.mkdir(mode=0o700)
+    forbidden = tmp_path / "forbidden"
+    forbidden.mkdir(mode=0o700)
+    view_destination = output_root / "view"
+    context_destination = output_root / "context"
+    if case == "same":
+        view_destination = context_destination = output_root / "shared"
+    elif case == "nested":
+        context_destination = view_destination / "context"
+    elif case == "physical-alias":
+        real_parent = output_root / "real"
+        real_parent.mkdir(mode=0o700)
+        alias_parent = output_root / "alias"
+        alias_parent.symlink_to(real_parent, target_is_directory=True)
+        view_destination = real_parent / "artifact"
+        context_destination = alias_parent / "artifact"
+    elif case == "existing-view":
+        view_destination.mkdir(mode=0o700)
+    elif case == "existing-context":
+        context_destination.mkdir(mode=0o700)
+    elif case == "repository":
+        view_destination = fixture.repository / "view"
+    elif case == "forbidden":
+        view_destination = forbidden / "view"
+    else:  # pragma: no cover - parameter invariant
+        raise AssertionError(f"unknown topology case: {case}")
+
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            executor = _executor(
+                fixture,
+                cas,
+                builder,
+                attempt_generation=attempt,
+                view_owner=view_owner,
+                context_owner=context_owner,
+                view_destination=view_destination,
+                context_destination=context_destination,
+                forbidden_paths=(forbidden,),
+            )
+            monkeypatch.setattr(
+                BM25IndexBuilder,
+                "prepare_from_repository_source",
+                lambda *_args, **_kwargs: pytest.fail(
+                    "builder ran before output topology was validated"
+                ),
+            )
+
+            with pytest.raises(error, match=message):
+                executor.execute(context)
+
+            assert not attempt.exists()
+            assert executor.attempt_output_owner.state == "empty"
+            assert view_owner.state == "empty"
+            assert context_owner.state == "empty"
+            assert not any(path.is_file() for path in (tmp_path / "cas").rglob("*"))
+    finally:
+        context_owner.close()
+        view_owner.close()
+        fixture.close()
+
+
+@pytest.mark.parametrize(
+    ("case", "error", "message"),
+    [
+        ("same", ValueError, "output destinations overlap"),
+        ("physical-alias", ValueError, "output destinations overlap"),
+        ("existing-context", FileExistsError, "destination must be missing"),
+    ],
+)
+def test_retained_generation_rechecks_output_topology_before_recapture_plan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+    error: type[Exception],
+    message: str,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    initial_view_owner = PublishedWorkspaceReceiptOwner()
+    initial_context_owner = PublishedWorkspaceReceiptOwner()
+    retry_view_owner = PublishedWorkspaceReceiptOwner()
+    retry_context_owner = PublishedWorkspaceReceiptOwner()
+    attempt = tmp_path / "attempt-generation"
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            executor = _executor(
+                fixture,
+                cas,
+                builder,
+                attempt_generation=attempt,
+                view_owner=initial_view_owner,
+                context_owner=initial_context_owner,
+            )
+            assert executor.execute(context).publishable
+            expected_manifest = RepoManifest.load(attempt / "repo_manifest.json")
+
+            retry_root = fixture.workspace / "retry"
+            retry_root.mkdir(mode=0o700)
+            view_destination = retry_root / "view"
+            context_destination = retry_root / "context"
+            if case == "same":
+                view_destination = context_destination = retry_root / "shared"
+            elif case == "physical-alias":
+                real_parent = retry_root / "real"
+                real_parent.mkdir(mode=0o700)
+                alias_parent = retry_root / "alias"
+                alias_parent.symlink_to(real_parent, target_is_directory=True)
+                view_destination = real_parent / "artifact"
+                context_destination = alias_parent / "artifact"
+            elif case == "existing-context":
+                context_destination.mkdir(mode=0o700)
+            else:  # pragma: no cover - parameter invariant
+                raise AssertionError(f"unknown topology case: {case}")
+
+            monkeypatch.setattr(
+                cache_import_module,
+                "_plan_retained_bm25_publication_view",
+                lambda *_args, **_kwargs: pytest.fail(
+                    "retained BM25 recapture was planned before topology validation"
+                ),
+            )
+            with pytest.raises(error, match=message):
+                cache_import_module.prepare_compiler_cache_job_view_from_generation(
+                    executor.attempt_output_owner,
+                    expected_manifest=expected_manifest,
+                    job=context.job,
+                    views=context.views,
+                    repository_source=fixture.source,
+                    view_output_owner=retry_view_owner,
+                    context_output_owner=retry_context_owner,
+                    view_destination=view_destination,
+                    context_destination=context_destination,
+                    workspace_provider=fixture.provider,
+                    repository_key=_REPOSITORY_KEY,
+                    object_store=cas,
+                    environ={},
+                )
+
+            assert retry_view_owner.state == "empty"
+            assert retry_context_owner.state == "empty"
+    finally:
+        retry_context_owner.close()
+        retry_view_owner.close()
+        initial_context_owner.close()
+        initial_view_owner.close()
         fixture.close()
 
 
@@ -1006,13 +1215,8 @@ def test_bm25_source_executor_repr_does_not_expose_environment(
     secret = "source-job-secret-marker"
     monkeypatch.setenv(variable, secret)
 
-    class UnusedProvider:
-        def require_support(self) -> None:
-            return None
-
-        def run_workspace(self, *_args, **_kwargs):
-            raise AssertionError("repr test unexpectedly used a workspace")
-
+    attempt_workspace = tmp_path / "attempt-workspace"
+    attempt_workspace.mkdir(mode=0o700)
     attempt_owner = PublishedWorkspaceReceiptOwner()
     view_owner = PublishedWorkspaceReceiptOwner()
     context_owner = PublishedWorkspaceReceiptOwner()
@@ -1022,7 +1226,7 @@ def test_bm25_source_executor_repr_does_not_expose_environment(
             display_commit=_COMMIT,
             builder=BM25IndexBuilder(),
             attempt_output_owner=attempt_owner,
-            attempt_workspace_provider=UnusedProvider(),
+            attempt_workspace_provider=LocalWorkspaceProvider(attempt_workspace),
             repository_source=object(),  # type: ignore[arg-type]
             view_output_owner=view_owner,
             context_output_owner=context_owner,
@@ -1035,6 +1239,42 @@ def test_bm25_source_executor_repr_does_not_expose_environment(
 
         assert executor.environ[variable] == secret
         assert secret not in repr(executor)
+    finally:
+        context_owner.close()
+        view_owner.close()
+        attempt_owner.close()
+
+
+def test_bm25_source_executor_rejects_protocol_only_attempt_provider(
+    tmp_path: Path,
+) -> None:
+    class ProtocolOnlyAttemptProvider:
+        def require_support(self) -> None:
+            raise AssertionError("incompatible provider support check was called")
+
+        def run_workspace(self, *_args, **_kwargs):
+            raise AssertionError("incompatible provider was used")
+
+    attempt_owner = PublishedWorkspaceReceiptOwner()
+    view_owner = PublishedWorkspaceReceiptOwner()
+    context_owner = PublishedWorkspaceReceiptOwner()
+    try:
+        with pytest.raises(TypeError, match="exact local workspace provider"):
+            BM25SourceJobExecutor(
+                attempt_generation=tmp_path / "attempt",
+                display_commit=_COMMIT,
+                builder=BM25IndexBuilder(),
+                attempt_output_owner=attempt_owner,
+                attempt_workspace_provider=ProtocolOnlyAttemptProvider(),  # type: ignore[arg-type]
+                repository_source=object(),  # type: ignore[arg-type]
+                view_output_owner=view_owner,
+                context_output_owner=context_owner,
+                view_destination=tmp_path / "view",
+                context_destination=tmp_path / "context",
+                workspace_provider=object(),  # type: ignore[arg-type]
+                repository_key=_REPOSITORY_KEY,
+                object_store=object(),  # type: ignore[arg-type]
+            )
     finally:
         context_owner.close()
         view_owner.close()

--- a/test/compiler/test_source_job.py
+++ b/test/compiler/test_source_job.py
@@ -81,8 +81,17 @@ class _SourceFixture:
     source: RepositorySourceBinding
     workspace: Path
     provider: LocalWorkspaceProvider
+    attempt_provider: LocalWorkspaceProvider
+    owners: list[PublishedWorkspaceReceiptOwner]
+
+    def owner(self) -> PublishedWorkspaceReceiptOwner:
+        owner = PublishedWorkspaceReceiptOwner()
+        self.owners.append(owner)
+        return owner
 
     def close(self) -> None:
+        for owner in reversed(self.owners):
+            owner.close()
         self.source.close()
 
 
@@ -106,6 +115,8 @@ def _source_fixture(
         source=source,
         workspace=workspace,
         provider=LocalWorkspaceProvider(workspace),
+        attempt_provider=LocalWorkspaceProvider(tmp_path),
+        owners=[],
     )
 
 
@@ -181,6 +192,8 @@ def _executor(
     attempt_generation: Path,
     view_owner: PublishedWorkspaceReceiptOwner,
     context_owner: PublishedWorkspaceReceiptOwner,
+    attempt_owner: PublishedWorkspaceReceiptOwner | None = None,
+    attempt_provider=None,
     forbidden_paths=(),
     environ=None,
 ) -> BM25SourceJobExecutor:
@@ -188,6 +201,8 @@ def _executor(
         attempt_generation=attempt_generation,
         display_commit=_COMMIT,
         builder=builder,
+        attempt_output_owner=attempt_owner or fixture.owner(),
+        attempt_workspace_provider=attempt_provider or fixture.attempt_provider,
         repository_source=fixture.source,
         view_output_owner=view_owner,
         context_output_owner=context_owner,
@@ -299,22 +314,27 @@ def test_bm25_source_executor_prepares_exact_artifact_without_lexical_reads(
             builder.source_selection = RepositorySourceSelection(("sample.py",))
             environment["CODENIB_SOURCE_JOB_TEST"] = "after"
 
-            real_prepare = source_job_module.prepare_compiler_cache_job_view
+            real_prepare = (
+                source_job_module.prepare_compiler_cache_job_view_from_generation
+            )
 
-            def delegated_prepare(cache_dir, **kwargs):
-                delegated.append(Path(cache_dir))
-                manifest = RepoManifest.load(Path(cache_dir) / "repo_manifest.json")
+            def delegated_prepare(cache_generation, **kwargs):
+                assert cache_generation.active
+                cache_dir = cache_generation.receipt.path
+                delegated.append(cache_dir)
+                manifest = RepoManifest.load(cache_dir / "repo_manifest.json")
                 assert manifest.commit == _COMMIT
                 assert manifest.indexes["bm25"].config["max_k"] == 17
                 assert manifest.indexes["bm25"].config["languages"] == ["python"]
+                assert kwargs["expected_manifest"].to_dict() == manifest.to_dict()
                 assert kwargs["forbidden_paths"] == (forbidden,)
                 assert kwargs["environ"]["CODENIB_SOURCE_JOB_TEST"] == "before"
-                return real_prepare(cache_dir, **kwargs)
+                return real_prepare(cache_generation, **kwargs)
 
             with monkeypatch.context() as guard:
                 guard.setattr(
                     source_job_module,
-                    "prepare_compiler_cache_job_view",
+                    "prepare_compiler_cache_job_view_from_generation",
                     delegated_prepare,
                 )
                 _guard_lexical_repository_reads(guard, fixture.repository)
@@ -338,6 +358,7 @@ def test_bm25_source_executor_prepares_exact_artifact_without_lexical_reads(
             for member in artifact.member_artifacts:
                 assert cas.verify(member.receipt.digest) == member.receipt
             assert delegated == [attempt]
+            assert executor.attempt_output_owner.active
             assert attempt.is_dir()
             manifest = RepoManifest.load(attempt / "repo_manifest.json")
             assert manifest.repo_path == str(fixture.repository)
@@ -367,7 +388,7 @@ def test_bm25_source_executor_prepares_exact_artifact_without_lexical_reads(
         fixture.close()
 
 
-def test_bm25_source_executor_threads_stop_check_into_attempt_lock(
+def test_bm25_source_executor_refuses_replaced_generation_before_prepare(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -375,15 +396,209 @@ def test_bm25_source_executor_threads_stop_check_into_attempt_lock(
     fixture = _source_fixture(tmp_path)
     view_owner = PublishedWorkspaceReceiptOwner()
     context_owner = PublishedWorkspaceReceiptOwner()
-    observed: list[object] = []
-    real_lock = source_job_module.compiler_cache_lock
+    attempt = tmp_path / "attempt-generation"
+    retained_attempt = tmp_path / "retained-attempt-generation"
+    real_prepare = source_job_module.prepare_compiler_cache_job_view_from_generation
+    attacked = False
+
+    def replace_generation(cache_generation, **kwargs):
+        nonlocal attacked
+        assert cache_generation.active
+        assert cache_generation.receipt.path == attempt
+        attacked = True
+        attempt.rename(retained_attempt)
+        attempt.mkdir(mode=0o700)
+        (attempt / "decoy-marker").write_text("untrusted", encoding="utf-8")
+        return real_prepare(cache_generation, **kwargs)
+
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            executor = _executor(
+                fixture,
+                cas,
+                builder,
+                attempt_generation=attempt,
+                view_owner=view_owner,
+                context_owner=context_owner,
+            )
+            monkeypatch.setattr(
+                source_job_module,
+                "prepare_compiler_cache_job_view_from_generation",
+                replace_generation,
+            )
+
+            with pytest.raises(
+                RuntimeError,
+                match="published workspace root handle changed",
+            ):
+                executor.execute(context)
+
+            assert attacked
+            assert executor.attempt_output_owner.active
+            assert retained_attempt.joinpath("repo_manifest.json").is_file()
+            assert attempt.joinpath("decoy-marker").read_text(encoding="utf-8") == (
+                "untrusted"
+            )
+            assert view_owner.state == "empty"
+            assert context_owner.state == "empty"
+            assert not (fixture.workspace / "published-bm25").exists()
+            assert not (fixture.workspace / "published-context").exists()
+            assert not any(path.is_file() for path in (tmp_path / "cas").rglob("*"))
+    finally:
+        context_owner.close()
+        view_owner.close()
+        fixture.close()
+
+
+def test_bm25_source_executor_rejects_retargeted_local_attempt_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = BM25IndexBuilder(languages=["python"])
+    fixture = _source_fixture(tmp_path)
+    view_owner = PublishedWorkspaceReceiptOwner()
+    context_owner = PublishedWorkspaceReceiptOwner()
+    scratch = tmp_path / "attempt-workspace"
+    scratch.mkdir(mode=0o700)
+    retained_scratch = tmp_path / "retained-attempt-workspace"
+    attempt = scratch / "attempt-generation"
+    attempt_provider = LocalWorkspaceProvider(scratch)
+    real_run = LocalWorkspaceProvider.run_workspace
+    attacked = False
+
+    def retarget_before_native_provision(
+        self,
+        request,
+        *,
+        receipt_owner,
+        operation,
+        check_cancelled=None,
+        _expected_parent_identity=None,
+        _replacement_source=None,
+    ):
+        nonlocal attacked
+        if self is attempt_provider and not attacked:
+            assert request.destination == attempt
+            assert _expected_parent_identity is not None
+            assert _replacement_source is None
+            attacked = True
+            scratch.rename(retained_scratch)
+            scratch.mkdir(mode=0o700)
+        return real_run(
+            self,
+            request,
+            receipt_owner=receipt_owner,
+            operation=operation,
+            check_cancelled=check_cancelled,
+            _expected_parent_identity=_expected_parent_identity,
+            _replacement_source=_replacement_source,
+        )
+
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            executor = _executor(
+                fixture,
+                cas,
+                builder,
+                attempt_generation=attempt,
+                view_owner=view_owner,
+                context_owner=context_owner,
+                attempt_provider=attempt_provider,
+            )
+            monkeypatch.setattr(
+                LocalWorkspaceProvider,
+                "run_workspace",
+                retarget_before_native_provision,
+            )
+
+            with pytest.raises(
+                RuntimeError,
+                match="native workspace parent differs from retained authority",
+            ):
+                executor.execute(context)
+
+            assert attacked
+            assert executor.attempt_output_owner.state == "empty"
+            assert not attempt.exists()
+            quarantined = tuple(scratch.iterdir())
+            assert quarantined
+            assert all(
+                entry.name.startswith(".codenib-workspace-orphan-") and entry.is_dir()
+                for entry in quarantined
+            )
+            assert not any(
+                descendant.is_file()
+                for entry in quarantined
+                for descendant in entry.rglob("*")
+            )
+            assert not tuple(retained_scratch.iterdir())
+            assert view_owner.state == "empty"
+            assert context_owner.state == "empty"
+            assert not any(path.is_file() for path in (tmp_path / "cas").rglob("*"))
+    finally:
+        context_owner.close()
+        view_owner.close()
+        fixture.close()
+
+
+def test_bm25_source_executor_threads_stop_check_into_attempt_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = BM25IndexBuilder(languages=["python"])
+    fixture = _source_fixture(tmp_path)
+    view_owner = PublishedWorkspaceReceiptOwner()
+    context_owner = PublishedWorkspaceReceiptOwner()
+    observed: list[tuple[str, object, tuple[int, ...] | None]] = []
 
     def expected_check() -> None:
         return None
 
-    def tracked_lock(cache_dir, **kwargs):
-        observed.append(kwargs.get("check_cancelled"))
-        return real_lock(cache_dir, **kwargs)
+    class TrackingAttemptProvider:
+        def require_support(self) -> None:
+            fixture.attempt_provider.require_support()
+
+        def run_workspace(
+            self,
+            request,
+            *,
+            receipt_owner,
+            operation,
+            check_cancelled=None,
+            _expected_parent_identity=None,
+        ):
+            observed.append(
+                (
+                    request.purpose,
+                    check_cancelled,
+                    _expected_parent_identity,
+                )
+            )
+            return fixture.attempt_provider.run_workspace(
+                request,
+                receipt_owner=receipt_owner,
+                operation=operation,
+                check_cancelled=check_cancelled,
+                _expected_parent_identity=_expected_parent_identity,
+            )
+
+    attempt_provider = TrackingAttemptProvider()
 
     try:
         with (
@@ -402,22 +617,20 @@ def test_bm25_source_executor_threads_stop_check_into_attempt_lock(
                 attempt_generation=tmp_path / "attempt-generation",
                 view_owner=view_owner,
                 context_owner=context_owner,
+                attempt_provider=attempt_provider,
             )
             monkeypatch.setattr(
                 source_job_module,
                 "_compiler_cache_job_stop_check",
                 lambda _token: expected_check,
             )
-            monkeypatch.setattr(
-                source_job_module,
-                "compiler_cache_lock",
-                tracked_lock,
-            )
-
             result = executor.execute(context)
 
             assert result.publishable
-            assert observed == [expected_check]
+            assert len(observed) == 1
+            assert observed[0][0] == "private-bm25-compiler-cache"
+            assert observed[0][1] is expected_check
+            assert observed[0][2] is not None
     finally:
         context_owner.close()
         view_owner.close()
@@ -470,7 +683,7 @@ def test_bm25_source_executor_rejects_job_mismatch_before_output_mutation(
             )
             monkeypatch.setattr(
                 BM25IndexBuilder,
-                "build_from_repository_source",
+                "prepare_from_repository_source",
                 lambda *_args, **_kwargs: pytest.fail(
                     "builder ran before source-job preflight completed"
                 ),
@@ -522,7 +735,7 @@ def test_bm25_source_executor_rejects_symlinked_attempt_inside_repository(
             )
             monkeypatch.setattr(
                 BM25IndexBuilder,
-                "build_from_repository_source",
+                "prepare_from_repository_source",
                 lambda *_args, **_kwargs: pytest.fail(
                     "builder ran for a repository-overlapping attempt"
                 ),
@@ -579,7 +792,7 @@ def test_bm25_source_executor_rejects_attempt_output_and_policy_overlap(
             )
             monkeypatch.setattr(
                 BM25IndexBuilder,
-                "build_from_repository_source",
+                "prepare_from_repository_source",
                 lambda *_args, **_kwargs: pytest.fail(
                     "builder ran for an overlapping attempt"
                 ),
@@ -613,12 +826,12 @@ def test_bm25_source_executor_preserves_stop_and_caller_retry_ownership(
         if armed:
             raise stopped
 
-    real_prepare = source_job_module.prepare_compiler_cache_job_view
+    real_prepare = source_job_module.prepare_compiler_cache_job_view_from_generation
 
-    def stop_during_prepare(cache_dir, **kwargs):
+    def stop_during_prepare(cache_generation, **kwargs):
         nonlocal armed
         armed = True
-        return real_prepare(cache_dir, **kwargs)
+        return real_prepare(cache_generation, **kwargs)
 
     try:
         with (
@@ -645,7 +858,7 @@ def test_bm25_source_executor_preserves_stop_and_caller_retry_ownership(
             )
             monkeypatch.setattr(
                 source_job_module,
-                "prepare_compiler_cache_job_view",
+                "prepare_compiler_cache_job_view_from_generation",
                 stop_during_prepare,
             )
 
@@ -655,11 +868,12 @@ def test_bm25_source_executor_preserves_stop_and_caller_retry_ownership(
             assert attempt.is_dir()
             assert (attempt / "bm25").is_dir()
             assert (attempt / "repo_manifest.json").is_file()
+            assert executor.attempt_output_owner.active
             assert view_owner.state == "empty"
             assert context_owner.state == "empty"
 
             armed = False
-            with pytest.raises(FileExistsError, match="must be missing"):
+            with pytest.raises(RuntimeError, match="attempt owner must be empty"):
                 executor.execute(context)
             assert attempt.is_dir()
     finally:
@@ -672,8 +886,6 @@ def test_bm25_source_executor_preserves_stop_during_source_build(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import codenib.index.sparse_idx.bm25_index as bm25_module
-
     builder = BM25IndexBuilder()
     fixture = _source_fixture(tmp_path)
     view_owner = PublishedWorkspaceReceiptOwner()
@@ -681,24 +893,20 @@ def test_bm25_source_executor_preserves_stop_during_source_build(
     attempt = tmp_path / "attempt-generation"
     stopped = KeyboardInterrupt("injected source-build stop")
     armed = False
-    write_calls = 0
-    real_dump = bm25_module._dump_json_interruptibly
+    chunk_calls = 0
+    real_json_chunks = source_job_module._json_byte_chunks
 
     def check_cancelled() -> None:
         if armed:
             raise stopped
 
-    def stop_during_dump(value, handle, checker):
-        class ArmAfterWrite:
-            def write(self, payload):
-                nonlocal armed, write_calls
-                written = handle.write(payload)
-                write_calls += 1
-                if write_calls == 3:
-                    armed = True
-                return written
-
-        return real_dump(value, ArmAfterWrite(), checker)
+    def stop_during_json(value, checker):
+        nonlocal armed, chunk_calls
+        for chunk in real_json_chunks(value, checker):
+            chunk_calls += 1
+            if chunk_calls == 3:
+                armed = True
+            yield chunk
 
     try:
         with (
@@ -724,13 +932,13 @@ def test_bm25_source_executor_preserves_stop_during_source_build(
                 lambda _token: check_cancelled,
             )
             monkeypatch.setattr(
-                bm25_module,
-                "_dump_json_interruptibly",
-                stop_during_dump,
+                source_job_module,
+                "_json_byte_chunks",
+                stop_during_json,
             )
             monkeypatch.setattr(
                 source_job_module,
-                "prepare_compiler_cache_job_view",
+                "prepare_compiler_cache_job_view_from_generation",
                 lambda *_args, **_kwargs: pytest.fail(
                     "cache preparation ran after source-build cancellation"
                 ),
@@ -740,12 +948,10 @@ def test_bm25_source_executor_preserves_stop_during_source_build(
                 executor.execute(context)
 
             assert raised.value is stopped
-            assert write_calls == 3
+            assert chunk_calls == 3
             assert fixture.source.usable
-            assert attempt.is_dir()
-            assert (attempt / "bm25").is_dir()
-            assert (attempt / "bm25" / "documents.json").stat().st_size > 0
-            assert not (attempt / "bm25" / "bm25_metadata.json").exists()
+            assert not attempt.exists()
+            assert executor.attempt_output_owner.state == "empty"
             assert view_owner.state == "empty"
             assert context_owner.state == "empty"
             assert not (fixture.workspace / "published-bm25").exists()
@@ -761,11 +967,17 @@ def test_bm25_source_executor_preserves_stop_during_source_build(
 def test_bm25_source_executor_api_has_no_publication_authority() -> None:
     assert compiler_module.BM25SourceJobExecutor is BM25SourceJobExecutor
     assert compiler_module.bm25_source_job_profile is bm25_source_job_profile
+    assert (
+        compiler_module.prepare_compiler_cache_job_view_from_generation
+        is source_job_module.prepare_compiler_cache_job_view_from_generation
+    )
     parameters = inspect.signature(BM25SourceJobExecutor).parameters
-    assert list(parameters)[:11] == [
+    assert list(parameters)[:13] == [
         "attempt_generation",
         "display_commit",
         "builder",
+        "attempt_output_owner",
+        "attempt_workspace_provider",
         "repository_source",
         "view_output_owner",
         "context_output_owner",
@@ -793,22 +1005,40 @@ def test_bm25_source_executor_repr_does_not_expose_environment(
     variable = "CODENIB_SOURCE_JOB_SECRET_SENTINEL"
     secret = "source-job-secret-marker"
     monkeypatch.setenv(variable, secret)
-    executor = BM25SourceJobExecutor(
-        attempt_generation=tmp_path / "attempt",
-        display_commit=_COMMIT,
-        builder=BM25IndexBuilder(),
-        repository_source=object(),  # type: ignore[arg-type]
-        view_output_owner=object(),  # type: ignore[arg-type]
-        context_output_owner=object(),  # type: ignore[arg-type]
-        view_destination=tmp_path / "view",
-        context_destination=tmp_path / "context",
-        workspace_provider=object(),  # type: ignore[arg-type]
-        repository_key=_REPOSITORY_KEY,
-        object_store=object(),  # type: ignore[arg-type]
-    )
 
-    assert executor.environ[variable] == secret
-    assert secret not in repr(executor)
+    class UnusedProvider:
+        def require_support(self) -> None:
+            return None
+
+        def run_workspace(self, *_args, **_kwargs):
+            raise AssertionError("repr test unexpectedly used a workspace")
+
+    attempt_owner = PublishedWorkspaceReceiptOwner()
+    view_owner = PublishedWorkspaceReceiptOwner()
+    context_owner = PublishedWorkspaceReceiptOwner()
+    try:
+        executor = BM25SourceJobExecutor(
+            attempt_generation=tmp_path / "attempt",
+            display_commit=_COMMIT,
+            builder=BM25IndexBuilder(),
+            attempt_output_owner=attempt_owner,
+            attempt_workspace_provider=UnusedProvider(),
+            repository_source=object(),  # type: ignore[arg-type]
+            view_output_owner=view_owner,
+            context_output_owner=context_owner,
+            view_destination=tmp_path / "view",
+            context_destination=tmp_path / "context",
+            workspace_provider=object(),  # type: ignore[arg-type]
+            repository_key=_REPOSITORY_KEY,
+            object_store=object(),  # type: ignore[arg-type]
+        )
+
+        assert executor.environ[variable] == secret
+        assert secret not in repr(executor)
+    finally:
+        context_owner.close()
+        view_owner.close()
+        attempt_owner.close()
 
 
 def test_bm25_source_job_profile_covers_builder_schema_axes() -> None:
@@ -837,6 +1067,8 @@ def test_bm25_source_executor_rejects_noncanonical_display_commit(
         "attempt_generation": attempt,
         "display_commit": "A" * 40,
         "builder": BM25IndexBuilder(),
+        "attempt_output_owner": object(),
+        "attempt_workspace_provider": object(),
         "repository_source": object(),
         "view_output_owner": object(),
         "context_output_owner": object(),


### PR DESCRIPTION
## Summary
Retain exact authority for prepare-only BM25 attempt generations from parent-bound publication through cache recapture and CAS ingestion. This rebases the remaining security fix onto the source-job design merged in #712 instead of restoring the superseded serving-time build path.

## Changes
- Split retained-source BM25 preparation from persistence so durable jobs keep canonical documents in memory and continue to skip serving-time `BM25Okapi` construction.
- Serialize documents, metadata, fingerprints, lock file, and manifest into one exact private workspace plan.
- Require an exact local provider, verify the attempt is its lexical and physical strict descendant before building, pin the attempt parent, and publish only against that retained parent identity.
- Validate lexical and physical output topology and output absence before source building, then repeat the destination gate at the public retained-generation boundary before recapture planning.
- Keep a caller-owned generation receipt active through preparation and consume its callback-scoped directory reader and BM25 subtree without reopening the cache pathname.
- Fail closed on parent retargeting, generation rename-plus-decoy, provider-root escape, output aliasing, and pre-existing output attacks before view output or CAS mutation.
- Update the storage roadmap and add cancellation, receipt, topology, capability, and native-parent regression coverage.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/compiler/test_cache_import.py test/compiler/test_source_job.py test/artifacts/test_strict_bm25_publication.py test/compiler/test_index_compiler.py -x --tb=short` (`396 passed`).
- Exact-head unit tier excluding the three documented local filesystem/log-capture baselines (`8453 passed, 35 skipped, 193 deselected`).
- Pre-commit passed for every changed file.

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published