### PR TITLE
feat(compiler): prepare BM25 jobs from retained source

### DIFF
--- a/codenib/code_chunker.py
+++ b/codenib/code_chunker.py
@@ -365,18 +365,22 @@ class CodeChunker:
         languages = self.repo_config.languages or self._detect_source_languages(
             records,
             source_selection=source_selection,
+            check_cancelled=check_cancelled,
         )
         extension_to_language = self._extension_language_map(languages)
-        selected = [
-            (record, extension_to_language[Path(record.path).suffix])
-            for record in records
+        selected: List[tuple[RepositorySourceFileRecord, str]] = []
+        for record in records:
+            if check_cancelled is not None:
+                check_cancelled()
             if self._source_record_is_selected(
                 record,
                 extension_to_language=extension_to_language,
                 repository_root=source_identity.root,
                 source_selection=source_selection,
-            )
-        ]
+            ):
+                selected.append(
+                    (record, extension_to_language[Path(record.path).suffix])
+                )
 
         logger.info("Chunking authenticated repository: %s", source_identity.root)
         logger.info("Target languages: %s", ", ".join(languages))
@@ -403,6 +407,7 @@ class CodeChunker:
                 if self.repo_config.skip_minified and self._is_minified_source(
                     source_text,
                     path=record.path,
+                    check_cancelled=check_cancelled,
                 ):
                     continue
                 try:
@@ -421,12 +426,18 @@ class CodeChunker:
                 if check_cancelled is not None:
                     check_cancelled()
 
+        if check_cancelled is not None:
+            check_cancelled()
         self._require_selected_chunks(
             chunks,
             source_selection,
             repository_root=source_identity.root,
+            check_cancelled=check_cancelled,
         )
-        self._update_nodes_from_chunks(chunks)
+        self._update_nodes_from_chunks(
+            chunks,
+            check_cancelled=check_cancelled,
+        )
         logger.info("Generated %d authenticated source chunks", len(chunks))
         return chunks
 
@@ -714,16 +725,34 @@ class CodeChunker:
             )
         return False
 
-    def _is_minified_source(self, source: str, *, path: str) -> bool:
+    def _is_minified_source(
+        self,
+        source: str,
+        *,
+        path: str,
+        check_cancelled: Callable[[], None] | None = None,
+    ) -> bool:
         """Apply the shared long-line policy to already-read source text."""
 
-        return self._has_minified_line(source.splitlines(keepends=True), path=path)
+        return self._has_minified_line(
+            source.splitlines(keepends=True),
+            path=path,
+            check_cancelled=check_cancelled,
+        )
 
-    def _has_minified_line(self, lines: Iterable[str], *, path: str) -> bool:
+    def _has_minified_line(
+        self,
+        lines: Iterable[str],
+        *,
+        path: str,
+        check_cancelled: Callable[[], None] | None = None,
+    ) -> bool:
         """Return whether a streamed or retained source has an oversized line."""
 
         threshold = self.repo_config.minified_line_threshold
         for line in lines:
+            if check_cancelled is not None:
+                check_cancelled()
             if len(line) > threshold:
                 logger.debug(
                     "Skipping minified file (line > %d chars): %s",
@@ -945,11 +974,14 @@ class CodeChunker:
         records: tuple[RepositorySourceFileRecord, ...],
         *,
         source_selection: RepositorySourceSelection,
+        check_cancelled: Callable[[], None] | None = None,
     ) -> List[str]:
         """Infer languages from one authenticated repository inventory."""
 
         extension_counts: Dict[str, int] = {}
         for record in records:
+            if check_cancelled is not None:
+                check_cancelled()
             if type(record) is not RepositorySourceFileRecord:
                 raise TypeError("authenticated repository file record is invalid")
             relative = Path(record.path)
@@ -995,12 +1027,15 @@ class CodeChunker:
         source_selection: RepositorySourceSelection,
         *,
         repository_root: Path,
+        check_cancelled: Callable[[], None] | None = None,
     ) -> None:
         """Reject any chunk whose lexical repository path escaped selection."""
 
         if not source_selection.exclude_subtrees:
             return
         for chunk in chunks:
+            if check_cancelled is not None:
+                check_cancelled()
             source_path = getattr(chunk, "file", None)
             try:
                 relative_path = repository_relative_source_path(
@@ -1079,7 +1114,12 @@ class CodeChunker:
         except Exception as e:
             logger.error(f"Error saving SWE-bench result: {e}")
 
-    def _update_nodes_from_chunks(self, chunks: List[CodeChunk]):
+    def _update_nodes_from_chunks(
+        self,
+        chunks: List[CodeChunk],
+        *,
+        check_cancelled: Callable[[], None] | None = None,
+    ):
         """
         Update the nodes list with unique node IDs from chunks.
 
@@ -1089,6 +1129,8 @@ class CodeChunker:
         # Extract node_ids from chunks, filtering for symbolic nodes (not just file paths)
         new_node_ids = set()
         for chunk in chunks:
+            if check_cancelled is not None:
+                check_cancelled()
             if chunk.node_id and ":" in chunk.node_id:
                 # Only include nodes that have symbols (contain ':')
                 # This excludes header/epilogue chunks which just use file paths
@@ -1097,6 +1139,8 @@ class CodeChunker:
         # Add new unique node IDs to the nodes list
         existing_nodes = set(self.nodes)
         for node_id in new_node_ids:
+            if check_cancelled is not None:
+                check_cancelled()
             if node_id not in existing_nodes:
                 self.nodes.append(node_id)
 

--- a/codenib/compiler/__init__.py
+++ b/codenib/compiler/__init__.py
@@ -93,6 +93,10 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
         load_contexts_from_manifest,
         required_index_types,
     )
+    from codenib.compiler.source_job import (
+        BM25SourceJobExecutor,
+        bm25_source_job_profile,
+    )
 
 _EXPORTS = {
     "CompilerCacheBm25RecaptureResult": (
@@ -274,6 +278,14 @@ _EXPORTS = {
         "codenib.compiler.skill_context",
         "required_index_types",
     ),
+    "BM25SourceJobExecutor": (
+        "codenib.compiler.source_job",
+        "BM25SourceJobExecutor",
+    ),
+    "bm25_source_job_profile": (
+        "codenib.compiler.source_job",
+        "bm25_source_job_profile",
+    ),
 }
 
 __all__ = [
@@ -302,6 +314,8 @@ __all__ = [
     "IndexCompiler",
     "IndexCompilerConfig",
     "IndexBuilderRegistry",
+    "BM25SourceJobExecutor",
+    "bm25_source_job_profile",
     # Manifest
     "RepoManifest",
     "ManifestIndexStateStore",

--- a/codenib/compiler/artifact_fingerprints.py
+++ b/codenib/compiler/artifact_fingerprints.py
@@ -11,7 +11,7 @@ import os
 import re
 import stat
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 
 _BM25_ARTIFACT_PATHS = (Path("documents.json"), Path("bm25_metadata.json"))
 _SHA256_RE = re.compile(r"[0-9a-f]{64}")
@@ -69,9 +69,27 @@ def _file_identity(metadata: os.stat_result) -> tuple[int, ...]:
     )
 
 
-def _file_fingerprint(path: Path) -> dict[str, Any]:
+def _file_fingerprint(
+    path: Path,
+    *,
+    check_cancelled: Callable[[], None] | None = None,
+) -> dict[str, Any]:
     descriptor = -1
+    cancellation_failure: BaseException | None = None
+    primary: BaseException | None = None
+
+    def poll() -> None:
+        nonlocal cancellation_failure
+        if check_cancelled is None:
+            return
+        try:
+            check_cancelled()
+        except BaseException as exc:  # preserve exact cooperative stop
+            cancellation_failure = exc
+            raise
+
     try:
+        poll()
         before = path.lstat()
         if (
             not stat.S_ISREG(before.st_mode)
@@ -92,11 +110,13 @@ def _file_fingerprint(path: Path) -> dict[str, Any]:
         digest = hashlib.sha256()
         remaining = opened.st_size
         while remaining:
+            poll()
             block = os.read(descriptor, min(remaining, _READ_BYTES))
             if not block:
                 raise ValueError(f"BM25 artifact file was truncated: {path}")
             digest.update(block)
             remaining -= len(block)
+        poll()
         if os.read(descriptor, 1):
             raise ValueError(f"BM25 artifact file grew while hashing: {path}")
         after_open = os.fstat(descriptor)
@@ -105,24 +125,51 @@ def _file_fingerprint(path: Path) -> dict[str, Any]:
             after_path
         ) != _file_identity(opened):
             raise ValueError(f"BM25 artifact file changed while hashing: {path}")
+        poll()
         return {"size": opened.st_size, "sha256": digest.hexdigest()}
     except OSError as exc:
-        raise ValueError(f"invalid BM25 artifact file: {path}") from exc
+        if exc is cancellation_failure:
+            primary = exc
+            raise
+        primary = ValueError(f"invalid BM25 artifact file: {path}")
+        raise primary from exc
+    except BaseException as exc:
+        primary = exc
+        raise
     finally:
         if descriptor >= 0:
-            os.close(descriptor)
+            try:
+                os.close(descriptor)
+            except BaseException as cleanup_failure:
+                if primary is None:
+                    raise
+                if isinstance(primary, Exception) and not isinstance(
+                    cleanup_failure,
+                    Exception,
+                ):
+                    raise cleanup_failure from primary
+                raise primary from cleanup_failure
 
 
 def bm25_artifact_file_fingerprints(
     root: str | Path,
+    *,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Fingerprint the complete persisted BM25 artifact."""
 
+    if check_cancelled is not None and not callable(check_cancelled):
+        raise TypeError("BM25 artifact cancellation must be callable")
     artifact_root = Path(root)
     fingerprints: dict[str, dict[str, Any]] = {}
     for relative in _BM25_ARTIFACT_PATHS:
+        if check_cancelled is not None:
+            check_cancelled()
         path = artifact_root / relative
-        fingerprints[relative.as_posix()] = _file_fingerprint(path)
+        fingerprints[relative.as_posix()] = _file_fingerprint(
+            path,
+            check_cancelled=check_cancelled,
+        )
     return fingerprints
 
 

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -161,10 +161,13 @@ def _require_selected_paths(
     *,
     repository_root: str,
     subject: str,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> None:
     """Reject non-canonical or excluded repository-relative result paths."""
 
     for source_path in paths:
+        if check_cancelled is not None:
+            check_cancelled()
         try:
             relative_path = repository_relative_source_path(
                 repository_root,
@@ -208,11 +211,14 @@ def _require_selected_documents(
     *,
     repository_root: str,
     subject: str,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> None:
     """Validate the repository file metadata on materialized documents."""
 
     paths = []
     for document in documents:
+        if check_cancelled is not None:
+            check_cancelled()
         metadata = getattr(document, "metadata", None)
         paths.append(metadata.get("file") if isinstance(metadata, dict) else None)
     _require_selected_paths(
@@ -220,6 +226,7 @@ def _require_selected_documents(
         paths,
         repository_root=repository_root,
         subject=subject,
+        check_cancelled=check_cancelled,
     )
 
 
@@ -345,6 +352,7 @@ class BM25IndexBuilder:
             source_selection=source_selection,
             artifact_identity=artifact_identity,
             chunks=chunks,
+            prepare_only=False,
             require_missing_output=False,
             check_cancelled=None,
         )
@@ -430,6 +438,7 @@ class BM25IndexBuilder:
             (getattr(chunk, "file", None) for chunk in chunks),
             repository_root=str(repository_root),
             subject="BM25 chunks",
+            check_cancelled=check_cancelled,
         )
         if check_cancelled is not None:
             check_cancelled()
@@ -440,6 +449,7 @@ class BM25IndexBuilder:
             source_selection=selected,
             artifact_identity=self._artifact_identity_for_selection(selected),
             chunks=chunks,
+            prepare_only=True,
             require_missing_output=True,
             check_cancelled=check_cancelled,
         )
@@ -453,6 +463,7 @@ class BM25IndexBuilder:
         source_selection: RepositorySourceSelection,
         artifact_identity: Dict[str, Any],
         chunks: List[Any],
+        prepare_only: bool,
         require_missing_output: bool,
         check_cancelled: Callable[[], None] | None,
     ) -> IndexStatus:
@@ -460,16 +471,27 @@ class BM25IndexBuilder:
 
         from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 
-        indexer = BM25CodeIndexer(
-            chunks=chunks,
-            max_k=self.max_k,
-            project_root=repo_path,
+        indexer = (
+            BM25CodeIndexer(
+                chunks=chunks,
+                max_k=self.max_k,
+                project_root=repo_path,
+                prepare_only=True,
+                check_cancelled=check_cancelled,
+            )
+            if prepare_only
+            else BM25CodeIndexer(
+                chunks=chunks,
+                max_k=self.max_k,
+                project_root=repo_path,
+            )
         )
         _require_selected_documents(
             source_selection,
             getattr(indexer, "documents", ()),
             repository_root=repo_path,
             subject="BM25 documents",
+            check_cancelled=check_cancelled,
         )
         if check_cancelled is not None:
             check_cancelled()
@@ -477,12 +499,33 @@ class BM25IndexBuilder:
             os.mkdir(output_dir, mode=0o700)
         else:
             os.makedirs(output_dir, exist_ok=True)
-        indexer.save_index(output_dir)
+        if check_cancelled is None:
+            indexer.save_index(output_dir)
+        else:
+            indexer.save_index(
+                output_dir,
+                check_cancelled=check_cancelled,
+            )
         from .artifact_fingerprints import bm25_artifact_file_fingerprints
 
-        artifact_files = bm25_artifact_file_fingerprints(output_dir)
+        artifact_files = (
+            bm25_artifact_file_fingerprints(output_dir)
+            if check_cancelled is None
+            else bm25_artifact_file_fingerprints(
+                output_dir,
+                check_cancelled=check_cancelled,
+            )
+        )
         if check_cancelled is not None:
             check_cancelled()
+
+        source_files: set[str] = set()
+        for chunk in chunks:
+            if check_cancelled is not None:
+                check_cancelled()
+            source_path = getattr(chunk, "file", "")
+            if source_path:
+                source_files.add(source_path)
 
         return IndexStatus(
             index_type="bm25",
@@ -495,9 +538,7 @@ class BM25IndexBuilder:
                 **artifact_identity,
                 "artifact_file_fingerprints": artifact_files,
                 "chunk_count": len(chunks),
-                "source_file_count": len(
-                    {chunk.file for chunk in chunks if getattr(chunk, "file", "")}
-                ),
+                "source_file_count": len(source_files),
                 # Retain the legacy field for existing manifest consumers.
                 "file_count": len(chunks),
             },

--- a/codenib/compiler/source_job.py
+++ b/codenib/compiler/source_job.py
@@ -1,0 +1,531 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prepare one FULL BM25 job directly from retained repository source.
+
+The adapter deliberately composes the existing compiler-cache preparation
+boundary.  It builds one caller-owned private cache generation, writes the
+exact single-view manifest expected by that boundary, and delegates strict
+recapture, context publication, and CAS ingestion.  It receives no catalog or
+ref mutation authority; the durable worker remains the only publisher.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import math
+import re
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import InitVar, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .._atomic_directory import lexical_directory_path
+from .._captured_directory import PublishedWorkspaceReceiptOwner
+from .._workspace_provider import StrictWorkspaceProvider
+from ..repository_source_selection import RepositorySourceSelection
+from ..source_fingerprint import (
+    RepositorySourceBinding,
+    RepositorySourceIdentitySnapshot,
+)
+from ..storage.job_worker import (
+    IndexJobExecutionContext,
+    IndexJobExecutionResult,
+    IndexJobStopReason,
+    IndexJobStopToken,
+    IndexJobViewExecutionResult,
+)
+from ..storage.models import (
+    DEFAULT_NAMESPACE_NAME,
+    IndexJobEffectiveMode,
+    IndexJobViewOutcome,
+    StorageIntegrityError,
+    StorageValidationError,
+    ViewProfile,
+    canonical_json,
+)
+from ..storage.protocols import RetainedImportObjectStore
+from ..storage.view_bundle import (
+    DEFAULT_MAX_BUNDLE_BYTES,
+    DEFAULT_MAX_BUNDLE_FILES,
+    DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+)
+from .cache_import import (
+    _compiler_cache_job_stop_check,
+    _preflight_cache_job_preparation_operation,
+    _require_missing,
+    prepare_compiler_cache_job_view,
+)
+from .cache_lock import compiler_cache_lock
+from .index_builders import BM25IndexBuilder
+from .manifest import MANIFEST_FILENAME, MANIFEST_VERSION, IndexEntry, RepoManifest
+from .manifest_import import (
+    DEFAULT_MAX_CONTEXT_BYTES,
+    DEFAULT_MAX_CONTEXT_FILES,
+    _snapshot_environment,
+    _snapshot_forbidden_paths,
+)
+from .manifest_storage import (
+    DEFAULT_MAX_MANIFEST_BYTES,
+    REPO_MANIFEST_PROFILE_NAME,
+    _profile_config,
+)
+from .resources import IndexState, IndexStatus
+
+_DISPLAY_COMMIT_RE = re.compile(r"[0-9a-f]{40}\Z", re.ASCII)
+_BM25_VIEW = "bm25"
+_BM25_SCOPE = "current_repo"
+
+
+@dataclass(frozen=True, slots=True)
+class _BoundSourceJobStopToken:
+    """Carry one exact source-job stop exception into cache preparation."""
+
+    token: IndexJobStopToken
+    check_cancelled: Callable[[], None]
+
+    @property
+    def reason(self) -> IndexJobStopReason | None:
+        return self.token.reason
+
+    def is_set(self) -> bool:
+        self.check_cancelled()
+        return False
+
+    def wait(self, timeout: float | None = None) -> bool:
+        return self.token.wait(timeout)
+
+
+@dataclass(frozen=True, slots=True)
+class _BM25BuilderConfiguration:
+    languages: tuple[str, ...]
+    max_k: int
+    max_lines_per_chunk: int
+    additional_ignore_dirs: tuple[str, ...]
+    source_selection: RepositorySourceSelection
+
+    def builder(self) -> BM25IndexBuilder:
+        return BM25IndexBuilder(
+            languages=list(self.languages),
+            max_k=self.max_k,
+            max_lines_per_chunk=self.max_lines_per_chunk,
+            additional_ignore_dirs=list(self.additional_ignore_dirs),
+            source_selection=RepositorySourceSelection(
+                self.source_selection.exclude_subtrees
+            ),
+        )
+
+    def profile(self) -> ViewProfile:
+        identity = self.builder().artifact_identity()
+        # Reuse the manifest planner's profile classifier so this source
+        # adapter cannot drift from imported compiler-cache identities.
+        entry = IndexEntry(
+            index_type=_BM25_VIEW,
+            path=f"views/{_BM25_VIEW}",
+            built_at="",
+            built_at_epoch=0.0,
+            status="fresh",
+            config=copy.deepcopy(identity),
+            metadata=copy.deepcopy(identity),
+            source_selection_digest=self.source_selection.digest,
+        )
+        config = _profile_config(
+            entry,
+            view_type=_BM25_VIEW,
+            manifest_version=MANIFEST_VERSION,
+        )
+        return ViewProfile.create(
+            _BM25_VIEW,
+            config,
+            name=REPO_MANIFEST_PROFILE_NAME,
+        )
+
+
+def _snapshot_builder(builder: BM25IndexBuilder) -> _BM25BuilderConfiguration:
+    if type(builder) is not BM25IndexBuilder:
+        raise TypeError("BM25 source job builder must use the exact builder type")
+    if type(builder.languages) is not list or any(
+        type(language) is not str for language in builder.languages
+    ):
+        raise TypeError("BM25 source job languages must be an exact text list")
+    if type(builder.additional_ignore_dirs) is not list or any(
+        type(path) is not str for path in builder.additional_ignore_dirs
+    ):
+        raise TypeError("BM25 source job ignore directories must be an exact text list")
+    if type(builder.max_k) is not int or type(builder.max_lines_per_chunk) is not int:
+        raise TypeError("BM25 source job numeric options must be exact integers")
+    if type(builder.source_selection) is not RepositorySourceSelection:
+        raise TypeError("BM25 source job selection must use the exact selection type")
+    snapshot = _BM25BuilderConfiguration(
+        languages=tuple(builder.languages),
+        max_k=builder.max_k,
+        max_lines_per_chunk=builder.max_lines_per_chunk,
+        additional_ignore_dirs=tuple(builder.additional_ignore_dirs),
+        source_selection=RepositorySourceSelection(
+            builder.source_selection.exclude_subtrees
+        ),
+    )
+    # Fail closed on incomplete or non-canonical compatibility axes now, not
+    # after an attempt generation has been created.
+    snapshot.profile()
+    return snapshot
+
+
+def bm25_source_job_profile(builder: BM25IndexBuilder) -> ViewProfile:
+    """Return the exact portable profile requested by this source adapter."""
+
+    return _snapshot_builder(builder).profile()
+
+
+def _exact_display_commit(value: object) -> str:
+    if type(value) is not str or _DISPLAY_COMMIT_RE.fullmatch(value) is None:
+        raise StorageValidationError(
+            "BM25 source job display commit must be a full lowercase Git SHA"
+        )
+    return value
+
+
+def _exact_attempt_generation(value: object) -> Path:
+    if type(value) is not type(Path()):
+        raise TypeError("BM25 source job attempt generation must be an exact Path")
+    generation = lexical_directory_path(value)
+    if generation == generation.parent:
+        raise ValueError(
+            "BM25 source job attempt generation cannot be a filesystem root"
+        )
+    return generation
+
+
+def _require_disjoint_attempt_generation(
+    generation: Path,
+    source: RepositorySourceIdentitySnapshot,
+    *,
+    boundaries: tuple[Path, ...],
+) -> None:
+    repository = lexical_directory_path(source.root)
+    try:
+        physical_generation = generation.resolve(strict=False)
+        physical_repository = repository.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(
+            "BM25 source job attempt topology cannot be authenticated"
+        ) from exc
+    inputs = ((repository, physical_repository, "repository"),)
+    outputs = tuple(
+        (
+            lexical_directory_path(boundary),
+            lexical_directory_path(boundary).resolve(strict=False),
+            "output or forbidden boundary",
+        )
+        for boundary in boundaries
+    )
+    for lexical, physical, label in (*inputs, *outputs):
+        if (
+            generation == lexical
+            or generation in lexical.parents
+            or lexical in generation.parents
+            or physical_generation == physical
+            or physical_generation in physical.parents
+            or physical in physical_generation.parents
+        ):
+            raise ValueError("BM25 source job attempt generation overlaps " + label)
+
+
+def _built_at(status: IndexStatus) -> tuple[str, float]:
+    value = status.last_built
+    if type(value) not in {int, float} or not math.isfinite(value) or value < 0:
+        raise StorageIntegrityError("BM25 source builder returned an invalid timestamp")
+    epoch = float(value)
+    try:
+        timestamp = datetime.fromtimestamp(epoch, timezone.utc).isoformat()
+    except (OverflowError, OSError, ValueError) as exc:
+        raise StorageIntegrityError(
+            "BM25 source builder returned an invalid timestamp"
+        ) from exc
+    return timestamp, epoch
+
+
+def _source_manifest(
+    status: IndexStatus,
+    *,
+    output: Path,
+    display_commit: str,
+    repository_source: RepositorySourceBinding,
+    expected_source: RepositorySourceIdentitySnapshot,
+    builder: _BM25BuilderConfiguration,
+    check_cancelled: Callable[[], None],
+) -> RepoManifest:
+    if type(status) is not IndexStatus:
+        raise StorageIntegrityError("BM25 source builder returned an invalid status")
+    if (
+        status.index_type != _BM25_VIEW
+        or status.state is not IndexState.FRESH
+        or status.scope != _BM25_SCOPE
+        or status.path != str(output)
+        or type(status.metadata) is not dict
+    ):
+        raise StorageIntegrityError("BM25 source builder returned inconsistent status")
+    expected_identity = builder.builder().artifact_identity()
+    if any(
+        status.metadata.get(key) != value for key, value in expected_identity.items()
+    ):
+        raise StorageIntegrityError(
+            "BM25 source builder changed its compatibility identity"
+        )
+    try:
+        # Detach through the canonical JSON boundary before it becomes a
+        # persisted manifest input.
+        metadata = json.loads(canonical_json(status.metadata))
+    except (RecursionError, TypeError, ValueError) as exc:
+        raise StorageIntegrityError(
+            "BM25 source builder returned non-canonical metadata"
+        ) from exc
+    built_at, built_at_epoch = _built_at(status)
+    source = repository_source.authenticated_identity_snapshot(
+        check_cancelled=check_cancelled,
+    )
+    if source != expected_source:
+        raise StorageIntegrityError("BM25 retained source changed after job preflight")
+    if source.source_selection != builder.source_selection:
+        raise StorageIntegrityError(
+            "BM25 source builder selection changed after job preflight"
+        )
+    selection_digest = builder.source_selection.digest
+    entry = IndexEntry(
+        index_type=_BM25_VIEW,
+        path=_BM25_VIEW,
+        built_at=built_at,
+        built_at_epoch=built_at_epoch,
+        status="fresh",
+        config=copy.deepcopy(metadata),
+        metadata=copy.deepcopy(metadata),
+        commit=display_commit,
+        source_fingerprint=source.fingerprint,
+        source_selection_digest=selection_digest,
+    )
+    manifest = RepoManifest(
+        repo_path=str(source.root),
+        commit=display_commit,
+        last_indexed_commit=display_commit,
+        source_fingerprint=source.fingerprint,
+        last_indexed_source_fingerprint=source.fingerprint,
+        source_selection=RepositorySourceSelection(
+            builder.source_selection.exclude_subtrees
+        ),
+        last_indexed_source_selection_digest=selection_digest,
+        languages=list(builder.languages),
+        file_count=source.file_count,
+        indexes={_BM25_VIEW: entry},
+        compiled_at=built_at,
+        compiled_at_epoch=built_at_epoch,
+    )
+    manifest.derive_capabilities()
+    # Exercise the exact persisted validation path before writing bytes.
+    return RepoManifest.from_dict(manifest.to_dict())
+
+
+@dataclass(frozen=True, slots=True)
+class BM25SourceJobExecutor:
+    """Prepare exactly one required FULL BM25 job from retained source bytes.
+
+    ``attempt_generation`` is a unique missing cache root owned by the caller.
+    The executor never removes it, including after cancellation or failure;
+    retries must supply another missing root. ``display_commit`` is provenance
+    for the strict portable context only. It is never derived from a lexical
+    repository read and does not alter the fingerprint-bound durable source ID.
+    """
+
+    attempt_generation: Path
+    display_commit: str
+    builder: InitVar[BM25IndexBuilder]
+    repository_source: RepositorySourceBinding
+    view_output_owner: PublishedWorkspaceReceiptOwner
+    context_output_owner: PublishedWorkspaceReceiptOwner
+    view_destination: Path
+    context_destination: Path
+    workspace_provider: StrictWorkspaceProvider
+    repository_key: str
+    object_store: RetainedImportObjectStore
+    namespace_name: str = DEFAULT_NAMESPACE_NAME
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES
+    max_context_files: int = DEFAULT_MAX_CONTEXT_FILES
+    max_context_bytes: int = DEFAULT_MAX_CONTEXT_BYTES
+    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES
+    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES
+    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES
+    forbidden_paths: Iterable[Path] = ()
+    environ: Mapping[str, str] | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    _builder: _BM25BuilderConfiguration = field(init=False, repr=False)
+    _profile: ViewProfile = field(init=False, repr=False)
+
+    def __post_init__(self, builder: BM25IndexBuilder) -> None:
+        configuration = _snapshot_builder(builder)
+        object.__setattr__(
+            self,
+            "attempt_generation",
+            _exact_attempt_generation(self.attempt_generation),
+        )
+        object.__setattr__(
+            self,
+            "display_commit",
+            _exact_display_commit(self.display_commit),
+        )
+        object.__setattr__(
+            self,
+            "forbidden_paths",
+            _snapshot_forbidden_paths(self.forbidden_paths),
+        )
+        object.__setattr__(self, "environ", _snapshot_environment(self.environ))
+        object.__setattr__(self, "_builder", configuration)
+        object.__setattr__(self, "_profile", configuration.profile())
+
+    def execute(
+        self,
+        context: IndexJobExecutionContext,
+    ) -> IndexJobExecutionResult:
+        """Build and prepare the claimed view without publication authority."""
+
+        if type(context) is not IndexJobExecutionContext:
+            raise TypeError("BM25 source executor requires an exact job context")
+        check_cancelled = _compiler_cache_job_stop_check(context.control.stop_token)
+        if check_cancelled is None:  # pragma: no cover - execution context invariant
+            raise AssertionError("BM25 source job context has no stop check")
+        check_cancelled()
+        _require_missing(
+            self.attempt_generation,
+            label="BM25 source job attempt generation",
+        )
+        operation, binding = _preflight_cache_job_preparation_operation(
+            self.attempt_generation,
+            view_type=_BM25_VIEW,
+            job=context.job,
+            views=context.views,
+            repository_source=self.repository_source,
+            view_output_owner=self.view_output_owner,
+            context_output_owner=self.context_output_owner,
+            view_destination=self.view_destination,
+            context_destination=self.context_destination,
+            workspace_provider=self.workspace_provider,
+            repository_key=self.repository_key,
+            object_store=self.object_store,
+            namespace_name=self.namespace_name,
+            max_manifest_bytes=self.max_manifest_bytes,
+            max_context_files=self.max_context_files,
+            max_context_bytes=self.max_context_bytes,
+            max_bundle_files=self.max_bundle_files,
+            max_bundle_bytes=self.max_bundle_bytes,
+            max_bundle_metadata_bytes=self.max_bundle_metadata_bytes,
+            forbidden_paths=self.forbidden_paths,
+            environ=self.environ,
+            check_cancelled=check_cancelled,
+        )
+        if binding.view.profile_id != self._profile.profile_id:
+            raise StorageValidationError(
+                "BM25 source job profile does not match the builder"
+            )
+        if binding.source_snapshot.source_selection != self._builder.source_selection:
+            raise StorageValidationError(
+                "BM25 source job selection does not match the retained source"
+            )
+        _require_disjoint_attempt_generation(
+            self.attempt_generation,
+            binding.source_snapshot,
+            boundaries=(
+                *operation.view_outputs.values(),
+                operation.context_output,
+                *operation.inputs.forbidden_paths,
+            ),
+        )
+        check_cancelled()
+        # Prove that all job/view/profile/source preflight remained read-only.
+        _require_missing(
+            self.attempt_generation,
+            label="BM25 source job attempt generation",
+        )
+
+        self.attempt_generation.mkdir(mode=0o700)
+        output = self.attempt_generation / _BM25_VIEW
+        builder = self._builder.builder()
+        with compiler_cache_lock(
+            self.attempt_generation,
+            check_cancelled=check_cancelled,
+        ):
+            status = builder.build_from_repository_source(
+                _BM25_SCOPE,
+                repository_source=self.repository_source,
+                output_dir=str(output),
+                source_selection=self._builder.source_selection,
+                check_cancelled=check_cancelled,
+            )
+            check_cancelled()
+            manifest = _source_manifest(
+                status,
+                output=output,
+                display_commit=self.display_commit,
+                repository_source=self.repository_source,
+                expected_source=binding.source_snapshot,
+                builder=self._builder,
+                check_cancelled=check_cancelled,
+            )
+            if bm25_source_job_profile(builder).profile_id != self._profile.profile_id:
+                raise StorageIntegrityError(
+                    "BM25 source builder profile changed during execution"
+                )
+            manifest.save(self.attempt_generation / MANIFEST_FILENAME)
+        check_cancelled()
+
+        prepared = prepare_compiler_cache_job_view(
+            self.attempt_generation,
+            view_type=_BM25_VIEW,
+            job=context.job,
+            views=context.views,
+            repository_source=self.repository_source,
+            view_output_owner=self.view_output_owner,
+            context_output_owner=self.context_output_owner,
+            view_destination=self.view_destination,
+            context_destination=self.context_destination,
+            workspace_provider=self.workspace_provider,
+            repository_key=self.repository_key,
+            object_store=self.object_store,
+            namespace_name=self.namespace_name,
+            stop_token=_BoundSourceJobStopToken(
+                context.control.stop_token,
+                check_cancelled,
+            ),
+            max_manifest_bytes=self.max_manifest_bytes,
+            max_context_files=self.max_context_files,
+            max_context_bytes=self.max_context_bytes,
+            max_bundle_files=self.max_bundle_files,
+            max_bundle_bytes=self.max_bundle_bytes,
+            max_bundle_metadata_bytes=self.max_bundle_metadata_bytes,
+            forbidden_paths=self.forbidden_paths,
+            environ=self.environ,
+        )
+        if (
+            prepared.view != binding.view
+            or prepared.artifact.profile_id != self._profile.profile_id
+        ):
+            raise StorageIntegrityError(
+                "BM25 source preparation returned a different requested view"
+            )
+        return IndexJobExecutionResult(
+            views=(
+                IndexJobViewExecutionResult.create(
+                    prepared.view,
+                    effective_mode=IndexJobEffectiveMode.FULL,
+                    outcome=IndexJobViewOutcome.SUCCEEDED,
+                    artifact=prepared.artifact,
+                    payload={"adapter": "bm25_source", "prepared": True},
+                ),
+            ),
+            retryable=False,
+        )
+
+
+__all__ = ["BM25SourceJobExecutor", "bm25_source_job_profile"]

--- a/codenib/index/sparse_idx/bm25_index.py
+++ b/codenib/index/sparse_idx/bm25_index.py
@@ -9,7 +9,7 @@ import os
 import re
 import stat
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Mapping, Optional
 
 from rank_bm25 import BM25Okapi
 
@@ -35,6 +35,7 @@ _SOURCE_MODES = {
     SOURCE_MODE_BOUND_REPOSITORY,
     SOURCE_MODE_PERSISTED_ONLY,
 }
+_JSON_WRITE_CHARS = 1024 * 1024
 _SECURE_SOURCE_DIRECTORY_FDS = (
     os.name == "posix"
     and hasattr(os, "O_DIRECTORY")
@@ -402,6 +403,68 @@ class BM25Retriever:
         )
 
 
+def _dump_json_interruptibly(
+    value: object,
+    handle: Any,
+    check_cancelled: Callable[[], None] | None,
+) -> None:
+    """Write the established JSON encoding while polling between chunks."""
+
+    chunks = iter(json.JSONEncoder(indent=2).iterencode(value))
+    while True:
+        if check_cancelled is not None:
+            check_cancelled()
+        try:
+            chunk = next(chunks)
+        except StopIteration:
+            break
+        for offset in range(0, len(chunk), _JSON_WRITE_CHARS):
+            if check_cancelled is not None:
+                check_cancelled()
+            handle.write(chunk[offset : offset + _JSON_WRITE_CHARS])
+    if check_cancelled is not None:
+        check_cancelled()
+
+
+def _raise_with_persistence_cleanup_failure(
+    primary: BaseException,
+    cleanup_failure: BaseException,
+) -> None:
+    """Preserve chronological cancellation priority across file cleanup."""
+
+    if isinstance(primary, Exception) and not isinstance(
+        cleanup_failure,
+        Exception,
+    ):
+        raise cleanup_failure from primary
+    raise primary from cleanup_failure
+
+
+def _write_json_interruptibly(
+    path: str,
+    value: object,
+    check_cancelled: Callable[[], None] | None,
+) -> None:
+    """Write one JSON file without letting close replace the build failure."""
+
+    handle = None
+    primary: BaseException | None = None
+    try:
+        handle = open(path, "w", encoding="utf-8")
+        _dump_json_interruptibly(value, handle, check_cancelled)
+    except BaseException as exc:
+        primary = exc
+        raise
+    finally:
+        if handle is not None:
+            try:
+                handle.close()
+            except BaseException as cleanup_failure:
+                if primary is None:
+                    raise
+                _raise_with_persistence_cleanup_failure(primary, cleanup_failure)
+
+
 class BM25CodeIndexer:
     """
     A class that builds a BM25 index from CodeGraph nodes and provides
@@ -415,6 +478,9 @@ class BM25CodeIndexer:
         max_k: int = 15,
         language: str = "english",
         project_root: Optional[str] = None,
+        *,
+        prepare_only: bool = False,
+        check_cancelled: Callable[[], None] | None = None,
     ):
         """
         Initialize the BM25CodeIndexer and optionally build the index immediately.
@@ -429,11 +495,31 @@ class BM25CodeIndexer:
                       Default is "english" which works well for processing code tokens
                       as it treats special characters as separators
             project_root: Repository root used to resolve relative source paths
+            prepare_only: Prepare canonical persisted documents without building
+                          the serving-time in-memory rank index.
+            check_cancelled: Cooperative stop check for prepare-only chunk builds.
         """
         self.max_k = max_k
         self.language = language
         self.documents = []
+        if type(prepare_only) is not bool:
+            raise TypeError("BM25 prepare-only policy must be an exact boolean")
+        if check_cancelled is not None and not callable(check_cancelled):
+            raise TypeError("BM25 build cancellation must be callable")
+        if code_graph is not None and (prepare_only or check_cancelled is not None):
+            raise ValueError(
+                "BM25 prepare-only mode and cancellation require source chunks "
+                "without a code graph"
+            )
+        if prepare_only and chunks is None:
+            raise ValueError("BM25 prepare-only mode requires source chunks")
+        if check_cancelled is not None and chunks is None:
+            raise ValueError("BM25 build cancellation requires source chunks")
+        if check_cancelled is not None and not prepare_only:
+            raise ValueError("BM25 build cancellation requires prepare-only mode")
+
         self.retriever = None
+        self._documents_prepared = False
         self.code_graph: CodeGraph = None
         self.project_root = project_root
         self.source_mode = SOURCE_MODE_LEGACY_DIRECT
@@ -444,7 +530,17 @@ class BM25CodeIndexer:
         if code_graph is not None:
             self.build_index_from_graph(code_graph)
         elif chunks is not None:
-            self.build_index_from_chunks(chunks, project_root=project_root)
+            if prepare_only:
+                self._prepare_documents_from_chunks(
+                    chunks,
+                    project_root=project_root,
+                    check_cancelled=check_cancelled,
+                )
+                self._documents_prepared = True
+            else:
+                # Preserve the established virtual-call shape for subclasses
+                # that override this public method.
+                self.build_index_from_chunks(chunks, project_root=project_root)
 
     def build_index_from_graph(self, code_graph: CodeGraph) -> BM25Retriever:
         """
@@ -460,6 +556,8 @@ class BM25CodeIndexer:
         self.project_root = code_graph.project_root
         self.source_mode = SOURCE_MODE_LEGACY_DIRECT
         self._source_binding = None
+        self._documents_prepared = False
+        self.retriever = None
 
         # Convert graph nodes to documents
         for vertex in code_graph.graph.vs:
@@ -472,6 +570,7 @@ class BM25CodeIndexer:
 
         # Create BM25Retriever with LangChain format
         self.retriever = BM25Retriever.from_documents(self.documents, k=self.max_k)
+        self._documents_prepared = True
 
         return self.retriever
 
@@ -491,6 +590,24 @@ class BM25CodeIndexer:
         Returns:
             BM25Retriever instance
         """
+        self._prepare_documents_from_chunks(
+            chunks,
+            project_root=project_root,
+            check_cancelled=None,
+        )
+        self.retriever = BM25Retriever.from_documents(self.documents, k=self.max_k)
+        self._documents_prepared = True
+        return self.retriever
+
+    def _prepare_documents_from_chunks(
+        self,
+        chunks: List[CodeChunk],
+        *,
+        project_root: Optional[str],
+        check_cancelled: Callable[[], None] | None,
+    ) -> None:
+        """Prepare canonical chunk documents without constructing BM25Okapi."""
+
         # Reset the index
         self.documents = []
         self.nodes = []
@@ -498,12 +615,16 @@ class BM25CodeIndexer:
         self.project_root = project_root
         self.source_mode = SOURCE_MODE_LEGACY_DIRECT
         self._source_binding = None
+        self._documents_prepared = False
+        self.retriever = None
 
         # Keep each bounded source span independently searchable. Overloads and
         # split large definitions can share a node_id, but merging them widens
         # the returned location and defeats the chunk-size contract.
         documents_by_span: dict[tuple[str, int, int], Document] = {}
         for chunk in chunks:
+            if check_cancelled is not None:
+                check_cancelled()
             node_id = getattr(chunk, "node_id", None)
             if not node_id:
                 continue
@@ -516,13 +637,22 @@ class BM25CodeIndexer:
                 )
                 documents_by_span.setdefault(key, doc)
 
-        self.documents = list(documents_by_span.values())
-        self.nodes = list(dict.fromkeys(key[0] for key in documents_by_span))
+        self.documents = []
+        self.nodes = []
+        seen_nodes: set[str] = set()
+        for key, document in documents_by_span.items():
+            if check_cancelled is not None:
+                check_cancelled()
+            self.documents.append(document)
+            if key[0] not in seen_nodes:
+                self.nodes.append(key[0])
+                seen_nodes.add(key[0])
 
-        # Create BM25Retriever with LangChain format
-        self.retriever = BM25Retriever.from_documents(self.documents, k=self.max_k)
-
-        return self.retriever
+        if check_cancelled is not None:
+            check_cancelled()
+        # The serving runtime reconstructs the unchanged BM25Okapi state from
+        # these canonical documents. Compiler preparation intentionally avoids
+        # the uninterruptible duplicate rank build.
 
     def _convert_chunk_to_document(self, chunk: CodeChunk) -> Optional[Document]:
         """Convert a source chunk while preserving its repository location."""
@@ -1061,17 +1191,26 @@ class BM25CodeIndexer:
             )
         return _read_source_text(self.project_root, file_path)
 
-    def save_index(self, directory_path: str):
+    def save_index(
+        self,
+        directory_path: str,
+        *,
+        check_cancelled: Callable[[], None] | None = None,
+    ):
         """
         Save the index to a directory.
 
         Args:
             directory_path: Path to save the index to
         """
-        if self.retriever is None:
+        if check_cancelled is not None and not callable(check_cancelled):
+            raise TypeError("BM25 persistence cancellation must be callable")
+        if self.retriever is None and not self._documents_prepared:
             raise ValueError(
                 "Index has not been built. Call build_index_from_graph first."
             )
+        if check_cancelled is not None:
+            check_cancelled()
 
         # Create directory if it doesn't exist
         os.makedirs(directory_path, exist_ok=True)
@@ -1079,13 +1218,18 @@ class BM25CodeIndexer:
         # Save documents as JSON since LangChain BM25Retriever doesn't have persist method
         documents_data = []
         for doc in self.documents:
+            if check_cancelled is not None:
+                check_cancelled()
             documents_data.append(
                 {"page_content": doc.page_content, "metadata": doc.metadata}
             )
 
         documents_file = os.path.join(directory_path, "documents.json")
-        with open(documents_file, "w", encoding="utf-8") as f:
-            json.dump(documents_data, f, indent=2)
+        _write_json_interruptibly(
+            documents_file,
+            documents_data,
+            check_cancelled,
+        )
 
         # Save additional metadata including project_root
         metadata = {
@@ -1096,8 +1240,11 @@ class BM25CodeIndexer:
             "language": self.language,
         }
         metadata_file = os.path.join(directory_path, "bm25_metadata.json")
-        with open(metadata_file, "w", encoding="utf-8") as f:
-            json.dump(metadata, f, indent=2)
+        _write_json_interruptibly(
+            metadata_file,
+            metadata,
+            check_cancelled,
+        )
 
     def load_index(self, directory_path: str):
         """
@@ -1162,6 +1309,7 @@ class BM25CodeIndexer:
         self.project_root = project_root
         self.source_mode = source_mode
         self._source_binding = None
+        self._documents_prepared = False
         self.max_k = max_k
         self.language = language
 
@@ -1189,3 +1337,4 @@ class BM25CodeIndexer:
                 seen_nodes.add(node_name)
 
         self.retriever = BM25Retriever.from_documents(self.documents, k=self.max_k)
+        self._documents_prepared = True

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1271,9 +1271,19 @@ supplies the authenticated inventory and bytes to the existing tree-sitter
 chunkers, which preserve normal filtering, relative-path, line, and
 compatibility contracts while parsing already-captured text. The builder writes
 only to a missing caller-owned private generation and attests the resulting
-BM25 artifact fingerprints. Durable source-job adapters, attempt resource and
-cleanup ownership, CLI/Web binding, vector source building, and graph source
-building remain absent.
+BM25 artifact fingerprints. The first durable source-job adapter now snapshots
+that builder's complete portable profile, authenticates exactly one active
+required `full` BM25 request and its dirty fingerprint source revision before
+creating output, and builds a caller-owned missing attempt root. It wraps the
+new BM25 generation in an exact single-view manifest, using a separately
+supplied full Git SHA only as display provenance, then delegates strict
+recapture, context evidence, and bundle/member CAS ingestion to the existing
+public prepare-only compiler-cache bridge. The returned
+`IndexJobExecutionResult` carries no catalog, lease, fencing, ref, or generation
+publication authority; the worker remains the sole publisher and the caller
+retains cleanup ownership for every attempt. Source-job resource factories and
+resolver/CLI/Web binding, vector source building, and graph source building
+remain absent.
 
 The compiler-cache bridge now also has a resource-scoped resolver seam. It
 attests the canonical running request before opening attempt resources, accepts
@@ -1325,8 +1335,9 @@ runtime now has the generation-safe refresh boundary described under M3.
 Status: in progress. The receipt-retained, fenced SQLite publication primitive
 and the explicit BM25 and schema-8 vector compiler-cache adapters, including
 their prepare-only worker bridge, are implemented. The first caller-scoped
-retained-source BM25 builder now produces a unique private generation; durable
-source-job adapters, vector and graph source builders, generic builder routing,
+retained-source BM25 builder and its prepare-only source-job adapter now produce
+and ingest a unique private generation without publication authority; vector
+and graph source builders, generic builder routing, source-job resource wiring,
 and remaining runtime wiring remain.
 
 - Make every builder write to a unique staging generation.
@@ -1351,18 +1362,22 @@ Status: in progress. Schema-v6 durable execution control is implemented for the
 local SQLite catalog. The backend-neutral prepare-only whole-job worker is
 implemented and verified with file-backed SQLite integration coverage. An
 explicit one-view compiler-cache executor now supplies parser-inert BM25 or
-schema-8 vector artifacts without catalog authority. Its resource-scoped
+schema-8 vector artifacts without catalog authority, and the first
+retained-source BM25 executor now prepares the same artifact closure from
+authenticated source bytes. The compiler-cache executor's resource-scoped
 resolver and trusted local target factory guarantee attempt-local cleanup,
-same-store binding, and exact configured repository/source identity, while
-the explicit CLI can run one bounded pass or a cursor-fair continuous scheduler
-over the current cache. The Web registry now prepares a complete replacement
+same-store binding, and exact configured repository/source identity, while the
+explicit CLI can run one bounded pass or a cursor-fair continuous scheduler
+over the current cache. The source executor intentionally has no resolver or
+resource factory yet. The Web registry now prepares a complete replacement
 bundle before atomically publishing it, pins the exact generation for each
 in-flight request, defers old vector/source cleanup until the final pin exits,
 and invalidates bundle-bound Wiki, edge-label, and commit-window caches by
-generation identity. The first #266 status, durable-read, and explicitly
-injected one-view write slices are present; source-job adapters, a production
-Web planner/default binding, success-triggered refresh, MCP, UI controls, and
-default routing remain absent.
+generation identity.
+The first #266 status, durable-read, and explicitly injected one-view write
+slices are present; remaining source-job adapters and resource wiring, a
+production Web planner/default binding, success-triggered refresh, MCP, UI
+controls, and default routing remain absent.
 
 - The backend-neutral worker now owns advisory scan/claim, per-attempt task
   authority, independent heartbeat sessions, cancellation precedence, bounded
@@ -1410,11 +1425,13 @@ default routing remain absent.
   final fenced heartbeat, and then publishes before releasing receipt
   retention. Slow object hashing therefore cannot expire an otherwise healthy
   worker and force a duplicate attempt.
-- Add prepare-only source-builder adapters, then wire the worker into runtime,
-  Web, MCP, and default routes. The trusted local factory and continuous CLI can
-  recapture an already-current single BM25 or vector cache view under the
-  worker, while the older self-publishing ingress APIs remain compatibility
-  paths and are never nested inside the worker.
+- Extend the implemented prepare-only retained-source BM25 adapter with an
+  attempt resource factory/resolver, then add vector and graph source adapters
+  and wire successful worker results into runtime, Web, MCP, and default routes.
+  The trusted local factory and continuous CLI can currently recapture only an
+  already-current single BM25 or vector cache view under the worker, while the
+  older self-publishing ingress APIs remain compatibility paths and are never
+  nested inside the worker.
 - Complete the #266 job and update APIs with accurate incremental versus rebuild
   behavior; the first read-only status slice is described below.
 - `RepoRegistry.load_all()` now reconciles each complete registry snapshot,

--- a/test/chunker/test_repo_chunking_config.py
+++ b/test/chunker/test_repo_chunking_config.py
@@ -283,6 +283,55 @@ def test_authenticated_repository_chunking_threads_cancellation_into_source_gate
     ]
 
 
+def test_authenticated_repository_chunking_stops_during_inventory_selection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_text("def a():\n    return 1\n", encoding="utf-8")
+    (repo / "b.py").write_text("def b():\n    return 2\n", encoding="utf-8")
+    chunker = CodeChunker(
+        language="python",
+        repo_config=RepoChunkingConfig(languages=["python"]),
+    )
+    stopped = KeyboardInterrupt("stop during retained inventory selection")
+    armed = False
+    selected = 0
+    real_select = chunker._source_record_is_selected
+
+    def select(*args, **kwargs):
+        nonlocal armed, selected
+        selected += 1
+        result = real_select(*args, **kwargs)
+        armed = True
+        return result
+
+    def check_cancelled() -> None:
+        if armed:
+            raise stopped
+
+    monkeypatch.setattr(chunker, "_source_record_is_selected", select)
+    monkeypatch.setattr(
+        chunker,
+        "_chunk_source_with_language",
+        lambda *_args, **_kwargs: pytest.fail(
+            "source parsing ran after inventory cancellation"
+        ),
+    )
+
+    with capture_repository_source(repo) as source:
+        with pytest.raises(BaseException) as raised:
+            chunker.chunk_repository_source(
+                source,
+                check_cancelled=check_cancelled,
+            )
+        assert raised.value is stopped
+        assert source.usable
+
+    assert selected == 1
+
+
 def test_authenticated_repository_chunking_rejects_policy_mismatch_before_reads(
     tmp_path: Path,
 ):

--- a/test/compiler/test_artifact_fingerprints.py
+++ b/test/compiler/test_artifact_fingerprints.py
@@ -95,3 +95,78 @@ def test_regular_file_fingerprint_rejects_a_changed_open_generation(
 
     with pytest.raises(ValueError, match="changed while hashing"):
         regular_file_fingerprint(path)
+
+
+def test_bm25_artifact_fingerprint_stops_between_blocks(tmp_path, monkeypatch):
+    import codenib.compiler.artifact_fingerprints as fingerprints
+
+    root = _bm25_artifact(tmp_path)
+    (root / "documents.json").write_bytes(b"x" * (2 * 1024 * 1024 + 1))
+    stopped = KeyboardInterrupt("stop during BM25 fingerprint")
+    armed = False
+    reads = 0
+    real_read = fingerprints.os.read
+
+    def read(descriptor, count):
+        nonlocal armed, reads
+        payload = real_read(descriptor, count)
+        if payload:
+            reads += 1
+            armed = True
+        return payload
+
+    def check_cancelled() -> None:
+        if armed:
+            raise stopped
+
+    monkeypatch.setattr(fingerprints.os, "read", read)
+
+    with pytest.raises(BaseException) as raised:
+        bm25_artifact_file_fingerprints(
+            root,
+            check_cancelled=check_cancelled,
+        )
+
+    assert raised.value is stopped
+    assert reads == 1
+
+
+def test_bm25_artifact_fingerprint_preserves_stop_over_close_failure(
+    tmp_path,
+    monkeypatch,
+):
+    import codenib.compiler.artifact_fingerprints as fingerprints
+
+    root = _bm25_artifact(tmp_path)
+    stopped = OSError("cooperative fingerprint stop")
+    close_failure = OSError("injected descriptor close failure")
+    armed = False
+    real_read = fingerprints.os.read
+    real_close = fingerprints.os.close
+
+    def read(descriptor, count):
+        nonlocal armed
+        payload = real_read(descriptor, count)
+        if payload:
+            armed = True
+        return payload
+
+    def check_cancelled() -> None:
+        if armed:
+            raise stopped
+
+    def close(descriptor):
+        real_close(descriptor)
+        raise close_failure
+
+    monkeypatch.setattr(fingerprints.os, "read", read)
+    monkeypatch.setattr(fingerprints.os, "close", close)
+
+    with pytest.raises(BaseException) as raised:
+        bm25_artifact_file_fingerprints(
+            root,
+            check_cancelled=check_cancelled,
+        )
+
+    assert raised.value is stopped
+    assert raised.value.__cause__ is close_failure

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -519,6 +519,60 @@ class TestBM25IndexBuilder:
 
         assert observed == [check_cancelled, check_cancelled]
 
+    def test_build_from_repository_source_stops_during_persistence(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        import codenib.compiler.artifact_fingerprints as fingerprints
+        from codenib.index.sparse_idx.bm25_index import BM25CodeIndexer
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "app.py").write_text(
+            "def app():\n    return 1\n",
+            encoding="utf-8",
+        )
+        private_root = tmp_path / "private"
+        private_root.mkdir()
+        output = private_root / "bm25"
+        stopped = KeyboardInterrupt("stop during BM25 persistence")
+        armed = False
+        real_save = BM25CodeIndexer.save_index
+
+        def check_cancelled() -> None:
+            if armed:
+                raise stopped
+
+        def arm_before_save(indexer, directory, **kwargs):
+            nonlocal armed
+            armed = True
+            return real_save(indexer, directory, **kwargs)
+
+        monkeypatch.setattr(BM25CodeIndexer, "save_index", arm_before_save)
+        monkeypatch.setattr(
+            fingerprints,
+            "bm25_artifact_file_fingerprints",
+            lambda *_args, **_kwargs: pytest.fail(
+                "artifact fingerprinting ran after cancellation"
+            ),
+        )
+
+        with capture_repository_source(repo) as source:
+            with pytest.raises(BaseException) as raised:
+                BM25IndexBuilder().build_from_repository_source(
+                    "current_repo",
+                    repository_source=source,
+                    output_dir=str(output),
+                    check_cancelled=check_cancelled,
+                )
+            assert raised.value is stopped
+            assert source.usable
+
+        assert output.is_dir()
+        assert not (output / "documents.json").exists()
+        assert not (output / "bm25_metadata.json").exists()
+
     def test_build_from_repository_source_rejects_changed_authority(
         self,
         tmp_path,

--- a/test/compiler/test_source_job.py
+++ b/test/compiler/test_source_job.py
@@ -1,0 +1,851 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import builtins
+import inspect
+import os
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+import codenib.compiler as compiler_module
+import codenib.compiler.source_job as source_job_module
+from codenib import LocalWorkspaceProvider
+from codenib._captured_directory import PublishedWorkspaceReceiptOwner
+from codenib.code_chunker import CodeChunker
+from codenib.code_chunking.base import BaseCodeChunker
+from codenib.compiler.index_builders import BM25IndexBuilder
+from codenib.compiler.manifest import RepoManifest
+from codenib.compiler.manifest_storage import BM25_PROFILE_AXES
+from codenib.compiler.source_job import BM25SourceJobExecutor, bm25_source_job_profile
+from codenib.repository_source_selection import RepositorySourceSelection
+from codenib.source_fingerprint import (
+    RepositorySourceBinding,
+    capture_repository_source,
+)
+from codenib.storage import (
+    INDEX_JOB_REQUEST_CONTRACT,
+    VIEW_BUNDLE_SCHEMA,
+    IndexJobExecutionContext,
+    IndexJobExecutionResult,
+    IndexJobStatus,
+    IndexJobStopReason,
+    LocalCAS,
+    SourceRevision,
+    SQLiteCatalog,
+    StorageValidationError,
+    ViewProfile,
+)
+
+_COMMIT = "a" * 40
+_REPOSITORY_KEY = "owner/repo"
+
+
+class _StopToken:
+    def __init__(self) -> None:
+        self._event = threading.Event()
+
+    @property
+    def reason(self) -> IndexJobStopReason | None:
+        if self._event.is_set():
+            return IndexJobStopReason.CANCEL_REQUESTED
+        return None
+
+    def is_set(self) -> bool:
+        return self._event.is_set()
+
+    def wait(self, timeout: float | None = None) -> bool:
+        return self._event.wait(timeout)
+
+
+@dataclass
+class _Control:
+    token: _StopToken
+
+    @property
+    def stop_token(self) -> _StopToken:
+        return self.token
+
+    def append_progress(self, *_args, **_kwargs):
+        raise AssertionError("source-job executor unexpectedly appended progress")
+
+
+@dataclass
+class _SourceFixture:
+    repository: Path
+    source: RepositorySourceBinding
+    workspace: Path
+    provider: LocalWorkspaceProvider
+
+    def close(self) -> None:
+        self.source.close()
+
+
+def _source_fixture(
+    tmp_path: Path,
+    *,
+    selection: RepositorySourceSelection | None = None,
+) -> _SourceFixture:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    (repository / "sample.py").write_text(
+        "def answer():\n    return 42\n",
+        encoding="utf-8",
+    )
+    selected = selection or RepositorySourceSelection()
+    source = capture_repository_source(repository, selection=selected)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    return _SourceFixture(
+        repository=repository,
+        source=source,
+        workspace=workspace,
+        provider=LocalWorkspaceProvider(workspace),
+    )
+
+
+def _execution_context(
+    catalog: SQLiteCatalog,
+    fixture: _SourceFixture,
+    profile: ViewProfile,
+    *,
+    source_fingerprint: str | None = None,
+    requested_mode: str = "full",
+    required: bool = True,
+    extra_view: bool = False,
+) -> IndexJobExecutionContext:
+    repository_id = catalog.create_repository(_REPOSITORY_KEY)
+    source_revision_id = catalog.create_source_revision(
+        repository_id,
+        commit_sha=None,
+        dirty=True,
+        source_fingerprint=source_fingerprint or fixture.source.fingerprint,
+    )
+    profile_id = catalog.create_view_profile(
+        "bm25",
+        profile.config,
+        name=profile.name,
+    )
+    views: dict[str, dict[str, object]] = {
+        "bm25": {
+            "profile_id": profile_id,
+            "requested_mode": requested_mode,
+            "required": required,
+        }
+    }
+    if extra_view:
+        vector_profile = ViewProfile.create("vector", {"fixture": True})
+        vector_profile_id = catalog.create_view_profile(
+            "vector",
+            vector_profile.config,
+            name=vector_profile.name,
+        )
+        views["vector"] = {
+            "profile_id": vector_profile_id,
+            "requested_mode": "full",
+            "required": True,
+        }
+    queued = catalog.create_job(
+        repository_id,
+        source_revision_id,
+        "bm25-retained-source",
+        {"contract": INDEX_JOB_REQUEST_CONTRACT, "views": views},
+        expected_ref_generation=0,
+    )
+    lease = catalog.acquire_job_lease(
+        queued.job_id,
+        owner_id="source-worker",
+        lease_duration_ms=60_000,
+    )
+    running = catalog.get_job(queued.job_id)
+    attempt = catalog.get_job_attempt(queued.job_id, running.attempt_count)
+    return IndexJobExecutionContext(
+        job=running,
+        views=catalog.get_job_views(queued.job_id),
+        attempt=attempt,
+        lease=lease,
+        control=_Control(_StopToken()),
+    )
+
+
+def _executor(
+    fixture: _SourceFixture,
+    cas: LocalCAS,
+    builder: BM25IndexBuilder,
+    *,
+    attempt_generation: Path,
+    view_owner: PublishedWorkspaceReceiptOwner,
+    context_owner: PublishedWorkspaceReceiptOwner,
+    forbidden_paths=(),
+    environ=None,
+) -> BM25SourceJobExecutor:
+    return BM25SourceJobExecutor(
+        attempt_generation=attempt_generation,
+        display_commit=_COMMIT,
+        builder=builder,
+        repository_source=fixture.source,
+        view_output_owner=view_owner,
+        context_output_owner=context_owner,
+        view_destination=fixture.workspace / "published-bm25",
+        context_destination=fixture.workspace / "published-context",
+        workspace_provider=fixture.provider,
+        repository_key=_REPOSITORY_KEY,
+        object_store=cas,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
+    )
+
+
+def _repository_path(value: object, repository: Path) -> bool:
+    if isinstance(value, int):
+        return False
+    try:
+        raw = os.fspath(value)
+    except TypeError:
+        return False
+    if not isinstance(raw, str):
+        return False
+    candidate = Path(raw)
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+    return candidate == repository or repository in candidate.parents
+
+
+def _guard_lexical_repository_reads(
+    monkeypatch: pytest.MonkeyPatch,
+    repository: Path,
+) -> None:
+    real_open = builtins.open
+    real_path_open = Path.open
+    real_walk = os.walk
+
+    def guarded_open(path, *args, **kwargs):
+        if _repository_path(path, repository):
+            raise AssertionError(f"lexical repository open: {path}")
+        return real_open(path, *args, **kwargs)
+
+    def guarded_path_open(path: Path, *args, **kwargs):
+        if _repository_path(path, repository):
+            raise AssertionError(f"lexical repository Path.open: {path}")
+        return real_path_open(path, *args, **kwargs)
+
+    def guarded_walk(path, *args, **kwargs):
+        if _repository_path(path, repository):
+            raise AssertionError(f"lexical repository walk: {path}")
+        return real_walk(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", guarded_open)
+    monkeypatch.setattr(Path, "open", guarded_path_open)
+    monkeypatch.setattr(os, "walk", guarded_walk)
+    monkeypatch.setattr(
+        CodeChunker,
+        "chunk_repository",
+        lambda *_args, **_kwargs: pytest.fail("lexical chunk_repository was called"),
+    )
+    monkeypatch.setattr(
+        BaseCodeChunker,
+        "_read_source",
+        lambda *_args, **_kwargs: pytest.fail("lexical chunk source read was called"),
+    )
+
+
+def test_bm25_source_executor_prepares_exact_artifact_without_lexical_reads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = BM25IndexBuilder(
+        languages=["python"],
+        max_k=17,
+        max_lines_per_chunk=41,
+        additional_ignore_dirs=["vendor"],
+    )
+    profile = bm25_source_job_profile(builder)
+    fixture = _source_fixture(tmp_path)
+    view_owner = PublishedWorkspaceReceiptOwner()
+    context_owner = PublishedWorkspaceReceiptOwner()
+    attempt = tmp_path / "attempt-generation"
+    forbidden = tmp_path / "forbidden"
+    environment = {"CODENIB_SOURCE_JOB_TEST": "before"}
+    delegated: list[Path] = []
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(catalog, fixture, profile)
+            executor = _executor(
+                fixture,
+                cas,
+                builder,
+                attempt_generation=attempt,
+                view_owner=view_owner,
+                context_owner=context_owner,
+                forbidden_paths=(path for path in (forbidden,)),
+                environ=environment,
+            )
+            assert executor.forbidden_paths == (forbidden,)
+            assert executor.environ == environment
+
+            # The executor owns a detached builder/environment snapshot.
+            builder.languages[:] = ["javascript"]
+            builder.max_k = 99
+            builder.max_lines_per_chunk = 3
+            builder.additional_ignore_dirs[:] = ["changed"]
+            builder.source_selection = RepositorySourceSelection(("sample.py",))
+            environment["CODENIB_SOURCE_JOB_TEST"] = "after"
+
+            real_prepare = source_job_module.prepare_compiler_cache_job_view
+
+            def delegated_prepare(cache_dir, **kwargs):
+                delegated.append(Path(cache_dir))
+                manifest = RepoManifest.load(Path(cache_dir) / "repo_manifest.json")
+                assert manifest.commit == _COMMIT
+                assert manifest.indexes["bm25"].config["max_k"] == 17
+                assert manifest.indexes["bm25"].config["languages"] == ["python"]
+                assert kwargs["forbidden_paths"] == (forbidden,)
+                assert kwargs["environ"]["CODENIB_SOURCE_JOB_TEST"] == "before"
+                return real_prepare(cache_dir, **kwargs)
+
+            with monkeypatch.context() as guard:
+                guard.setattr(
+                    source_job_module,
+                    "prepare_compiler_cache_job_view",
+                    delegated_prepare,
+                )
+                _guard_lexical_repository_reads(guard, fixture.repository)
+                result = executor.execute(context)
+
+            assert type(result) is IndexJobExecutionResult
+            assert result.publishable
+            assert result.retryable is False
+            assert result.views[0].payload == {
+                "adapter": "bm25_source",
+                "prepared": True,
+            }
+            artifact = result.views[0].artifact
+            assert artifact is not None
+            assert artifact.profile_id == profile.profile_id
+            assert artifact.schema_version == VIEW_BUNDLE_SCHEMA
+            assert len(artifact.member_artifacts) == 2
+            assert cas.verify(artifact.object_artifact.receipt.digest) == (
+                artifact.object_artifact.receipt
+            )
+            for member in artifact.member_artifacts:
+                assert cas.verify(member.receipt.digest) == member.receipt
+            assert delegated == [attempt]
+            assert attempt.is_dir()
+            manifest = RepoManifest.load(attempt / "repo_manifest.json")
+            assert manifest.repo_path == str(fixture.repository)
+            assert manifest.source_fingerprint == fixture.source.fingerprint
+            assert manifest.source_selection == RepositorySourceSelection()
+            assert (
+                context.job.source_revision_id
+                == SourceRevision.dirty(
+                    context.job.repository_id,
+                    source_fingerprint=fixture.source.fingerprint,
+                    commit_sha=None,
+                ).source_revision_id
+            )
+            assert (
+                context.job.source_revision_id
+                != SourceRevision.dirty(
+                    context.job.repository_id,
+                    source_fingerprint=fixture.source.fingerprint,
+                    commit_sha=_COMMIT,
+                ).source_revision_id
+            )
+            assert catalog.get_job(context.job.job_id).status is IndexJobStatus.RUNNING
+            assert catalog.get_job(context.job.job_id) == context.job
+    finally:
+        context_owner.close()
+        view_owner.close()
+        fixture.close()
+
+
+def test_bm25_source_executor_threads_stop_check_into_attempt_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = BM25IndexBuilder(languages=["python"])
+    fixture = _source_fixture(tmp_path)
+    view_owner = PublishedWorkspaceReceiptOwner()
+    context_owner = PublishedWorkspaceReceiptOwner()
+    observed: list[object] = []
+    real_lock = source_job_module.compiler_cache_lock
+
+    def expected_check() -> None:
+        return None
+
+    def tracked_lock(cache_dir, **kwargs):
+        observed.append(kwargs.get("check_cancelled"))
+        return real_lock(cache_dir, **kwargs)
+
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            executor = _executor(
+                fixture,
+                cas,
+                builder,
+                attempt_generation=tmp_path / "attempt-generation",
+                view_owner=view_owner,
+                context_owner=context_owner,
+            )
+            monkeypatch.setattr(
+                source_job_module,
+                "_compiler_cache_job_stop_check",
+                lambda _token: expected_check,
+            )
+            monkeypatch.setattr(
+                source_job_module,
+                "compiler_cache_lock",
+                tracked_lock,
+            )
+
+            result = executor.execute(context)
+
+            assert result.publishable
+            assert observed == [expected_check]
+    finally:
+        context_owner.close()
+        view_owner.close()
+        fixture.close()
+
+
+@pytest.mark.parametrize("mismatch", ["profile", "source", "mode", "required", "views"])
+def test_bm25_source_executor_rejects_job_mismatch_before_output_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mismatch: str,
+) -> None:
+    builder = BM25IndexBuilder(languages=["python"], max_k=17)
+    expected_profile = bm25_source_job_profile(builder)
+    job_profile = (
+        bm25_source_job_profile(BM25IndexBuilder(languages=["python"], max_k=18))
+        if mismatch == "profile"
+        else expected_profile
+    )
+    fixture = _source_fixture(tmp_path)
+    view_owner = PublishedWorkspaceReceiptOwner()
+    context_owner = PublishedWorkspaceReceiptOwner()
+    attempt = tmp_path / "attempt-generation"
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            changed_fingerprint = fixture.source.fingerprint[:-1] + (
+                "0" if fixture.source.fingerprint[-1] != "0" else "1"
+            )
+            context = _execution_context(
+                catalog,
+                fixture,
+                job_profile,
+                source_fingerprint=(
+                    changed_fingerprint if mismatch == "source" else None
+                ),
+                requested_mode="incremental" if mismatch == "mode" else "full",
+                required=mismatch != "required",
+                extra_view=mismatch == "views",
+            )
+            executor = _executor(
+                fixture,
+                cas,
+                builder,
+                attempt_generation=attempt,
+                view_owner=view_owner,
+                context_owner=context_owner,
+            )
+            monkeypatch.setattr(
+                BM25IndexBuilder,
+                "build_from_repository_source",
+                lambda *_args, **_kwargs: pytest.fail(
+                    "builder ran before source-job preflight completed"
+                ),
+            )
+
+            with pytest.raises(StorageValidationError):
+                executor.execute(context)
+
+            assert not attempt.exists()
+            assert view_owner.state == "empty"
+            assert context_owner.state == "empty"
+            assert not (fixture.workspace / "published-bm25").exists()
+            assert not (fixture.workspace / "published-context").exists()
+            assert not any(path.is_file() for path in (tmp_path / "cas").rglob("*"))
+    finally:
+        context_owner.close()
+        view_owner.close()
+        fixture.close()
+
+
+def test_bm25_source_executor_rejects_symlinked_attempt_inside_repository(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    view_owner = PublishedWorkspaceReceiptOwner()
+    context_owner = PublishedWorkspaceReceiptOwner()
+    linked_parent = tmp_path / "linked-parent"
+    linked_parent.symlink_to(fixture.repository, target_is_directory=True)
+    attempt = linked_parent / "attempt-generation"
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            executor = _executor(
+                fixture,
+                cas,
+                builder,
+                attempt_generation=attempt,
+                view_owner=view_owner,
+                context_owner=context_owner,
+            )
+            monkeypatch.setattr(
+                BM25IndexBuilder,
+                "build_from_repository_source",
+                lambda *_args, **_kwargs: pytest.fail(
+                    "builder ran for a repository-overlapping attempt"
+                ),
+            )
+
+            with pytest.raises(ValueError, match="overlaps repository"):
+                executor.execute(context)
+
+            assert not (fixture.repository / "attempt-generation").exists()
+            assert view_owner.state == "empty"
+            assert context_owner.state == "empty"
+    finally:
+        context_owner.close()
+        view_owner.close()
+        fixture.close()
+
+
+@pytest.mark.parametrize("boundary", ["view", "context", "forbidden"])
+def test_bm25_source_executor_rejects_attempt_output_and_policy_overlap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    boundary: str,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    view_owner = PublishedWorkspaceReceiptOwner()
+    context_owner = PublishedWorkspaceReceiptOwner()
+    forbidden = tmp_path / "forbidden"
+    forbidden.mkdir(mode=0o700)
+    attempt_parents = {
+        "view": fixture.workspace / "published-bm25",
+        "context": fixture.workspace / "published-context",
+        "forbidden": forbidden,
+    }
+    attempt = attempt_parents[boundary] / "attempt-generation"
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            executor = _executor(
+                fixture,
+                cas,
+                builder,
+                attempt_generation=attempt,
+                view_owner=view_owner,
+                context_owner=context_owner,
+                forbidden_paths=(forbidden,),
+            )
+            monkeypatch.setattr(
+                BM25IndexBuilder,
+                "build_from_repository_source",
+                lambda *_args, **_kwargs: pytest.fail(
+                    "builder ran for an overlapping attempt"
+                ),
+            )
+
+            with pytest.raises(ValueError, match="output or forbidden boundary"):
+                executor.execute(context)
+
+            assert not attempt.exists()
+            assert view_owner.state == "empty"
+            assert context_owner.state == "empty"
+    finally:
+        context_owner.close()
+        view_owner.close()
+        fixture.close()
+
+
+def test_bm25_source_executor_preserves_stop_and_caller_retry_ownership(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    view_owner = PublishedWorkspaceReceiptOwner()
+    context_owner = PublishedWorkspaceReceiptOwner()
+    attempt = tmp_path / "attempt-generation"
+    stopped = KeyboardInterrupt("injected source-job stop")
+    armed = False
+
+    def check_cancelled() -> None:
+        if armed:
+            raise stopped
+
+    real_prepare = source_job_module.prepare_compiler_cache_job_view
+
+    def stop_during_prepare(cache_dir, **kwargs):
+        nonlocal armed
+        armed = True
+        return real_prepare(cache_dir, **kwargs)
+
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            executor = _executor(
+                fixture,
+                cas,
+                builder,
+                attempt_generation=attempt,
+                view_owner=view_owner,
+                context_owner=context_owner,
+            )
+            monkeypatch.setattr(
+                source_job_module,
+                "_compiler_cache_job_stop_check",
+                lambda _token: check_cancelled,
+            )
+            monkeypatch.setattr(
+                source_job_module,
+                "prepare_compiler_cache_job_view",
+                stop_during_prepare,
+            )
+
+            with pytest.raises(BaseException) as raised:
+                executor.execute(context)
+            assert raised.value is stopped
+            assert attempt.is_dir()
+            assert (attempt / "bm25").is_dir()
+            assert (attempt / "repo_manifest.json").is_file()
+            assert view_owner.state == "empty"
+            assert context_owner.state == "empty"
+
+            armed = False
+            with pytest.raises(FileExistsError, match="must be missing"):
+                executor.execute(context)
+            assert attempt.is_dir()
+    finally:
+        context_owner.close()
+        view_owner.close()
+        fixture.close()
+
+
+def test_bm25_source_executor_preserves_stop_during_source_build(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.index.sparse_idx.bm25_index as bm25_module
+
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    view_owner = PublishedWorkspaceReceiptOwner()
+    context_owner = PublishedWorkspaceReceiptOwner()
+    attempt = tmp_path / "attempt-generation"
+    stopped = KeyboardInterrupt("injected source-build stop")
+    armed = False
+    write_calls = 0
+    real_dump = bm25_module._dump_json_interruptibly
+
+    def check_cancelled() -> None:
+        if armed:
+            raise stopped
+
+    def stop_during_dump(value, handle, checker):
+        class ArmAfterWrite:
+            def write(self, payload):
+                nonlocal armed, write_calls
+                written = handle.write(payload)
+                write_calls += 1
+                if write_calls == 3:
+                    armed = True
+                return written
+
+        return real_dump(value, ArmAfterWrite(), checker)
+
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            executor = _executor(
+                fixture,
+                cas,
+                builder,
+                attempt_generation=attempt,
+                view_owner=view_owner,
+                context_owner=context_owner,
+            )
+            monkeypatch.setattr(
+                source_job_module,
+                "_compiler_cache_job_stop_check",
+                lambda _token: check_cancelled,
+            )
+            monkeypatch.setattr(
+                bm25_module,
+                "_dump_json_interruptibly",
+                stop_during_dump,
+            )
+            monkeypatch.setattr(
+                source_job_module,
+                "prepare_compiler_cache_job_view",
+                lambda *_args, **_kwargs: pytest.fail(
+                    "cache preparation ran after source-build cancellation"
+                ),
+            )
+
+            with pytest.raises(BaseException) as raised:
+                executor.execute(context)
+
+            assert raised.value is stopped
+            assert write_calls == 3
+            assert fixture.source.usable
+            assert attempt.is_dir()
+            assert (attempt / "bm25").is_dir()
+            assert (attempt / "bm25" / "documents.json").stat().st_size > 0
+            assert not (attempt / "bm25" / "bm25_metadata.json").exists()
+            assert view_owner.state == "empty"
+            assert context_owner.state == "empty"
+            assert not (fixture.workspace / "published-bm25").exists()
+            assert not (fixture.workspace / "published-context").exists()
+            assert not any(path.is_file() for path in (tmp_path / "cas").rglob("*"))
+            assert catalog.get_job(context.job.job_id).status is IndexJobStatus.RUNNING
+    finally:
+        context_owner.close()
+        view_owner.close()
+        fixture.close()
+
+
+def test_bm25_source_executor_api_has_no_publication_authority() -> None:
+    assert compiler_module.BM25SourceJobExecutor is BM25SourceJobExecutor
+    assert compiler_module.bm25_source_job_profile is bm25_source_job_profile
+    parameters = inspect.signature(BM25SourceJobExecutor).parameters
+    assert list(parameters)[:11] == [
+        "attempt_generation",
+        "display_commit",
+        "builder",
+        "repository_source",
+        "view_output_owner",
+        "context_output_owner",
+        "view_destination",
+        "context_destination",
+        "workspace_provider",
+        "repository_key",
+        "object_store",
+    ]
+    assert not {
+        "catalog",
+        "owner_id",
+        "lease_owner",
+        "fencing_token",
+        "ref_name",
+        "expected_generation",
+        "generation_id",
+    } & set(parameters)
+
+
+def test_bm25_source_executor_repr_does_not_expose_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    variable = "CODENIB_SOURCE_JOB_SECRET_SENTINEL"
+    secret = "source-job-secret-marker"
+    monkeypatch.setenv(variable, secret)
+    executor = BM25SourceJobExecutor(
+        attempt_generation=tmp_path / "attempt",
+        display_commit=_COMMIT,
+        builder=BM25IndexBuilder(),
+        repository_source=object(),  # type: ignore[arg-type]
+        view_output_owner=object(),  # type: ignore[arg-type]
+        context_output_owner=object(),  # type: ignore[arg-type]
+        view_destination=tmp_path / "view",
+        context_destination=tmp_path / "context",
+        workspace_provider=object(),  # type: ignore[arg-type]
+        repository_key=_REPOSITORY_KEY,
+        object_store=object(),  # type: ignore[arg-type]
+    )
+
+    assert executor.environ[variable] == secret
+    assert secret not in repr(executor)
+
+
+def test_bm25_source_job_profile_covers_builder_schema_axes() -> None:
+    baseline = bm25_source_job_profile(BM25IndexBuilder())
+    config = baseline.config
+    assert config["builder_schema"] == 8
+    assert set(config["compatibility"]) == set(BM25_PROFILE_AXES) - {"builder_schema"}
+    variants = (
+        BM25IndexBuilder(languages=["python", "go"]),
+        BM25IndexBuilder(max_k=17),
+        BM25IndexBuilder(max_lines_per_chunk=41),
+        BM25IndexBuilder(additional_ignore_dirs=["vendor"]),
+        BM25IndexBuilder(source_selection=RepositorySourceSelection(("generated",))),
+    )
+    assert all(
+        bm25_source_job_profile(builder).profile_id != baseline.profile_id
+        for builder in variants
+    )
+
+
+def test_bm25_source_executor_rejects_noncanonical_display_commit(
+    tmp_path: Path,
+) -> None:
+    attempt = tmp_path / "attempt"
+    parameters = {
+        "attempt_generation": attempt,
+        "display_commit": "A" * 40,
+        "builder": BM25IndexBuilder(),
+        "repository_source": object(),
+        "view_output_owner": object(),
+        "context_output_owner": object(),
+        "view_destination": Path("view"),
+        "context_destination": Path("context"),
+        "workspace_provider": object(),
+        "repository_key": _REPOSITORY_KEY,
+        "object_store": object(),
+    }
+    with pytest.raises(StorageValidationError, match="full lowercase Git SHA"):
+        BM25SourceJobExecutor(**parameters)  # type: ignore[arg-type]
+    assert not attempt.exists()

--- a/test/index/sparse_idx/test_bm25_chunk_metadata.py
+++ b/test/index/sparse_idx/test_bm25_chunk_metadata.py
@@ -4,8 +4,27 @@
 
 from pathlib import Path
 
+import pytest
+
 from codenib.code_chunking.base import CodeChunk
-from codenib.index.sparse_idx.bm25_index import BM25CodeIndexer
+from codenib.index.sparse_idx.bm25_index import (
+    _JSON_WRITE_CHARS,
+    BM25CodeIndexer,
+    BM25Retriever,
+    _dump_json_interruptibly,
+)
+
+
+def _chunk(content: str, line: int, name: str) -> CodeChunk:
+    return CodeChunk(
+        content=content,
+        start_line=line,
+        end_line=line,
+        chunk_type="function",
+        name=name,
+        file="pkg/search.py",
+        node_id=f"pkg/search.py:{name}()",
+    )
 
 
 def test_chunk_index_persists_source_location_and_content(tmp_path: Path) -> None:
@@ -150,3 +169,207 @@ def test_loaded_index_restores_candidate_limit_before_retriever(tmp_path: Path) 
     assert loaded.retriever is not None
     assert loaded.retriever.k == 32
     assert len(loaded.search("symbol", top_k=20)) == 20
+
+
+def test_prepare_only_index_persists_exact_eager_documents(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chunks = [
+        _chunk("def alpha(): return 'ordinary term'", 0, "alpha"),
+        _chunk("def omega(): return 'unique omega marker'", 2, "omega"),
+    ]
+    eager = BM25CodeIndexer(chunks=chunks, max_k=8, project_root="/repo")
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(
+            BM25Retriever,
+            "from_documents",
+            classmethod(
+                lambda _cls, *_args, **_kwargs: pytest.fail(
+                    "prepare-only construction built an in-memory rank index"
+                )
+            ),
+        )
+        prepared = BM25CodeIndexer(
+            chunks=chunks,
+            max_k=8,
+            project_root="/repo",
+            prepare_only=True,
+        )
+
+    assert prepared.retriever is None
+    eager_root = tmp_path / "eager"
+    prepared_root = tmp_path / "prepared"
+    eager.save_index(str(eager_root))
+    prepared.save_index(str(prepared_root))
+    for name in ("documents.json", "bm25_metadata.json"):
+        assert (prepared_root / name).read_bytes() == (eager_root / name).read_bytes()
+
+    loaded = BM25CodeIndexer()
+    loaded.load_index(str(prepared_root))
+    assert [item.node_name for item in loaded.search("omega", top_k=2)] == [
+        item.node_name for item in eager.search("omega", top_k=2)
+    ]
+
+    empty = BM25CodeIndexer(chunks=[], prepare_only=True)
+    empty_root = tmp_path / "empty"
+    empty.save_index(str(empty_root))
+    assert (empty_root / "documents.json").read_bytes() == b"[]"
+
+
+def test_prepare_only_index_rejects_graph_precedence_ambiguity() -> None:
+    with pytest.raises(ValueError, match="without a code graph"):
+        BM25CodeIndexer(
+            code_graph=object(),
+            chunks=[],
+            prepare_only=True,
+            check_cancelled=lambda: None,
+        )
+
+
+def test_prepare_only_index_stops_between_chunk_conversions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chunks = [
+        _chunk("def first(): return 1", 0, "first"),
+        _chunk("def second(): return 2", 2, "second"),
+    ]
+    stopped = KeyboardInterrupt("stop between BM25 document conversions")
+    converted = 0
+    armed = False
+    real_convert = BM25CodeIndexer._convert_chunk_to_document
+
+    def convert(indexer, chunk):
+        nonlocal armed, converted
+        document = real_convert(indexer, chunk)
+        converted += 1
+        armed = True
+        return document
+
+    def check_cancelled() -> None:
+        if armed:
+            raise stopped
+
+    monkeypatch.setattr(BM25CodeIndexer, "_convert_chunk_to_document", convert)
+    monkeypatch.setattr(
+        BM25Retriever,
+        "from_documents",
+        classmethod(
+            lambda _cls, *_args, **_kwargs: pytest.fail(
+                "rank construction ran after conversion cancellation"
+            )
+        ),
+    )
+
+    with pytest.raises(BaseException) as raised:
+        BM25CodeIndexer(
+            chunks=chunks,
+            prepare_only=True,
+            check_cancelled=check_cancelled,
+        )
+
+    assert raised.value is stopped
+    assert converted == 1
+
+
+def test_interruptible_json_dump_stops_after_first_write() -> None:
+    stopped = KeyboardInterrupt("stop during BM25 JSON persistence")
+    writes: list[str] = []
+    armed = False
+
+    class Writer:
+        def write(self, payload: str) -> None:
+            nonlocal armed
+            writes.append(payload)
+            if len(payload) == _JSON_WRITE_CHARS:
+                armed = True
+
+    def check_cancelled() -> None:
+        if armed:
+            raise stopped
+
+    with pytest.raises(BaseException) as raised:
+        _dump_json_interruptibly(
+            [{"payload": "x" * (2 * 1024 * 1024)}],
+            Writer(),
+            check_cancelled,
+        )
+
+    assert raised.value is stopped
+    assert armed
+    assert max(map(len, writes)) <= _JSON_WRITE_CHARS
+    assert sum(map(len, writes)) < 2 * 1024 * 1024
+
+
+def test_interruptible_json_save_preserves_stop_over_close_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.index.sparse_idx.bm25_index as bm25_module
+
+    stopped = KeyboardInterrupt("stop during BM25 JSON persistence")
+    close_failure = OSError("injected JSON close failure")
+    armed = False
+
+    class Writer:
+        def write(self, payload: str) -> int:
+            nonlocal armed
+            armed = True
+            return len(payload)
+
+        def close(self) -> None:
+            raise close_failure
+
+    def check_cancelled() -> None:
+        if armed:
+            raise stopped
+
+    monkeypatch.setattr(
+        bm25_module, "open", lambda *_args, **_kwargs: Writer(), raising=False
+    )
+    indexer = BM25CodeIndexer(chunks=[], prepare_only=True)
+
+    with pytest.raises(BaseException) as raised:
+        indexer.save_index(
+            str(tmp_path),
+            check_cancelled=check_cancelled,
+        )
+
+    assert raised.value is stopped
+    assert raised.value.__cause__ is close_failure
+
+
+def test_legacy_chunk_indexer_override_remains_persistable(tmp_path: Path) -> None:
+    class LegacyIndexer(BM25CodeIndexer):
+        def build_index_from_chunks(self, chunks, *, project_root=None):
+            self.documents = []
+            self.retriever = object()
+            return self.retriever
+
+    indexer = LegacyIndexer(chunks=[])
+    indexer.save_index(str(tmp_path))
+
+    assert (tmp_path / "documents.json").read_bytes() == b"[]"
+
+
+def test_failed_eager_rank_build_is_not_persistable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failed = RuntimeError("injected BM25 rank construction failure")
+    indexer = BM25CodeIndexer()
+
+    def fail(_cls, *_args, **_kwargs):
+        raise failed
+
+    monkeypatch.setattr(BM25Retriever, "from_documents", classmethod(fail))
+
+    with pytest.raises(BaseException) as raised:
+        indexer.build_index_from_chunks([_chunk("def value(): return 1", 0, "value")])
+
+    assert raised.value is failed
+    assert indexer.retriever is None
+    with pytest.raises(ValueError, match="Index has not been built"):
+        indexer.save_index(str(tmp_path / "failed"))
+    assert not (tmp_path / "failed").exists()


### PR DESCRIPTION
## Summary
Prepare one required FULL BM25 job from authenticated retained source without granting the executor catalog, fencing, ref, or publication authority. This also makes retained-source BM25 preparation cooperatively cancellable across selection, chunking, persistence, hashing, and attempt-lock acquisition. Advances #266.

## Changes
- Add BM25SourceJobExecutor and bm25_source_job_profile for exact job, profile, source, and single-view preflight.
- Build a caller-owned missing attempt generation and return strict CAS-backed artifacts for IndexJobWorker publication.
- Add prepare-only BM25 document persistence that is byte-identical to eager builds and avoids duplicate in-memory BM25 construction.
- Poll and preserve exact cancellation through authenticated inventory processing, document conversion, bounded JSON writes, artifact fingerprint reads, and cleanup failures.
- Update the hybrid storage roadmap with the implemented adapter boundary and explicitly deferred resource-factory/runtime wiring.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- Python 3.10, 3.12, and 3.14 changed-surface gates: 241 passed on each interpreter.
- Full compiler suite: 984 passed.
- Full chunker suite: 99 passed.
- Focused sparse BM25 suite: 69 passed, 1 expected skip.
- Black, isort with the Black profile, flake8, three-version py_compile, and git diff --check passed.

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published