### PR TITLE
feat(storage): resolve retained BM25 source jobs

### DIFF
--- a/codenib/compiler/__init__.py
+++ b/codenib/compiler/__init__.py
@@ -48,11 +48,16 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
     from codenib.compiler.index_builders import IndexBuilderRegistry
     from codenib.compiler.index_compiler import IndexCompiler, IndexCompilerConfig
     from codenib.compiler.job_resolver import (
+        BM25SourceJobResolver,
+        BM25SourceJobResourceFactory,
+        BM25SourceJobResourceScope,
         CompilerCacheJobResolver,
         CompilerCacheJobResourceFactory,
         CompilerCacheJobResourceScope,
     )
     from codenib.compiler.job_resources import (
+        LocalBM25SourceJobResourceFactory,
+        LocalBM25SourceJobTarget,
         LocalCompilerCacheJobResourceFactory,
         LocalCompilerCacheJobTarget,
     )
@@ -100,6 +105,18 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
     )
 
 _EXPORTS = {
+    "BM25SourceJobResolver": (
+        "codenib.compiler.job_resolver",
+        "BM25SourceJobResolver",
+    ),
+    "BM25SourceJobResourceFactory": (
+        "codenib.compiler.job_resolver",
+        "BM25SourceJobResourceFactory",
+    ),
+    "BM25SourceJobResourceScope": (
+        "codenib.compiler.job_resolver",
+        "BM25SourceJobResourceScope",
+    ),
     "CompilerCacheBm25RecaptureResult": (
         "codenib.compiler.cache_import",
         "CompilerCacheBm25RecaptureResult",
@@ -187,6 +204,14 @@ _EXPORTS = {
     "LocalCompilerCacheJobTarget": (
         "codenib.compiler.job_resources",
         "LocalCompilerCacheJobTarget",
+    ),
+    "LocalBM25SourceJobResourceFactory": (
+        "codenib.compiler.job_resources",
+        "LocalBM25SourceJobResourceFactory",
+    ),
+    "LocalBM25SourceJobTarget": (
+        "codenib.compiler.job_resources",
+        "LocalBM25SourceJobTarget",
     ),
     "IndexCompiler": ("codenib.compiler.index_compiler", "IndexCompiler"),
     "IndexCompilerConfig": (
@@ -294,6 +319,9 @@ _EXPORTS = {
 }
 
 __all__ = [
+    "BM25SourceJobResolver",
+    "BM25SourceJobResourceFactory",
+    "BM25SourceJobResourceScope",
     # Index compilation
     "CompilerCacheBm25RecaptureResult",
     "CompilerCacheImportResult",
@@ -305,6 +333,8 @@ __all__ = [
     "CompilerCacheJobResourceScope",
     "LocalCompilerCacheJobResourceFactory",
     "LocalCompilerCacheJobTarget",
+    "LocalBM25SourceJobResourceFactory",
+    "LocalBM25SourceJobTarget",
     "CompilerCacheMultiViewImportResult",
     "CompilerCacheTopologyGuard",
     "CompilerCacheVectorJobPublicationResult",

--- a/codenib/compiler/job_resolver.py
+++ b/codenib/compiler/job_resolver.py
@@ -26,6 +26,7 @@ from ..storage.models import (
 )
 from ..storage.protocols import RetainedImportObjectStore
 from .cache_import import CompilerCacheJobExecutor
+from .source_job import BM25SourceJobExecutor
 
 _SUPPORTED_CACHE_VIEWS = frozenset({"bm25", "vector"})
 _MISSING_EXECUTION_RESULT = object()
@@ -62,6 +63,24 @@ class CompilerCacheJobResourceScope:
             raise TypeError("compiler cache resource scope requires a context manager")
 
 
+@dataclass(frozen=True, slots=True)
+class BM25SourceJobResourceScope:
+    """Side-effect-free declaration for one retained-source BM25 attempt."""
+
+    object_store: RetainedImportObjectStore
+    resources: AbstractContextManager[BM25SourceJobExecutor]
+
+    def __post_init__(self) -> None:
+        if type(self) is not BM25SourceJobResourceScope:
+            raise TypeError("BM25 source resource scope must use the exact type")
+        if not isinstance(self.object_store, RetainedImportObjectStore):
+            raise TypeError(
+                "BM25 source resource scope requires a retained import store"
+            )
+        if not isinstance(self.resources, AbstractContextManager):
+            raise TypeError("BM25 source resource scope requires a context manager")
+
+
 @runtime_checkable
 class CompilerCacheJobResourceFactory(Protocol):
     """Declare fresh attempt-scoped authorities for one cache executor.
@@ -82,19 +101,36 @@ class CompilerCacheJobResourceFactory(Protocol):
     ) -> CompilerCacheJobResourceScope: ...
 
 
+@runtime_checkable
+class BM25SourceJobResourceFactory(Protocol):
+    """Declare fresh attempt-scoped authorities for one BM25 source executor.
+
+    ``create_scope`` must only assemble a side-effect-free descriptor. The
+    returned context manager owns source capture, receipt owners, workspace
+    destinations, and their ordered cleanup. The supplied object store must be
+    declared unchanged on the scope and attached unchanged to its executor.
+    """
+
+    def create_scope(
+        self,
+        context: IndexJobExecutionContext,
+        *,
+        object_store: RetainedImportObjectStore,
+    ) -> BM25SourceJobResourceScope: ...
+
+
 def _add_cleanup_exception_note(
     primary: BaseException,
     secondary: BaseException,
+    *,
+    label: str,
 ) -> None:
     """Best-effort note cleanup failure without replacing the primary error."""
 
     try:
         add_note = getattr(primary, "add_note", None)
         if callable(add_note):
-            add_note(
-                "compiler cache resource cleanup also failed: "
-                f"{type(secondary).__name__}"
-            )
+            add_note(f"{label} cleanup also failed: {type(secondary).__name__}")
     except BaseException:  # noqa: B036 - notes must not replace execution failure
         pass
 
@@ -173,13 +209,61 @@ def _execute_in_resource_scope(
             raise
         if cleanup_exc is not primary:
             _inherit_cleanup_owners(primary, cleanup_exc)
-            _add_cleanup_exception_note(primary, cleanup_exc)
+            _add_cleanup_exception_note(
+                primary,
+                cleanup_exc,
+                label="compiler cache resource",
+            )
     if primary is not None:
         raise primary
     if type(result) is not IndexJobExecutionResult:
         raise StorageIntegrityError(
             "compiler cache resource scope returned no execution result"
         )
+    return result
+
+
+def _execute_in_bm25_source_resource_scope(
+    scope: BM25SourceJobResourceScope,
+    context: IndexJobExecutionContext,
+) -> IndexJobExecutionResult:
+    """Execute a source build without letting cleanup suppress its failure."""
+
+    result: object = _MISSING_EXECUTION_RESULT
+    primary: BaseException | None = None
+    try:
+        with scope.resources as executor:
+            try:
+                if type(executor) is not BM25SourceJobExecutor:
+                    raise TypeError(
+                        "BM25 source resource factory returned an invalid executor"
+                    )
+                if executor.object_store is not scope.object_store:
+                    raise StorageIntegrityError(
+                        "BM25 source executor differs from its declared object store"
+                    )
+                result = executor.execute(context)
+                if type(result) is not IndexJobExecutionResult:
+                    raise StorageIntegrityError(
+                        "BM25 source executor returned an invalid result"
+                    )
+            except BaseException as exc:  # noqa: B036 - rethrown after cleanup
+                primary = exc
+                raise
+    except BaseException as cleanup_exc:  # noqa: B036 - preserve primary failure
+        if primary is None:
+            raise
+        if cleanup_exc is not primary:
+            _inherit_cleanup_owners(primary, cleanup_exc)
+            _add_cleanup_exception_note(
+                primary,
+                cleanup_exc,
+                label="BM25 source resource",
+            )
+    if primary is not None:
+        raise primary
+    if type(result) is not IndexJobExecutionResult:
+        raise StorageIntegrityError("BM25 source resource scope returned no result")
     return result
 
 
@@ -288,6 +372,36 @@ class _ScopedCompilerCacheJobExecutor:
 
 
 @dataclass(frozen=True, slots=True)
+class _ScopedBM25SourceJobExecutor:
+    job: IndexJobRecord
+    views: tuple[IndexJobViewRecord, ...]
+    resource_factory: BM25SourceJobResourceFactory
+    object_store: RetainedImportObjectStore
+
+    def execute(
+        self,
+        context: IndexJobExecutionContext,
+    ) -> IndexJobExecutionResult:
+        if type(context) is not IndexJobExecutionContext:
+            raise TypeError("scoped BM25 source executor requires an exact context")
+        if context.job != self.job or context.views != self.views:
+            raise StorageIntegrityError(
+                "scoped BM25 source executor received a different job attempt"
+            )
+        scope = self.resource_factory.create_scope(
+            context,
+            object_store=self.object_store,
+        )
+        if type(scope) is not BM25SourceJobResourceScope:
+            raise TypeError("BM25 source resource factory must return an exact scope")
+        if scope.object_store is not self.object_store:
+            raise StorageIntegrityError(
+                "BM25 source resource scope must use the resolver object store"
+            )
+        return _execute_in_bm25_source_resource_scope(scope, context)
+
+
+@dataclass(frozen=True, slots=True)
 class CompilerCacheJobResolver:
     """Resolve one supported cache job through fresh scoped authorities.
 
@@ -341,7 +455,56 @@ class CompilerCacheJobResolver:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class BM25SourceJobResolver:
+    """Resolve one retained-source BM25 job through fresh scoped authorities."""
+
+    resource_factory: BM25SourceJobResourceFactory
+    object_store: RetainedImportObjectStore
+
+    def __post_init__(self) -> None:
+        if type(self) is not BM25SourceJobResolver:
+            raise TypeError("BM25 source job resolver must use the exact type")
+        if not isinstance(self.resource_factory, BM25SourceJobResourceFactory):
+            raise TypeError("BM25 source job resolver requires a resource factory")
+        if not isinstance(self.object_store, RetainedImportObjectStore):
+            raise TypeError("BM25 source job resolver requires a retained import store")
+
+    def resolve(
+        self,
+        job: IndexJobRecord,
+        views: tuple[IndexJobViewRecord, ...],
+    ) -> IndexJobExecutor:
+        detached_job = _detach_resolved_job(job)
+        detached_views = _detach_resolved_views(views)
+        if detached_views != _canonical_resolved_views(detached_job):
+            raise StorageIntegrityError(
+                "BM25 source resolver views differ from the job request"
+            )
+        if (
+            detached_job.status is not IndexJobStatus.RUNNING
+            or detached_job.cancel_requested
+            or len(detached_views) != 1
+            or detached_views[0].job_id != detached_job.job_id
+            or detached_views[0].view_type != "bm25"
+            or detached_views[0].requested_mode is not IndexJobRequestedMode.FULL
+            or detached_views[0].required is not True
+        ):
+            raise StorageValidationError(
+                "BM25 source resolver requires one active required FULL BM25 view"
+            )
+        return _ScopedBM25SourceJobExecutor(
+            job=detached_job,
+            views=detached_views,
+            resource_factory=self.resource_factory,
+            object_store=self.object_store,
+        )
+
+
 __all__ = [
+    "BM25SourceJobResolver",
+    "BM25SourceJobResourceFactory",
+    "BM25SourceJobResourceScope",
     "CompilerCacheJobResolver",
     "CompilerCacheJobResourceFactory",
     "CompilerCacheJobResourceScope",

--- a/codenib/compiler/job_resolver.py
+++ b/codenib/compiler/job_resolver.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Resource-scoped resolver for prepare-only compiler-cache jobs."""
+"""Resource-scoped resolvers for prepare-only cache and source jobs."""
 
 from __future__ import annotations
 

--- a/codenib/compiler/job_resources.py
+++ b/codenib/compiler/job_resources.py
@@ -2,14 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Trusted local resources for prepare-only compiler-cache job attempts."""
+"""Trusted local resources for prepare-only cache and source job attempts."""
 
 from __future__ import annotations
 
 import logging
 import secrets
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import InitVar, dataclass, field
 from pathlib import Path
 from types import MappingProxyType
 from typing import Iterator, Mapping
@@ -48,9 +48,16 @@ from .cache_import import (
     _compiler_cache_job_stop_check,
     compiler_cache_source_selection,
 )
-from .job_resolver import CompilerCacheJobResourceScope
+from .index_builders import BM25IndexBuilder
+from .job_resolver import BM25SourceJobResourceScope, CompilerCacheJobResourceScope
 from .manifest_import import _require_static_methods, _snapshot_environment
 from .snapshot_store import normalize_repo
+from .source_job import (
+    BM25SourceJobExecutor,
+    _BM25BuilderConfiguration,
+    _exact_display_commit,
+    _snapshot_builder,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +68,21 @@ _SUPPORTED_CACHE_VIEWS = frozenset({"bm25", "vector"})
 
 def _paths_overlap(first: Path, second: Path) -> bool:
     return first == second or first in second.parents or second in first.parents
+
+
+def _require_physical_roots_disjoint(
+    first: Path,
+    second: Path,
+    *,
+    label: str,
+) -> None:
+    try:
+        physical_first = first.resolve(strict=True)
+        physical_second = second.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(f"{label} cannot be authenticated") from exc
+    if _paths_overlap(physical_first, physical_second):
+        raise ValueError(f"{label} must not overlap")
 
 
 @dataclass(frozen=True, slots=True)
@@ -163,6 +185,97 @@ class LocalCompilerCacheJobTarget:
         return self.workspace_provider.allowed_root
 
 
+@dataclass(frozen=True, slots=True)
+class LocalBM25SourceJobTarget:
+    """One explicitly trusted source-builder and local workspace binding."""
+
+    repository_root: Path
+    workspace_provider: LocalWorkspaceProvider
+    repository_key: str
+    display_commit: str
+    builder: InitVar[BM25IndexBuilder]
+    namespace_name: str = DEFAULT_NAMESPACE_NAME
+    environ: Mapping[str, str] | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    _repository_id: str = field(init=False, repr=False)
+    _builder: _BM25BuilderConfiguration = field(init=False, repr=False)
+    _profile_id: str = field(init=False, repr=False)
+
+    def __post_init__(self, builder: BM25IndexBuilder) -> None:
+        if type(self) is not LocalBM25SourceJobTarget:
+            raise TypeError("local BM25 source target must use the exact type")
+        if not isinstance(self.repository_root, Path):
+            raise TypeError("BM25 source target repository root must be a Path")
+        if type(self.workspace_provider) is not LocalWorkspaceProvider:
+            raise TypeError(
+                "BM25 source target requires an exact local workspace provider"
+            )
+        if type(self.repository_key) is not str or type(self.namespace_name) is not str:
+            raise TypeError(
+                "BM25 source target namespace and repository key must be exact text"
+            )
+
+        repository_root = lexical_repository_path(self.repository_root)
+        workspace_root = self.workspace_provider.allowed_root
+        if repository_root == repository_root.parent:
+            raise ValueError(
+                "BM25 source target repository cannot be a filesystem root"
+            )
+        if _paths_overlap(workspace_root, repository_root):
+            raise ValueError(
+                "BM25 source target workspace must not overlap the repository"
+            )
+        namespace = NamespaceIdentity(self.namespace_name)
+        repository = RepositoryIdentity(
+            namespace_id=namespace.namespace_id,
+            repository_key=self.repository_key,
+        )
+        if (
+            namespace.name != self.namespace_name
+            or repository.repository_key != self.repository_key
+        ):
+            raise StorageValidationError(
+                "BM25 source target namespace and repository key must be canonical"
+            )
+        try:
+            normalized_repository = normalize_repo(repository.repository_key)
+        except ValueError as exc:
+            raise StorageValidationError(
+                "BM25 source target repository key is not canonical"
+            ) from exc
+        if normalized_repository != repository.repository_key:
+            raise StorageValidationError(
+                "BM25 source target repository key is not canonical"
+            )
+        configuration = _snapshot_builder(builder)
+        profile = configuration.profile()
+        object.__setattr__(self, "repository_root", repository_root)
+        object.__setattr__(self, "repository_key", repository.repository_key)
+        object.__setattr__(self, "namespace_name", namespace.name)
+        object.__setattr__(
+            self, "display_commit", _exact_display_commit(self.display_commit)
+        )
+        object.__setattr__(self, "environ", _snapshot_environment(self.environ))
+        object.__setattr__(self, "_repository_id", repository.repository_id)
+        object.__setattr__(self, "_builder", configuration)
+        object.__setattr__(self, "_profile_id", profile.profile_id)
+
+    @property
+    def repository_id(self) -> str:
+        return self._repository_id
+
+    @property
+    def workspace_root(self) -> Path:
+        return self.workspace_provider.allowed_root
+
+    @property
+    def profile_id(self) -> str:
+        return self._profile_id
+
+
 @dataclass(slots=True)
 class _AttemptWorkspaceCleanupOwner:
     """Close one receipt authority, then isolate its exact published tree."""
@@ -170,6 +283,7 @@ class _AttemptWorkspaceCleanupOwner:
     owner: PublishedWorkspaceReceiptOwner
     destination: Path
     label: str
+    job_label: str = "Compiler-cache job"
     _ownership: object | None = field(default=None, init=False, repr=False)
     _closed: bool = field(default=False, init=False, repr=False)
 
@@ -177,13 +291,18 @@ class _AttemptWorkspaceCleanupOwner:
     def closed(self) -> bool:
         return self._closed
 
-    @staticmethod
-    def _record_orphan(orphan: DirectoryOrphan | None, *, label: str) -> None:
+    def _record_orphan(
+        self,
+        orphan: DirectoryOrphan | None,
+        *,
+        label: str,
+    ) -> None:
         if orphan is None:
             return
         logger.warning(
-            "Compiler-cache job %s retained an orphan for quiescent GC: "
+            "%s %s retained an orphan for quiescent GC: "
             "path=%s digest=%s entries=%d bytes=%d verified=%s",
+            self.job_label,
             label,
             orphan.path,
             orphan.ownership_digest,
@@ -201,7 +320,7 @@ class _AttemptWorkspaceCleanupOwner:
                 binding = self.owner.destination_binding
                 if binding.destination != self.destination:
                     raise StorageIntegrityError(
-                        "compiler cache workspace receipt changed destination"
+                        f"{self.job_label} workspace receipt changed destination"
                     )
                 self._ownership = binding.ownership
             elif state == "closed":
@@ -209,12 +328,12 @@ class _AttemptWorkspaceCleanupOwner:
                 return
             elif state != "empty":
                 raise StorageIntegrityError(
-                    "compiler cache workspace receipt has an invalid state"
+                    f"{self.job_label} workspace receipt has an invalid state"
                 )
 
         self.owner.close()
         if not self.owner.closed:
-            raise RuntimeError("compiler cache workspace receipt did not close")
+            raise RuntimeError(f"{self.job_label} workspace receipt did not close")
         if self._ownership is not None:
             orphan = discard_owned_directory(self.destination, self._ownership)
             self._record_orphan(orphan, label=self.label)
@@ -250,7 +369,7 @@ def _attempt_nonce() -> str:
     if len(nonce) != 2 * _NONCE_BYTES or any(
         character not in "0123456789abcdef" for character in nonce
     ):
-        raise RuntimeError("compiler cache job destination nonce is invalid")
+        raise RuntimeError("job destination nonce is invalid")
     return nonce
 
 
@@ -495,7 +614,262 @@ class LocalCompilerCacheJobResourceFactory:
             raise
 
 
+@dataclass(frozen=True, slots=True)
+class LocalBM25SourceJobResourceFactory:
+    """Resolve configured local repositories into fresh BM25 source attempts."""
+
+    targets: tuple[LocalBM25SourceJobTarget, ...]
+    _targets_by_repository_id: Mapping[str, LocalBM25SourceJobTarget] = field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        if type(self) is not LocalBM25SourceJobResourceFactory:
+            raise TypeError(
+                "local BM25 source resource factory must use the exact type"
+            )
+        if type(self.targets) is not tuple or not (
+            1 <= len(self.targets) <= _MAX_LOCAL_TARGETS
+        ):
+            raise ValueError(
+                "local BM25 source resource factory requires bounded targets"
+            )
+        targets_by_repository_id: dict[str, LocalBM25SourceJobTarget] = {}
+        for target in self.targets:
+            if type(target) is not LocalBM25SourceJobTarget:
+                raise TypeError("local BM25 source resource target is invalid")
+            if target.repository_id in targets_by_repository_id:
+                raise ValueError(
+                    "local BM25 source resource factory has duplicate repository IDs"
+                )
+            targets_by_repository_id[target.repository_id] = target
+        object.__setattr__(
+            self,
+            "_targets_by_repository_id",
+            MappingProxyType(targets_by_repository_id),
+        )
+
+    def accepts_candidate(self, job: IndexJobRecord) -> bool:
+        """Return exact pre-claim eligibility for this source target set."""
+
+        if type(job) is not IndexJobRecord:
+            raise StorageValidationError(
+                "local BM25 source candidate must be an exact job record"
+            )
+        target = self._targets_by_repository_id.get(job.repository_id)
+        if target is None:
+            return False
+        try:
+            request = IndexJobRequest(
+                repository_id=job.repository_id,
+                source_revision_id=job.source_revision_id,
+                ref_name=job.ref_name,
+                idempotency_key=job.idempotency_key,
+                expected_ref_generation=job.expected_ref_generation,
+                max_attempts=job.max_attempts,
+                request_json=job.request_json,
+            )
+        except StorageValidationError as exc:
+            raise StorageIntegrityError(
+                "local BM25 source candidate request is invalid"
+            ) from exc
+        if request.job_id != job.job_id or request.request_digest != job.request_digest:
+            raise StorageIntegrityError(
+                "local BM25 source candidate request identity is inconsistent"
+            )
+        views = request.view_requests
+        return (
+            len(views) == 1
+            and views[0].job_id == job.job_id
+            and views[0].view_type == "bm25"
+            and views[0].profile_id == target.profile_id
+            and views[0].requested_mode is IndexJobRequestedMode.FULL
+            and views[0].required is True
+        )
+
+    def create_scope(
+        self,
+        context: IndexJobExecutionContext,
+        *,
+        object_store: RetainedImportObjectStore,
+    ) -> BM25SourceJobResourceScope:
+        if type(context) is not IndexJobExecutionContext:
+            raise TypeError(
+                "local BM25 source resource factory requires an exact context"
+            )
+        if not isinstance(object_store, RetainedImportObjectStore):
+            raise TypeError(
+                "local BM25 source resource factory requires a retained import store"
+            )
+        if not isinstance(object_store, InterruptibleReceiptVerifyingObjectStore):
+            raise TypeError(
+                "local BM25 source resource factory requires interruptible receipt "
+                "verification"
+            )
+        if not isinstance(object_store, InterruptibleStreamingObjectStore):
+            raise TypeError(
+                "local BM25 source resource factory requires interruptible streaming "
+                "ingestion"
+            )
+        _require_static_methods(
+            object_store,
+            label="local BM25 source object store",
+            names=(
+                "put_chunks_interruptibly",
+                "verify_receipt_interruptibly",
+            ),
+        )
+        target = self._targets_by_repository_id.get(context.job.repository_id)
+        if target is None:
+            raise StorageValidationError(
+                "BM25 source job repository has no trusted local target"
+            )
+        if (
+            len(context.views) != 1
+            or context.views[0].view_type != "bm25"
+            or context.views[0].profile_id != target.profile_id
+            or context.views[0].requested_mode is not IndexJobRequestedMode.FULL
+            or context.views[0].required is not True
+        ):
+            raise StorageValidationError(
+                "local BM25 source resource factory requires one matching FULL view"
+            )
+        return BM25SourceJobResourceScope(
+            object_store=object_store,
+            resources=self._open(
+                context,
+                object_store=object_store,
+                target=target,
+            ),
+        )
+
+    @contextmanager
+    def _open(
+        self,
+        context: IndexJobExecutionContext,
+        *,
+        object_store: RetainedImportObjectStore,
+        target: LocalBM25SourceJobTarget,
+    ) -> Iterator[BM25SourceJobExecutor]:
+        check_cancelled = _compiler_cache_job_stop_check(context.control.stop_token)
+        if check_cancelled is None:  # pragma: no cover - context invariant
+            raise AssertionError("BM25 source job context has no stop check")
+        nonce = _attempt_nonce()
+        prefix = f".codenib-source-job-{nonce}"
+        attempt_destination = target.workspace_root / f"{prefix}-attempt"
+        view_destination = target.workspace_root / f"{prefix}-bm25"
+        context_destination = target.workspace_root / f"{prefix}-context"
+        attempt_owner = PublishedWorkspaceReceiptOwner()
+        view_owner = PublishedWorkspaceReceiptOwner()
+        context_owner = PublishedWorkspaceReceiptOwner()
+        attempt_cleanup = _AttemptWorkspaceCleanupOwner(
+            attempt_owner,
+            attempt_destination,
+            "source attempt",
+            job_label="BM25 source job",
+        )
+        view_cleanup = _AttemptWorkspaceCleanupOwner(
+            view_owner,
+            view_destination,
+            "source BM25",
+            job_label="BM25 source job",
+        )
+        context_cleanup = _AttemptWorkspaceCleanupOwner(
+            context_owner,
+            context_destination,
+            "source context",
+            job_label="BM25 source job",
+        )
+        source_owner = SourceBindingCleanupOwner()
+        cleanup_owners = (
+            context_cleanup,
+            view_cleanup,
+            attempt_cleanup,
+            source_owner,
+        )
+        cleanup_actions = tuple(
+            _OrderedAction(
+                label=f"BM25 source job {cleanup.label} cleanup also failed",
+                action=cleanup.close,
+                complete=lambda cleanup=cleanup: cleanup.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=cleanup,
+            )
+            for cleanup in (context_cleanup, view_cleanup, attempt_cleanup)
+        ) + (
+            _OrderedAction(
+                label="BM25 source job source cleanup also failed",
+                action=source_owner.close,
+                complete=lambda: source_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=source_owner,
+            ),
+        )
+
+        try:
+            with _run_context_with_cleanup_actions(cleanup_actions):
+                check_cancelled()
+                target.workspace_provider.require_support()
+                _require_physical_roots_disjoint(
+                    target.workspace_root,
+                    target.repository_root,
+                    label="BM25 source target physical workspace and repository",
+                )
+                repository_source = capture_repository_source(
+                    target.repository_root,
+                    exclude_roots=(target.workspace_root,),
+                    selection=target._builder.source_selection,
+                    _source_owner=source_owner.retain,
+                    check_cancelled=check_cancelled,
+                )
+                source_owner.retain(repository_source)
+                source_revision = SourceRevision.dirty(
+                    target.repository_id,
+                    source_fingerprint=repository_source.fingerprint,
+                    commit_sha=None,
+                )
+                if source_revision.source_revision_id != context.job.source_revision_id:
+                    raise StorageValidationError(
+                        "BM25 source job source has no current trusted local target"
+                    )
+                check_cancelled()
+                yield BM25SourceJobExecutor(
+                    attempt_generation=attempt_destination,
+                    display_commit=target.display_commit,
+                    builder=target._builder.builder(),
+                    attempt_output_owner=attempt_owner,
+                    attempt_workspace_provider=target.workspace_provider,
+                    repository_source=repository_source,
+                    view_output_owner=view_owner,
+                    context_output_owner=context_owner,
+                    view_destination=view_destination,
+                    context_destination=context_destination,
+                    workspace_provider=target.workspace_provider,
+                    repository_key=target.repository_key,
+                    object_store=object_store,
+                    namespace_name=target.namespace_name,
+                    environ=target.environ,
+                )
+        except BaseException as error:  # noqa: B036 - retain cleanup authority
+            pending = tuple(
+                owner for owner in cleanup_owners if _cleanup_owner_pending(owner)
+            )
+            if pending and isinstance(error, Exception):
+                wrapped = StorageIntegrityError(
+                    "BM25 source job attempt resource cleanup did not settle"
+                )
+                _inherit_cleanup_owners(wrapped, error)
+                for owner in pending:
+                    _attach_publication_cleanup_owner(wrapped, owner)
+                raise wrapped from error
+            raise
+
+
 __all__ = [
+    "LocalBM25SourceJobResourceFactory",
+    "LocalBM25SourceJobTarget",
     "LocalCompilerCacheJobResourceFactory",
     "LocalCompilerCacheJobTarget",
 ]

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1289,8 +1289,8 @@ separately supplied full Git SHA remains display provenance only. The returned
 `IndexJobExecutionResult` carries no catalog, lease, fencing, ref, or final
 generation publication authority; the worker remains the sole publisher and
 the caller retains cleanup ownership for every attempt. Source-job resource
-factories and resolver/CLI/Web binding, vector source building, and graph source
-building remain absent.
+factory and resolver wiring is described below; production CLI/Web binding,
+vector source building, and graph source building remain absent.
 
 The compiler-cache bridge now also has a resource-scoped resolver seam. It
 attests the canonical running request before opening attempt resources, accepts
@@ -1315,6 +1315,21 @@ cleanup is promoted to a storage-integrity failure with a retryable owner. The
 factory rechecks cooperative stop state around cache selection and source
 capture and fails before workspace/CAS work when the current source revision no
 longer matches the job.
+
+The retained-source BM25 bridge now has the matching resource-scoped resolver
+and trusted local target factory. Each source target freezes the exact builder
+profile, display commit, environment, repository identity/root, and private
+workspace provider. Its pre-claim filter accepts only that target's single
+required `full` BM25 profile. Scope declaration is side-effect free; entry
+authenticates lexical and physical repository/workspace separation before
+source capture, binds the worker's exact retained object store, recaptures the
+current dirty fingerprint, and creates fresh nonce-scoped attempt, BM25, and
+context destinations. Ordered exit closes source and receipt authorities and
+isolates only their receipt-owned trees for quiescent GC. A changed source
+fails before build or CAS mutation, and worker integration coverage proves the
+previous published ref remains unchanged. This is still a library binding: no
+production CLI, Web planner, runtime refresh trigger, or default route selects
+it yet.
 
 The production CLI binding exposes that target as `codenib jobs run-once` and
 `codenib jobs run`. Both freeze the same existing-only repository/cache/catalog/
@@ -1345,8 +1360,9 @@ their prepare-only worker bridge, are implemented. The first caller-scoped
 retained-source BM25 builder and its prepare-only source-job adapter now publish
 and ingest a unique private generation under an exact retained parent and
 generation receipt, without final publication authority or a cache-path reopen;
-vector and graph source builders, generic builder routing, source-job resource
-wiring, and remaining runtime wiring remain.
+its local attempt resource factory and resolver are implemented. Vector and
+graph source builders, generic builder routing, production source-job entry
+points, and remaining runtime wiring remain.
 
 - Make every builder write to a unique staging generation.
 - Add per-view profile adapters that fail closed on incomplete compatibility
@@ -1372,20 +1388,19 @@ implemented and verified with file-backed SQLite integration coverage. An
 explicit one-view compiler-cache executor now supplies parser-inert BM25 or
 schema-8 vector artifacts without catalog authority, and the first
 retained-source BM25 executor now prepares the same artifact closure from
-authenticated source bytes. The compiler-cache executor's resource-scoped
-resolver and trusted local target factory guarantee attempt-local cleanup,
-same-store binding, and exact configured repository/source identity, while the
-explicit CLI can run one bounded pass or a cursor-fair continuous scheduler
-over the current cache. The source executor intentionally has no resolver or
-resource factory yet. The Web registry now prepares a complete replacement
+authenticated source bytes. Both executor paths now have resource-scoped
+resolvers and trusted local target factories that guarantee attempt-local
+cleanup, same-store binding, and exact configured repository/source identity.
+The explicit CLI can run one bounded pass or a cursor-fair continuous scheduler
+over the current compiler cache; it does not yet select the source builder. The
+Web registry now prepares a complete replacement
 bundle before atomically publishing it, pins the exact generation for each
 in-flight request, defers old vector/source cleanup until the final pin exits,
 and invalidates bundle-bound Wiki, edge-label, and commit-window caches by
 generation identity.
 The first #266 status, durable-read, and explicitly injected one-view write
-slices are present; remaining source-job adapters and resource wiring, a
-production Web planner/default binding, success-triggered refresh, MCP, UI
-controls, and default routing remain absent.
+slices are present; a production source-job CLI and Web planner/default binding,
+success-triggered refresh, MCP, UI controls, and default routing remain absent.
 
 - The backend-neutral worker now owns advisory scan/claim, per-attempt task
   authority, independent heartbeat sessions, cancellation precedence, bounded
@@ -1433,13 +1448,13 @@ controls, and default routing remain absent.
   final fenced heartbeat, and then publishes before releasing receipt
   retention. Slow object hashing therefore cannot expire an otherwise healthy
   worker and force a duplicate attempt.
-- Extend the implemented prepare-only retained-source BM25 adapter with an
-  attempt resource factory/resolver, then add vector and graph source adapters
-  and wire successful worker results into runtime, Web, MCP, and default routes.
-  The trusted local factory and continuous CLI can currently recapture only an
-  already-current single BM25 or vector cache view under the worker, while the
-  older self-publishing ingress APIs remain compatibility paths and are never
-  nested inside the worker.
+- The retained-source BM25 attempt resource factory/resolver is implemented;
+  add its production worker entry, then add vector and graph source adapters and
+  wire successful worker results into runtime, Web, MCP, and default routes.
+  The existing continuous CLI still selects only the trusted local
+  compiler-cache factory and can recapture an already-current single BM25 or
+  vector cache view. Older self-publishing ingress APIs remain compatibility
+  paths and are never nested inside the worker.
 - Complete the #266 job and update APIs with accurate incremental versus rebuild
   behavior; the first read-only status slice is described below.
 - `RepoRegistry.load_all()` now reconciles each complete registry snapshot,

--- a/test/compiler/test_source_job.py
+++ b/test/compiler/test_source_job.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 
 import builtins
 import inspect
+import json
 import os
 import threading
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -15,12 +17,22 @@ import pytest
 
 import codenib.compiler as compiler_module
 import codenib.compiler.cache_import as cache_import_module
+import codenib.compiler.job_resources as job_resources_module
 import codenib.compiler.source_job as source_job_module
 from codenib import LocalWorkspaceProvider
 from codenib._captured_directory import PublishedWorkspaceReceiptOwner
 from codenib.code_chunker import CodeChunker
 from codenib.code_chunking.base import BaseCodeChunker
 from codenib.compiler.index_builders import BM25IndexBuilder
+from codenib.compiler.job_resolver import (
+    BM25SourceJobResolver,
+    BM25SourceJobResourceFactory,
+    BM25SourceJobResourceScope,
+)
+from codenib.compiler.job_resources import (
+    LocalBM25SourceJobResourceFactory,
+    LocalBM25SourceJobTarget,
+)
 from codenib.compiler.manifest import RepoManifest
 from codenib.compiler.manifest_storage import BM25_PROFILE_AXES
 from codenib.compiler.source_job import BM25SourceJobExecutor, bm25_source_job_profile
@@ -36,9 +48,12 @@ from codenib.storage import (
     IndexJobExecutionResult,
     IndexJobStatus,
     IndexJobStopReason,
+    IndexJobWorker,
+    IndexJobWorkerDisposition,
     LocalCAS,
     SourceRevision,
     SQLiteCatalog,
+    StorageIntegrityError,
     StorageValidationError,
     ViewProfile,
 )
@@ -1371,3 +1386,508 @@ def test_bm25_source_executor_rejects_noncanonical_display_commit(
     with pytest.raises(StorageValidationError, match="full lowercase Git SHA"):
         BM25SourceJobExecutor(**parameters)  # type: ignore[arg-type]
     assert not attempt.exists()
+
+
+def test_local_bm25_source_job_factory_runs_worker_and_cleans_attempt(
+    tmp_path: Path,
+) -> None:
+    builder = BM25IndexBuilder(languages=["python"], max_k=17)
+    profile = bm25_source_job_profile(builder)
+    fixture = _source_fixture(tmp_path)
+    catalog_path = tmp_path / "catalog.sqlite"
+    environment = {"CODENIB_SOURCE_RESOURCE_TEST": "before"}
+    target = LocalBM25SourceJobTarget(
+        repository_root=fixture.repository,
+        workspace_provider=fixture.provider,
+        repository_key=_REPOSITORY_KEY,
+        display_commit=_COMMIT,
+        builder=builder,
+        environ=environment,
+    )
+    assert target.profile_id == profile.profile_id
+    assert target.environ == environment
+
+    builder.languages[:] = ["javascript"]
+    builder.max_k = 99
+    builder.source_selection = RepositorySourceSelection(("sample.py",))
+    environment["CODENIB_SOURCE_RESOURCE_TEST"] = "after"
+
+    try:
+        with SQLiteCatalog(catalog_path) as catalog:
+            repository_id = catalog.create_repository(_REPOSITORY_KEY)
+            assert repository_id == target.repository_id
+            source_revision_id = catalog.create_source_revision(
+                repository_id,
+                commit_sha=None,
+                dirty=True,
+                source_fingerprint=fixture.source.fingerprint,
+            )
+            profile_id = catalog.create_view_profile(
+                "bm25",
+                profile.config,
+                name=profile.name,
+            )
+            assert profile_id == target.profile_id
+            queued = catalog.create_job(
+                repository_id,
+                source_revision_id,
+                "local-bm25-source-worker",
+                {
+                    "contract": INDEX_JOB_REQUEST_CONTRACT,
+                    "views": {
+                        "bm25": {
+                            "profile_id": profile_id,
+                            "requested_mode": "full",
+                            "required": True,
+                        }
+                    },
+                },
+            )
+
+        with LocalCAS(tmp_path / "cas") as cas:
+            resources = LocalBM25SourceJobResourceFactory((target,))
+            assert resources.accepts_candidate(queued)
+            worker = IndexJobWorker(
+                catalog_factory=lambda: SQLiteCatalog(catalog_path, create=False),
+                object_store=cas,
+                resolver=BM25SourceJobResolver(
+                    resource_factory=resources,
+                    object_store=cas,
+                ),
+                candidate_filter=resources.accepts_candidate,
+                lease_duration_ms=60_000,
+                heartbeat_interval_ms=5,
+                owner_id_factory=lambda: "local-bm25-source-worker",
+            )
+
+            outcome = worker.run_once()
+
+            assert outcome.disposition is IndexJobWorkerDisposition.SUCCEEDED
+            assert outcome.job_id == queued.job_id
+            assert not tuple(fixture.workspace.glob(".codenib-source-job-*"))
+            orphans = tuple(fixture.workspace.glob(".*.discarded-*"))
+            assert len(orphans) == 3
+            assert all(orphan.is_dir() for orphan in orphans)
+            with SQLiteCatalog(catalog_path, create=False) as catalog:
+                completed = catalog.get_job(queued.job_id)
+                assert completed.status is IndexJobStatus.SUCCEEDED
+                assert completed.result_snapshot_id is not None
+                events = catalog.list_job_events(queued.job_id)
+                assert any(
+                    json.loads(event.payload_json).get("adapter") == "bm25_source"
+                    for event in events
+                )
+    finally:
+        fixture.close()
+
+
+def test_local_bm25_source_worker_preserves_current_ref_after_source_changes(
+    tmp_path: Path,
+) -> None:
+    builder = BM25IndexBuilder(languages=["python"])
+    profile = bm25_source_job_profile(builder)
+    fixture = _source_fixture(tmp_path)
+    catalog_path = tmp_path / "catalog.sqlite"
+    target = LocalBM25SourceJobTarget(
+        repository_root=fixture.repository,
+        workspace_provider=fixture.provider,
+        repository_key=_REPOSITORY_KEY,
+        display_commit=_COMMIT,
+        builder=builder,
+        environ={},
+    )
+    request = {
+        "contract": INDEX_JOB_REQUEST_CONTRACT,
+        "views": {
+            "bm25": {
+                "profile_id": profile.profile_id,
+                "requested_mode": "full",
+                "required": True,
+            }
+        },
+    }
+    try:
+        with SQLiteCatalog(catalog_path) as catalog:
+            repository_id = catalog.create_repository(_REPOSITORY_KEY)
+            source_revision_id = catalog.create_source_revision(
+                repository_id,
+                commit_sha=None,
+                dirty=True,
+                source_fingerprint=fixture.source.fingerprint,
+            )
+            assert (
+                catalog.create_view_profile(
+                    "bm25",
+                    profile.config,
+                    name=profile.name,
+                )
+                == profile.profile_id
+            )
+            first = catalog.create_job(
+                repository_id,
+                source_revision_id,
+                "source-before-mutation",
+                request,
+                max_attempts=1,
+            )
+
+        with LocalCAS(tmp_path / "cas") as cas:
+            resources = LocalBM25SourceJobResourceFactory((target,))
+            worker = IndexJobWorker(
+                catalog_factory=lambda: SQLiteCatalog(catalog_path, create=False),
+                object_store=cas,
+                resolver=BM25SourceJobResolver(
+                    resource_factory=resources,
+                    object_store=cas,
+                ),
+                candidate_filter=resources.accepts_candidate,
+                lease_duration_ms=60_000,
+                heartbeat_interval_ms=5,
+                owner_id_factory=lambda: "local-bm25-source-worker",
+            )
+
+            first_outcome = worker.run_once()
+
+            assert first_outcome.disposition is IndexJobWorkerDisposition.SUCCEEDED
+            assert first_outcome.job_id == first.job_id
+            with SQLiteCatalog(catalog_path, create=False) as catalog:
+                preserved_ref = catalog.resolve_ref(repository_id)
+                stale = catalog.create_job(
+                    repository_id,
+                    source_revision_id,
+                    "source-after-mutation",
+                    request,
+                    expected_ref_generation=preserved_ref["generation"],
+                    max_attempts=1,
+                )
+            orphans_before = frozenset(fixture.workspace.glob(".*.discarded-*"))
+            (fixture.repository / "sample.py").write_text(
+                "def answer():\n    return 43\n",
+                encoding="utf-8",
+            )
+
+            stale_outcome = worker.run_once()
+
+            assert stale_outcome.disposition is IndexJobWorkerDisposition.FAILED
+            assert stale_outcome.job_id == stale.job_id
+            assert not tuple(fixture.workspace.glob(".codenib-source-job-*"))
+            assert frozenset(fixture.workspace.glob(".*.discarded-*")) == orphans_before
+            with SQLiteCatalog(catalog_path, create=False) as catalog:
+                failed = catalog.get_job(stale.job_id)
+                assert failed.status is IndexJobStatus.FAILED
+                assert failed.error_code == "worker_executor_failed"
+                assert failed.result_snapshot_id is None
+                assert catalog.resolve_ref(repository_id) == preserved_ref
+    finally:
+        fixture.close()
+
+
+def test_bm25_source_resource_types_are_lazy_public_exports() -> None:
+    assert compiler_module.BM25SourceJobResolver is BM25SourceJobResolver
+    assert compiler_module.BM25SourceJobResourceFactory is BM25SourceJobResourceFactory
+    assert compiler_module.BM25SourceJobResourceScope is BM25SourceJobResourceScope
+    assert (
+        compiler_module.LocalBM25SourceJobResourceFactory
+        is LocalBM25SourceJobResourceFactory
+    )
+    assert compiler_module.LocalBM25SourceJobTarget is LocalBM25SourceJobTarget
+
+
+@pytest.mark.parametrize(
+    ("case", "expected"),
+    [
+        ("matching", True),
+        ("profile", False),
+        ("incremental", False),
+        ("optional", False),
+        ("vector", False),
+        ("multi-view", False),
+        ("foreign", False),
+    ],
+)
+def test_local_bm25_source_candidate_filter_requires_exact_target(
+    tmp_path: Path,
+    case: str,
+    expected: bool,
+) -> None:
+    builder = BM25IndexBuilder(max_k=17)
+    profile = bm25_source_job_profile(builder)
+    fixture = _source_fixture(tmp_path)
+    target = LocalBM25SourceJobTarget(
+        repository_root=fixture.repository,
+        workspace_provider=fixture.provider,
+        repository_key=_REPOSITORY_KEY,
+        display_commit=_COMMIT,
+        builder=builder,
+        environ={},
+    )
+    try:
+        with SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog:
+            repository_id = catalog.create_repository(
+                "owner/foreign" if case == "foreign" else _REPOSITORY_KEY
+            )
+            source_revision_id = catalog.create_source_revision(
+                repository_id,
+                commit_sha=None,
+                dirty=True,
+                source_fingerprint=fixture.source.fingerprint,
+            )
+            requested_profile = (
+                bm25_source_job_profile(BM25IndexBuilder(max_k=18))
+                if case == "profile"
+                else profile
+            )
+            profile_id = catalog.create_view_profile(
+                "bm25",
+                requested_profile.config,
+                name=requested_profile.name,
+            )
+            view_type = "vector" if case == "vector" else "bm25"
+            if view_type == "vector":
+                profile_id = catalog.create_view_profile(
+                    "vector",
+                    {"fixture": True},
+                )
+            views: dict[str, dict[str, object]] = {
+                view_type: {
+                    "profile_id": profile_id,
+                    "requested_mode": (
+                        "incremental" if case == "incremental" else "full"
+                    ),
+                    "required": case != "optional",
+                }
+            }
+            if case == "multi-view":
+                views["vector"] = {
+                    "profile_id": catalog.create_view_profile(
+                        "vector",
+                        {"fixture": "multi"},
+                    ),
+                    "requested_mode": "full",
+                    "required": True,
+                }
+            queued = catalog.create_job(
+                repository_id,
+                source_revision_id,
+                f"source-candidate-{case}",
+                {"contract": INDEX_JOB_REQUEST_CONTRACT, "views": views},
+            )
+
+        resources = LocalBM25SourceJobResourceFactory((target,))
+        assert resources.accepts_candidate(queued) is expected
+    finally:
+        fixture.close()
+
+
+def test_local_bm25_source_scope_is_side_effect_free_until_enter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    target = LocalBM25SourceJobTarget(
+        repository_root=fixture.repository,
+        workspace_provider=fixture.provider,
+        repository_key=_REPOSITORY_KEY,
+        display_commit=_COMMIT,
+        builder=builder,
+        environ={},
+    )
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+            monkeypatch.setattr(
+                job_resources_module,
+                "capture_repository_source",
+                lambda *_args, **_kwargs: pytest.fail(
+                    "source authority was acquired while declaring the scope"
+                ),
+            )
+
+            scope = resources.create_scope(context, object_store=cas)
+
+            assert type(scope) is BM25SourceJobResourceScope
+            assert scope.object_store is cas
+            assert not tuple(fixture.workspace.iterdir())
+    finally:
+        fixture.close()
+
+
+def test_bm25_source_scope_cleanup_cannot_replace_executor_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    view_owner = PublishedWorkspaceReceiptOwner()
+    context_owner = PublishedWorkspaceReceiptOwner()
+    primary = StorageIntegrityError("primary BM25 source failure")
+    cleanup = OSError("injected BM25 source cleanup failure")
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            executor = _executor(
+                fixture,
+                cas,
+                builder,
+                attempt_generation=tmp_path / "attempt",
+                view_owner=view_owner,
+                context_owner=context_owner,
+            )
+
+            @contextmanager
+            def failing_cleanup():
+                try:
+                    yield executor
+                finally:
+                    raise cleanup
+
+            class FailingCleanupFactory:
+                def create_scope(self, attempt_context, *, object_store):
+                    assert attempt_context is context
+                    assert object_store is cas
+                    return BM25SourceJobResourceScope(
+                        object_store=cas,
+                        resources=failing_cleanup(),
+                    )
+
+            def fail_execute(*_args, **_kwargs):
+                raise primary
+
+            monkeypatch.setattr(
+                BM25SourceJobExecutor,
+                "execute",
+                fail_execute,
+            )
+            resolved = BM25SourceJobResolver(
+                resource_factory=FailingCleanupFactory(),
+                object_store=cas,
+            ).resolve(context.job, context.views)
+
+            with pytest.raises(StorageIntegrityError) as caught:
+                resolved.execute(context)
+
+            assert caught.value is primary
+            assert any(
+                "BM25 source resource cleanup also failed: OSError" in note
+                for note in getattr(primary, "__notes__", ())
+            )
+    finally:
+        context_owner.close()
+        view_owner.close()
+        fixture.close()
+
+
+def test_local_bm25_source_scope_rejects_physical_workspace_overlap_before_capture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    physical_workspace = fixture.repository / "physical-workspace"
+    physical_workspace.mkdir(mode=0o700)
+    workspace_alias = tmp_path / "workspace-alias"
+    workspace_alias.symlink_to(fixture.repository, target_is_directory=True)
+    target = LocalBM25SourceJobTarget(
+        repository_root=fixture.repository,
+        workspace_provider=LocalWorkspaceProvider(
+            workspace_alias / physical_workspace.name
+        ),
+        repository_key=_REPOSITORY_KEY,
+        display_commit=_COMMIT,
+        builder=builder,
+        environ={},
+    )
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+            monkeypatch.setattr(
+                job_resources_module,
+                "capture_repository_source",
+                lambda *_args, **_kwargs: pytest.fail(
+                    "source capture ran before physical topology validation"
+                ),
+            )
+
+            scope = resources.create_scope(context, object_store=cas)
+
+            with pytest.raises(
+                ValueError,
+                match="physical workspace and repository must not overlap",
+            ):
+                with scope.resources:
+                    pass
+            assert not tuple(physical_workspace.iterdir())
+    finally:
+        fixture.close()
+
+
+def test_bm25_source_resolver_rejects_foreign_scope_store_before_enter(
+    tmp_path: Path,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    entered = False
+    try:
+        with (
+            LocalCAS(tmp_path / "worker-cas") as worker_store,
+            LocalCAS(tmp_path / "foreign-cas") as foreign_store,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+
+            @contextmanager
+            def unexpected_resources():
+                nonlocal entered
+                entered = True
+                raise AssertionError("foreign resource scope was entered")
+                yield  # pragma: no cover
+
+            class ForeignStoreFactory:
+                def create_scope(self, attempt_context, *, object_store):
+                    assert attempt_context is context
+                    assert object_store is worker_store
+                    return BM25SourceJobResourceScope(
+                        object_store=foreign_store,
+                        resources=unexpected_resources(),
+                    )
+
+            resolved = BM25SourceJobResolver(
+                resource_factory=ForeignStoreFactory(),
+                object_store=worker_store,
+            ).resolve(context.job, context.views)
+
+            with pytest.raises(StorageIntegrityError, match="resolver object store"):
+                resolved.execute(context)
+
+            assert entered is False
+            assert not tuple(fixture.workspace.iterdir())
+    finally:
+        fixture.close()


### PR DESCRIPTION
## Summary

Add the production-shaped resolver and explicit local resource factory that let the durable worker build one FULL BM25 view from retained repository source without granting the adapter catalog publication authority. Advances #199.

## Changes

- add a side-effect-free BM25 source resource scope and resolver with exact request, executor, and object-store identity checks
- freeze trusted local repository, builder profile, environment, display provenance, and workspace bindings before a worker attempt
- capture and re-attest the dirty source revision before any build or CAS mutation
- create fresh nonce-scoped attempt, BM25, and context authorities and settle them in ordered cleanup
- reject lexical or physical repository/workspace overlap and preserve primary execution failures across cleanup failures
- add end-to-end worker success, stale-source/ref-preservation, candidate-filter, authority, topology, and cleanup tests
- update `docs/storage_backend_roadmap.md` with the completed resolver/factory milestone and remaining CLI/Web/runtime gates

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `pre-commit run --files codenib/compiler/__init__.py codenib/compiler/job_resolver.py codenib/compiler/job_resources.py docs/storage_backend_roadmap.md test/compiler/test_source_job.py`
- `pytest -q test/compiler/test_source_job.py test/test_lazy_imports.py --tb=short` (51 passed)
- `pytest -q test/compiler/test_cache_import.py --tb=short` (118 passed)
- unit tier excluding three documented local baseline cases (8467 passed, 35 skipped, 193 deselected)
- excluded local baselines: one Web caplog capture case and two filesystem same-tick CAS ctime cases

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published