### PR TITLE
feat(storage): retain owned path build authority

### DIFF
--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -3082,6 +3082,7 @@ def _open_posix_publication_authority(
     parent_resource: int | None,
     expected_parent_identity: tuple[int, ...] | None,
     create_missing: bool = False,
+    missing_parent_mode: int = 0o755,
     authority_owner: _PublicationAuthorityOwner | None = None,
 ) -> _PublicationAuthority:
     if not _SAFE_OWNERSHIP_DIRECTORY_FDS:
@@ -3112,7 +3113,11 @@ def _open_posix_publication_authority(
                 if not create_missing:
                     raise
                 try:
-                    os.mkdir(part, mode=0o755, dir_fd=path_descriptor)
+                    os.mkdir(
+                        part,
+                        mode=missing_parent_mode,
+                        dir_fd=path_descriptor,
+                    )
                 except FileExistsError as exc:
                     raise RuntimeError(
                         "publication parent appeared while it was created"
@@ -3334,6 +3339,7 @@ def _open_publication_authority(
     parent_resource: int | None,
     expected_parent_identity: tuple[int, ...] | None,
     create_missing: bool = False,
+    missing_parent_mode: int = 0o755,
     authority_owner: _PublicationAuthorityOwner | None = None,
 ) -> _PublicationAuthority:
     """Open a platform authority before any namespace mutation."""
@@ -3345,6 +3351,7 @@ def _open_publication_authority(
             parent_resource=parent_resource,
             expected_parent_identity=expected_parent_identity,
             create_missing=create_missing,
+            missing_parent_mode=missing_parent_mode,
             authority_owner=authority_owner,
         )
     if sys.platform == "win32":
@@ -7180,6 +7187,305 @@ def reopen_authenticated_directory(
                 ),
             ),
         )
+
+
+class _OwnedDirectoryIsolationOwner:
+    """Persist a planned orphan name across every rename handoff seam."""
+
+    __slots__ = (
+        "authority",
+        "path",
+        "ownership",
+        "_candidate",
+        "_orphan",
+        "_pid",
+    )
+
+    def __init__(
+        self,
+        authority: _PublicationAuthority,
+        path: Path,
+        ownership: _TreeOwnership,
+    ) -> None:
+        if not isinstance(authority, _PublicationAuthority):
+            raise TypeError("authority must be a publication authority")
+        if not isinstance(ownership, _TreeOwnership):
+            raise TypeError("ownership must be a captured directory ownership token")
+        lexical = lexical_directory_path(path)
+        if lexical.parent != authority.display_parent:
+            raise ValueError("owned temporary directory uses another parent authority")
+        self.authority = authority
+        self.path = lexical
+        self.ownership = ownership
+        self._candidate: Path | None = None
+        self._orphan: DirectoryOrphan | None = None
+        self._pid = os.getpid()
+
+    @property
+    def orphan(self) -> DirectoryOrphan | None:
+        return self._orphan
+
+    @property
+    def closed(self) -> bool:
+        return self._orphan is not None
+
+    def _require_process(self) -> None:
+        if self._pid != os.getpid():
+            raise RuntimeError(
+                "owned directory isolation cannot cross a process boundary"
+            )
+
+    def _metadata(self, path: Path, *, label: str) -> object | None:
+        return _directory_or_missing_at(
+            self.authority,
+            path.name,
+            path=path,
+            label=label,
+        )
+
+    def _is_exact_root(self, metadata: object | None) -> bool:
+        return metadata is not None and (
+            _directory_inode_identity(metadata) == self.ownership.root_identity
+        )
+
+    def _require_exact_tree(
+        self,
+        path: Path,
+        *,
+        label: str,
+        allow_root_rename: bool = False,
+    ) -> None:
+        _require_tree_ownership_at(
+            self.authority,
+            path.name,
+            path=path,
+            expected=self.ownership,
+            label=label,
+            allow_root_rename=allow_root_rename,
+        )
+
+    def _install_orphan(
+        self,
+        candidate: Path,
+        *,
+        verified_at_isolation: bool = True,
+    ) -> DirectoryOrphan:
+        orphan = _orphan_metadata(
+            self.authority,
+            candidate,
+            self.ownership,
+            verified_at_isolation=verified_at_isolation,
+        )
+        self._orphan = orphan
+        return orphan
+
+    def _capture_matching_tree(
+        self,
+        path: Path,
+        *,
+        label: str,
+    ) -> _TreeOwnership:
+        observed = self.authority.capture_child(
+            path.name,
+            path=path,
+            label=label,
+        )
+        _require_matching_ownership(
+            observed,
+            self.ownership,
+            label=label,
+            allow_root_rename=True,
+        )
+        return observed
+
+    def _adopt_restored_source(self) -> bool:
+        """Rebind a restored source whose directory version changed on rename."""
+
+        try:
+            metadata = self._metadata(
+                self.path,
+                label="restored owned temporary directory",
+            )
+            if not self._is_exact_root(metadata):
+                return False
+            observed = self._capture_matching_tree(
+                self.path,
+                label="restored owned temporary directory",
+            )
+        except (OSError, RuntimeError, ValueError):
+            return False
+        self.ownership = observed
+        self._candidate = None
+        self._orphan = None
+        return True
+
+    def _retain_verified_candidate(self, candidate: Path) -> DirectoryOrphan | None:
+        """Keep a candidate only after freshly authenticating its complete tree."""
+
+        try:
+            metadata = self._metadata(
+                candidate,
+                label="retained directory orphan",
+            )
+            if not self._is_exact_root(metadata):
+                return None
+            observed = self._capture_matching_tree(
+                candidate,
+                label="retained directory orphan",
+            )
+            self.ownership = observed
+            return self._install_orphan(candidate)
+        except (OSError, RuntimeError, ValueError):
+            return None
+
+    def _restore_or_retain_unverified(self, candidate: Path) -> DirectoryOrphan | None:
+        try:
+            self.authority.rename_noreplace(candidate.name, self.path.name)
+        except (OSError, RuntimeError):
+            # A backend error can be observed after the rename committed.  Do
+            # not mint a receipt for the old candidate name until namespace
+            # state has been reconciled through the retained authority.
+            pass
+        if self._adopt_restored_source():
+            return None
+        return self._retain_verified_candidate(candidate)
+
+    def isolate(self) -> DirectoryOrphan | None:
+        """Reconcile or perform one no-replace move into the retained name."""
+
+        self._require_process()
+        if self._orphan is not None:
+            return self._orphan
+        for _attempt in range(_MAX_ORPHAN_NAME_ATTEMPTS * 2):
+            candidate = self._candidate
+            try:
+                source_metadata = self._metadata(
+                    self.path,
+                    label="owned temporary directory",
+                )
+                source_is_exact = self._is_exact_root(source_metadata)
+                if candidate is not None:
+                    try:
+                        candidate_metadata = self._metadata(
+                            candidate,
+                            label="discarded directory orphan",
+                        )
+                    except ValueError:
+                        if not source_is_exact:
+                            return None
+                        if self._adopt_restored_source():
+                            continue
+                        return None
+                    if self._is_exact_root(candidate_metadata):
+                        try:
+                            self._require_exact_tree(
+                                candidate,
+                                label="moved destination",
+                                allow_root_rename=True,
+                            )
+                            return self._install_orphan(candidate)
+                        except (OSError, RuntimeError, ValueError):
+                            return self._restore_or_retain_unverified(candidate)
+                    if source_is_exact:
+                        if self._adopt_restored_source():
+                            continue
+                        return None
+                    return None
+                elif not source_is_exact:
+                    return None
+
+                try:
+                    self._require_exact_tree(
+                        self.path,
+                        label="owned temporary directory",
+                    )
+                except (OSError, RuntimeError, ValueError):
+                    return None
+                if candidate is None:
+                    candidate = _random_orphan_path(
+                        display_parent=self.path.parent,
+                        destination_name=self.path.name,
+                        purpose="discarded",
+                    )
+                    # Publish the candidate before the only destructive call.
+                    self._candidate = candidate
+                try:
+                    self.authority.rename_noreplace(
+                        self.path.name,
+                        candidate.name,
+                    )
+                except FileExistsError:
+                    # Reconcile whether this was a collision or an injected
+                    # post-commit exception translated by a backend seam.
+                    continue
+                # Re-enter through observed namespace state.  An asynchronous
+                # exception before this back-edge still leaves ``_candidate``
+                # sufficient for an explicit retry.
+                continue
+            except (OSError, RuntimeError, ValueError):
+                return None
+        raise RuntimeError("could not claim directory under a bounded orphan name")
+
+    def verify_orphan(self) -> DirectoryOrphan:
+        """Revalidate the exact moved child before releasing its authority."""
+
+        self._require_process()
+        orphan = self._orphan
+        candidate = self._candidate
+        if orphan is None or candidate is None:
+            raise RuntimeError("owned directory isolation has no retained orphan")
+        locator = orphan.locator
+        if (
+            orphan.path != candidate
+            or locator.parent_path != self.authority.display_parent
+            or locator.child_name != candidate.name
+            or locator.backend_tag != self.authority.backend_tag
+            or locator.parent_identity != self.authority.identity
+        ):
+            raise RuntimeError("owned directory orphan binding changed")
+        _require_matching_ownership(
+            locator.ownership,
+            self.ownership,
+            label="retained directory orphan",
+            allow_root_rename=True,
+        )
+        self.authority.verify_path_binding()
+        self._require_exact_tree(
+            candidate,
+            label="retained directory orphan",
+            allow_root_rename=True,
+        )
+        self.authority.verify_path_binding()
+        return orphan
+
+    def close(self) -> None:
+        if self.isolate() is None:
+            raise RuntimeError("owned directory could not be isolated")
+
+
+def _discard_owned_directory_with_authority(
+    authority: _PublicationAuthority,
+    path: Path,
+    ownership: _TreeOwnership,
+    *,
+    isolation_owner: _OwnedDirectoryIsolationOwner | None = None,
+) -> DirectoryOrphan | None:
+    """Isolate one exact tree through an already-retained parent authority."""
+
+    owner = (
+        _OwnedDirectoryIsolationOwner(authority, path, ownership)
+        if isolation_owner is None
+        else isolation_owner
+    )
+    if not isinstance(owner, _OwnedDirectoryIsolationOwner):
+        raise TypeError("isolation_owner must own a directory isolation")
+    if (
+        owner.authority is not authority
+        or owner.path != lexical_directory_path(path)
+        or owner.ownership != ownership
+    ):
+        raise ValueError("directory isolation owner binding does not match")
+    return owner.isolate()
 
 
 def discard_owned_directory(

--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -18,7 +18,8 @@ import sys
 from contextlib import contextmanager
 from dataclasses import InitVar, dataclass
 from pathlib import Path, PurePosixPath
-from typing import Callable, Iterable, Iterator, Mapping, Sequence, TypeVar
+from threading import RLock
+from typing import Callable, Iterable, Iterator, Mapping, Sequence, TypeVar, final
 
 try:
     import fcntl as _fcntl
@@ -37,9 +38,13 @@ from ._atomic_directory import (
     _adopt_native_posix_replacement_authority,
     _annotate_secondary_error,
     _capture_posix_directory_descriptor,
+    _discard_owned_directory_with_authority,
     _NativeReplacementPublication,
     _open_publication_authority,
+    _OrderedAction,
+    _OwnedDirectoryIsolationOwner,
     _PosixResourceOwner,
+    _publication_authority_owner_released,
     _PublicationAuthority,
     _PublicationAuthorityOwner,
     _publish_native_replacement_with_authority,
@@ -47,6 +52,8 @@ from ._atomic_directory import (
     _rename_noreplace_at,
     _require_matching_ownership,
     _require_rename_noreplace_platform,
+    _run_context_with_cleanup_actions,
+    _simple_child_name,
     _TreeOwnership,
     _validate_ownership_inventory_budget,
     directory_ownership_entry_identities,
@@ -5148,13 +5155,15 @@ class OwnedDirectoryStage:
         *,
         _parent_authority: _PublicationAuthority | None = None,
         _expected_destination_ownership: object = _UNSET_DESTINATION_OWNERSHIP,
+        _construction_owner: object | None = None,
     ) -> None:
         self.destination = lexical_directory_path(destination)
-        self.path = self.destination.parent / (
-            f".{self.destination.name}.normalize-{secrets.token_hex(12)}"
+        self.path = self.destination.parent / _owned_directory_stage_name(
+            self.destination.name,
         )
-        self._stage_parent_fd = -1
-        self._descriptor = -1
+        self._resources = _PosixResourceOwner()
+        self._stage_parent_record = None
+        self._root_record = None
         self._parent_authority = _parent_authority
         self._has_expected_destination_ownership = (
             _expected_destination_ownership is not _UNSET_DESTINATION_OWNERSHIP
@@ -5166,10 +5175,17 @@ class OwnedDirectoryStage:
             str,
             tuple[tuple[int, ...], int, int, str],
         ] = {}
+        self._initial = None
+        self._stage_identity: tuple[int, ...] | None = None
+        self._creation_confirmed_identity: tuple[int, ...] | None = None
         self._cleanup_ownership = None
+        if _construction_owner is not None:
+            install = getattr(_construction_owner, "_install_stage", None)
+            if not callable(install):
+                raise TypeError("owned stage construction owner is invalid")
+            install(self)
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
         flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
-        created = False
         try:
             if self._parent_authority is None:
                 self._parent_authority = _open_publication_authority(
@@ -5177,19 +5193,29 @@ class OwnedDirectoryStage:
                     parent_resource=None,
                     expected_parent_identity=None,
                 )
-            self._stage_parent_fd = os.dup(self._parent_authority.resource)
+            stage_parent_fd = self._resources.duplicate(self._parent_authority.resource)
+            self._stage_parent_record = self._resources.record_for_cleanup(
+                stage_parent_fd
+            )
             self._parent_identity = self._parent_authority.identity
+            existing = self._parent_authority.child_metadata(
+                self.path.name,
+                path=self.path,
+                label="owned stage",
+            )
+            if existing is not None:
+                raise FileExistsError(f"owned stage already exists: {self.path}")
             os.mkdir(
                 self.path.name,
                 mode=0o700,
-                dir_fd=self._stage_parent_fd,
+                dir_fd=stage_parent_fd,
             )
-            created = True
             created_metadata = os.stat(
                 self.path.name,
-                dir_fd=self._stage_parent_fd,
+                dir_fd=stage_parent_fd,
                 follow_symlinks=False,
             )
+            self._creation_confirmed_identity = _root_identity(created_metadata)
             try:
                 self._initial = self._parent_authority.capture_child(
                     self.path.name,
@@ -5201,12 +5227,13 @@ class OwnedDirectoryStage:
                 raise RuntimeError(
                     "owned stage root changed during initialization"
                 ) from exc
-            self._descriptor = os.open(
+            descriptor = self._resources.open(
                 self.path.name,
                 flags,
-                dir_fd=self._stage_parent_fd,
+                dir_fd=stage_parent_fd,
             )
-            opened = os.fstat(self._descriptor)
+            self._root_record = self._resources.record_for_cleanup(descriptor)
+            opened = os.fstat(descriptor)
             if (
                 _root_identity(created_metadata) != _root_identity(opened)
                 or _root_identity(opened)
@@ -5218,13 +5245,28 @@ class OwnedDirectoryStage:
             self._stage_identity = _root_identity(opened)
             self._cleanup_ownership = self._initial
             self._verify_parent_path()
-        except BaseException:
-            self.close()
-            # A created but unverified stage is intentionally left as an
-            # orphan; deleting by name could remove a raced foreign object.
-            if not created:
-                self.path = self.destination.parent / self.path.name
+        except BaseException as primary_error:
+            if _construction_owner is None:
+                try:
+                    self.close()
+                except BaseException as close_error:  # noqa: B036 - keep first
+                    _annotate_secondary_error(
+                        primary_error,
+                        "owned stage initialization cleanup also failed",
+                        close_error,
+                    )
+                    _attach_cleanup_owner(primary_error, self)
             raise
+
+    @property
+    def _stage_parent_fd(self) -> int:
+        record = self._stage_parent_record
+        return -1 if record is None else record.descriptor
+
+    @property
+    def _descriptor(self) -> int:
+        record = self._root_record
+        return -1 if record is None else record.descriptor
 
     @classmethod
     def prepare(
@@ -5278,22 +5320,24 @@ class OwnedDirectoryStage:
             raise RuntimeError("owned stage did not capture its destination")
         return self._expected_destination_ownership
 
+    def _close_descriptors(self) -> None:
+        self._resources.close_all()
+
     def close(self) -> None:
-        if self._descriptor >= 0:
+        try:
+            self._close_descriptors()
+        except BaseException as exc:  # noqa: B036 - retain exact descriptor owner
+            _attach_cleanup_owner(exc, self)
+            raise
+        authority = self._parent_authority
+        if authority is not None:
             try:
-                os.close(self._descriptor)
-            except OSError:
-                pass
-            self._descriptor = -1
-        if self._stage_parent_fd >= 0:
-            try:
-                os.close(self._stage_parent_fd)
-            except OSError:
-                pass
-            self._stage_parent_fd = -1
-        if self._parent_authority is not None:
-            self._parent_authority.close()
-            self._parent_authority = None
+                authority.close()
+            except BaseException as exc:  # noqa: B036 - retain authority owner
+                _attach_cleanup_owner(exc, self)
+                raise
+            else:
+                self._parent_authority = None
 
     @staticmethod
     def _record_orphan(orphan: DirectoryOrphan | None, *, operation: str) -> None:
@@ -5320,10 +5364,11 @@ class OwnedDirectoryStage:
         return None
 
     def _verify_parent_path(self) -> None:
-        if self._stage_parent_fd < 0 or self._parent_authority is None:
+        stage_parent_fd = self._stage_parent_fd
+        if stage_parent_fd < 0 or self._parent_authority is None:
             raise RuntimeError("owned stage parent is closed")
         try:
-            opened = os.fstat(self._stage_parent_fd)
+            opened = os.fstat(stage_parent_fd)
             self._parent_authority.verify_path_binding()
         except OSError as exc:
             raise RuntimeError("owned stage parent changed") from exc
@@ -5331,13 +5376,15 @@ class OwnedDirectoryStage:
             raise RuntimeError("owned stage parent changed")
 
     def _verify_root_descriptor(self) -> None:
-        if self._descriptor < 0:
+        descriptor = self._descriptor
+        stage_parent_fd = self._stage_parent_fd
+        if descriptor < 0 or stage_parent_fd < 0:
             raise RuntimeError("owned stage is closed")
         try:
-            opened = os.fstat(self._descriptor)
+            opened = os.fstat(descriptor)
             path_metadata = os.stat(
                 self.path.name,
-                dir_fd=self._stage_parent_fd,
+                dir_fd=stage_parent_fd,
                 follow_symlinks=False,
             )
         except OSError as exc:
@@ -5573,11 +5620,911 @@ class OwnedDirectoryStage:
         return orphan
 
 
+def _require_owned_path_build_support() -> None:
+    """Fail before mutation when retained POSIX path building is unavailable."""
+
+    if not (sys.platform.startswith("linux") or sys.platform == "darwin"):
+        raise RuntimeError("owned path build directories are unsupported on this host")
+    if not _SAFE_OWNERSHIP_DIRECTORY_FDS:
+        raise RuntimeError(
+            "owned path build directories require no-follow directory-fd support"
+        )
+    if not callable(getattr(os, "geteuid", None)):
+        raise RuntimeError(
+            "owned path build directory ownership cannot be authenticated"
+        )
+    _require_rename_noreplace_platform()
+
+
+def _require_owned_build_directory(
+    descriptor: int,
+    *,
+    label: str,
+    private: bool,
+) -> None:
+    """Require one retained directory descriptor to be owner controlled."""
+
+    get_effective_uid = getattr(os, "geteuid", None)
+    if not callable(get_effective_uid):
+        raise RuntimeError(f"{label} ownership cannot be authenticated")
+    try:
+        metadata = os.fstat(descriptor)
+    except OSError as exc:
+        raise RuntimeError(f"{label} cannot be authenticated") from exc
+    mode = stat.S_IMODE(metadata.st_mode)
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != get_effective_uid()
+        or mode & 0o022
+        or mode & 0o700 != 0o700
+        or (private and mode & 0o077)
+    ):
+        privacy = " private" if private else ""
+        raise PermissionError(f"{label} must be an owner-controlled{privacy} directory")
+
+
+_RETAINED_OWNED_PATH_BUILD_DIRECTORIES: list[OwnedPathBuildDirectory] = []
+_RETAINED_OWNED_PATH_BUILD_LOCK = RLock()
+_RETAINED_OWNED_PATH_BUILD_RETRY_LOCK = RLock()
+_RETAINED_OWNED_PATH_BUILD_PID = os.getpid()
+_OWNED_PATH_BUILD_LEASE_RESULT_MISSING = object()
+
+
+@dataclass(slots=True)
+class _OwnedPathBuildLeaseOutcome:
+    """Carry a callback result or exact failure beyond lock settlement."""
+
+    value: object = _OWNED_PATH_BUILD_LEASE_RESULT_MISSING
+    error: BaseException | None = None
+
+
+class _OwnedPathBuildRetryLease:
+    """Release one nonblocking path-build lifecycle lock after interruption."""
+
+    __slots__ = (
+        "_acquire_blocking",
+        "_acquisition_started",
+        "_concurrent_error",
+        "_lock",
+        "_reentrant_error",
+    )
+
+    def __init__(
+        self,
+        lock,
+        *,
+        acquire_blocking: bool,
+        reentrant_error: str,
+        concurrent_error: str,
+    ) -> None:
+        self._lock = lock
+        self._acquire_blocking = acquire_blocking
+        self._reentrant_error = reentrant_error
+        self._concurrent_error = concurrent_error
+        self._acquisition_started = False
+
+    def _held_by_current_thread(self) -> bool:
+        ownership_check = getattr(self._lock, "_is_owned", None)
+        if not callable(ownership_check):
+            raise RuntimeError("owned path build retry lock lacks owner tracking")
+        return bool(ownership_check())
+
+    @property
+    def closed(self) -> bool:
+        if not self._acquisition_started:
+            return True
+        return not self._held_by_current_thread()
+
+    def acquire_nonblocking(self) -> None:
+        if self._held_by_current_thread():
+            raise RuntimeError(self._reentrant_error)
+        self._acquisition_started = True
+        if not self._lock.acquire(blocking=self._acquire_blocking):
+            self._acquisition_started = False
+            raise RuntimeError(self._concurrent_error)
+
+    def close(self) -> None:
+        if not self._acquisition_started:
+            return
+        if self._held_by_current_thread():
+            self._lock.release()
+        self._acquisition_started = False
+
+
+def _capture_owned_path_build_lease_outcome(
+    callback: Callable[[], _WorkspaceResult],
+    outcome: _OwnedPathBuildLeaseOutcome,
+) -> None:
+    """Keep operation failures out of the native lock's unwind path."""
+
+    try:
+        outcome.value = callback()
+    except BaseException as error:  # noqa: B036 - unwrap after lock release
+        outcome.error = error
+
+
+def _owned_path_build_operation_context(
+    error: BaseException,
+) -> BaseException | None:
+    """Recover an operation error interrupted at its outcome-store handler."""
+
+    try:
+        context = vars(BaseException)["__context__"].__get__(error, type(error))
+    except BaseException:  # noqa: B036 - inspection cannot replace failure
+        return None
+    if not issubclass(type(context), BaseException):
+        return None
+    try:
+        error_traceback = vars(BaseException)["__traceback__"].__get__(
+            error,
+            type(error),
+        )
+        capture_frames = []
+        while error_traceback is not None:
+            frame = error_traceback.tb_frame
+            if frame.f_code is _capture_owned_path_build_lease_outcome.__code__:
+                capture_frames.append(frame)
+            error_traceback = error_traceback.tb_next
+        context_traceback = vars(BaseException)["__traceback__"].__get__(
+            context,
+            type(context),
+        )
+        while context_traceback is not None:
+            frame = context_traceback.tb_frame
+            if any(frame is capture_frame for capture_frame in capture_frames):
+                return context
+            context_traceback = context_traceback.tb_next
+    except BaseException:  # noqa: B036 - inspection cannot replace failure
+        return None
+    return None
+
+
+def _run_with_owned_path_build_lease(
+    lease: _OwnedPathBuildRetryLease,
+    callback: Callable[[], _WorkspaceResult],
+    *,
+    release_label: str,
+) -> _WorkspaceResult:
+    """Run one callback while settling a preinstalled nonblocking lease."""
+
+    outcome = _OwnedPathBuildLeaseOutcome()
+    release_lease = _OrderedAction(
+        label=release_label,
+        action=lease.close,
+        complete=lambda: lease.closed,
+        retry_incomplete="cancellation",
+        incomplete_owner=lease,
+    )
+    # The outer plan covers the inner cleanup runner's own call boundary and
+    # the explicit fallback call below.  With one asynchronous interruption,
+    # at least one already-installed plan can reconcile the idempotent lease.
+    try:
+        with _run_context_with_cleanup_actions((release_lease,)):
+            try:
+                with _run_context_with_cleanup_actions((release_lease,)):
+                    lease.acquire_nonblocking()
+                    _capture_owned_path_build_lease_outcome(callback, outcome)
+            except BaseException as primary_error:  # noqa: B036 - release exact lock
+                try:
+                    lease.close()
+                except BaseException as release_error:  # noqa: B036 - keep primary
+                    _annotate_secondary_error(
+                        primary_error,
+                        release_label,
+                        release_error,
+                    )
+                    _attach_cleanup_owner(primary_error, lease)
+                raise  # preserve lease settlement failure
+    except BaseException as settlement_error:  # noqa: B036 - recover exact callback
+        operation_error = outcome.error
+        if operation_error is None:
+            operation_error = _owned_path_build_operation_context(settlement_error)
+        if operation_error is not None and operation_error is not settlement_error:
+            _annotate_secondary_error(
+                operation_error,
+                release_label,
+                settlement_error,
+            )
+            raise operation_error from settlement_error
+        raise
+    if outcome.error is not None:
+        raise outcome.error
+    if outcome.value is _OWNED_PATH_BUILD_LEASE_RESULT_MISSING:
+        raise RuntimeError("owned path build lease callback did not return")
+    return outcome.value  # type: ignore[return-value]
+
+
+def _synchronize_owned_path_build_process() -> None:
+    """Drop inherited namespace owners without reusing a forked lock."""
+
+    global _RETAINED_OWNED_PATH_BUILD_LOCK
+    global _RETAINED_OWNED_PATH_BUILD_RETRY_LOCK
+    global _RETAINED_OWNED_PATH_BUILD_PID
+    pid = os.getpid()
+    if pid == _RETAINED_OWNED_PATH_BUILD_PID:
+        return
+    inherited = tuple(_RETAINED_OWNED_PATH_BUILD_DIRECTORIES)
+    _RETAINED_OWNED_PATH_BUILD_LOCK = RLock()
+    _RETAINED_OWNED_PATH_BUILD_RETRY_LOCK = RLock()
+    # A child may close its inherited descriptors at exit, but must never
+    # isolate a filesystem tree still owned by the parent process. Remove only
+    # the identities observed before reset: a signal-reentrant prepare may add
+    # a genuine child owner while this outer reset is paused.
+    for inherited_owner in inherited:
+        if (
+            type(inherited_owner) is OwnedPathBuildDirectory
+            and inherited_owner._owner_pid == pid
+        ):
+            continue
+        try:
+            # CPython's list removal recognizes the exact object before any
+            # equality dispatch and completes the search/delete in one native
+            # operation.  A reentrant child reset may already have removed
+            # this identity; it must never turn a saved numeric index into a
+            # deletion of the child owner subsequently appended there.
+            _RETAINED_OWNED_PATH_BUILD_DIRECTORIES.remove(inherited_owner)
+        except ValueError:
+            pass
+    # Publish the new PID only after every inherited process-local object was
+    # replaced.  An interruption before this final store retries the reset.
+    _RETAINED_OWNED_PATH_BUILD_PID = pid
+
+
+def _run_with_owned_path_build_registry(
+    callback: Callable[[], _WorkspaceResult],
+) -> _WorkspaceResult:
+    """Run one short registry operation under a recoverable blocking lease."""
+
+    registry_lease = _OwnedPathBuildRetryLease(
+        _RETAINED_OWNED_PATH_BUILD_LOCK,
+        acquire_blocking=True,
+        reentrant_error="owned path build registry operation is reentrant",
+        concurrent_error="owned path build registry lock acquisition failed",
+    )
+    return _run_with_owned_path_build_lease(
+        registry_lease,
+        callback,
+        release_label="owned path build registry lease release also failed",
+    )
+
+
+def _register_owned_path_build_directory(owner: OwnedPathBuildDirectory) -> None:
+    _synchronize_owned_path_build_process()
+
+    def register() -> None:
+        if any(
+            retained is owner for retained in _RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+        ):
+            return
+        _RETAINED_OWNED_PATH_BUILD_DIRECTORIES.append(owner)
+
+    _run_with_owned_path_build_registry(register)
+
+
+def _forget_owned_path_build_directory(owner: OwnedPathBuildDirectory) -> None:
+    _synchronize_owned_path_build_process()
+
+    def forget() -> None:
+        _RETAINED_OWNED_PATH_BUILD_DIRECTORIES[:] = [
+            retained
+            for retained in _RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+            if retained is not owner
+        ]
+
+    _run_with_owned_path_build_registry(forget)
+
+
+def _owned_path_build_directory_retained(owner: OwnedPathBuildDirectory) -> bool:
+    _synchronize_owned_path_build_process()
+
+    def retained() -> bool:
+        return any(
+            retained is owner for retained in _RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+        )
+
+    return _run_with_owned_path_build_registry(retained)
+
+
+def _snapshot_owned_path_build_directories() -> tuple[OwnedPathBuildDirectory, ...]:
+    _synchronize_owned_path_build_process()
+    return _run_with_owned_path_build_registry(
+        lambda: tuple(_RETAINED_OWNED_PATH_BUILD_DIRECTORIES)
+    )
+
+
+def retry_retained_owned_path_build_cleanup(
+    accept_orphan: Callable[[DirectoryOrphan], None],
+) -> None:
+    """Close retained path builds after their worker scope is quiescent.
+
+    This explicit boundary also settles a build whose successful ``prepare``
+    return was interrupted before its caller could receive the owner.  The
+    callback accepts each authenticated orphan before its full owner is
+    released. Delivery is at least once, so the callback must be idempotent and
+    must not recursively invoke this retry boundary. The first owner or sink
+    failure ends the round; every later owner remains registered for retry.
+    """
+
+    if not callable(accept_orphan):
+        raise TypeError("owned path build orphan acceptor must be callable")
+    _synchronize_owned_path_build_process()
+    retry_lease = _OwnedPathBuildRetryLease(
+        _RETAINED_OWNED_PATH_BUILD_RETRY_LOCK,
+        acquire_blocking=False,
+        reentrant_error="owned path build cleanup retry is reentrant",
+        concurrent_error="owned path build cleanup retry is already active",
+    )
+
+    def retry_round() -> None:
+        owners = _snapshot_owned_path_build_directories()
+        for owner in owners:
+            owner._retry_quiescent_cleanup(accept_orphan)
+
+    _run_with_owned_path_build_lease(
+        retry_lease,
+        retry_round,
+        release_label="owned path build retry lease release also failed",
+    )
+
+
+class _OwnedPathOperationLease:
+    """Clear one operation marker through the ordered retry protocol."""
+
+    __slots__ = ("owner",)
+
+    def __init__(self, owner: OwnedPathBuildDirectory) -> None:
+        self.owner = owner
+
+    @property
+    def closed(self) -> bool:
+        return self.owner._operation_lease is not self
+
+    def close(self) -> None:
+        if self.owner._operation_lease is self:
+            self.owner._operation_lease = None
+
+
+class _AmbiguousOwnedPathBuildRoot(RuntimeError):
+    """A stage name exists without authenticated creation identity."""
+
+
+def _owned_directory_stage_name(
+    destination_name: str,
+    *,
+    token: str | None = None,
+) -> str:
+    """Return one bounded hidden stage name for an owned destination."""
+
+    if token is None:
+        token = secrets.token_hex(12)
+    return _simple_child_name(
+        f".{destination_name}.normalize-{token}",
+        label="owned stage",
+    )
+
+
+@final
+class OwnedPathBuildDirectory:
+    """Own one private directory used by an arbitrary path-based writer.
+
+    Construction is intentionally sealed to this exact class. Fork recovery
+    authenticates retained owners by this concrete type and process identity;
+    accepting a subclass would make its cleanup authority unverifiable.
+    The object exists before parent or stage acquisition begins.  Its retained
+    slots therefore cover construction, path-operation, isolation, and close
+    handoff interruptions without transferring cleanup through a return value.
+    Initial creation assumes the owner-controlled parent is quiescent.  If a
+    directory appears without a committed post-``mkdir`` identity, cleanup
+    leaves that ambiguous entry untouched and releases only retained handles.
+    """
+
+    def __init__(
+        self,
+        destination: Path,
+        *,
+        require_private_parent: bool,
+    ) -> None:
+        if type(self) is not OwnedPathBuildDirectory:
+            raise TypeError(
+                "owned path build directory does not support subclass construction"
+            )
+        self._destination = destination
+        self._path = destination
+        self._require_private_parent = require_private_parent
+        self._authority_owner = _PublicationAuthorityOwner()
+        self._stage: OwnedDirectoryStage | None = None
+        self._isolation_owner: _OwnedDirectoryIsolationOwner | None = None
+        self._operation_lease: _OwnedPathOperationLease | None = None
+        self._lifecycle_lock = RLock()
+        self._owner_pid = os.getpid()
+        self._state = "opening"
+        _register_owned_path_build_directory(self)
+
+    @classmethod
+    def prepare(
+        cls,
+        destination: Path,
+        *,
+        create_parent: bool = False,
+        require_private_parent: bool = True,
+    ) -> OwnedPathBuildDirectory:
+        """Create a fresh private build root under one retained authority."""
+
+        if cls is not OwnedPathBuildDirectory:
+            raise TypeError(
+                "owned path build directory does not support subclass construction"
+            )
+        if type(destination) is not type(Path()):
+            raise TypeError("owned path build destination must be an exact Path")
+        if type(create_parent) is not bool:
+            raise TypeError("owned path build create_parent must be a boolean")
+        if type(require_private_parent) is not bool:
+            raise TypeError("owned path build require_private_parent must be a boolean")
+        _require_owned_path_build_support()
+        lexical = lexical_directory_path(destination)
+        # Validate the exact derived component length before constructing the
+        # retained owner or creating a missing parent.  The random token is
+        # always 24 ASCII bytes, so a fixed token proves every generated name.
+        _owned_directory_stage_name(lexical.name, token="0" * 24)
+        resource = cls(
+            lexical,
+            require_private_parent=require_private_parent,
+        )
+        cleanup = _OrderedAction(
+            label="owned path build preparation cleanup also failed",
+            action=resource.close,
+            complete=lambda: resource.closed,
+            retry_incomplete="cancellation",
+            incomplete_owner=resource,
+        )
+        with _run_context_with_cleanup_actions(
+            (cleanup,),
+            cleanup_on_success=False,
+        ):
+            resource._acquire(create_parent=create_parent)
+            return resource
+
+    def _acquire(self, *, create_parent: bool) -> None:
+        authority = _open_publication_authority(
+            self._destination.parent,
+            parent_resource=None,
+            expected_parent_identity=None,
+            create_missing=create_parent,
+            missing_parent_mode=0o700,
+            authority_owner=self._authority_owner,
+        )
+        authority.verify_path_binding()
+        _require_owned_build_directory(
+            authority.resource,
+            label="owned path build parent",
+            private=self._require_private_parent,
+        )
+        try:
+            destination_metadata = authority.child_metadata(
+                self._destination.name,
+                path=self._destination,
+                label="owned path build destination",
+            )
+        except ValueError as exc:
+            raise FileExistsError(
+                f"owned path build destination already exists: {self._destination}"
+            ) from exc
+        if destination_metadata is not None:
+            raise FileExistsError(
+                f"owned path build destination already exists: {self._destination}"
+            )
+        authority.verify_path_binding()
+        OwnedDirectoryStage(
+            self._destination,
+            _parent_authority=authority,
+            _expected_destination_ownership=None,
+            _construction_owner=self,
+        )
+        self._verify_active("initialization", allow_opening=True)
+        self._state = "active"
+
+    def _install_stage(self, stage: OwnedDirectoryStage) -> None:
+        if self._stage is not None:
+            raise RuntimeError("owned path build stage is already installed")
+        self._stage = stage
+        self._path = stage.path
+
+    @property
+    def path(self) -> Path:
+        """Return the diagnostic writer path bound by this owner."""
+
+        return self._path
+
+    @property
+    def closed(self) -> bool:
+        """Return whether isolation and retained-authority cleanup completed."""
+
+        return self._state == "closed" and not _owned_path_build_directory_retained(
+            self
+        )
+
+    def _require_owner_pid(self) -> None:
+        if os.getpid() != self._owner_pid:
+            raise RuntimeError("owned path build directory cannot cross a PID boundary")
+
+    def _settle_quiescent_operation(self) -> None:
+        """Release a path lease abandoned at its public return handoff."""
+
+        self._require_owner_pid()
+        lease = self._operation_lease
+        if lease is not None:
+            lease.close()
+
+    def _run_lifecycle(
+        self, callback: Callable[[], _WorkspaceResult]
+    ) -> _WorkspaceResult:
+        """Serialize one isolation/ack transition and reject callback recursion."""
+
+        self._require_owner_pid()
+        lifecycle_lease = _OwnedPathBuildRetryLease(
+            self._lifecycle_lock,
+            acquire_blocking=False,
+            reentrant_error="owned path build lifecycle operation is reentrant",
+            concurrent_error="owned path build lifecycle operation is already active",
+        )
+        return _run_with_owned_path_build_lease(
+            lifecycle_lease,
+            callback,
+            release_label="owned path build lifecycle lease release also failed",
+        )
+
+    def _retry_quiescent_cleanup(
+        self,
+        accept_orphan: Callable[[DirectoryOrphan], None],
+    ) -> None:
+        def cleanup_owner() -> None:
+            self._settle_quiescent_operation()
+            orphan = self._isolate_and_close(
+                require_orphan=False,
+                _release_retention=False,
+            )
+            if orphan is not None:
+                accept_orphan(orphan)
+            _forget_owned_path_build_directory(self)
+
+        self._run_lifecycle(cleanup_owner)
+
+    def _require_available(self, operation: str) -> None:
+        self._require_owner_pid()
+        if self._state == "closed":
+            raise RuntimeError("owned path build directory is closed")
+        if self._state != "active":
+            raise RuntimeError("owned path build directory is not active")
+        if self._isolation_owner is not None:
+            raise RuntimeError("owned path build directory is isolated")
+        if self._operation_lease is not None:
+            raise RuntimeError(f"owned path build {operation} is reentrant")
+
+    def _require_stage(self) -> OwnedDirectoryStage:
+        stage = self._stage
+        if stage is None:
+            raise RuntimeError("owned path build stage was not acquired")
+        return stage
+
+    def _require_authority(self) -> _PublicationAuthority:
+        authority = self._authority_owner.authority
+        if authority is None:
+            raise RuntimeError("owned path build parent authority is closed")
+        return authority
+
+    def _verify_parent(self) -> None:
+        authority = self._require_authority()
+        authority.verify_path_binding()
+        _require_owned_build_directory(
+            authority.resource,
+            label="owned path build parent",
+            private=self._require_private_parent,
+        )
+        stage = self._stage
+        if stage is None or stage._stage_parent_fd < 0:
+            return
+        opened = os.fstat(stage._stage_parent_fd)
+        expected = getattr(stage, "_parent_identity", authority.identity)
+        if _root_identity(opened) != expected:
+            raise RuntimeError("owned path build parent changed")
+
+    def _verify_active(self, operation: str, *, allow_opening: bool = False) -> None:
+        self._require_owner_pid()
+        if self._state != "active" and not (allow_opening and self._state == "opening"):
+            raise RuntimeError("owned path build directory is not active")
+        stage = self._require_stage()
+        try:
+            self._verify_parent()
+            stage._verify_root_descriptor()
+            _require_owned_build_directory(
+                stage._descriptor,
+                label="owned path build root",
+                private=True,
+            )
+        except (OSError, RuntimeError) as exc:
+            raise RuntimeError(
+                f"owned path build directory changed during {operation}"
+            ) from exc
+
+    @contextmanager
+    def path_operation(self, label: str) -> Iterator[Path]:
+        """Bracket one arbitrary path writer with retained binding checks."""
+
+        if type(label) is not str:
+            raise TypeError("owned path build operation label must be exact text")
+        if not label:
+            raise ValueError("owned path build operation label must not be empty")
+        self._require_available("path operation")
+        lease = _OwnedPathOperationLease(self)
+        cleanup = _OrderedAction(
+            label="owned path build operation marker cleanup also failed",
+            action=lease.close,
+            complete=lambda: lease.closed,
+            retry_incomplete="cancellation",
+            incomplete_owner=lease,
+        )
+        with _run_context_with_cleanup_actions((cleanup,)):
+            if self._operation_lease is not None:
+                raise RuntimeError("owned path build path operation is reentrant")
+            self._operation_lease = lease
+            self._verify_active(f"before {label}")
+            try:
+                yield self._path
+            except BaseException as primary_error:  # noqa: B036 - keep body first
+                try:
+                    self._verify_active(f"after failed {label}")
+                except BaseException as continuity_error:  # noqa: B036
+                    _annotate_secondary_error(
+                        primary_error,
+                        "owned path build verification also failed",
+                        continuity_error,
+                    )
+                raise
+            self._verify_active(f"after {label}")
+
+    def _capture_current(
+        self,
+        *,
+        required_root_file: str | None,
+        check_cancelled: Callable[[], None] | None,
+        require_active_descriptor: bool,
+    ) -> object | None:
+        authority = self._require_authority()
+        stage = self._require_stage()
+        self._verify_parent()
+        metadata = authority.child_metadata(
+            stage.path.name,
+            path=stage.path,
+            label="owned path build directory",
+        )
+        if metadata is None:
+            return None
+        initial = stage._initial
+        expected_identity = stage._stage_identity
+        if expected_identity is None and initial is not None:
+            expected_identity = directory_ownership_root_identity(initial)
+        if expected_identity is None:
+            expected_identity = stage._creation_confirmed_identity
+        if expected_identity is None:
+            raise _AmbiguousOwnedPathBuildRoot(
+                "owned path build root creation identity is ambiguous"
+            )
+        observed_identity = _root_identity(metadata)
+        if observed_identity != expected_identity:
+            raise RuntimeError("owned path build root changed before ownership capture")
+        if require_active_descriptor:
+            stage._verify_root_descriptor()
+        ownership = authority.capture_child(
+            stage.path.name,
+            path=stage.path,
+            label="owned path build directory",
+            required_root_file=required_root_file,
+            allow_empty_root=required_root_file is None,
+            check_cancelled=check_cancelled,
+        )
+        captured_identity = directory_ownership_root_identity(ownership)
+        if captured_identity != expected_identity:
+            raise RuntimeError("owned path build root changed during ownership capture")
+        if stage._stage_identity is None:
+            stage._stage_identity = captured_identity
+        if stage._initial is None:
+            stage._initial = ownership
+        stage._cleanup_ownership = ownership
+        self._verify_parent()
+        return ownership
+
+    def capture_ownership(
+        self,
+        *,
+        required_root_file: str | None = None,
+        check_cancelled: Callable[[], None] | None = None,
+    ) -> object:
+        """Capture the arbitrary current tree through the retained authority."""
+
+        self._require_available("ownership capture")
+        if check_cancelled is not None and not callable(check_cancelled):
+            raise TypeError("owned path build cancellation check must be callable")
+        self._verify_active("before ownership capture")
+        primary_error: BaseException | None = None
+        try:
+            ownership = self._capture_current(
+                required_root_file=required_root_file,
+                check_cancelled=check_cancelled,
+                require_active_descriptor=True,
+            )
+            if ownership is None:
+                raise RuntimeError("owned path build directory disappeared")
+        except BaseException as exc:
+            primary_error = exc
+            try:
+                self._verify_active("after failed ownership capture")
+            except BaseException as continuity_error:  # noqa: B036 - keep first
+                _annotate_secondary_error(
+                    primary_error,
+                    "owned path build verification also failed",
+                    continuity_error,
+                )
+            raise
+        self._verify_active("after ownership capture")
+        return ownership
+
+    def _close_resources(self, *, validate_binding: bool) -> None:
+        authority = self._authority_owner.authority
+        if validate_binding and authority is not None:
+            self._verify_parent()
+        stage = self._stage
+        if stage is not None:
+            stage._close_descriptors()
+        authority = self._authority_owner.authority
+        if validate_binding and authority is not None:
+            authority.verify_path_binding()
+            _require_owned_build_directory(
+                authority.resource,
+                label="owned path build parent",
+                private=self._require_private_parent,
+            )
+            isolation_owner = self._isolation_owner
+            if isolation_owner is not None:
+                isolation_owner.verify_orphan()
+        self._authority_owner.close()
+        if stage is not None and self._authority_owner.authority is None:
+            stage._parent_authority = None
+
+    def _settle_released_resources(self) -> bool:
+        stage = self._stage
+        authority = self._authority_owner.authority
+        if not (stage is None or stage._resources.closed) or not (
+            authority is None or authority._closed
+        ):
+            return False
+        # ``_PublicationAuthorityOwner`` owns a second monotonic transition:
+        # cancellation may land after its authority was closed but before its
+        # registry entry was released.  Complete that handoff before dropping
+        # this full-resource owner.
+        self._authority_owner.close()
+        return _publication_authority_owner_released(self._authority_owner)
+
+    def _isolate_and_close(
+        self,
+        *,
+        require_orphan: bool,
+        _release_retention: bool = True,
+    ) -> DirectoryOrphan | None:
+        self._require_owner_pid()
+        ownership_check = getattr(self._lifecycle_lock, "_is_owned", None)
+        if not callable(ownership_check) or not ownership_check():
+            raise RuntimeError("owned path build lifecycle authority is required")
+        if self._state != "closed":
+            try:
+                if self._settle_released_resources():
+                    # Closing owns this monotonic transition.  If cancellation
+                    # landed after exact handles closed but before this state
+                    # assignment, a retry settles without recapturing.
+                    self._state = "closed"
+            except BaseException as exc:
+                _attach_cleanup_owner(exc, self)
+                raise
+        if self._state == "closed":
+            if _release_retention:
+                try:
+                    _forget_owned_path_build_directory(self)
+                except BaseException as exc:  # noqa: B036 - retain return owner
+                    _attach_cleanup_owner(exc, self)
+                    raise
+            orphan_owner = self._isolation_owner
+            if orphan_owner is None:
+                if require_orphan:
+                    raise RuntimeError("owned path build directory has no orphan")
+                return None
+            return orphan_owner.orphan
+        if self._operation_lease is not None:
+            raise RuntimeError("owned path build isolation is reentrant")
+        try:
+            stage = self._stage
+            validate_binding = False
+            if stage is not None:
+                if self._isolation_owner is None:
+                    try:
+                        ownership = self._capture_current(
+                            required_root_file=None,
+                            check_cancelled=None,
+                            require_active_descriptor=self._state == "active",
+                        )
+                    except _AmbiguousOwnedPathBuildRoot:
+                        if require_orphan or self._state != "opening":
+                            raise
+                        ownership = None
+                    if ownership is None and self._state == "active":
+                        raise RuntimeError(
+                            "owned path build directory disappeared before isolation"
+                        )
+                    if ownership is not None:
+                        self._isolation_owner = _OwnedDirectoryIsolationOwner(
+                            self._require_authority(),
+                            stage.path,
+                            ownership,
+                        )
+                isolation_owner = self._isolation_owner
+                if isolation_owner is not None and isolation_owner.orphan is None:
+                    orphan = _discard_owned_directory_with_authority(
+                        self._require_authority(),
+                        stage.path,
+                        isolation_owner.ownership,
+                        isolation_owner=isolation_owner,
+                    )
+                    if orphan is None:
+                        raise RuntimeError(
+                            "owned path build directory could not be isolated"
+                        )
+                validate_binding = isolation_owner is not None
+            self._close_resources(validate_binding=validate_binding)
+            self._state = "closed"
+            if _release_retention:
+                _forget_owned_path_build_directory(self)
+            isolation_owner = self._isolation_owner
+            orphan = None if isolation_owner is None else isolation_owner.orphan
+            if require_orphan and orphan is None:
+                raise RuntimeError("owned path build directory has no orphan")
+            return orphan
+        except BaseException as exc:
+            _attach_cleanup_owner(exc, self)
+            raise
+
+    def isolate(self) -> DirectoryOrphan:
+        """Isolate the exact tree while retaining receipt-delivery ownership.
+
+        The caller acknowledges durable receipt storage by calling ``close``.
+        Until then, quiescent retained cleanup can redeliver the same orphan if
+        this method's public return handoff is interrupted.
+        """
+
+        orphan = self._run_lifecycle(
+            lambda: self._isolate_and_close(
+                require_orphan=True,
+                _release_retention=False,
+            )
+        )
+        assert orphan is not None
+        return orphan
+
+    def close(self) -> None:
+        """Isolate this tree without delivering its authenticated receipt.
+
+        Callers that need the receipt must call :meth:`isolate`, store that
+        result durably, and then call ``close`` to acknowledge delivery.  A
+        direct close intentionally leaves the hidden name for the owning
+        attempt pool's later quiescent reaper.
+        """
+
+        self._run_lifecycle(lambda: self._isolate_and_close(require_orphan=False))
+
+
 __all__ = [
     "AuthenticatedFile",
     "AuthenticatedSnapshotReader",
     "CapturedDirectoryReader",
     "OwnedDirectoryStage",
+    "OwnedPathBuildDirectory",
     "OwnedWorkspaceAuthority",
     "PublishedWorkspaceDestinationBinding",
     "PublishedWorkspaceReceipt",
@@ -5587,4 +6534,5 @@ __all__ = [
     "WorkspaceFile",
     "WorkspacePlan",
     "require_owned_workspace_publication_support",
+    "retry_retained_owned_path_build_cleanup",
 ]

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1289,8 +1289,31 @@ separately supplied full Git SHA remains display provenance only. The returned
 `IndexJobExecutionResult` carries no catalog, lease, fencing, ref, or final
 generation publication authority; the worker remains the sole publisher and
 the caller retains cleanup ownership for every attempt. Source-job resource
-factory and resolver wiring is described below; production CLI/Web binding,
+factory, resolver, and production CLI wiring are described below; Web binding,
 vector source building, and graph source building remain absent.
+
+A general caller-owned path-build directory now supplies a retained attempt
+boundary for arbitrary path writers and the next cleanup hardening of the
+implemented source-job resource factory. It creates under a retained no-follow
+owner-controlled parent, captures the completed tree, atomically isolates that
+exact tree, retains
+interrupted cleanup for an explicit quiescent retry that delivers authenticated
+orphan receipts to an idempotent caller sink before acknowledging cleanup
+ownership, and never grants catalog publication authority. Delivery is at
+least once across interruption. Direct isolation likewise retains its owner
+until the caller acknowledges durable receipt storage with `close`, so an
+interrupted public return can be redelivered by the process-local retry. That
+retry is serialized through callback acknowledgement; its sink must not
+recursively invoke the boundary. The native `mkdir`-to-first-identity handoff
+is intentionally fail-closed: if the hidden name cannot be authenticated, it
+is left untouched and never becomes cleanup authority. A follow-up must place
+the implemented source-job factory's attempt, BM25, and context destinations
+under one such outer owner, preserve its exact job/source/profile and
+worker-only binding, release all inner receipt authorities before isolation,
+and add an attempt-pool reaper that reconciles stale names only at a quiescent
+boundary. The legacy one-shot directory-discard and plain stage-construction
+return contracts remain unchanged; cancellation-safe integrations must use the
+retained owner and explicit receipt acknowledgement.
 
 The compiler-cache bridge now also has a resource-scoped resolver seam. It
 attests the canonical running request before opening attempt resources, accepts
@@ -1375,8 +1398,11 @@ retained-source BM25 builder and its prepare-only source-job adapter now publish
 and ingest a unique private generation under an exact retained parent and
 generation receipt, without final publication authority or a cache-path reopen;
 its local attempt resource factory, resolver, and explicit production CLI entry
-are implemented. Vector and graph source builders, generic builder routing, and
-remaining runtime wiring remain.
+are implemented. The general caller-owned path-build cleanup primitive intended
+to enclose that factory's three transient destinations is also implemented but
+not yet adopted there.
+Vector and graph source builders, generic builder routing, and remaining
+runtime wiring remain.
 
 - Make every builder write to a unique staging generation.
 - Add per-view profile adapters that fail closed on incomplete compatibility

--- a/test/test_captured_directory.py
+++ b/test/test_captured_directory.py
@@ -4,7 +4,12 @@
 
 from __future__ import annotations
 
+import contextlib
+import dis
 import errno
+import gc
+import hashlib
+import inspect
 import os
 import signal
 import stat
@@ -33,6 +38,7 @@ from codenib._captured_directory import (
     AuthenticatedSnapshotReader,
     CapturedDirectoryReader,
     OwnedDirectoryStage,
+    OwnedPathBuildDirectory,
     OwnedWorkspaceAuthority,
     PublishedWorkspaceDestinationBinding,
     PublishedWorkspaceReceipt,
@@ -42,6 +48,7 @@ from codenib._captured_directory import (
     WorkspaceFile,
     WorkspacePlan,
     require_owned_workspace_publication_support,
+    retry_retained_owned_path_build_cleanup,
 )
 
 
@@ -1242,6 +1249,2679 @@ def test_owned_stage_rejects_root_swap_between_capture_and_open(
     assert swapped
     assert (tmp_path / swapped["active"]).is_dir()
     assert (tmp_path / swapped["stolen"]).is_dir()
+
+
+def test_owned_stage_close_retains_descriptor_after_preclose_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stage = OwnedDirectoryStage(tmp_path / "destination")
+    descriptor = stage._descriptor
+    real_close = captured_directory.os.close
+    interrupted = False
+    close_error = OSError(errno.EIO, "injected descriptor close failure")
+
+    def fail_before_close(candidate: int) -> None:
+        nonlocal interrupted
+        if candidate == descriptor and not interrupted:
+            interrupted = True
+            raise close_error
+        real_close(candidate)
+
+    monkeypatch.setattr(captured_directory.os, "close", fail_before_close)
+
+    with pytest.raises(OSError, match="descriptor close failure") as caught:
+        stage.close()
+
+    assert caught.value is close_error
+    assert caught.value.captured_directory_cleanup_owner is stage
+    os.fstat(descriptor)
+    assert stage._descriptor == descriptor
+
+    stage.close()
+    assert stage._descriptor == -1
+    with pytest.raises(OSError) as closed:
+        os.fstat(descriptor)
+    assert closed.value.errno == errno.EBADF
+
+
+def _retry_owned_path_build_cleanup() -> tuple[atomic_directory.DirectoryOrphan, ...]:
+    orphans: list[atomic_directory.DirectoryOrphan] = []
+    retry_retained_owned_path_build_cleanup(orphans.append)
+    return tuple(orphans)
+
+
+def test_owned_path_build_rejects_subclass_construction_before_mutation(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+
+    class ChildOwnedPathBuildDirectory(OwnedPathBuildDirectory):
+        pass
+
+    destination = tmp_path / "missing" / "attempt"
+
+    with pytest.raises(TypeError, match="does not support subclass construction"):
+        ChildOwnedPathBuildDirectory.prepare(destination, create_parent=True)
+    with pytest.raises(TypeError, match="does not support subclass construction"):
+        ChildOwnedPathBuildDirectory(
+            destination,
+            require_private_parent=True,
+        )
+
+    assert not destination.parent.exists()
+    assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+
+
+def test_owned_path_build_captures_and_isolates_arbitrary_partial_files(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    destination = parent / "attempt"
+    owner = OwnedPathBuildDirectory.prepare(destination)
+
+    assert owner.path.parent == parent
+    assert owner.path != destination
+    assert not destination.exists()
+    assert "OwnedPathBuildDirectory" in captured_directory.__all__
+    assert stat.S_IMODE(owner.path.stat().st_mode) == 0o700
+    with owner.path_operation("partial path writer") as writer_path:
+        nested = writer_path / "nested"
+        nested.mkdir()
+        (nested / "payload.bin").write_bytes(b"partial bytes")
+        (writer_path / ".writer.lock").write_bytes(b"lock")
+
+    ownership = owner.capture_ownership()
+    assert directory_ownership_file_records(ownership) == (
+        atomic_directory.TreeFileRecord(
+            path=".writer.lock",
+            mode=0o644,
+            size=4,
+            sha256=hashlib.sha256(b"lock").hexdigest(),
+        ),
+        atomic_directory.TreeFileRecord(
+            path="nested/payload.bin",
+            mode=0o644,
+            size=13,
+            sha256=hashlib.sha256(b"partial bytes").hexdigest(),
+        ),
+    )
+
+    orphan = owner.isolate()
+
+    assert not owner.closed
+    assert not owner.path.exists()
+    assert not destination.exists()
+    assert (
+        orphan.reopen(
+            lambda reader: reader.read_bytes("nested/payload.bin", max_bytes=32)
+        )
+        == b"partial bytes"
+    )
+    assert owner.isolate() is orphan
+    owner.close()
+    assert owner.closed
+
+
+def test_owned_path_build_requires_a_missing_destination(tmp_path: Path) -> None:
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    destination = parent / "attempt"
+    destination.write_bytes(b"foreign")
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        OwnedPathBuildDirectory.prepare(destination)
+
+    assert destination.read_bytes() == b"foreign"
+    assert not tuple(parent.glob(".attempt.normalize-*"))
+
+
+def test_owned_path_build_isolate_return_handoff_redelivers_retained_orphan(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    interruption = KeyboardInterrupt("isolate return handoff")
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_owned_path_return(
+            OwnedPathBuildDirectory.isolate,
+            lambda: OwnedPathBuildDirectory.prepare(parent / "attempt").isolate(),
+            predicate=lambda _frame, result: isinstance(
+                result,
+                atomic_directory.DirectoryOrphan,
+            ),
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    gc.collect()
+    retained = tuple(captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES)
+    assert len(retained) == 1
+    owner = retained[0]
+    assert owner._state == "closed"
+    assert not owner.closed
+    assert not owner.path.exists()
+
+    orphans = _retry_owned_path_build_cleanup()
+
+    assert len(orphans) == 1
+    assert owner.closed
+    assert orphans[0].reopen(lambda reader: reader.inventory()) == ()
+
+
+def test_owned_path_build_requires_private_parent_before_root_creation(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "shared"
+    parent.mkdir(mode=0o755)
+    destination = parent / "attempt"
+
+    with pytest.raises(PermissionError, match="private directory"):
+        OwnedPathBuildDirectory.prepare(destination)
+
+    assert not destination.exists()
+    assert not tuple(parent.glob(".attempt.normalize-*"))
+
+    owner = OwnedPathBuildDirectory.prepare(
+        destination,
+        require_private_parent=False,
+    )
+    owner.close()
+    assert owner.closed
+
+
+def test_owned_path_build_relaxed_parent_still_rejects_shared_writes(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "shared-writable"
+    parent.mkdir(mode=0o777)
+    parent.chmod(0o777)
+    destination = parent / "attempt"
+
+    with pytest.raises(PermissionError, match="owner-controlled"):
+        OwnedPathBuildDirectory.prepare(
+            destination,
+            require_private_parent=False,
+        )
+
+    assert not tuple(parent.glob(".attempt.normalize-*"))
+    assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+
+
+@pytest.mark.skipif(
+    not Path("/proc/self/fd").is_dir(),
+    reason="requires procfs",
+)
+def test_owned_path_build_privacy_rejection_releases_read_only_authority(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "non-private"
+    parent.mkdir(mode=0o755)
+    before = len(tuple(Path("/proc/self/fd").iterdir()))
+
+    with pytest.raises(PermissionError, match="private directory"):
+        OwnedPathBuildDirectory.prepare(parent / "attempt")
+
+    assert not tuple(parent.glob(".attempt.normalize-*"))
+    assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+    assert len(tuple(Path("/proc/self/fd").iterdir())) == before
+
+
+def test_owned_path_build_support_gate_precedes_parent_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "missing" / "nested" / "attempt"
+    monkeypatch.setattr(captured_directory.sys, "platform", "win32")
+
+    with pytest.raises(RuntimeError, match="unsupported"):
+        OwnedPathBuildDirectory.prepare(destination, create_parent=True)
+
+    assert not (tmp_path / "missing").exists()
+    assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+
+
+@pytest.mark.skipif(
+    not Path("/proc/self/fd").is_dir(),
+    reason="requires procfs",
+)
+def test_owned_path_build_stage_name_gate_precedes_parent_mutation(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "missing"
+    destination_name = "a" * 220
+    destination = parent / destination_name
+    stage_name = f".{destination_name}.normalize-{'0' * 24}"
+    assert (
+        len(os.fsencode(destination_name))
+        <= atomic_directory._MAX_OWNERSHIP_COMPONENT_BYTES
+    )
+    assert (
+        len(os.fsencode(stage_name)) > atomic_directory._MAX_OWNERSHIP_COMPONENT_BYTES
+    )
+    before = len(tuple(Path("/proc/self/fd").iterdir()))
+
+    with pytest.raises(ValueError, match="owned stage must be one bounded file name"):
+        OwnedPathBuildDirectory.prepare(destination, create_parent=True)
+
+    assert not parent.exists()
+    assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+    assert _retry_owned_path_build_cleanup() == ()
+    assert len(tuple(Path("/proc/self/fd").iterdir())) == before
+
+
+@pytest.mark.skipif(
+    not Path("/proc/self/fd").is_dir(),
+    reason="requires procfs",
+)
+def test_owned_path_build_invalid_generated_stage_name_releases_opening_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "missing"
+    before = len(tuple(Path("/proc/self/fd").iterdir()))
+    monkeypatch.setattr(
+        captured_directory.secrets,
+        "token_hex",
+        lambda _: "x" * 256,
+    )
+
+    with pytest.raises(ValueError, match="owned stage must be one bounded file name"):
+        OwnedPathBuildDirectory.prepare(parent / "attempt", create_parent=True)
+
+    assert parent.is_dir()
+    assert stat.S_IMODE(parent.stat().st_mode) == 0o700
+    assert not tuple(parent.iterdir())
+    assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+    assert _retry_owned_path_build_cleanup() == ()
+    assert len(tuple(Path("/proc/self/fd").iterdir())) == before
+
+
+@pytest.mark.skipif(
+    not Path("/proc/self/fd").is_dir(),
+    reason="requires procfs",
+)
+def test_owned_path_build_mkdir_race_leaves_unknown_child_untouched(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    before = len(tuple(Path("/proc/self/fd").iterdir()))
+    real_mkdir = captured_directory.os.mkdir
+    raced: list[Path] = []
+
+    def race_mkdir(path, mode=0o777, *, dir_fd=None):
+        if (
+            not raced
+            and isinstance(path, str)
+            and path.startswith(".attempt.normalize-")
+            and dir_fd is not None
+        ):
+            real_mkdir(path, mode=0o700, dir_fd=dir_fd)
+            candidate = parent / path
+            candidate.joinpath("valuable.bin").write_bytes(b"foreign")
+            raced.append(candidate)
+            raise FileExistsError(errno.EEXIST, "injected mkdir race", path)
+        return real_mkdir(path, mode=mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(captured_directory.os, "mkdir", race_mkdir)
+
+    with pytest.raises(FileExistsError, match="mkdir race"):
+        OwnedPathBuildDirectory.prepare(parent / "attempt")
+
+    assert len(raced) == 1
+    assert raced[0].joinpath("valuable.bin").read_bytes() == b"foreign"
+    assert not tuple(parent.glob("*discarded-*"))
+    assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+    assert len(tuple(Path("/proc/self/fd").iterdir())) == before
+
+
+def test_owned_path_build_post_mkdir_interrupt_leaves_unauthenticated_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    real_stat = captured_directory.os.stat
+    interruption = KeyboardInterrupt("before created identity handoff")
+    interrupted = False
+
+    def interrupt_created_stat(path, *args, **kwargs):
+        nonlocal interrupted
+        if (
+            not interrupted
+            and isinstance(path, str)
+            and path.startswith(".attempt.normalize-")
+            and kwargs.get("dir_fd") is not None
+        ):
+            try:
+                real_stat(path, *args, **kwargs)
+            except FileNotFoundError:
+                pass
+            else:
+                interrupted = True
+                raise interruption
+        return real_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(captured_directory.os, "stat", interrupt_created_stat)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        OwnedPathBuildDirectory.prepare(parent / "attempt")
+
+    assert caught.value is interruption
+    roots = tuple(parent.glob(".attempt.normalize-*"))
+    assert len(roots) == 1
+    assert roots[0].is_dir()
+    assert not tuple(parent.glob("*discarded-*"))
+    assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+
+
+def test_owned_path_build_ambiguous_cleanup_reconciles_after_close_interrupt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    real_mkdir = captured_directory.os.mkdir
+    real_close_resources = OwnedPathBuildDirectory._close_resources
+    raced: list[Path] = []
+    interruption = KeyboardInterrupt("after exact resource close")
+    interrupted = False
+
+    def race_mkdir(path, mode=0o777, *, dir_fd=None):
+        if (
+            not raced
+            and isinstance(path, str)
+            and path.startswith(".attempt.normalize-")
+            and dir_fd is not None
+        ):
+            real_mkdir(path, mode=0o700, dir_fd=dir_fd)
+            candidate = parent / path
+            candidate.joinpath("valuable.bin").write_bytes(b"foreign")
+            raced.append(candidate)
+            raise FileExistsError(errno.EEXIST, "injected mkdir race", path)
+        return real_mkdir(path, mode=mode, dir_fd=dir_fd)
+
+    def close_then_interrupt(
+        owner: OwnedPathBuildDirectory,
+        *,
+        validate_binding: bool,
+    ) -> None:
+        nonlocal interrupted
+        real_close_resources(owner, validate_binding=validate_binding)
+        if not interrupted:
+            interrupted = True
+            raise interruption
+
+    monkeypatch.setattr(captured_directory.os, "mkdir", race_mkdir)
+    monkeypatch.setattr(
+        OwnedPathBuildDirectory,
+        "_close_resources",
+        close_then_interrupt,
+    )
+
+    with pytest.raises(FileExistsError, match="mkdir race"):
+        OwnedPathBuildDirectory.prepare(parent / "attempt")
+
+    assert interrupted
+    assert raced[0].joinpath("valuable.bin").read_bytes() == b"foreign"
+    assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+
+
+@pytest.mark.skipif(
+    not Path("/proc/self/fd").is_dir(),
+    reason="requires procfs",
+)
+def test_owned_path_build_stage_constructor_return_interrupt_has_full_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    before = len(tuple(Path("/proc/self/fd").iterdir()))
+    real_init = OwnedDirectoryStage.__init__
+    interruption = KeyboardInterrupt("after stage construction")
+    resources: list[OwnedPathBuildDirectory] = []
+
+    def construct_then_interrupt(stage: OwnedDirectoryStage, *args, **kwargs) -> None:
+        resource = kwargs.get("_construction_owner")
+        assert isinstance(resource, OwnedPathBuildDirectory)
+        resources.append(resource)
+        real_init(stage, *args, **kwargs)
+        raise interruption
+
+    monkeypatch.setattr(OwnedDirectoryStage, "__init__", construct_then_interrupt)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        OwnedPathBuildDirectory.prepare(parent / "attempt")
+
+    assert caught.value is interruption
+    assert len(resources) == 1
+    owner = resources[0]
+    assert owner.closed
+    assert not tuple(parent.glob(".attempt.normalize-*"))
+    assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+    assert len(tuple(Path("/proc/self/fd").iterdir())) == before
+    orphan = owner.isolate()
+    assert orphan.reopen(lambda reader: reader.inventory()) == ()
+
+
+def _interrupt_owned_path_on_line(
+    function: object,
+    source_fragment: str,
+    callback: object,
+    *,
+    predicate: object | None = None,
+    error: BaseException,
+) -> None:
+    assert callable(function)
+    assert callable(callback)
+    assert predicate is None or callable(predicate)
+    source, first_line = inspect.getsourcelines(function)
+    target_lines = {
+        first_line + offset
+        for offset, line in enumerate(source)
+        if line.strip() == source_fragment
+    }
+    assert len(target_lines) == 1
+    code = function.__code__
+    previous_trace = sys.gettrace()
+    injected = False
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal injected
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_lines = True
+            return trace
+        if (
+            not injected
+            and event == "line"
+            and frame.f_code is code
+            and frame.f_lineno in target_lines
+            and (predicate is None or predicate(frame.f_locals))
+        ):
+            injected = True
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+        assert injected, f"failed to interrupt before {source_fragment}"
+
+
+def _interrupt_owned_path_after_attribute_store(
+    function: object,
+    attribute_name: str,
+    callback: object,
+    *,
+    next_line_fragment: str,
+    error: BaseException,
+) -> None:
+    assert callable(function)
+    instructions = tuple(dis.get_instructions(function))
+    indexes = tuple(
+        index
+        for index, instruction in enumerate(instructions[:-1])
+        if instruction.opname == "STORE_ATTR" and instruction.argval == attribute_name
+    )
+    assert len(indexes) == 1
+    opcode_offsets = {instructions[indexes[0] + 1].offset}
+    source, first_line = inspect.getsourcelines(function)
+    line_numbers = {
+        first_line + offset
+        for offset, line in enumerate(source)
+        if line.strip() == next_line_fragment
+    }
+    assert len(line_numbers) == 1
+    code = function.__code__
+    previous_trace = sys.gettrace()
+    injected = False
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal injected
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            frame.f_trace_lines = True
+            return trace
+        if (
+            not injected
+            and frame.f_code is code
+            and (
+                event == "opcode"
+                and frame.f_lasti in opcode_offsets
+                or event == "line"
+                and frame.f_lineno in line_numbers
+            )
+        ):
+            injected = True
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+        assert injected, f"failed to interrupt after {attribute_name} store"
+
+
+def _interrupt_owned_path_after_global_store(
+    function: object,
+    global_name: str,
+    callback: object,
+    *,
+    error: BaseException,
+) -> None:
+    assert callable(function)
+    assert callable(callback)
+    instructions = tuple(dis.get_instructions(function))
+    indexes = tuple(
+        index
+        for index, instruction in enumerate(instructions[:-1])
+        if instruction.opname == "STORE_GLOBAL" and instruction.argval == global_name
+    )
+    assert len(indexes) == 1
+    opcode_offset = instructions[indexes[0] + 1].offset
+    code = function.__code__
+    previous_trace = sys.gettrace()
+    injected = False
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal injected
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            return trace
+        if (
+            not injected
+            and event == "opcode"
+            and frame.f_code is code
+            and frame.f_lasti == opcode_offset
+        ):
+            injected = True
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+        assert injected, f"failed to interrupt after {global_name} store"
+
+
+def _call_owned_path_after_global_store(
+    function: object,
+    global_name: str,
+    callback: object,
+) -> None:
+    assert callable(function)
+    assert callable(callback)
+    instructions = tuple(dis.get_instructions(function))
+    indexes = tuple(
+        index
+        for index, instruction in enumerate(instructions[:-1])
+        if instruction.opname == "STORE_GLOBAL" and instruction.argval == global_name
+    )
+    assert len(indexes) == 1
+    opcode_offset = instructions[indexes[0] + 1].offset
+    code = function.__code__
+    previous_trace = sys.gettrace()
+    called = False
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal called
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            return trace
+        if (
+            not called
+            and event == "opcode"
+            and frame.f_code is code
+            and frame.f_lasti == opcode_offset
+        ):
+            called = True
+            sys.settrace(None)
+            callback()
+        return trace
+
+    sys.settrace(trace)
+    try:
+        function()
+    finally:
+        sys.settrace(previous_trace)
+        assert called, f"failed to call after {global_name} store"
+
+
+def _call_owned_path_before_global_load(
+    function: object,
+    global_name: str,
+    callback: object,
+    *,
+    occurrence: int = 0,
+) -> None:
+    assert callable(function)
+    assert callable(callback)
+    offsets = tuple(
+        instruction.offset
+        for instruction in dis.get_instructions(function)
+        if instruction.opname == "LOAD_GLOBAL" and instruction.argval == global_name
+    )
+    assert 0 <= occurrence < len(offsets)
+    opcode_offset = offsets[occurrence]
+    code = function.__code__
+    previous_trace = sys.gettrace()
+    called = False
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal called
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            return trace
+        if (
+            not called
+            and event == "opcode"
+            and frame.f_code is code
+            and frame.f_lasti == opcode_offset
+        ):
+            called = True
+            sys.settrace(None)
+            callback()
+        return trace
+
+    sys.settrace(trace)
+    try:
+        function()
+    finally:
+        sys.settrace(previous_trace)
+        assert called, f"failed to call before loading {global_name}"
+
+
+def _call_owned_path_after_named_load(
+    function: object,
+    name: str,
+    callback: object,
+) -> None:
+    assert callable(function)
+    assert callable(callback)
+    instructions = tuple(dis.get_instructions(function))
+    indexes = tuple(
+        index
+        for index, instruction in enumerate(instructions[:-1])
+        if instruction.argval == name
+        and instruction.opname in {"LOAD_ATTR", "LOAD_METHOD"}
+    )
+    assert len(indexes) == 1
+    opcode_offset = instructions[indexes[0] + 1].offset
+    code = function.__code__
+    previous_trace = sys.gettrace()
+    called = False
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal called
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            return trace
+        if (
+            not called
+            and event == "opcode"
+            and frame.f_code is code
+            and frame.f_lasti == opcode_offset
+        ):
+            called = True
+            sys.settrace(None)
+            callback()
+        return trace
+
+    sys.settrace(trace)
+    try:
+        function()
+    finally:
+        sys.settrace(previous_trace)
+        assert called, f"failed to call after loading {name}"
+
+
+def _call_owned_path_on_return(function: object, callback: object) -> None:
+    assert callable(function)
+    assert callable(callback)
+    code = function.__code__
+    previous_trace = sys.gettrace()
+    called = False
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal called
+        if event == "call" and frame.f_code is code:
+            return trace
+        if not called and event == "return" and frame.f_code is code:
+            called = True
+            sys.settrace(None)
+            callback()
+        return trace
+
+    sys.settrace(trace)
+    try:
+        function()
+    finally:
+        sys.settrace(previous_trace)
+        assert called, "failed to call at the return handoff"
+
+
+def _prime_owned_path_opcode_tracing(function: object, callback: object) -> None:
+    assert callable(function)
+    assert callable(callback)
+    code = function.__code__
+    previous_trace = sys.gettrace()
+    observed = False
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal observed
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            return trace
+        if event == "opcode" and frame.f_code is code:
+            observed = True
+        return trace
+
+    try:
+        for _attempt in range(2):
+            sys.settrace(trace)
+            callback()
+            sys.settrace(previous_trace)
+            if observed:
+                break
+    finally:
+        sys.settrace(previous_trace)
+        assert observed, "failed to prime opcode tracing"
+
+
+def _interrupt_owned_path_on_opcode(
+    function: object,
+    opname: str,
+    callback: object,
+    *,
+    occurrence: int = 0,
+    error: BaseException,
+) -> None:
+    assert callable(function)
+    assert callable(callback)
+    offsets = tuple(
+        instruction.offset
+        for instruction in dis.get_instructions(function)
+        if instruction.opname == opname
+    )
+    assert 0 <= occurrence < len(offsets)
+    target_offset = offsets[occurrence]
+    code = function.__code__
+    previous_trace = sys.gettrace()
+    injected = False
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal injected
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            return trace
+        if (
+            not injected
+            and event == "opcode"
+            and frame.f_code is code
+            and frame.f_lasti == target_offset
+        ):
+            injected = True
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+        assert injected, f"failed to interrupt at {opname}"
+
+
+def _interrupt_owned_path_return(
+    function: object,
+    callback: object,
+    *,
+    predicate: object,
+    error: BaseException,
+) -> None:
+    assert callable(function)
+    assert callable(callback)
+    assert callable(predicate)
+    code = function.__code__
+    previous_trace = sys.gettrace()
+    injected = False
+
+    def trace(frame: object, event: str, arg: object) -> object:
+        nonlocal injected
+        if event == "call" and frame.f_code is code:
+            return trace
+        if (
+            not injected
+            and event == "return"
+            and frame.f_code is code
+            and predicate(frame, arg)
+        ):
+            injected = True
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+        assert injected, "failed to interrupt the return handoff"
+
+
+def test_owned_path_build_prepare_acquire_interrupt_runs_preinstalled_cleanup(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    interruption = KeyboardInterrupt("after acquire")
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_owned_path_on_line(
+            OwnedPathBuildDirectory.prepare.__func__,
+            "return resource",
+            lambda: OwnedPathBuildDirectory.prepare(parent / "attempt"),
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    assert not tuple(parent.glob(".attempt.normalize-*"))
+    assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+
+
+def test_owned_path_build_prepare_cleanup_boundary_preserves_exact_primary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    real_acquire = OwnedPathBuildDirectory._acquire
+    primary = RuntimeError("exact acquire primary")
+    interruption = KeyboardInterrupt("cleanup runner entry")
+
+    def acquire_then_fail(
+        owner: OwnedPathBuildDirectory,
+        *,
+        create_parent: bool,
+    ) -> None:
+        real_acquire(owner, create_parent=create_parent)
+        raise primary
+
+    monkeypatch.setattr(
+        OwnedPathBuildDirectory,
+        "_acquire",
+        acquire_then_fail,
+    )
+
+    with pytest.raises(RuntimeError, match="exact acquire primary") as caught:
+        _interrupt_owned_path_on_line(
+            atomic_directory._run_context_with_cleanup_actions.__wrapped__,
+            "_run_ordered_actions(failures)",
+            lambda: OwnedPathBuildDirectory.prepare(parent / "attempt"),
+            predicate=lambda local: local.get("context_error") is primary,
+            error=interruption,
+        )
+
+    assert caught.value is primary
+    retained = tuple(captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES)
+    assert len(retained) == 1
+    owner = retained[0]
+    assert owner.path.is_dir()
+
+    orphans = _retry_owned_path_build_cleanup()
+
+    assert owner.closed
+    assert len(orphans) == 1
+    assert orphans[0].reopen(lambda reader: reader.inventory()) == ()
+
+
+def test_owned_path_build_prepare_return_handoff_is_quiescently_retryable(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    interruption = KeyboardInterrupt("prepare return handoff")
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_owned_path_return(
+            OwnedPathBuildDirectory.prepare.__func__,
+            lambda: OwnedPathBuildDirectory.prepare(parent / "attempt"),
+            predicate=lambda _frame, result: isinstance(
+                result,
+                OwnedPathBuildDirectory,
+            ),
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    retained = tuple(captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES)
+    assert len(retained) == 1
+    owner = retained[0]
+    assert owner.path.is_dir()
+
+    orphans = _retry_owned_path_build_cleanup()
+
+    assert owner.closed
+    assert not owner.path.exists()
+    assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+    assert len(orphans) == 1
+    assert orphans[0].reopen(lambda reader: reader.inventory()) == ()
+
+
+def test_owned_path_build_quiescent_acceptor_failure_retains_exact_receipt(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    owner.path.joinpath("payload.bin").write_bytes(b"bytes")
+    accepted: list[atomic_directory.DirectoryOrphan] = []
+    failure = RuntimeError("orphan sink failed")
+
+    def reject(orphan: atomic_directory.DirectoryOrphan) -> None:
+        accepted.append(orphan)
+        raise failure
+
+    with pytest.raises(RuntimeError, match="orphan sink failed") as caught:
+        retry_retained_owned_path_build_cleanup(reject)
+
+    assert caught.value is failure
+    assert len(accepted) == 1
+    assert owner._state == "closed"
+    assert not owner.closed
+    assert owner in captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+
+    redelivered = _retry_owned_path_build_cleanup()
+
+    assert redelivered == (accepted[0],)
+    assert owner.closed
+    assert (
+        accepted[0].reopen(
+            lambda reader: reader.read_bytes("payload.bin", max_bytes=16)
+        )
+        == b"bytes"
+    )
+
+
+def test_owned_path_build_quiescent_acceptor_return_interrupt_redelivers(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    accepted: list[atomic_directory.DirectoryOrphan] = []
+    interruption = KeyboardInterrupt("orphan accept return")
+
+    def accept(orphan: atomic_directory.DirectoryOrphan) -> None:
+        accepted.append(orphan)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_owned_path_return(
+            accept,
+            lambda: retry_retained_owned_path_build_cleanup(accept),
+            predicate=lambda _frame, result: result is None,
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    assert len(accepted) == 1
+    assert not owner.closed
+    assert owner in captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+
+    redelivered = _retry_owned_path_build_cleanup()
+
+    assert redelivered == (accepted[0],)
+    assert owner.closed
+
+
+def test_owned_path_build_quiescent_acceptor_rejects_recursive_cleanup(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    accepted: list[atomic_directory.DirectoryOrphan] = []
+
+    def accept(orphan: atomic_directory.DirectoryOrphan) -> None:
+        accepted.append(orphan)
+        assert not owner.closed
+        with pytest.raises(RuntimeError, match="cleanup retry is reentrant"):
+            retry_retained_owned_path_build_cleanup(accept)
+        with pytest.raises(RuntimeError, match="lifecycle operation is reentrant"):
+            owner.close()
+
+    retry_retained_owned_path_build_cleanup(accept)
+
+    assert len(accepted) == 1
+    assert owner.closed
+    assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+
+
+def test_owned_path_build_quiescent_cleanup_rejects_concurrent_retry(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    owner.path.joinpath("payload.bin").write_bytes(b"bytes")
+    accepting = threading.Event()
+    release_acceptor = threading.Event()
+    accepted: list[atomic_directory.DirectoryOrphan] = []
+    worker_errors: list[BaseException] = []
+
+    def accept(orphan: atomic_directory.DirectoryOrphan) -> None:
+        accepted.append(orphan)
+        accepting.set()
+        if not release_acceptor.wait(timeout=10):
+            raise RuntimeError("test acceptor was not released")
+
+    def cleanup() -> None:
+        try:
+            retry_retained_owned_path_build_cleanup(accept)
+        except BaseException as exc:  # noqa: B036 - report thread failure
+            worker_errors.append(exc)
+
+    worker = threading.Thread(target=cleanup)
+    worker.start()
+    assert accepting.wait(timeout=5)
+    try:
+        with pytest.raises(RuntimeError, match="cleanup retry is already active"):
+            retry_retained_owned_path_build_cleanup(accepted.append)
+    finally:
+        release_acceptor.set()
+        worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert not worker_errors
+    assert len(accepted) == 1
+    assert owner.closed
+    assert (
+        accepted[0].reopen(
+            lambda reader: reader.read_bytes("payload.bin", max_bytes=16)
+        )
+        == b"bytes"
+    )
+
+
+@pytest.mark.parametrize("seam", ["acquire", "release"])
+def test_owned_path_build_quiescent_retry_lease_interrupt_is_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    seam: str,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    interruption = KeyboardInterrupt(f"retry lease {seam}")
+    interrupted = False
+    lease_type = captured_directory._OwnedPathBuildRetryLease
+    method_name = "acquire_nonblocking" if seam == "acquire" else "close"
+    real_method = getattr(lease_type, method_name)
+
+    def interrupt_after_transition(lease) -> None:
+        nonlocal interrupted
+        real_method(lease)
+        if (
+            lease._lock is captured_directory._RETAINED_OWNED_PATH_BUILD_RETRY_LOCK
+            and not interrupted
+        ):
+            interrupted = True
+            raise interruption
+
+    monkeypatch.setattr(lease_type, method_name, interrupt_after_transition)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        retry_retained_owned_path_build_cleanup(lambda _orphan: None)
+
+    assert caught.value is interruption
+    if seam == "acquire":
+        assert not owner.closed
+        assert owner in captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+    else:
+        assert owner.closed
+
+    monkeypatch.setattr(lease_type, method_name, real_method)
+    recovered = _retry_owned_path_build_cleanup()
+
+    if seam == "acquire":
+        assert len(recovered) == 1
+        assert owner.closed
+    else:
+        assert recovered == ()
+
+
+def test_owned_path_build_lifecycle_failure_handler_interrupt_releases_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    natural_failure = ValueError("natural isolation failure")
+    interruption = KeyboardInterrupt("lifecycle failure handler")
+    real_isolate = OwnedPathBuildDirectory._isolate_and_close
+
+    def fail_isolation(
+        _owner: OwnedPathBuildDirectory,
+        *,
+        require_orphan: bool,
+        _release_retention: bool = True,
+    ) -> None:
+        raise natural_failure
+
+    monkeypatch.setattr(
+        OwnedPathBuildDirectory,
+        "_isolate_and_close",
+        fail_isolation,
+    )
+
+    with pytest.raises(ValueError, match="natural isolation failure") as caught:
+        _interrupt_owned_path_on_line(
+            captured_directory._capture_owned_path_build_lease_outcome,
+            "outcome.error = error",
+            owner.close,
+            predicate=lambda values: values.get("error") is natural_failure,
+            error=interruption,
+        )
+
+    assert caught.value is natural_failure
+    assert caught.value.__cause__ is interruption or any(
+        str(interruption) in note for note in getattr(caught.value, "__notes__", ())
+    )
+    acquired: list[bool] = []
+
+    def probe_lifecycle_lock() -> None:
+        locked = owner._lifecycle_lock.acquire(timeout=1)
+        acquired.append(locked)
+        if locked:
+            owner._lifecycle_lock.release()
+
+    probe = threading.Thread(target=probe_lifecycle_lock)
+    probe.start()
+    probe.join(timeout=5)
+    assert not probe.is_alive()
+    assert acquired == [True]
+
+    monkeypatch.setattr(
+        OwnedPathBuildDirectory,
+        "_isolate_and_close",
+        real_isolate,
+    )
+    owner.close()
+    assert owner.closed
+
+
+def test_owned_path_build_lifecycle_return_interrupt_releases_lock(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    interruption = KeyboardInterrupt("lifecycle return")
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_owned_path_return(
+            OwnedPathBuildDirectory._run_lifecycle,
+            lambda: owner._run_lifecycle(lambda: None),
+            predicate=lambda _frame, result: result is None,
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    acquired: list[bool] = []
+
+    def probe_lifecycle_lock() -> None:
+        locked = owner._lifecycle_lock.acquire(timeout=1)
+        acquired.append(locked)
+        if locked:
+            owner._lifecycle_lock.release()
+
+    probe = threading.Thread(target=probe_lifecycle_lock)
+    probe.start()
+    probe.join(timeout=5)
+    assert not probe.is_alive()
+    assert acquired == [True]
+    owner.close()
+    assert owner.closed
+
+
+def test_owned_path_build_lifecycle_normal_settle_interrupt_releases_lock(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    interruption = KeyboardInterrupt("lifecycle normal settlement")
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_owned_path_on_line(
+            captured_directory._run_context_with_cleanup_actions.__wrapped__,
+            "_run_ordered_actions(failures)",
+            lambda: owner._run_lifecycle(lambda: None),
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    acquired: list[bool] = []
+
+    def probe_lifecycle_lock() -> None:
+        locked = owner._lifecycle_lock.acquire(timeout=1)
+        acquired.append(locked)
+        if locked:
+            owner._lifecycle_lock.release()
+
+    probe = threading.Thread(target=probe_lifecycle_lock)
+    probe.start()
+    probe.join(timeout=5)
+    assert not probe.is_alive()
+    assert acquired == [True]
+    owner.close()
+    assert owner.closed
+
+
+def test_owned_path_build_lifecycle_settlement_does_not_promote_ambient_error(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    ambient = RuntimeError("ambient caller error")
+    interruption = KeyboardInterrupt("lifecycle settlement")
+
+    try:
+        raise ambient
+    except RuntimeError:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            _interrupt_owned_path_on_line(
+                captured_directory._run_context_with_cleanup_actions.__wrapped__,
+                "_run_ordered_actions(failures)",
+                lambda: owner._run_lifecycle(lambda: None),
+                predicate=lambda values: any(
+                    getattr(action, "label", None)
+                    == "owned path build lifecycle lease release also failed"
+                    for action in values["failures"].actions
+                ),
+                error=interruption,
+            )
+
+    assert caught.value is interruption
+    assert caught.value is not ambient
+    assert not owner.closed
+    assert owner in captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+    acquired: list[bool] = []
+
+    def probe_lifecycle_lock() -> None:
+        locked = owner._lifecycle_lock.acquire(timeout=1)
+        acquired.append(locked)
+        if locked:
+            owner._lifecycle_lock.release()
+
+    probe = threading.Thread(target=probe_lifecycle_lock)
+    probe.start()
+    probe.join(timeout=5)
+    assert not probe.is_alive()
+    assert acquired == [True]
+    owner.close()
+    assert owner.closed
+
+
+def test_owned_path_build_global_retry_normal_settle_interrupt_releases_lock() -> None:
+    _retry_owned_path_build_cleanup()
+    interruption = KeyboardInterrupt("global retry normal settlement")
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_owned_path_on_line(
+            captured_directory._run_context_with_cleanup_actions.__wrapped__,
+            "_run_ordered_actions(failures)",
+            lambda: retry_retained_owned_path_build_cleanup(lambda _orphan: None),
+            predicate=lambda values: any(
+                getattr(action, "label", None)
+                == "owned path build retry lease release also failed"
+                for action in values["failures"].actions
+            ),
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    acquired: list[bool] = []
+
+    def probe_retry_lock() -> None:
+        locked = captured_directory._RETAINED_OWNED_PATH_BUILD_RETRY_LOCK.acquire(
+            timeout=1
+        )
+        acquired.append(locked)
+        if locked:
+            captured_directory._RETAINED_OWNED_PATH_BUILD_RETRY_LOCK.release()
+
+    probe = threading.Thread(target=probe_retry_lock)
+    probe.start()
+    probe.join(timeout=5)
+    assert not probe.is_alive()
+    assert acquired == [True]
+    assert _retry_owned_path_build_cleanup() == ()
+
+
+def test_owned_path_build_registry_normal_settle_interrupt_releases_lock() -> None:
+    _retry_owned_path_build_cleanup()
+    interruption = KeyboardInterrupt("registry normal settlement")
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_owned_path_on_line(
+            captured_directory._run_context_with_cleanup_actions.__wrapped__,
+            "_run_ordered_actions(failures)",
+            lambda: captured_directory._owned_path_build_directory_retained(object()),
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    acquired: list[bool] = []
+
+    def probe_registry_lock() -> None:
+        locked = captured_directory._RETAINED_OWNED_PATH_BUILD_LOCK.acquire(timeout=1)
+        acquired.append(locked)
+        if locked:
+            captured_directory._RETAINED_OWNED_PATH_BUILD_LOCK.release()
+
+    probe = threading.Thread(target=probe_registry_lock)
+    probe.start()
+    probe.join(timeout=5)
+    assert not probe.is_alive()
+    assert acquired == [True]
+
+
+def test_owned_path_build_registry_error_handler_interrupt_preserves_primary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    natural_failure = RuntimeError("registry append failed")
+    interruption = KeyboardInterrupt("registry outcome handler")
+
+    class FailingRegistry(list):
+        def append(self, _owner) -> None:
+            raise natural_failure
+
+    monkeypatch.setattr(
+        captured_directory,
+        "_RETAINED_OWNED_PATH_BUILD_DIRECTORIES",
+        FailingRegistry(),
+    )
+
+    with pytest.raises(RuntimeError, match="registry append failed") as caught:
+        _interrupt_owned_path_on_line(
+            captured_directory._capture_owned_path_build_lease_outcome,
+            "outcome.error = error",
+            lambda: captured_directory._register_owned_path_build_directory(object()),
+            predicate=lambda values: values.get("error") is natural_failure,
+            error=interruption,
+        )
+
+    assert caught.value is natural_failure
+    assert caught.value.__cause__ is interruption or any(
+        str(interruption) in note for note in getattr(caught.value, "__notes__", ())
+    )
+    acquired: list[bool] = []
+
+    def probe_registry_lock() -> None:
+        locked = captured_directory._RETAINED_OWNED_PATH_BUILD_LOCK.acquire(timeout=1)
+        acquired.append(locked)
+        if locked:
+            captured_directory._RETAINED_OWNED_PATH_BUILD_LOCK.release()
+
+    probe = threading.Thread(target=probe_registry_lock)
+    probe.start()
+    probe.join(timeout=5)
+    assert not probe.is_alive()
+    assert acquired == [True]
+
+
+@pytest.mark.parametrize("failure_kind", ["append", "iteration"])
+def test_owned_path_build_registry_native_with_interrupt_releases_lock(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_kind: str,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    lease_type = captured_directory._OwnedPathBuildRetryLease
+    helper = captured_directory._run_with_owned_path_build_lease
+    prime_lease = lease_type(
+        threading.RLock(),
+        acquire_blocking=False,
+        reentrant_error="prime reentrant",
+        concurrent_error="prime concurrent",
+    )
+    _prime_owned_path_opcode_tracing(
+        helper,
+        lambda: helper(
+            prime_lease,
+            lambda: None,
+            release_label="prime lease release",
+        ),
+    )
+    natural_failure = RuntimeError(f"registry {failure_kind} failed")
+    interruption = KeyboardInterrupt(f"registry {failure_kind} with handler")
+
+    class FailingRegistry(list):
+        def append(self, owner) -> None:
+            if failure_kind == "append":
+                raise natural_failure
+            super().append(owner)
+
+        def __iter__(self):
+            if failure_kind == "iteration":
+                raise natural_failure
+            return super().__iter__()
+
+    def bypass_outcome(callback, _outcome) -> None:
+        callback()
+
+    monkeypatch.setattr(
+        captured_directory,
+        "_RETAINED_OWNED_PATH_BUILD_DIRECTORIES",
+        FailingRegistry(),
+    )
+    monkeypatch.setattr(
+        captured_directory,
+        "_capture_owned_path_build_lease_outcome",
+        bypass_outcome,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_owned_path_on_opcode(
+            helper,
+            "WITH_EXCEPT_START",
+            lambda: captured_directory._register_owned_path_build_directory(object()),
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    assert caught.value.__context__ is natural_failure
+    acquired: list[bool] = []
+
+    def probe_registry_lock() -> None:
+        locked = captured_directory._RETAINED_OWNED_PATH_BUILD_LOCK.acquire(timeout=1)
+        acquired.append(locked)
+        if locked:
+            captured_directory._RETAINED_OWNED_PATH_BUILD_LOCK.release()
+
+    probe = threading.Thread(target=probe_registry_lock)
+    probe.start()
+    probe.join(timeout=5)
+    assert not probe.is_alive()
+    assert acquired == [True]
+
+
+@pytest.mark.parametrize(
+    "source_fragment",
+    ["lease.close()", "raise  # preserve lease settlement failure"],
+)
+def test_owned_path_build_lifecycle_fallback_interrupt_releases_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source_fragment: str,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    lease_type = captured_directory._OwnedPathBuildRetryLease
+    real_close = lease_type.close
+    natural_failure = OSError(errno.EIO, "initial lease release failed")
+    interruption = KeyboardInterrupt(f"fallback seam {source_fragment}")
+    close_calls = 0
+
+    def fail_first_close(lease) -> None:
+        nonlocal close_calls
+        close_calls += 1
+        if close_calls == 1:
+            raise natural_failure
+        real_close(lease)
+
+    monkeypatch.setattr(lease_type, "close", fail_first_close)
+
+    expected_error = (
+        natural_failure if source_fragment == "lease.close()" else interruption
+    )
+    with pytest.raises(type(expected_error)) as caught:
+        _interrupt_owned_path_on_line(
+            captured_directory._run_with_owned_path_build_lease,
+            source_fragment,
+            lambda: owner._run_lifecycle(lambda: None),
+            predicate=lambda values: values.get("primary_error") is natural_failure,
+            error=interruption,
+        )
+
+    assert caught.value is expected_error
+    acquired: list[bool] = []
+
+    def probe_lifecycle_lock() -> None:
+        locked = owner._lifecycle_lock.acquire(timeout=1)
+        acquired.append(locked)
+        if locked:
+            owner._lifecycle_lock.release()
+
+    probe = threading.Thread(target=probe_lifecycle_lock)
+    probe.start()
+    probe.join(timeout=5)
+    assert not probe.is_alive()
+    assert acquired == [True]
+
+    monkeypatch.setattr(lease_type, "close", real_close)
+    owner.close()
+    assert owner.closed
+
+
+def test_owned_path_build_quiescent_partial_failure_preserves_prior_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    first = OwnedPathBuildDirectory.prepare(parent / "first")
+    second = OwnedPathBuildDirectory.prepare(parent / "second")
+    first.path.joinpath("payload.bin").write_bytes(b"first")
+    second.path.joinpath("payload.bin").write_bytes(b"second")
+    real_isolate = OwnedPathBuildDirectory._isolate_and_close
+    failure = RuntimeError("second cleanup failed")
+    failed = False
+
+    def fail_second_once(
+        owner: OwnedPathBuildDirectory,
+        *,
+        require_orphan: bool,
+        _release_retention: bool = True,
+    ):
+        nonlocal failed
+        if owner is second and not failed:
+            failed = True
+            raise failure
+        return real_isolate(
+            owner,
+            require_orphan=require_orphan,
+            _release_retention=_release_retention,
+        )
+
+    monkeypatch.setattr(
+        OwnedPathBuildDirectory,
+        "_isolate_and_close",
+        fail_second_once,
+    )
+    accepted: list[atomic_directory.DirectoryOrphan] = []
+
+    with pytest.raises(RuntimeError, match="second cleanup failed") as caught:
+        retry_retained_owned_path_build_cleanup(accepted.append)
+
+    assert caught.value is failure
+    assert len(accepted) == 1
+    assert first.closed
+    assert not second.closed
+    assert second in captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+    assert (
+        accepted[0].reopen(
+            lambda reader: reader.read_bytes("payload.bin", max_bytes=16)
+        )
+        == b"first"
+    )
+
+    remaining = _retry_owned_path_build_cleanup()
+
+    assert len(remaining) == 1
+    assert second.closed
+    assert (
+        remaining[0].reopen(
+            lambda reader: reader.read_bytes("payload.bin", max_bytes=16)
+        )
+        == b"second"
+    )
+
+
+def test_owned_path_build_quiescent_first_failure_retains_later_owners(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    first = OwnedPathBuildDirectory.prepare(parent / "first")
+    second = OwnedPathBuildDirectory.prepare(parent / "second")
+    failure = RuntimeError("first cleanup failed")
+    real_retry = OwnedPathBuildDirectory._retry_quiescent_cleanup
+
+    def fail_first_once(
+        owner: OwnedPathBuildDirectory,
+        accept_orphan,
+    ) -> None:
+        if owner is first:
+            raise failure
+        real_retry(owner, accept_orphan)
+
+    monkeypatch.setattr(
+        OwnedPathBuildDirectory,
+        "_retry_quiescent_cleanup",
+        fail_first_once,
+    )
+
+    with pytest.raises(RuntimeError, match="first cleanup failed") as caught:
+        retry_retained_owned_path_build_cleanup(lambda _orphan: None)
+
+    assert caught.value is failure
+    assert not first.closed
+    assert not second.closed
+    assert first in captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+    assert second in captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+
+    monkeypatch.setattr(
+        OwnedPathBuildDirectory,
+        "_retry_quiescent_cleanup",
+        real_retry,
+    )
+    remaining = _retry_owned_path_build_cleanup()
+
+    assert len(remaining) == 2
+    assert first.closed
+    assert second.closed
+
+
+def test_owned_path_build_quiescent_return_interrupt_follows_acceptance(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    accepted: list[atomic_directory.DirectoryOrphan] = []
+    interruption = KeyboardInterrupt("quiescent retry return")
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_owned_path_return(
+            retry_retained_owned_path_build_cleanup,
+            lambda: retry_retained_owned_path_build_cleanup(accepted.append),
+            predicate=lambda _frame, result: result is None,
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    assert len(accepted) == 1
+    assert owner.closed
+    assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+    assert accepted[0].reopen(lambda reader: reader.inventory()) == ()
+
+
+def test_owned_path_build_operation_activation_interrupt_clears_lease(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    interruption = KeyboardInterrupt("operation activation")
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_owned_path_after_attribute_store(
+            OwnedPathBuildDirectory.path_operation.__wrapped__,
+            "_operation_lease",
+            lambda: owner.path_operation("writer").__enter__(),
+            next_line_fragment='self._verify_active(f"before {label}")',
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    assert owner._operation_lease is None
+    owner.close()
+    assert owner.closed
+
+
+def test_owned_path_build_operation_generator_return_interrupt_clears_lease(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    interruption = KeyboardInterrupt("operation generator return")
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_owned_path_return(
+            OwnedPathBuildDirectory.path_operation.__wrapped__,
+            lambda: owner.path_operation("writer").__enter__(),
+            predicate=lambda frame, result: (
+                frame.f_locals.get("self") is owner and result == owner.path
+            ),
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    # CPython 3.10 can retain the suspended generator at this return event;
+    # newer interpreters unwind it immediately.  The explicit quiescent
+    # boundary must settle either state without requiring a live caller.
+    _retry_owned_path_build_cleanup()
+    assert owner._operation_lease is None
+    assert owner.closed
+
+
+def test_owned_path_build_operation_context_return_uses_quiescent_retry(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    operation = owner.path_operation("writer")
+    interruption = KeyboardInterrupt("operation context return")
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_owned_path_return(
+            contextlib._GeneratorContextManager.__enter__,
+            operation.__enter__,
+            predicate=lambda frame, result: (
+                frame.f_locals.get("self") is operation and result == owner.path
+            ),
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    assert owner._operation_lease is not None
+    with pytest.raises(RuntimeError, match="reentrant"):
+        owner.close()
+
+    _retry_owned_path_build_cleanup()
+
+    assert owner._operation_lease is None
+    assert owner.closed
+    operation.gen.close()
+
+
+@pytest.mark.parametrize(
+    "handoff",
+    ("closed-authority-pointer", "released-pointer-registry"),
+)
+def test_owned_path_build_reconciles_authority_close_handoffs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    handoff: str,
+) -> None:
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    with owner.path_operation("writer"):
+        owner.path.joinpath("payload.bin").write_bytes(b"bytes")
+    authority_owner = owner._authority_owner
+    interruption = KeyboardInterrupt(handoff)
+    interrupted = False
+
+    if handoff == "closed-authority-pointer":
+        real_close = atomic_directory._PublicationAuthorityOwner.close
+
+        def close_authority_then_interrupt(candidate, **kwargs) -> None:
+            nonlocal interrupted
+            if candidate is authority_owner and not interrupted:
+                authority = candidate.authority
+                assert authority is not None
+                authority.close()
+                assert authority._closed
+                interrupted = True
+                raise interruption
+            real_close(candidate, **kwargs)
+
+        monkeypatch.setattr(
+            atomic_directory._PublicationAuthorityOwner,
+            "close",
+            close_authority_then_interrupt,
+        )
+    else:
+        real_forget = atomic_directory._forget_publication_authority_owner
+
+        def forget_then_interrupt(candidate) -> None:
+            nonlocal interrupted
+            if candidate is authority_owner and not interrupted:
+                interrupted = True
+                raise interruption
+            real_forget(candidate)
+
+        monkeypatch.setattr(
+            atomic_directory,
+            "_forget_publication_authority_owner",
+            forget_then_interrupt,
+        )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        owner.isolate()
+
+    assert caught.value is interruption
+    assert caught.value.captured_directory_cleanup_owner is owner
+    assert not owner.closed
+    assert not atomic_directory._publication_authority_owner_released(authority_owner)
+
+    orphan = owner.isolate()
+
+    assert not owner.closed
+    assert atomic_directory._publication_authority_owner_released(authority_owner)
+    assert (
+        orphan.reopen(lambda reader: reader.read_bytes("payload.bin", max_bytes=16))
+        == b"bytes"
+    )
+    owner.close()
+    assert owner.closed
+
+
+@pytest.mark.parametrize(
+    "global_name",
+    [
+        "_RETAINED_OWNED_PATH_BUILD_LOCK",
+        "_RETAINED_OWNED_PATH_BUILD_RETRY_LOCK",
+        "_RETAINED_OWNED_PATH_BUILD_PID",
+    ],
+)
+def test_owned_path_build_process_sync_store_interrupt_is_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+    global_name: str,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    original_pid = captured_directory._RETAINED_OWNED_PATH_BUILD_PID
+    original_registry_lock = captured_directory._RETAINED_OWNED_PATH_BUILD_LOCK
+    original_retry_lock = captured_directory._RETAINED_OWNED_PATH_BUILD_RETRY_LOCK
+    original_registry = captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+    assert not original_registry
+    inherited_owner = object()
+    child_pid = original_pid + 10_000_000
+    monkeypatch.setattr(
+        captured_directory,
+        "_RETAINED_OWNED_PATH_BUILD_LOCK",
+        original_registry_lock,
+    )
+    monkeypatch.setattr(
+        captured_directory,
+        "_RETAINED_OWNED_PATH_BUILD_RETRY_LOCK",
+        original_retry_lock,
+    )
+    monkeypatch.setattr(
+        captured_directory,
+        "_RETAINED_OWNED_PATH_BUILD_DIRECTORIES",
+        [inherited_owner],
+    )
+    monkeypatch.setattr(
+        captured_directory,
+        "_RETAINED_OWNED_PATH_BUILD_PID",
+        original_pid,
+    )
+    _prime_owned_path_opcode_tracing(
+        captured_directory._synchronize_owned_path_build_process,
+        captured_directory._synchronize_owned_path_build_process,
+    )
+    monkeypatch.setattr(captured_directory.os, "getpid", lambda: child_pid)
+    interruption = KeyboardInterrupt(f"after {global_name}")
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_owned_path_after_global_store(
+            captured_directory._synchronize_owned_path_build_process,
+            global_name,
+            captured_directory._synchronize_owned_path_build_process,
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    if global_name == "_RETAINED_OWNED_PATH_BUILD_PID":
+        assert captured_directory._RETAINED_OWNED_PATH_BUILD_PID == child_pid
+        assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+    else:
+        assert captured_directory._RETAINED_OWNED_PATH_BUILD_PID == original_pid
+
+    captured_directory._synchronize_owned_path_build_process()
+
+    assert captured_directory._RETAINED_OWNED_PATH_BUILD_PID == child_pid
+    assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+    assert captured_directory._RETAINED_OWNED_PATH_BUILD_LOCK.acquire(timeout=1)
+    captured_directory._RETAINED_OWNED_PATH_BUILD_LOCK.release()
+    assert captured_directory._RETAINED_OWNED_PATH_BUILD_RETRY_LOCK.acquire(timeout=1)
+    captured_directory._RETAINED_OWNED_PATH_BUILD_RETRY_LOCK.release()
+
+
+def test_owned_path_build_process_sync_return_interrupt_is_committed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    original_pid = captured_directory._RETAINED_OWNED_PATH_BUILD_PID
+    original_registry_lock = captured_directory._RETAINED_OWNED_PATH_BUILD_LOCK
+    original_retry_lock = captured_directory._RETAINED_OWNED_PATH_BUILD_RETRY_LOCK
+    original_registry = captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+    assert not original_registry
+    child_pid = original_pid + 10_000_000
+    monkeypatch.setattr(
+        captured_directory,
+        "_RETAINED_OWNED_PATH_BUILD_LOCK",
+        original_registry_lock,
+    )
+    monkeypatch.setattr(
+        captured_directory,
+        "_RETAINED_OWNED_PATH_BUILD_RETRY_LOCK",
+        original_retry_lock,
+    )
+    monkeypatch.setattr(
+        captured_directory,
+        "_RETAINED_OWNED_PATH_BUILD_DIRECTORIES",
+        [object()],
+    )
+    monkeypatch.setattr(
+        captured_directory,
+        "_RETAINED_OWNED_PATH_BUILD_PID",
+        original_pid,
+    )
+    monkeypatch.setattr(captured_directory.os, "getpid", lambda: child_pid)
+    interruption = KeyboardInterrupt("process sync return")
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_owned_path_return(
+            captured_directory._synchronize_owned_path_build_process,
+            captured_directory._synchronize_owned_path_build_process,
+            predicate=lambda _frame, result: result is None,
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    assert captured_directory._RETAINED_OWNED_PATH_BUILD_PID == child_pid
+    assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+    captured_directory._synchronize_owned_path_build_process()
+    assert captured_directory._RETAINED_OWNED_PATH_BUILD_PID == child_pid
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_owned_path_build_process_sync_reentrant_subclass_rejection_preserves_base(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    child_parent = tmp_path / "child-private"
+    child_parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    owner.path.joinpath("payload.bin").write_bytes(b"parent")
+    _prime_owned_path_opcode_tracing(
+        captured_directory._synchronize_owned_path_build_process,
+        captured_directory._synchronize_owned_path_build_process,
+    )
+    child = os.fork()
+    if child == 0:  # pragma: no branch - child reports exact status
+        signal.signal(signal.SIGALRM, lambda *_args: os._exit(70))
+        signal.alarm(5)
+        try:
+
+            class ChildOwnedPathBuildDirectory(OwnedPathBuildDirectory):
+                pass
+
+            def reject_subclass_then_prepare_base() -> None:
+                try:
+                    ChildOwnedPathBuildDirectory.prepare(
+                        child_parent / "subclass-attempt"
+                    )
+                except TypeError as error:
+                    if "does not support subclass construction" not in str(error):
+                        os._exit(71)
+                else:
+                    os._exit(72)
+                child_owner = OwnedPathBuildDirectory.prepare(
+                    child_parent / "base-attempt"
+                )
+                child_owner.path.joinpath("payload.bin").write_bytes(b"child")
+
+            _call_owned_path_before_global_load(
+                captured_directory._synchronize_owned_path_build_process,
+                "_RETAINED_OWNED_PATH_BUILD_DIRECTORIES",
+                reject_subclass_then_prepare_base,
+            )
+            gc.collect()
+            retained = captured_directory._snapshot_owned_path_build_directories()
+            if len(retained) != 1 or type(retained[0]) is not OwnedPathBuildDirectory:
+                os._exit(73)
+            if tuple(child_parent.glob(".subclass-attempt.normalize-*")):
+                os._exit(74)
+            child_orphans = _retry_owned_path_build_cleanup()
+            if len(child_orphans) != 1 or not retained[0].closed:
+                os._exit(75)
+            if (
+                child_orphans[0].reopen(
+                    lambda reader: reader.read_bytes("payload.bin", max_bytes=16)
+                )
+                != b"child"
+            ):
+                os._exit(76)
+        except BaseException:  # noqa: B036 - child reports exact failure
+            os._exit(77)
+        os._exit(0)
+
+    _pid, status = os.waitpid(child, 0)
+
+    assert os.WIFEXITED(status)
+    assert os.WEXITSTATUS(status) == 0
+    assert owner.path.joinpath("payload.bin").read_bytes() == b"parent"
+    assert not owner.closed
+    owner.close()
+    assert owner.closed
+
+
+@pytest.mark.parametrize(
+    "sync_seam",
+    [
+        "_RETAINED_OWNED_PATH_BUILD_LOCK",
+        "_RETAINED_OWNED_PATH_BUILD_RETRY_LOCK",
+        "_RETAINED_OWNED_PATH_BUILD_PID",
+        "remove",
+        "return",
+    ],
+)
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_owned_path_build_process_sync_reentrant_prepare_retains_child_owner(
+    tmp_path: Path,
+    sync_seam: str,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    child_parent = tmp_path / "child-private"
+    child_parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    owner.path.joinpath("payload.bin").write_bytes(b"parent")
+    _prime_owned_path_opcode_tracing(
+        captured_directory._synchronize_owned_path_build_process,
+        captured_directory._synchronize_owned_path_build_process,
+    )
+    child = os.fork()
+    if child == 0:  # pragma: no branch - child reports exact status
+        signal.signal(signal.SIGALRM, lambda *_args: os._exit(80))
+        signal.alarm(5)
+        try:
+
+            def prepare_child_owner() -> None:
+                child_owner = OwnedPathBuildDirectory.prepare(child_parent / "attempt")
+                child_owner.path.joinpath("payload.bin").write_bytes(b"child")
+
+            if sync_seam == "return":
+                _call_owned_path_on_return(
+                    captured_directory._synchronize_owned_path_build_process,
+                    prepare_child_owner,
+                )
+            elif sync_seam == "remove":
+                _call_owned_path_after_named_load(
+                    captured_directory._synchronize_owned_path_build_process,
+                    "remove",
+                    prepare_child_owner,
+                )
+            else:
+                _call_owned_path_after_global_store(
+                    captured_directory._synchronize_owned_path_build_process,
+                    sync_seam,
+                    prepare_child_owner,
+                )
+            gc.collect()
+            retained = captured_directory._snapshot_owned_path_build_directories()
+            if len(retained) != 1 or retained[0]._owner_pid != os.getpid():
+                os._exit(81)
+            child_orphans = _retry_owned_path_build_cleanup()
+            if len(child_orphans) != 1 or not retained[0].closed:
+                os._exit(82)
+            if (
+                child_orphans[0].reopen(
+                    lambda reader: reader.read_bytes("payload.bin", max_bytes=16)
+                )
+                != b"child"
+            ):
+                os._exit(83)
+            if captured_directory._snapshot_owned_path_build_directories():
+                os._exit(84)
+        except BaseException:  # noqa: B036 - child reports exact failure
+            os._exit(85)
+        os._exit(0)
+
+    _pid, status = os.waitpid(child, 0)
+
+    assert os.WIFEXITED(status)
+    assert os.WEXITSTATUS(status) == 0
+    assert owner.path.joinpath("payload.bin").read_bytes() == b"parent"
+    assert not owner.closed
+    owner.close()
+    assert owner.closed
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_owned_path_build_retained_registry_resets_forked_lock_without_cleanup(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    child_parent = tmp_path / "child-private"
+    child_parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    with owner.path_operation("writer"):
+        owner.path.joinpath("payload.bin").write_bytes(b"parent")
+    locked = threading.Event()
+    release = threading.Event()
+
+    def hold_registry_lock() -> None:
+        with captured_directory._RETAINED_OWNED_PATH_BUILD_RETRY_LOCK:
+            with owner._lifecycle_lock:
+                with captured_directory._RETAINED_OWNED_PATH_BUILD_LOCK:
+                    locked.set()
+                    release.wait(timeout=10)
+
+    holder = threading.Thread(target=hold_registry_lock)
+    holder.start()
+    assert locked.wait(timeout=5)
+    child = os.fork()
+    if child == 0:  # pragma: no branch - child reports exact status
+        signal.signal(signal.SIGALRM, lambda *_args: os._exit(90))
+        signal.alarm(3)
+        try:
+            _retry_owned_path_build_cleanup()
+            if not owner.path.joinpath("payload.bin").is_file():
+                os._exit(91)
+            try:
+                owner.close()
+            except RuntimeError as error:
+                if "PID boundary" not in str(error):
+                    os._exit(92)
+            else:
+                os._exit(93)
+            if not owner.path.joinpath("payload.bin").is_file():
+                os._exit(94)
+            child_owner = OwnedPathBuildDirectory.prepare(child_parent / "attempt")
+            child_owner.path.joinpath("payload.bin").write_bytes(b"child")
+            child_orphans = _retry_owned_path_build_cleanup()
+            if len(child_orphans) != 1 or not child_owner.closed:
+                os._exit(96)
+            if (
+                child_orphans[0].reopen(
+                    lambda reader: reader.read_bytes("payload.bin", max_bytes=16)
+                )
+                != b"child"
+            ):
+                os._exit(97)
+        except BaseException:  # noqa: B036 - child reports exact failure
+            os._exit(95)
+        os._exit(0)
+
+    try:
+        _pid, status = os.waitpid(child, 0)
+    finally:
+        release.set()
+        holder.join(timeout=5)
+
+    assert not holder.is_alive()
+    assert os.WIFEXITED(status)
+    assert os.WEXITSTATUS(status) == 0
+    assert owner.path.joinpath("payload.bin").read_bytes() == b"parent"
+    assert not owner.closed
+    owner.close()
+    assert owner.closed
+
+
+def test_owned_path_build_rejects_preexisting_ancestor_symlink(
+    tmp_path: Path,
+) -> None:
+    foreign = tmp_path / "foreign"
+    foreign.mkdir(mode=0o700)
+    trusted = tmp_path / "trusted"
+    trusted.mkdir(mode=0o700)
+    (trusted / "alias").symlink_to(foreign, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="real directory"):
+        OwnedPathBuildDirectory.prepare(trusted / "alias" / "attempt")
+
+    assert not tuple(foreign.glob(".attempt.normalize-*"))
+
+
+def test_owned_path_build_create_parent_uses_private_missing_parent(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "new" / "nested" / "attempt"
+
+    owner = OwnedPathBuildDirectory.prepare(destination, create_parent=True)
+    try:
+        assert stat.S_IMODE(destination.parent.stat().st_mode) == 0o700
+        assert not destination.exists()
+    finally:
+        owner.close()
+
+
+def test_owned_path_build_rejects_ancestor_replacement_and_retries_cleanup(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    with owner.path_operation("initial writer"):
+        (owner.path / "owned.bin").write_bytes(b"owned")
+    saved_parent = tmp_path / "saved-parent"
+    parent.rename(saved_parent)
+    parent.mkdir(mode=0o700)
+    owner.path.mkdir(mode=0o700)
+    valuable = owner.path / "valuable.bin"
+    valuable.write_bytes(b"foreign")
+
+    with pytest.raises(RuntimeError, match="changed during before raced writer"):
+        with owner.path_operation("raced writer"):
+            (owner.path / "should-not-exist").write_bytes(b"bad")
+    with pytest.raises(RuntimeError) as caught:
+        owner.close()
+
+    assert caught.value.captured_directory_cleanup_owner is owner
+    assert not owner.closed
+    assert valuable.read_bytes() == b"foreign"
+    assert not (owner.path / "should-not-exist").exists()
+
+    foreign_parent = tmp_path / "foreign-parent"
+    parent.rename(foreign_parent)
+    saved_parent.rename(parent)
+    owner.close()
+
+    assert owner.closed
+    assert (
+        foreign_parent / owner.path.name / "valuable.bin"
+    ).read_bytes() == b"foreign"
+
+
+def test_owned_path_build_rejects_child_replacement_and_retries_cleanup(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    with owner.path_operation("initial writer"):
+        (owner.path / "owned.bin").write_bytes(b"owned")
+    stolen = parent / "stolen-owned-root"
+    owner.path.rename(stolen)
+    owner.path.mkdir(mode=0o700)
+    valuable = owner.path / "valuable.bin"
+    valuable.write_bytes(b"foreign")
+
+    with pytest.raises(RuntimeError, match="changed during before raced writer"):
+        with owner.path_operation("raced writer"):
+            (owner.path / "should-not-exist").write_bytes(b"bad")
+    with pytest.raises(RuntimeError) as caught:
+        owner.close()
+
+    assert caught.value.captured_directory_cleanup_owner is owner
+    assert not owner.closed
+    assert valuable.read_bytes() == b"foreign"
+    foreign = parent / "foreign-root"
+    owner.path.rename(foreign)
+    stolen.rename(owner.path)
+    owner.close()
+
+    assert owner.closed
+    assert (foreign / "valuable.bin").read_bytes() == b"foreign"
+    assert not (foreign / "should-not-exist").exists()
+
+
+def test_owned_path_build_rejects_active_root_disappearance_until_restored(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    with owner.path_operation("path writer"):
+        owner.path.joinpath("payload.bin").write_bytes(b"owned")
+    stolen = parent / "stolen-owned-root"
+    owner.path.rename(stolen)
+
+    with pytest.raises(RuntimeError, match="disappeared") as caught:
+        owner.close()
+
+    assert caught.value.captured_directory_cleanup_owner is owner
+    assert not owner.closed
+    assert stolen.joinpath("payload.bin").read_bytes() == b"owned"
+    stolen.rename(owner.path)
+
+    orphan = owner.isolate()
+    assert not owner.closed
+    assert (
+        orphan.reopen(lambda reader: reader.read_bytes("payload.bin", max_bytes=16))
+        == b"owned"
+    )
+    owner.close()
+    assert owner.closed
+
+
+def test_owned_path_build_preserves_capture_cancellation_and_remains_owned(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    with owner.path_operation("path writer"):
+        for index in range(3):
+            (owner.path / f"payload-{index}.bin").write_bytes(b"bytes")
+    interruption = KeyboardInterrupt("capture cancelled")
+
+    def cancel() -> None:
+        raise interruption
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        owner.capture_ownership(check_cancelled=cancel)
+
+    assert caught.value is interruption
+    assert not owner.closed
+    assert owner.path.is_dir()
+    owner.close()
+    assert owner.closed
+
+
+def test_owned_path_build_retains_retry_after_isolation_cleanup_interrupt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    with owner.path_operation("path writer"):
+        (owner.path / "payload.bin").write_bytes(b"bytes")
+    interruption = KeyboardInterrupt("cleanup interrupted")
+    real_close = captured_directory.OwnedDirectoryStage._close_descriptors
+    interrupted = False
+
+    def interrupt_once(stage: OwnedDirectoryStage) -> None:
+        nonlocal interrupted
+        if stage is owner._stage and not interrupted:
+            interrupted = True
+            raise interruption
+        real_close(stage)
+
+    monkeypatch.setattr(
+        captured_directory.OwnedDirectoryStage,
+        "_close_descriptors",
+        interrupt_once,
+    )
+    with pytest.raises(KeyboardInterrupt) as caught:
+        owner.isolate()
+
+    assert caught.value is interruption
+    assert caught.value.captured_directory_cleanup_owner is owner
+    assert not owner.closed
+    assert not owner.path.exists()
+
+    orphan = owner.isolate()
+    assert not owner.closed
+    assert (
+        orphan.reopen(lambda reader: reader.read_bytes("payload.bin", max_bytes=16))
+        == b"bytes"
+    )
+    owner.close()
+    assert owner.closed
+
+
+def test_owned_path_build_reconciles_move_before_helper_result_handoff(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    with owner.path_operation("path writer"):
+        owner.path.joinpath("payload.bin").write_bytes(b"bytes")
+    real_discard = captured_directory._discard_owned_directory_with_authority
+    interruption = KeyboardInterrupt("after isolation helper result")
+    interrupted = False
+
+    def discard_then_interrupt(*args, **kwargs):
+        nonlocal interrupted
+        orphan = real_discard(*args, **kwargs)
+        if not interrupted:
+            interrupted = True
+            raise interruption
+        return orphan
+
+    monkeypatch.setattr(
+        captured_directory,
+        "_discard_owned_directory_with_authority",
+        discard_then_interrupt,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        owner.isolate()
+
+    assert caught.value is interruption
+    assert caught.value.captured_directory_cleanup_owner is owner
+    assert not owner.path.exists()
+    retained = owner._isolation_owner
+    assert retained is not None and retained.orphan is not None
+
+    orphan = owner.isolate()
+    assert orphan is retained.orphan
+    assert not owner.closed
+    assert (
+        orphan.reopen(lambda reader: reader.read_bytes("payload.bin", max_bytes=16))
+        == b"bytes"
+    )
+    owner.close()
+    assert owner.closed
+
+
+@pytest.mark.parametrize("post_commit_error", (False, True))
+def test_owned_path_build_rebinds_restored_source_before_isolation_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    post_commit_error: bool,
+) -> None:
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    with owner.path_operation("path writer"):
+        owner.path.joinpath("payload.bin").write_bytes(b"bytes")
+    real_require = atomic_directory._OwnedDirectoryIsolationOwner._require_exact_tree
+    failed_verification = False
+
+    def fail_first_moved_verification(
+        isolation_owner,
+        path: Path,
+        *,
+        label: str,
+        allow_root_rename: bool = False,
+    ) -> None:
+        nonlocal failed_verification
+        if label == "moved destination" and not failed_verification:
+            failed_verification = True
+            raise RuntimeError("injected moved-tree verification failure")
+        real_require(
+            isolation_owner,
+            path,
+            label=label,
+            allow_root_rename=allow_root_rename,
+        )
+
+    monkeypatch.setattr(
+        atomic_directory._OwnedDirectoryIsolationOwner,
+        "_require_exact_tree",
+        fail_first_moved_verification,
+    )
+    restore_interrupted = False
+    if post_commit_error:
+        authority = owner._authority_owner.authority
+        assert authority is not None
+        real_rename = atomic_directory._PublicationAuthority.rename_noreplace
+
+        def restore_then_error(candidate, source: str, destination: str):
+            nonlocal restore_interrupted
+            result = real_rename(candidate, source, destination)
+            if (
+                candidate is authority
+                and destination == owner.path.name
+                and source != owner.path.name
+                and not restore_interrupted
+            ):
+                restore_interrupted = True
+                raise OSError(errno.EIO, "injected post-restore failure")
+            return result
+
+        monkeypatch.setattr(
+            atomic_directory._PublicationAuthority,
+            "rename_noreplace",
+            restore_then_error,
+        )
+
+    with pytest.raises(RuntimeError, match="could not be isolated") as caught:
+        owner.isolate()
+
+    assert caught.value.captured_directory_cleanup_owner is owner
+    assert failed_verification
+    assert restore_interrupted is post_commit_error
+    assert owner.path.joinpath("payload.bin").read_bytes() == b"bytes"
+    retained = owner._isolation_owner
+    assert retained is not None
+    assert retained.orphan is None
+    assert retained._candidate is None
+
+    orphan = owner.isolate()
+
+    assert not owner.closed
+    assert (
+        orphan.reopen(lambda reader: reader.read_bytes("payload.bin", max_bytes=16))
+        == b"bytes"
+    )
+    owner.close()
+    assert owner.closed
+
+
+def test_owned_path_build_rechecks_parent_after_descriptor_close_interrupt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    with owner.path_operation("path writer"):
+        owner.path.joinpath("payload.bin").write_bytes(b"bytes")
+    real_close = OwnedDirectoryStage._close_descriptors
+    interruption = KeyboardInterrupt("after descriptor close")
+    interrupted = False
+
+    def close_then_interrupt(stage: OwnedDirectoryStage) -> None:
+        nonlocal interrupted
+        real_close(stage)
+        if stage is owner._stage and not interrupted:
+            interrupted = True
+            raise interruption
+
+    monkeypatch.setattr(
+        OwnedDirectoryStage,
+        "_close_descriptors",
+        close_then_interrupt,
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        owner.isolate()
+
+    retained = owner._isolation_owner
+    assert retained is not None and retained.orphan is not None
+    orphan = retained.orphan
+    saved_parent = tmp_path / "saved-private"
+    parent.rename(saved_parent)
+    parent.mkdir(mode=0o700)
+
+    with pytest.raises(RuntimeError) as caught:
+        owner.isolate()
+
+    assert caught.value.captured_directory_cleanup_owner is owner
+    assert not owner.closed
+    assert (
+        saved_parent.joinpath(orphan.path.name, "payload.bin").read_bytes() == b"bytes"
+    )
+    replacement_parent = tmp_path / "replacement-private"
+    parent.rename(replacement_parent)
+    saved_parent.rename(parent)
+
+    assert owner.isolate() is orphan
+    assert not owner.closed
+    owner.close()
+    assert owner.closed
+
+
+def test_owned_path_build_rechecks_orphan_child_before_authority_release(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    owner = OwnedPathBuildDirectory.prepare(parent / "attempt")
+    with owner.path_operation("path writer"):
+        owner.path.joinpath("payload.bin").write_bytes(b"bytes")
+    real_close = OwnedDirectoryStage._close_descriptors
+    interruption = KeyboardInterrupt("after descriptor close")
+    interrupted = False
+
+    def close_then_interrupt(stage: OwnedDirectoryStage) -> None:
+        nonlocal interrupted
+        real_close(stage)
+        if stage is owner._stage and not interrupted:
+            interrupted = True
+            raise interruption
+
+    monkeypatch.setattr(
+        OwnedDirectoryStage,
+        "_close_descriptors",
+        close_then_interrupt,
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        owner.isolate()
+
+    retained = owner._isolation_owner
+    assert retained is not None and retained.orphan is not None
+    orphan = retained.orphan
+    saved_orphan = parent / "saved-exact-orphan"
+    orphan.path.rename(saved_orphan)
+    orphan.path.mkdir(mode=0o700)
+    orphan.path.joinpath("valuable.bin").write_bytes(b"foreign")
+
+    with pytest.raises(RuntimeError) as caught:
+        owner.isolate()
+
+    assert caught.value.captured_directory_cleanup_owner is owner
+    assert not owner.closed
+    assert orphan.path.joinpath("valuable.bin").read_bytes() == b"foreign"
+    foreign = parent / "foreign-orphan"
+    orphan.path.rename(foreign)
+    saved_orphan.rename(orphan.path)
+
+    assert owner.isolate() is orphan
+    assert not owner.closed
+    assert foreign.joinpath("valuable.bin").read_bytes() == b"foreign"
+    assert (
+        orphan.reopen(lambda reader: reader.read_bytes("payload.bin", max_bytes=16))
+        == b"bytes"
+    )
+    owner.close()
+    assert owner.closed
 
 
 def test_workspace_plan_is_canonical_and_bound_to_its_subject() -> None:


### PR DESCRIPTION
## Summary

Adds a sealed caller-scoped owned path build authority for arbitrary path writers. The boundary retains its exact parent, stage, cleanup, and orphan receipt through cancellation, fork, namespace drift, and public return handoffs without granting catalog or final publication authority.

## Changes

- Add `OwnedPathBuildDirectory` with no-follow parent validation, private attempt creation, captured ownership, exact-tree isolation, and explicit receipt acknowledgement.
- Add process-local quiescent cleanup with serialized at-least-once orphan delivery and fork-safe retained-owner reconciliation.
- Harden `OwnedDirectoryStage` descriptor and construction cleanup so the new owner can reconcile interrupted acquisition and close operations.
- Reject an overlong derived stage component before owner registration or missing-parent mutation, and settle an unexpectedly invalid generated name without retaining roots or descriptors.
- Document direct `close()` as an explicit receipt-delivery waiver; durable consumers must use `isolate()` followed by durable receipt storage and `close()` acknowledgement.
- Reconcile the storage roadmap with the implemented BM25 factory, resolver, and CLI entry while leaving OwnedPath adoption and the attempt-pool reaper pending.
- Add adversarial coverage for cancellation, cleanup precedence, fork reentry, lock settlement, last-reference handoff, namespace swaps, ambiguous creation, receipt redelivery, and bounded stage names.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Python 3.10, 3.12, and 3.14: 560 passed, 10 skipped in the combined atomic-directory and captured-directory suites on each version.
- Owned-path focused tier: 65 passed on each supported Python version.
- Python 3.12 unit tier excluding the unchanged Docker-host test: 8,546 passed, 34 skipped, 190 deselected. The unfiltered run reached 4,031 passed before the host's missing `/usr/bin/docker` triggered that pre-existing environment-dependent test.
- Black, isort, flake8, `py_compile` on all three versions, and `git diff --check` passed.
- Independent fork, interruption, authority, receipt, bounded-name, and namespace adversarial probes passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
