### PR TITLE
feat(cli): run BM25 jobs from retained source

### DIFF
--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -4047,6 +4047,11 @@ def _run_with_local_bm25_source_job_worker(
                 namespace_name=namespace,
                 repository_root_authority=repository_authority,
                 environ=_publication_environment(),
+                display_commit_resolver=lambda: _bm25_source_job_display_commit(
+                    paths.repo_path
+                ),
+                workspace_parent_identity=topology.workspace_binding.identity,
+                topology_verifier=topology.verify,
             )
             resources = LocalBM25SourceJobResourceFactory((target,))
             worker = IndexJobWorker(

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -22,7 +22,7 @@ from collections import Counter
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
-from typing import Callable, Iterable, Sequence
+from typing import Callable, Iterable, Sequence, TypeVar
 
 from ._version import package_version
 from .provider_routes import (
@@ -57,6 +57,7 @@ _MAX_RETAINED_MOUNTINFO_ENTRIES = 65_536
 _MAX_RETAINED_MOUNTINFO_LINE_BYTES = 64 * 1024
 _MAX_RETAINED_ALIAS_COMPONENTS = 256
 _MAX_RETAINED_ALIAS_PATH_BYTES = 4_096
+_JobCandidate = TypeVar("_JobCandidate")
 
 
 class CLIError(RuntimeError):
@@ -3838,6 +3839,43 @@ def _bm25_source_job_display_commit(repo_path: Path) -> str:
     return commit
 
 
+def _bm25_source_job_infrastructure_guard(
+    verifier: Callable[[], None],
+) -> Callable[[], None]:
+    """Promote retained-topology loss beyond ordinary job retry handling."""
+
+    if not callable(verifier):
+        raise TypeError("BM25 source worker topology verifier must be callable")
+
+    def verify() -> None:
+        from .storage import StorageIntegrityError
+
+        try:
+            verifier()
+        except CLIError as exc:
+            raise StorageIntegrityError(
+                "BM25 source worker retained topology changed"
+            ) from exc
+
+    return verify
+
+
+def _index_job_candidate_filter_with_guard(
+    verifier: Callable[[], None],
+    candidate_filter: Callable[[_JobCandidate], bool],
+) -> Callable[[_JobCandidate], bool]:
+    """Recheck infrastructure before a candidate can acquire a job lease."""
+
+    if not callable(verifier) or not callable(candidate_filter):
+        raise TypeError("guarded job candidate filter requires callables")
+
+    def accepts(candidate: _JobCandidate) -> bool:
+        verifier()
+        return candidate_filter(candidate)
+
+    return accepts
+
+
 def _run_with_local_index_job_worker(args: argparse.Namespace, operation):
     """Run one callback with the selected exact local worker adapter."""
 
@@ -4035,6 +4073,9 @@ def _run_with_local_bm25_source_job_worker(
                     require_preprovisioned=True,
                 )
             )
+            attempt_topology_verifier = _bm25_source_job_infrastructure_guard(
+                topology.verify
+            )
             target = LocalBM25SourceJobTarget(
                 repository_root=paths.repo_path,
                 workspace_provider=provider,
@@ -4051,7 +4092,7 @@ def _run_with_local_bm25_source_job_worker(
                     paths.repo_path
                 ),
                 workspace_parent_identity=topology.workspace_binding.identity,
-                topology_verifier=topology.verify,
+                topology_verifier=attempt_topology_verifier,
             )
             resources = LocalBM25SourceJobResourceFactory((target,))
             worker = IndexJobWorker(
@@ -4067,7 +4108,10 @@ def _run_with_local_bm25_source_job_worker(
                 lease_duration_ms=args.lease_duration_ms,
                 heartbeat_interval_ms=args.heartbeat_interval_ms,
                 scan_limit=args.scan_limit,
-                candidate_filter=resources.accepts_candidate,
+                candidate_filter=_index_job_candidate_filter_with_guard(
+                    attempt_topology_verifier,
+                    resources.accepts_candidate,
+                ),
             )
             topology.verify()
             result = operation(worker)

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -2495,6 +2495,48 @@ def _new_compiler_cache_import_nonce() -> str:
 
 
 @dataclass(frozen=True, slots=True)
+class _BM25SourceJobWorkerPaths:
+    repo_path: Path
+    catalog_path: Path
+    cas_root: Path
+    workspace_root: Path
+    topology_probe: Path
+
+
+def _bm25_source_job_worker_paths(
+    args: argparse.Namespace,
+) -> _BM25SourceJobWorkerPaths:
+    """Freeze source-worker paths without touching its attempt namespace."""
+
+    import secrets
+
+    repo_path = resolve_repo_path(args.repo)
+    catalog_path = _lexical_cli_path(args.catalog, label="catalog")
+    cas_root = _lexical_cli_path(args.cas_root, label="CAS root")
+    workspace_root = _lexical_cli_path(args.workspace_root, label="workspace root")
+    for first, first_label, second, second_label in (
+        (catalog_path, "catalog", cas_root, "CAS root"),
+        (catalog_path, "catalog", workspace_root, "workspace root"),
+        (cas_root, "CAS root", workspace_root, "workspace root"),
+        (repo_path, "repository", catalog_path, "catalog"),
+        (repo_path, "repository", cas_root, "CAS root"),
+        (repo_path, "repository", workspace_root, "workspace root"),
+    ):
+        if _paths_overlap(first, second):
+            raise CLIError(f"{first_label} must not overlap the {second_label}")
+    nonce = secrets.token_hex(16)
+    if re.fullmatch(r"[0-9a-f]{32}", nonce, flags=re.ASCII) is None:
+        raise RuntimeError("BM25 source worker topology nonce is invalid")
+    return _BM25SourceJobWorkerPaths(
+        repo_path=repo_path,
+        catalog_path=catalog_path,
+        cas_root=cas_root,
+        workspace_root=workspace_root,
+        topology_probe=(workspace_root / f".codenib-source-worker-topology-{nonce}"),
+    )
+
+
+@dataclass(frozen=True, slots=True)
 class _CompilerCacheImportPaths:
     repo_path: Path
     cache_dir: Path
@@ -3770,8 +3812,53 @@ def _run_artifact_import_cache(args: argparse.Namespace) -> int:
         raise
 
 
+def _bm25_source_job_worker_selection(
+    args: argparse.Namespace,
+) -> RepositorySourceSelection:
+    exclude_dirs = getattr(args, "exclude_dir", None)
+    clear = bool(getattr(args, "clear_exclude_dirs", False))
+    if exclude_dirs is not None and clear:
+        raise CLIError("--exclude-dir and --clear-exclude-dirs are mutually exclusive")
+    if clear or exclude_dirs is None:
+        return RepositorySourceSelection()
+    try:
+        return RepositorySourceSelection(exclude_dirs)
+    except (TypeError, ValueError) as exc:
+        raise CLIError(f"invalid --exclude-dir: {exc}") from exc
+
+
+def _bm25_source_job_display_commit(repo_path: Path) -> str:
+    from .compiler.checkout_identity import checkout_commit
+
+    commit = (checkout_commit(repo_path) or "").strip().lower()
+    if re.fullmatch(r"[0-9a-f]{40}", commit) is None:
+        raise CLIError(
+            "BM25 source workers require a Git checkout with a full resolved HEAD"
+        )
+    return commit
+
+
 def _run_with_local_index_job_worker(args: argparse.Namespace, operation):
-    """Run one callback while retaining an exact local worker topology."""
+    """Run one callback with the selected exact local worker adapter."""
+
+    if not callable(operation):
+        raise TypeError("local index job worker operation must be callable")
+    if bool(getattr(args, "source_bm25", False)):
+        return _run_with_local_bm25_source_job_worker(args, operation)
+    if (
+        getattr(args, "language", ())
+        or getattr(args, "exclude_dir", None) is not None
+        or bool(getattr(args, "clear_exclude_dirs", False))
+    ):
+        raise CLIError("--language and source-selection options require --source-bm25")
+    return _run_with_local_compiler_cache_job_worker(args, operation)
+
+
+def _run_with_local_compiler_cache_job_worker(
+    args: argparse.Namespace,
+    operation,
+):
+    """Run one callback while retaining an exact local cache-worker topology."""
 
     from . import LocalWorkspaceProvider
     from ._atomic_directory import _OrderedAction, _run_context_with_cleanup_actions
@@ -3798,8 +3885,6 @@ def _run_with_local_index_job_worker(args: argparse.Namespace, operation):
         _inherit_publication_cleanup_owners(wrapped, exc)
         raise wrapped from exc
 
-    if not callable(operation):
-        raise TypeError("local index job worker operation must be callable")
     missing_result = object()
     result = missing_result
     try:
@@ -3861,6 +3946,141 @@ def _run_with_local_index_job_worker(args: argparse.Namespace, operation):
         raise
 
 
+def _run_with_local_bm25_source_job_worker(
+    args: argparse.Namespace,
+    operation,
+):
+    """Run one callback with a retained-source BM25 worker topology."""
+
+    from . import LocalWorkspaceProvider
+    from ._atomic_directory import _OrderedAction, _run_context_with_cleanup_actions
+    from .artifacts.runtime import SourceBindingCleanupOwner
+    from .compiler.index_builders import BM25IndexBuilder
+    from .compiler.job_resolver import BM25SourceJobResolver
+    from .compiler.job_resources import (
+        LocalBM25SourceJobResourceFactory,
+        LocalBM25SourceJobTarget,
+    )
+    from .source_fingerprint import pin_repository_source_root
+    from .storage import IndexJobWorker, LocalCAS
+
+    repository, namespace = _retained_materialization_identity(
+        args.repository,
+        args.namespace,
+    )
+    paths = _bm25_source_job_worker_paths(args)
+    selection = _bm25_source_job_worker_selection(args)
+
+    missing_result = object()
+    result = missing_result
+    try:
+        object_store_owner = _RetainedMaterializationResourceOwner()
+        topology_owner = _RetainedMaterializationResourceOwner()
+        repository_authority_owner = SourceBindingCleanupOwner()
+        cleanup_actions = (
+            _OrderedAction(
+                label="source worker local CAS cleanup also failed",
+                action=object_store_owner.close,
+                complete=lambda: object_store_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=object_store_owner,
+            ),
+            _OrderedAction(
+                label="source worker path authority cleanup also failed",
+                action=topology_owner.close,
+                complete=lambda: topology_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=topology_owner,
+            ),
+            _OrderedAction(
+                label="source worker repository authority cleanup also failed",
+                action=repository_authority_owner.close,
+                complete=lambda: repository_authority_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=repository_authority_owner,
+            ),
+        )
+        with _run_context_with_cleanup_actions(cleanup_actions):
+            repository_authority = pin_repository_source_root(
+                paths.repo_path,
+                _source_owner=repository_authority_owner.retain,
+            )
+            provider = LocalWorkspaceProvider(paths.workspace_root)
+            provider.require_support()
+            repository_authority.verify()
+            topology = topology_owner.acquire(
+                lambda: _require_retained_materialization_topology(
+                    paths.catalog_path,
+                    paths.cas_root,
+                    paths.workspace_root,
+                    paths.topology_probe,
+                    repo_path=paths.repo_path,
+                    repository_authority=repository_authority,
+                )
+            )
+            topology.verify()
+            languages = _selected_languages(
+                paths.repo_path,
+                args.language,
+                source_selection=selection,
+            )
+            topology.verify()
+            display_commit = _bm25_source_job_display_commit(paths.repo_path)
+            topology.verify()
+            object_store = object_store_owner.acquire(
+                lambda: LocalCAS(
+                    topology.cas_root,
+                    require_preprovisioned=True,
+                )
+            )
+            target = LocalBM25SourceJobTarget(
+                repository_root=paths.repo_path,
+                workspace_provider=provider,
+                repository_key=repository,
+                display_commit=display_commit,
+                builder=BM25IndexBuilder(
+                    languages=languages,
+                    source_selection=selection,
+                ),
+                namespace_name=namespace,
+                repository_root_authority=repository_authority,
+                environ=_publication_environment(),
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+            worker = IndexJobWorker(
+                catalog_factory=_ExistingIndexJobCatalogFactory(
+                    topology.catalog_path,
+                    topology.catalog_identity,
+                ),
+                object_store=object_store,
+                resolver=BM25SourceJobResolver(
+                    resource_factory=resources,
+                    object_store=object_store,
+                ),
+                lease_duration_ms=args.lease_duration_ms,
+                heartbeat_interval_ms=args.heartbeat_interval_ms,
+                scan_limit=args.scan_limit,
+                candidate_filter=resources.accepts_candidate,
+            )
+            topology.verify()
+            result = operation(worker)
+            topology.verify()
+        if result is missing_result:  # pragma: no cover - callback always returns
+            raise RuntimeError("index job worker operation returned no result")
+        return result
+    except BaseException as primary_error:  # noqa: B036 - preserve cancellation
+        if isinstance(primary_error, CLIError):
+            raise
+        if isinstance(
+            primary_error,
+            (OSError, RuntimeError, ValueError, sqlite3.Error),
+        ):
+            wrapped = CLIError(str(primary_error))
+            _inherit_publication_cleanup_owners(wrapped, primary_error)
+            raise wrapped from primary_error
+        raise
+
+
 def _index_job_run_payload(result) -> dict[str, object]:
     return {
         "attempt_count": result.attempt_count,
@@ -3880,7 +4100,7 @@ def _compact_json_line(payload: dict[str, object]) -> str:
 
 
 def _run_jobs_run_once(args: argparse.Namespace) -> int:
-    """Run one bounded prepare-only compiler-cache worker scan."""
+    """Run one bounded prepare-only index worker scan."""
 
     result = _run_with_local_index_job_worker(args, lambda worker: worker.run_once())
     payload = _index_job_run_payload(result)
@@ -3943,7 +4163,7 @@ def _jobs_scheduler_stop_signal():
 
 
 def _run_jobs_continuous(args: argparse.Namespace) -> int:
-    """Continuously traverse eligible compiler-cache jobs with cursor fairness."""
+    """Continuously traverse eligible index jobs with cursor fairness."""
 
     from .storage import IndexJobWorkerScheduler
 
@@ -5709,7 +5929,11 @@ def _add_embedding_route_arguments(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def _add_source_selection_arguments(parser: argparse.ArgumentParser) -> None:
+def _add_source_selection_arguments(
+    parser: argparse.ArgumentParser,
+    *,
+    persisted: bool = True,
+) -> None:
     selection = parser.add_mutually_exclusive_group()
     selection.add_argument(
         "--exclude-dir",
@@ -5717,14 +5941,22 @@ def _add_source_selection_arguments(parser: argparse.ArgumentParser) -> None:
         default=None,
         metavar="PATH",
         help=(
-            "replace persisted custom exclusions with this exact "
-            "repository-relative subtree; repeat for multiple paths"
+            (
+                "replace persisted custom exclusions with this exact "
+                if persisted
+                else "exclude this exact "
+            )
+            + "repository-relative subtree; repeat for multiple paths"
         ),
     )
     selection.add_argument(
         "--clear-exclude-dirs",
         action="store_true",
-        help="clear persisted custom subtree exclusions",
+        help=(
+            "clear persisted custom subtree exclusions"
+            if persisted
+            else "use no custom subtree exclusions"
+        ),
     )
 
 
@@ -5735,11 +5967,23 @@ def _add_jobs_worker_arguments(parser: argparse.ArgumentParser) -> None:
         "repo",
         help="trusted local repository source for eligible jobs",
     )
-    parser.add_argument(
+    worker_input = parser.add_mutually_exclusive_group(required=True)
+    worker_input.add_argument(
         "--cache-dir",
-        required=True,
         help="existing compiler cache containing current BM25/vector views",
     )
+    worker_input.add_argument(
+        "--source-bm25",
+        action="store_true",
+        help="build matching FULL BM25 jobs directly from retained source",
+    )
+    parser.add_argument(
+        "--language",
+        action="append",
+        default=[],
+        help="source language for --source-bm25; repeat or comma-separate values",
+    )
+    _add_source_selection_arguments(parser, persisted=False)
     parser.add_argument(
         "--catalog",
         required=True,

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -3844,6 +3844,8 @@ def _run_with_local_index_job_worker(args: argparse.Namespace, operation):
     if not callable(operation):
         raise TypeError("local index job worker operation must be callable")
     if bool(getattr(args, "source_bm25", False)):
+        if getattr(args, "cache_dir", None) is not None:
+            raise CLIError("--cache-dir cannot be combined with --source-bm25")
         return _run_with_local_bm25_source_job_worker(args, operation)
     if (
         getattr(args, "language", ())

--- a/codenib/compiler/job_resources.py
+++ b/codenib/compiler/job_resources.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from dataclasses import InitVar, dataclass, field
 from pathlib import Path
 from types import MappingProxyType
-from typing import Iterator, Mapping
+from typing import Callable, Iterator, Mapping
 
 from .._atomic_directory import (
     DirectoryOrphan,
@@ -24,8 +24,10 @@ from .._atomic_directory import (
 )
 from .._captured_directory import PublishedWorkspaceReceiptOwner
 from .._local_workspace_provider import LocalWorkspaceProvider
+from .._workspace_provider import StrictWorkspaceRequest, StrictWorkspaceSession
 from ..artifacts.runtime import SourceBindingCleanupOwner
 from ..source_fingerprint import (
+    RepositorySourceBinding,
     RepositorySourceRootAuthority,
     capture_repository_source,
     lexical_repository_path,
@@ -87,6 +89,53 @@ def _require_physical_roots_disjoint(
         raise ValueError(f"{label} cannot be authenticated") from exc
     if _paths_overlap(physical_first, physical_second):
         raise ValueError(f"{label} must not overlap")
+
+
+@dataclass(frozen=True, slots=True)
+class _RetainedBM25WorkspaceProvider:
+    """Bind every source-job provision to one retained worker topology."""
+
+    delegate: LocalWorkspaceProvider
+    parent_identity: tuple[int, ...] | None
+    topology_verifier: Callable[[], None] | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+
+    def _verify(self) -> None:
+        if self.topology_verifier is not None:
+            self.topology_verifier()
+
+    def require_support(self) -> None:
+        self._verify()
+        self.delegate.require_support()
+        self._verify()
+
+    def run_workspace(
+        self,
+        request: StrictWorkspaceRequest,
+        *,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        operation: Callable[[StrictWorkspaceSession], object],
+        check_cancelled: Callable[[], None] | None = None,
+    ) -> object:
+        self._verify()
+        arguments = {
+            "receipt_owner": receipt_owner,
+            "operation": operation,
+            "_expected_parent_identity": self.parent_identity,
+        }
+        if check_cancelled is None:
+            result = self.delegate.run_workspace(request, **arguments)
+        else:
+            result = self.delegate.run_workspace(
+                request,
+                **arguments,
+                check_cancelled=check_cancelled,
+            )
+        self._verify()
+        return result
 
 
 @dataclass(frozen=True, slots=True)
@@ -209,6 +258,21 @@ class LocalBM25SourceJobTarget:
         repr=False,
         compare=False,
     )
+    display_commit_resolver: Callable[[], str] | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    workspace_parent_identity: tuple[int, ...] | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    topology_verifier: Callable[[], None] | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
     _repository_id: str = field(init=False, repr=False)
     _builder: _BM25BuilderConfiguration = field(init=False, repr=False)
     _profile_id: str = field(init=False, repr=False)
@@ -248,6 +312,21 @@ class LocalBM25SourceJobTarget:
                 raise ValueError(
                     "BM25 source target repository authority differs from its root"
                 )
+        display_commit_resolver = self.display_commit_resolver
+        if display_commit_resolver is not None and not callable(
+            display_commit_resolver
+        ):
+            raise TypeError("BM25 source target display commit resolver is invalid")
+        workspace_parent_identity = self.workspace_parent_identity
+        if workspace_parent_identity is not None and (
+            type(workspace_parent_identity) is not tuple
+            or len(workspace_parent_identity) < 2
+            or any(type(value) is not int for value in workspace_parent_identity)
+        ):
+            raise TypeError("BM25 source target workspace identity is invalid")
+        topology_verifier = self.topology_verifier
+        if topology_verifier is not None and not callable(topology_verifier):
+            raise TypeError("BM25 source target topology verifier is invalid")
         namespace = NamespaceIdentity(self.namespace_name)
         repository = RepositoryIdentity(
             namespace_id=namespace.namespace_id,
@@ -282,6 +361,15 @@ class LocalBM25SourceJobTarget:
         object.__setattr__(self, "_repository_id", repository.repository_id)
         object.__setattr__(self, "_builder", configuration)
         object.__setattr__(self, "_profile_id", profile.profile_id)
+        object.__setattr__(
+            self,
+            "workspace_parent_identity",
+            (
+                None
+                if workspace_parent_identity is None
+                else tuple(workspace_parent_identity)
+            ),
+        )
 
     @property
     def repository_id(self) -> str:
@@ -294,6 +382,57 @@ class LocalBM25SourceJobTarget:
     @property
     def profile_id(self) -> str:
         return self._profile_id
+
+    def verify_topology(self) -> None:
+        """Recheck the optional caller-retained worker topology."""
+
+        if self.topology_verifier is not None:
+            self.topology_verifier()
+
+    def current_display_commit(self) -> str:
+        """Resolve provenance while the configured root/topology stays live."""
+
+        self.verify_topology()
+        authority = self.repository_root_authority
+        if authority is not None:
+            authority.verify()
+        resolver = self.display_commit_resolver
+        commit = self.display_commit if resolver is None else resolver()
+        if authority is not None:
+            authority.verify()
+        self.verify_topology()
+        return _exact_display_commit(commit)
+
+    def capture_source(
+        self,
+        *,
+        source_owner: SourceBindingCleanupOwner,
+        check_cancelled: Callable[[], None] | None = None,
+    ) -> RepositorySourceBinding:
+        """Capture the exact source policy under the retained worker topology."""
+
+        if type(source_owner) is not SourceBindingCleanupOwner:
+            raise TypeError("BM25 source target requires an exact source cleanup owner")
+        if check_cancelled is not None and not callable(check_cancelled):
+            raise TypeError("BM25 source target stop check must be callable")
+        self.verify_topology()
+        self.workspace_provider.require_support()
+        _require_physical_roots_disjoint(
+            self.workspace_root,
+            self.repository_root,
+            label="BM25 source target physical workspace and repository",
+        )
+        self.verify_topology()
+        source = capture_repository_source(
+            self.repository_root,
+            exclude_roots=(self.workspace_root,),
+            selection=self._builder.source_selection,
+            _source_owner=source_owner.retain,
+            expected_root_authority=self.repository_root_authority,
+            check_cancelled=check_cancelled,
+        )
+        self.verify_topology()
+        return source
 
 
 @dataclass(slots=True)
@@ -831,18 +970,9 @@ class LocalBM25SourceJobResourceFactory:
         try:
             with _run_context_with_cleanup_actions(cleanup_actions):
                 check_cancelled()
-                target.workspace_provider.require_support()
-                _require_physical_roots_disjoint(
-                    target.workspace_root,
-                    target.repository_root,
-                    label="BM25 source target physical workspace and repository",
-                )
-                repository_source = capture_repository_source(
-                    target.repository_root,
-                    exclude_roots=(target.workspace_root,),
-                    selection=target._builder.source_selection,
-                    _source_owner=source_owner.retain,
-                    expected_root_authority=target.repository_root_authority,
+                display_commit = target.current_display_commit()
+                repository_source = target.capture_source(
+                    source_owner=source_owner,
                     check_cancelled=check_cancelled,
                 )
                 source_owner.retain(repository_source)
@@ -855,10 +985,25 @@ class LocalBM25SourceJobResourceFactory:
                     raise StorageValidationError(
                         "BM25 source job source has no current trusted local target"
                     )
+                repository_source.verify_snapshot(check_cancelled=check_cancelled)
+                if target.current_display_commit() != display_commit:
+                    raise StorageValidationError(
+                        "BM25 source job Git HEAD changed during source capture"
+                    )
+                workspace_provider = (
+                    target.workspace_provider
+                    if target.workspace_parent_identity is None
+                    and target.topology_verifier is None
+                    else _RetainedBM25WorkspaceProvider(
+                        delegate=target.workspace_provider,
+                        parent_identity=target.workspace_parent_identity,
+                        topology_verifier=target.topology_verifier,
+                    )
+                )
                 check_cancelled()
                 yield BM25SourceJobExecutor(
                     attempt_generation=attempt_destination,
-                    display_commit=target.display_commit,
+                    display_commit=display_commit,
                     builder=target._builder.builder(),
                     attempt_output_owner=attempt_owner,
                     attempt_workspace_provider=target.workspace_provider,
@@ -867,12 +1012,20 @@ class LocalBM25SourceJobResourceFactory:
                     context_output_owner=context_owner,
                     view_destination=view_destination,
                     context_destination=context_destination,
-                    workspace_provider=target.workspace_provider,
+                    workspace_provider=workspace_provider,
                     repository_key=target.repository_key,
                     object_store=object_store,
                     namespace_name=target.namespace_name,
                     environ=target.environ,
+                    attempt_parent_identity=target.workspace_parent_identity,
+                    attempt_topology_verifier=target.topology_verifier,
                 )
+                check_cancelled()
+                repository_source.verify_snapshot(check_cancelled=check_cancelled)
+                if target.current_display_commit() != display_commit:
+                    raise StorageValidationError(
+                        "BM25 source job Git HEAD changed before publication"
+                    )
         except BaseException as error:  # noqa: B036 - retain cleanup authority
             pending = tuple(
                 owner for owner in cleanup_owners if _cleanup_owner_pending(owner)

--- a/codenib/compiler/job_resources.py
+++ b/codenib/compiler/job_resources.py
@@ -199,12 +199,12 @@ class LocalBM25SourceJobTarget:
     display_commit: str
     builder: InitVar[BM25IndexBuilder]
     namespace_name: str = DEFAULT_NAMESPACE_NAME
-    repository_root_authority: RepositorySourceRootAuthority | None = field(
+    environ: Mapping[str, str] | None = field(
         default=None,
         repr=False,
         compare=False,
     )
-    environ: Mapping[str, str] | None = field(
+    repository_root_authority: RepositorySourceRootAuthority | None = field(
         default=None,
         repr=False,
         compare=False,

--- a/codenib/compiler/job_resources.py
+++ b/codenib/compiler/job_resources.py
@@ -25,7 +25,11 @@ from .._atomic_directory import (
 from .._captured_directory import PublishedWorkspaceReceiptOwner
 from .._local_workspace_provider import LocalWorkspaceProvider
 from ..artifacts.runtime import SourceBindingCleanupOwner
-from ..source_fingerprint import capture_repository_source, lexical_repository_path
+from ..source_fingerprint import (
+    RepositorySourceRootAuthority,
+    capture_repository_source,
+    lexical_repository_path,
+)
 from ..storage.job_worker import IndexJobExecutionContext
 from ..storage.models import (
     DEFAULT_NAMESPACE_NAME,
@@ -195,6 +199,11 @@ class LocalBM25SourceJobTarget:
     display_commit: str
     builder: InitVar[BM25IndexBuilder]
     namespace_name: str = DEFAULT_NAMESPACE_NAME
+    repository_root_authority: RepositorySourceRootAuthority | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
     environ: Mapping[str, str] | None = field(
         default=None,
         repr=False,
@@ -228,6 +237,17 @@ class LocalBM25SourceJobTarget:
             raise ValueError(
                 "BM25 source target workspace must not overlap the repository"
             )
+        repository_authority = self.repository_root_authority
+        if repository_authority is not None:
+            if type(repository_authority) is not RepositorySourceRootAuthority:
+                raise TypeError(
+                    "BM25 source target repository authority has an invalid type"
+                )
+            repository_authority.verify()
+            if repository_authority.root != repository_root:
+                raise ValueError(
+                    "BM25 source target repository authority differs from its root"
+                )
         namespace = NamespaceIdentity(self.namespace_name)
         repository = RepositoryIdentity(
             namespace_id=namespace.namespace_id,
@@ -822,6 +842,7 @@ class LocalBM25SourceJobResourceFactory:
                     exclude_roots=(target.workspace_root,),
                     selection=target._builder.source_selection,
                     _source_owner=source_owner.retain,
+                    expected_root_authority=target.repository_root_authority,
                     check_cancelled=check_cancelled,
                 )
                 source_owner.retain(repository_source)

--- a/codenib/compiler/source_job.py
+++ b/codenib/compiler/source_job.py
@@ -204,12 +204,21 @@ class _RetainedCacheWorkspaceProvider:
     delegate: LocalWorkspaceProvider
     parent_authority: _PublicationAuthority = field(repr=False, compare=False)
     parent_identity: tuple[int, ...]
+    topology_verifier: Callable[[], None] | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
 
     def _verify_parent(self) -> None:
+        if self.topology_verifier is not None:
+            self.topology_verifier()
         self.parent_authority.verify_path_binding()
         observed = publication_parent_identity(self.parent_authority.resource)
         if observed != self.parent_identity:
             raise RuntimeError("BM25 source cache parent authority changed")
+        if self.topology_verifier is not None:
+            self.topology_verifier()
 
     def require_support(self) -> None:
         self._verify_parent()
@@ -853,6 +862,12 @@ class BM25SourceJobExecutor:
         repr=False,
         compare=False,
     )
+    attempt_parent_identity: tuple[int, ...] | None = None
+    attempt_topology_verifier: Callable[[], None] | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
     _builder: _BM25BuilderConfiguration = field(init=False, repr=False)
     _profile: ViewProfile = field(init=False, repr=False)
 
@@ -901,6 +916,21 @@ class BM25SourceJobExecutor:
         _require_attempt_provider_destination(
             self.attempt_generation,
             self.attempt_workspace_provider,
+        )
+        parent_identity = self.attempt_parent_identity
+        if parent_identity is not None and (
+            type(parent_identity) is not tuple
+            or len(parent_identity) < 2
+            or any(type(value) is not int for value in parent_identity)
+        ):
+            raise TypeError("BM25 source job attempt parent identity is invalid")
+        topology_verifier = self.attempt_topology_verifier
+        if topology_verifier is not None and not callable(topology_verifier):
+            raise TypeError("BM25 source job topology verifier must be callable")
+        object.__setattr__(
+            self,
+            "attempt_parent_identity",
+            None if parent_identity is None else tuple(parent_identity),
         )
         object.__setattr__(self, "_builder", configuration)
         object.__setattr__(self, "_profile", configuration.profile())
@@ -967,6 +997,8 @@ class BM25SourceJobExecutor:
             forbidden_paths=operation.inputs.forbidden_paths,
         )
         check_cancelled()
+        if self.attempt_topology_verifier is not None:
+            self.attempt_topology_verifier()
         with _PublicationAuthorityOwner() as parent_owner:
             parent_authority = _open_publication_authority(
                 self.attempt_generation.parent,
@@ -975,10 +1007,18 @@ class BM25SourceJobExecutor:
                 authority_owner=parent_owner,
             )
             parent_identity = publication_parent_identity(parent_authority.resource)
+            if (
+                self.attempt_parent_identity is not None
+                and parent_identity != self.attempt_parent_identity
+            ):
+                raise RuntimeError(
+                    "BM25 source attempt parent differs from retained topology"
+                )
             retained_provider = _RetainedCacheWorkspaceProvider(
                 delegate=self.attempt_workspace_provider,
                 parent_authority=parent_authority,
                 parent_identity=parent_identity,
+                topology_verifier=self.attempt_topology_verifier,
             )
             parent_authority.verify_path_binding()
             _preflight_source_job_topology(

--- a/codenib/web/index_job_writes.py
+++ b/codenib/web/index_job_writes.py
@@ -249,12 +249,12 @@ def _replayed_job_response(
 
 
 class CatalogIndexJobWriter:
-    """Create one honest FULL cache job through an atomic catalog slot.
+    """Create one honest FULL worker job through an atomic catalog slot.
 
-    The current production worker can recapture exactly one already-current
-    BM25 or vector compiler-cache view. This writer therefore rejects
-    incremental, symbol-graph, multi-view, and force requests instead of
-    claiming a capability the worker does not implement.
+    The current production adapters can prepare one exact retained-source BM25
+    view or recapture one already-current BM25/vector compiler-cache view. This
+    writer therefore rejects incremental, symbol-graph, multi-view, and force
+    requests instead of claiming a capability no worker implements.
     """
 
     def __init__(

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -336,8 +336,13 @@ workspace root obey the same physical-separation and existing-only requirements
 as `artifact import-cache`. Source mode pins the repository hierarchy before
 provider probing, language detection, or Git inspection and hands that exact
 authority to every attempt capture. It requires a Git checkout with a full
-resolved `HEAD`; that commit is display metadata, while the authenticated dirty
-source fingerprint remains the durable source identity. The worker opens an
+resolved `HEAD`; each attempt resolves that commit around source capture and
+again before returning its prepared result, so a long-running worker never
+stamps later bytes with its startup commit. The commit is display metadata,
+while the authenticated dirty source fingerprint remains the durable source
+identity. Every source attempt, BM25 view, and context provision is also bound
+to the retained startup workspace identity and rechecks the complete storage
+topology before and after provider work. The worker opens an
 independent exact SQLite session for its main transaction and every heartbeat,
 while retaining one strict CAS authority for the complete invocation. A
 claim-time eligibility filter runs before owner allocation or catalog mutation,

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -20,8 +20,9 @@ The provider is not enabled by CodeNib's default compiler or runtime path. Six
 explicit routes use it: `codenib index --publish-retained` builds and publishes
 current BM25/vector views in one compiler-cache lease, `codenib artifact
 import-cache` recaptures an already existing selected cache, `codenib jobs
-run-once` prepares and publishes at most one eligible durable cache job,
-`codenib jobs run` continuously schedules the same explicitly scoped jobs,
+run-once` prepares and publishes at most one eligible durable cache-import or
+retained-source BM25 job, `codenib jobs run` continuously schedules the same
+explicitly scoped jobs,
 `codenib artifact materialize` publishes a retained catalog ref or immutable
 snapshot to a missing portable-artifact directory, and retained `codenib mcp`
 cold-start materializes and holds one such generation for a single stdio server

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -311,23 +311,36 @@ repository, namespace, and ref with the original `--expected-generation`.
 The retry gets fresh missing evidence destinations but resolves the same
 snapshot and generation without advancing the ref again.
 
-## Run durable cache jobs
+## Run durable index jobs
 
 `codenib jobs run-once` examines one bounded advisory catalog page and executes
-at most one job for one explicitly configured local repository target. The job
-must already exist in the catalog and request exactly one required `full` BM25
-or vector view whose profile and dirty source-revision identity match the
-current compiler cache. This command does not create jobs, build or update a
-stale cache, loop continuously, or hot-switch a query runtime.
+at most one job for one explicitly configured local repository target. Select
+exactly one worker input:
 
-The repository, cache, SQLite catalog, strict LocalCAS, and private workspace
-root obey the same physical-separation and existing-only requirements as
-`artifact import-cache`. The worker opens an independent exact SQLite session
-for its main transaction and every heartbeat, while retaining one strict CAS
-authority for the complete pass. A claim-time eligibility filter runs before
-owner allocation or catalog mutation: jobs for other repository IDs, multi-view
-requests, optional views, incremental requests, graph, and other unsupported
-builders remain untouched in the queue.
+- `--cache-dir PATH` retains the existing compiler-cache adapter. A job must
+  request exactly one required `full` BM25 or vector view whose profile and
+  dirty source-revision identity match that current cache.
+- `--source-bm25` enables the retained-source builder. A job must request one
+  required `full` BM25 view whose profile exactly matches the selected
+  languages and source exclusions, and whose dirty source fingerprint matches
+  a fresh authenticated capture. Vector, graph, optional, incremental, and
+  multi-view jobs remain in the queue.
+
+Neither mode creates jobs or hot-switches a query runtime. Source mode builds a
+private attempt generation directly from source; cache mode does not build or
+update a stale cache.
+
+The repository, optional cache, SQLite catalog, strict LocalCAS, and private
+workspace root obey the same physical-separation and existing-only requirements
+as `artifact import-cache`. Source mode pins the repository hierarchy before
+provider probing, language detection, or Git inspection and hands that exact
+authority to every attempt capture. It requires a Git checkout with a full
+resolved `HEAD`; that commit is display metadata, while the authenticated dirty
+source fingerprint remains the durable source identity. The worker opens an
+independent exact SQLite session for its main transaction and every heartbeat,
+while retaining one strict CAS authority for the complete invocation. A
+claim-time eligibility filter runs before owner allocation or catalog mutation,
+so jobs outside the selected adapter and explicit target remain untouched.
 
 For example, process at most one current-cache job from the first 64 advisory
 candidates:
@@ -341,6 +354,24 @@ codenib jobs run-once /srv/src/repository \
   --repository owner/repository
 ```
 
+Build a matching Python BM25 job directly from retained source instead:
+
+```bash
+codenib jobs run-once /srv/src/repository \
+  --source-bm25 \
+  --language python \
+  --catalog /var/lib/codenib/catalog.sqlite3 \
+  --cas-root /var/lib/codenib/cas \
+  --workspace-root /var/lib/codenib/workspaces \
+  --repository owner/repository
+```
+
+Repeat `--language` or pass comma-separated values for a multi-language BM25
+profile. If it is omitted, CodeNib detects supported languages from the selected
+source. `--exclude-dir PATH` is repeatable and defines the exact custom subtree
+exclusions for this worker profile; `--clear-exclude-dirs` explicitly selects
+none. These source-only options are rejected with `--cache-dir`.
+
 `--scan-limit` may select 1 through 256 candidates. Lease and heartbeat timing
 are configurable, but the heartbeat must remain less than one third of the
 lease. The default text output reports disposition, job ID, and attempt; use
@@ -349,11 +380,12 @@ cancellation, or authority loss is a durable worker disposition rather than a
 CLI infrastructure failure. Storage-integrity, topology, and cleanup failures
 still make the command fail.
 
-Each attempt captures a fresh retained source and uses new nonce-scoped view
-and context destinations. After CAS ingestion and worker-owned publication, the
-receipt authorities close and the exact owned directories are atomically moved
-to authenticated orphan names for later quiescent GC; the command never
-recursively deletes a mutable path.
+Each attempt captures a fresh retained source and uses new nonce-scoped output
+destinations. Source builds own an attempt generation plus BM25 and context
+outputs; cache imports own BM25/vector and context outputs as applicable. After
+CAS ingestion and worker-owned publication, receipt authorities close and the
+exact owned directories are atomically moved to authenticated orphan names for
+later quiescent GC; the command never recursively deletes a mutable path.
 
 `codenib jobs run` retains the same authorities while traversing the complete
 runnable keyspace frozen at the start of each cycle. The catalog first records
@@ -392,9 +424,10 @@ records. SIGTERM requests a graceful stop after the active page or job; SIGINT
 keeps the standard exit-130 interruption path. Catalog, topology, worker, and
 cleanup failures are never retried or downgraded by the idle scheduler.
 
-This route still recaptures an already-current compiler cache. It does not
-create jobs, rebuild stale views, coordinate SQLite session startup across
-independent processes, register a query runtime, or hot-switch a live bundle.
+Cache mode still recaptures an already-current compiler cache; source mode can
+build only its exact FULL BM25 profile. Neither mode creates jobs, coordinates
+SQLite session startup across independent processes, registers a query runtime,
+or hot-switches a live bundle.
 
 ## Materialize a retained artifact
 

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1345,8 +1345,11 @@ mode pins the repository hierarchy before provider probing or repository reads,
 passes that authority into every fresh capture, and accepts only the exact FULL
 BM25 builder profile selected by its language and exclusion arguments. It also
 re-resolves display provenance per attempt and rejects HEAD drift before fenced
-publication rather than stamping later source bytes with the startup commit. A
-trusted candidate filter runs on a detached canonical job before owner
+publication rather than stamping later source bytes with the startup commit.
+The source candidate filter rechecks retained topology before lease acquisition,
+and every later attempt verifier promotes topology loss to a storage-integrity
+alarm, so a continuous scheduler terminates instead of consuming job retries.
+A trusted candidate filter runs on a detached canonical job before owner
 allocation or lease acquisition, so foreign repositories and unsupported view
 requests remain untouched. `run-once`
 examines one bounded advisory page and executes at most one eligible job. The

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1318,8 +1318,9 @@ longer matches the job.
 
 The retained-source BM25 bridge now has the matching resource-scoped resolver
 and trusted local target factory. Each source target freezes the exact builder
-profile, display commit, environment, repository identity/root, optional
-pre-pinned root authority, and private workspace provider. Its pre-claim filter
+profile, environment, repository identity/root, optional pre-pinned root
+authority, private workspace provider, and optional per-attempt provenance and
+topology guards. Its pre-claim filter
 accepts only that target's single required `full` BM25 profile. Scope
 declaration is side-effect free; entry authenticates lexical and physical
 repository/workspace separation before source capture, binds the worker's exact
@@ -1328,8 +1329,11 @@ fresh nonce-scoped attempt, BM25, and context destinations. Ordered exit closes
 source and receipt authorities and isolates only their receipt-owned trees for
 quiescent GC. A changed source fails before build or CAS mutation, and worker
 integration coverage proves the previous published ref remains unchanged. The
-production CLI now selects this binding explicitly; no Web planner, runtime
-refresh trigger, or default route selects it yet.
+production CLI now selects this binding explicitly. It resolves one stable Git
+HEAD around each fresh source capture and again before returning the prepared
+result, and binds every attempt/view/context provision to the retained startup
+workspace identity while rechecking the complete storage topology. No Web
+planner, runtime refresh trigger, or default route selects it yet.
 
 The production CLI binding exposes both trusted local adapters through
 `codenib jobs run-once` and `codenib jobs run`, with an explicit mutually
@@ -1339,7 +1343,9 @@ sessions for each main pass and heartbeat, and retain the strict local CAS for
 the whole invocation. Cache mode additionally binds its compiler cache. Source
 mode pins the repository hierarchy before provider probing or repository reads,
 passes that authority into every fresh capture, and accepts only the exact FULL
-BM25 builder profile selected by its language and exclusion arguments. A
+BM25 builder profile selected by its language and exclusion arguments. It also
+re-resolves display provenance per attempt and rejects HEAD drift before fenced
+publication rather than stamping later source bytes with the startup commit. A
 trusted candidate filter runs on a detached canonical job before owner
 allocation or lease acquisition, so foreign repositories and unsupported view
 requests remain untouched. `run-once`

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1318,26 +1318,31 @@ longer matches the job.
 
 The retained-source BM25 bridge now has the matching resource-scoped resolver
 and trusted local target factory. Each source target freezes the exact builder
-profile, display commit, environment, repository identity/root, and private
-workspace provider. Its pre-claim filter accepts only that target's single
-required `full` BM25 profile. Scope declaration is side-effect free; entry
-authenticates lexical and physical repository/workspace separation before
-source capture, binds the worker's exact retained object store, recaptures the
-current dirty fingerprint, and creates fresh nonce-scoped attempt, BM25, and
-context destinations. Ordered exit closes source and receipt authorities and
-isolates only their receipt-owned trees for quiescent GC. A changed source
-fails before build or CAS mutation, and worker integration coverage proves the
-previous published ref remains unchanged. This is still a library binding: no
-production CLI, Web planner, runtime refresh trigger, or default route selects
-it yet.
+profile, display commit, environment, repository identity/root, optional
+pre-pinned root authority, and private workspace provider. Its pre-claim filter
+accepts only that target's single required `full` BM25 profile. Scope
+declaration is side-effect free; entry authenticates lexical and physical
+repository/workspace separation before source capture, binds the worker's exact
+retained object store, recaptures the current dirty fingerprint, and creates
+fresh nonce-scoped attempt, BM25, and context destinations. Ordered exit closes
+source and receipt authorities and isolates only their receipt-owned trees for
+quiescent GC. A changed source fails before build or CAS mutation, and worker
+integration coverage proves the previous published ref remains unchanged. The
+production CLI now selects this binding explicitly; no Web planner, runtime
+refresh trigger, or default route selects it yet.
 
-The production CLI binding exposes that target as `codenib jobs run-once` and
-`codenib jobs run`. Both freeze the same existing-only repository/cache/catalog/
-CAS/workspace topology used by retained cache import, open independent exact
-SQLite sessions for each main pass and heartbeat, and retain the strict local
-CAS for the whole invocation. A trusted candidate filter runs on a detached
-canonical job before owner allocation or lease acquisition, so foreign
-repositories and unsupported view requests remain untouched. `run-once`
+The production CLI binding exposes both trusted local adapters through
+`codenib jobs run-once` and `codenib jobs run`, with an explicit mutually
+exclusive choice between `--cache-dir` and `--source-bm25`. Both freeze an
+existing-only repository/catalog/CAS/workspace topology, open independent exact SQLite
+sessions for each main pass and heartbeat, and retain the strict local CAS for
+the whole invocation. Cache mode additionally binds its compiler cache. Source
+mode pins the repository hierarchy before provider probing or repository reads,
+passes that authority into every fresh capture, and accepts only the exact FULL
+BM25 builder profile selected by its language and exclusion arguments. A
+trusted candidate filter runs on a detached canonical job before owner
+allocation or lease acquisition, so foreign repositories and unsupported view
+requests remain untouched. `run-once`
 examines one bounded advisory page and executes at most one eligible job. The
 continuous scheduler freezes an attested catalog insertion watermark for each
 cycle, carries an attested keyset cursor across its bounded pages, wraps only
@@ -1348,9 +1353,9 @@ wrapped retry or make a configured cycle limit unbounded. SQLite schema 7
 allocates that watermark from an explicit immutable `AUTOINCREMENT` job
 sequence, validates a gap-free job-to-sequence closure, and backfills existing
 jobs in canonical creation order; it therefore remains stable across `VACUUM`
-instead of depending on mutable implicit rowids. Cache-building adapters,
-job-triggered runtime registration, and default routing remain absent. The Web
-runtime now has the generation-safe refresh boundary described under M3.
+instead of depending on mutable implicit rowids. Job-triggered runtime
+registration and default routing remain absent. The Web runtime now has the
+generation-safe refresh boundary described under M3.
 
 ### M2: Immutable generation publication
 
@@ -1360,9 +1365,9 @@ their prepare-only worker bridge, are implemented. The first caller-scoped
 retained-source BM25 builder and its prepare-only source-job adapter now publish
 and ingest a unique private generation under an exact retained parent and
 generation receipt, without final publication authority or a cache-path reopen;
-its local attempt resource factory and resolver are implemented. Vector and
-graph source builders, generic builder routing, production source-job entry
-points, and remaining runtime wiring remain.
+its local attempt resource factory, resolver, and explicit production CLI entry
+are implemented. Vector and graph source builders, generic builder routing, and
+remaining runtime wiring remain.
 
 - Make every builder write to a unique staging generation.
 - Add per-view profile adapters that fail closed on incomplete compatibility
@@ -1392,15 +1397,15 @@ authenticated source bytes. Both executor paths now have resource-scoped
 resolvers and trusted local target factories that guarantee attempt-local
 cleanup, same-store binding, and exact configured repository/source identity.
 The explicit CLI can run one bounded pass or a cursor-fair continuous scheduler
-over the current compiler cache; it does not yet select the source builder. The
-Web registry now prepares a complete replacement
+over either an exact current compiler cache or the explicit retained-source BM25
+builder. The Web registry now prepares a complete replacement
 bundle before atomically publishing it, pins the exact generation for each
 in-flight request, defers old vector/source cleanup until the final pin exits,
 and invalidates bundle-bound Wiki, edge-label, and commit-window caches by
 generation identity.
 The first #266 status, durable-read, and explicitly injected one-view write
-slices are present; a production source-job CLI and Web planner/default binding,
-success-triggered refresh, MCP, UI controls, and default routing remain absent.
+slices are present; a Web planner/default binding, success-triggered refresh,
+MCP, UI controls, and default routing remain absent.
 
 - The backend-neutral worker now owns advisory scan/claim, per-attempt task
   authority, independent heartbeat sessions, cancellation precedence, bounded

--- a/test/compiler/test_source_job.py
+++ b/test/compiler/test_source_job.py
@@ -1416,6 +1416,19 @@ def test_local_bm25_source_target_binds_exact_repository_root_authority(
     foreign = tmp_path / "foreign-repository"
     foreign.mkdir(mode=0o700)
     try:
+        positional_environment = {"CODENIB_SOURCE_POSITIONAL_TEST": "preserved"}
+        positional_target = LocalBM25SourceJobTarget(
+            fixture.repository,
+            fixture.provider,
+            _REPOSITORY_KEY,
+            _COMMIT,
+            BM25IndexBuilder(),
+            "default",
+            positional_environment,
+        )
+        assert positional_target.environ == positional_environment
+        assert positional_target.repository_root_authority is None
+
         with pin_repository_source_root(fixture.repository) as authority:
             target = LocalBM25SourceJobTarget(
                 repository_root=fixture.repository,

--- a/test/compiler/test_source_job.py
+++ b/test/compiler/test_source_job.py
@@ -22,6 +22,7 @@ import codenib.compiler.cache_import as cache_import_module
 import codenib.compiler.job_resources as job_resources_module
 import codenib.compiler.source_job as source_job_module
 from codenib import LocalWorkspaceProvider
+from codenib._atomic_directory import publication_parent_identity
 from codenib._captured_directory import (
     PublishedWorkspaceReceiptOwner,
     UnsupportedWorkspaceCreation,
@@ -155,6 +156,27 @@ def _source_fixture(
         attempt_provider=LocalWorkspaceProvider(tmp_path),
         owners=[],
     )
+
+
+def _git_head(repository: Path) -> str:
+    return subprocess.run(
+        ("git", "-C", os.fspath(repository), "rev-parse", "HEAD"),
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _commit_source(repository: Path, content: str, message: str) -> str:
+    (repository / "sample.py").write_text(content, encoding="utf-8")
+    for command in (("add", "sample.py"), ("commit", "-m", message)):
+        subprocess.run(
+            ("git", "-C", os.fspath(repository), *command),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    return _git_head(repository)
 
 
 def _execution_context(
@@ -1943,6 +1965,103 @@ def test_local_bm25_source_scope_threads_repository_root_authority(
 
             assert observed == [authority]
             assert not tuple(fixture.workspace.iterdir())
+    finally:
+        fixture.close()
+
+
+def test_local_bm25_source_scope_resolves_display_commit_per_attempt(
+    tmp_path: Path,
+) -> None:
+    builder = BM25IndexBuilder(languages=["python"])
+    fixture = _source_fixture(tmp_path, git_checkout=True)
+    initial_commit = _git_head(fixture.repository)
+    target = LocalBM25SourceJobTarget(
+        repository_root=fixture.repository,
+        workspace_provider=fixture.provider,
+        repository_key=_REPOSITORY_KEY,
+        display_commit=initial_commit,
+        builder=builder,
+        display_commit_resolver=lambda: _git_head(fixture.repository),
+        environ={},
+    )
+    try:
+        fixture.source.close()
+        current_commit = _commit_source(
+            fixture.repository,
+            "def answer():\n    return 43\n",
+            "advance fixture",
+        )
+        fixture.source = capture_repository_source(fixture.repository)
+        assert current_commit != initial_commit
+
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+
+            with resources.create_scope(
+                context,
+                object_store=cas,
+            ).resources as executor:
+                assert executor.display_commit == current_commit
+
+        assert not tuple(fixture.workspace.iterdir())
+    finally:
+        fixture.close()
+
+
+def test_local_bm25_source_scope_rejects_replaced_retained_workspace(
+    tmp_path: Path,
+) -> None:
+    builder = BM25IndexBuilder(languages=["python"])
+    fixture = _source_fixture(tmp_path)
+    descriptor = os.open(fixture.workspace, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        workspace_identity = publication_parent_identity(descriptor)
+    finally:
+        os.close(descriptor)
+    target = LocalBM25SourceJobTarget(
+        repository_root=fixture.repository,
+        workspace_provider=fixture.provider,
+        repository_key=_REPOSITORY_KEY,
+        display_commit=_COMMIT,
+        builder=builder,
+        workspace_parent_identity=workspace_identity,
+        environ={},
+    )
+    displaced = tmp_path / "displaced-workspace"
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+            resolved = BM25SourceJobResolver(
+                resource_factory=resources,
+                object_store=cas,
+            ).resolve(context.job, context.views)
+            fixture.workspace.rename(displaced)
+            fixture.workspace.mkdir(mode=0o700)
+
+            with pytest.raises(
+                RuntimeError,
+                match="attempt parent differs from retained topology",
+            ):
+                resolved.execute(context)
+
+            assert not tuple(fixture.workspace.iterdir())
+            assert not tuple(displaced.iterdir())
     finally:
         fixture.close()
 

--- a/test/compiler/test_source_job.py
+++ b/test/compiler/test_source_job.py
@@ -8,6 +8,7 @@ import builtins
 import inspect
 import json
 import os
+import subprocess
 import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -15,12 +16,16 @@ from pathlib import Path
 
 import pytest
 
+import codenib.cli as cli_module
 import codenib.compiler as compiler_module
 import codenib.compiler.cache_import as cache_import_module
 import codenib.compiler.job_resources as job_resources_module
 import codenib.compiler.source_job as source_job_module
 from codenib import LocalWorkspaceProvider
-from codenib._captured_directory import PublishedWorkspaceReceiptOwner
+from codenib._captured_directory import (
+    PublishedWorkspaceReceiptOwner,
+    UnsupportedWorkspaceCreation,
+)
 from codenib.code_chunker import CodeChunker
 from codenib.code_chunking.base import BaseCodeChunker
 from codenib.compiler.index_builders import BM25IndexBuilder
@@ -40,6 +45,7 @@ from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.source_fingerprint import (
     RepositorySourceBinding,
     capture_repository_source,
+    pin_repository_source_root,
 )
 from codenib.storage import (
     INDEX_JOB_REQUEST_CONTRACT,
@@ -115,6 +121,7 @@ def _source_fixture(
     tmp_path: Path,
     *,
     selection: RepositorySourceSelection | None = None,
+    git_checkout: bool = False,
 ) -> _SourceFixture:
     repository = tmp_path / "repository"
     repository.mkdir(mode=0o700)
@@ -122,6 +129,20 @@ def _source_fixture(
         "def answer():\n    return 42\n",
         encoding="utf-8",
     )
+    if git_checkout:
+        for command in (
+            ("init",),
+            ("config", "user.email", "source-job@example.invalid"),
+            ("config", "user.name", "Source Job Test"),
+            ("add", "sample.py"),
+            ("commit", "-m", "fixture"),
+        ):
+            subprocess.run(
+                ("git", "-C", os.fspath(repository), *command),
+                check=True,
+                capture_output=True,
+                text=True,
+            )
     selected = selection or RepositorySourceSelection()
     source = capture_repository_source(repository, selection=selected)
     workspace = tmp_path / "workspace"
@@ -1388,6 +1409,55 @@ def test_bm25_source_executor_rejects_noncanonical_display_commit(
     assert not attempt.exists()
 
 
+def test_local_bm25_source_target_binds_exact_repository_root_authority(
+    tmp_path: Path,
+) -> None:
+    fixture = _source_fixture(tmp_path)
+    foreign = tmp_path / "foreign-repository"
+    foreign.mkdir(mode=0o700)
+    try:
+        with pin_repository_source_root(fixture.repository) as authority:
+            target = LocalBM25SourceJobTarget(
+                repository_root=fixture.repository,
+                workspace_provider=fixture.provider,
+                repository_key=_REPOSITORY_KEY,
+                display_commit=_COMMIT,
+                builder=BM25IndexBuilder(),
+                repository_root_authority=authority,
+                environ={},
+            )
+            assert target.repository_root_authority is authority
+
+        with pin_repository_source_root(foreign) as foreign_authority:
+            with pytest.raises(
+                ValueError,
+                match="repository authority differs from its root",
+            ):
+                LocalBM25SourceJobTarget(
+                    repository_root=fixture.repository,
+                    workspace_provider=fixture.provider,
+                    repository_key=_REPOSITORY_KEY,
+                    display_commit=_COMMIT,
+                    builder=BM25IndexBuilder(),
+                    repository_root_authority=foreign_authority,
+                    environ={},
+                )
+
+        with pytest.raises(TypeError, match="authority has an invalid type"):
+            LocalBM25SourceJobTarget(
+                repository_root=fixture.repository,
+                workspace_provider=fixture.provider,
+                repository_key=_REPOSITORY_KEY,
+                display_commit=_COMMIT,
+                builder=BM25IndexBuilder(),
+                repository_root_authority=object(),  # type: ignore[arg-type]
+                environ={},
+            )
+        assert not tuple(fixture.workspace.iterdir())
+    finally:
+        fixture.close()
+
+
 def test_local_bm25_source_job_factory_runs_worker_and_cleans_attempt(
     tmp_path: Path,
 ) -> None:
@@ -1477,6 +1547,98 @@ def test_local_bm25_source_job_factory_runs_worker_and_cleans_attempt(
                     json.loads(event.payload_json).get("adapter") == "bm25_source"
                     for event in events
                 )
+    finally:
+        fixture.close()
+
+
+def test_jobs_run_once_source_bm25_executes_matching_catalog_job(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    builder = BM25IndexBuilder(languages=["python"])
+    profile = bm25_source_job_profile(builder)
+    fixture = _source_fixture(tmp_path, git_checkout=True)
+    catalog_path = tmp_path / "catalog.sqlite"
+    cas_root = tmp_path / "cas"
+    queued = None
+    try:
+        try:
+            fixture.provider.require_support()
+        except UnsupportedWorkspaceCreation as exc:
+            pytest.skip(str(exc))
+        with LocalCAS.provision(cas_root):
+            pass
+        with SQLiteCatalog(catalog_path) as catalog:
+            repository_id = catalog.create_repository(_REPOSITORY_KEY)
+            source_revision_id = catalog.create_source_revision(
+                repository_id,
+                commit_sha=None,
+                dirty=True,
+                source_fingerprint=fixture.source.fingerprint,
+            )
+            profile_id = catalog.create_view_profile(
+                "bm25",
+                profile.config,
+                name=profile.name,
+            )
+            assert profile_id == profile.profile_id
+            queued = catalog.create_job(
+                repository_id,
+                source_revision_id,
+                "source-cli-worker",
+                {
+                    "contract": INDEX_JOB_REQUEST_CONTRACT,
+                    "views": {
+                        "bm25": {
+                            "profile_id": profile_id,
+                            "requested_mode": "full",
+                            "required": True,
+                        }
+                    },
+                },
+            )
+
+        args = cli_module.build_parser().parse_args(
+            [
+                "jobs",
+                "run-once",
+                os.fspath(fixture.repository),
+                "--source-bm25",
+                "--language",
+                "python",
+                "--catalog",
+                os.fspath(catalog_path),
+                "--cas-root",
+                os.fspath(cas_root),
+                "--workspace-root",
+                os.fspath(fixture.workspace),
+                "--repository",
+                _REPOSITORY_KEY,
+                "--lease-duration-ms",
+                "60000",
+                "--heartbeat-interval-ms",
+                "5",
+                "--json",
+            ]
+        )
+
+        assert args.handler(args) == 0
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload == {
+            "attempt_count": 1,
+            "disposition": "succeeded",
+            "job_id": queued.job_id,
+        }
+        assert not tuple(fixture.workspace.glob(".codenib-source-job-*"))
+        assert not tuple(fixture.workspace.glob(".codenib-source-worker-topology-*"))
+        orphans = tuple(fixture.workspace.glob(".*.discarded-*"))
+        assert len(orphans) == 3
+        assert all(orphan.is_dir() for orphan in orphans)
+        with SQLiteCatalog(catalog_path, create=False) as catalog:
+            completed = catalog.get_job(queued.job_id)
+            assert completed.status is IndexJobStatus.SUCCEEDED
+            assert completed.result_snapshot_id is not None
     finally:
         fixture.close()
 
@@ -1716,6 +1878,57 @@ def test_local_bm25_source_scope_is_side_effect_free_until_enter(
 
             assert type(scope) is BM25SourceJobResourceScope
             assert scope.object_store is cas
+            assert not tuple(fixture.workspace.iterdir())
+    finally:
+        fixture.close()
+
+
+def test_local_bm25_source_scope_threads_repository_root_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    observed: list[object] = []
+    real_capture = job_resources_module.capture_repository_source
+    try:
+        with (
+            pin_repository_source_root(fixture.repository) as authority,
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            target = LocalBM25SourceJobTarget(
+                repository_root=fixture.repository,
+                workspace_provider=fixture.provider,
+                repository_key=_REPOSITORY_KEY,
+                display_commit=_COMMIT,
+                builder=builder,
+                repository_root_authority=authority,
+                environ={},
+            )
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+
+            def capture(*args: object, **kwargs: object):
+                observed.append(kwargs.get("expected_root_authority"))
+                return real_capture(*args, **kwargs)
+
+            monkeypatch.setattr(
+                job_resources_module,
+                "capture_repository_source",
+                capture,
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+
+            with resources.create_scope(
+                context, object_store=cas
+            ).resources as executor:
+                assert type(executor) is BM25SourceJobExecutor
+
+            assert observed == [authority]
             assert not tuple(fixture.workspace.iterdir())
     finally:
         fixture.close()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -575,6 +575,11 @@ def test_jobs_run_once_parser_exposes_bounded_worker_inputs() -> None:
     assert defaults.heartbeat_interval_ms == 5_000
     assert defaults.scan_limit == 64
     assert defaults.json is False
+    assert defaults.cache_dir == "/src/repo/.codenib_index"
+    assert defaults.source_bm25 is False
+    assert defaults.language == []
+    assert defaults.exclude_dir is None
+    assert defaults.clear_exclude_dirs is False
     assert configured.namespace == "production"
     assert configured.lease_duration_ms == 60_000
     assert configured.heartbeat_interval_ms == 10_000
@@ -584,6 +589,154 @@ def test_jobs_run_once_parser_exposes_bounded_worker_inputs() -> None:
     with pytest.raises(SystemExit) as invalid:
         cli.build_parser().parse_args([*base, "--scan-limit", "0"])
     assert invalid.value.code == 2
+
+
+def test_jobs_worker_parser_requires_one_explicit_input_mode() -> None:
+    topology = [
+        "--catalog",
+        "/state/catalog.sqlite3",
+        "--cas-root",
+        "/state/cas",
+        "--workspace-root",
+        "/state/workspaces",
+        "--repository",
+        "owner/repo",
+    ]
+    parser = cli.build_parser()
+
+    source = parser.parse_args(
+        [
+            "jobs",
+            "run-once",
+            "/src/repo",
+            "--source-bm25",
+            "--language",
+            "python,go",
+            "--exclude-dir",
+            "generated",
+            *topology,
+        ]
+    )
+
+    assert source.cache_dir is None
+    assert source.source_bm25 is True
+    assert source.language == ["python,go"]
+    assert source.exclude_dir == ["generated"]
+    assert source.clear_exclude_dirs is False
+
+    with pytest.raises(SystemExit) as missing:
+        parser.parse_args(["jobs", "run-once", "/src/repo", *topology])
+    assert missing.value.code == 2
+    with pytest.raises(SystemExit) as mixed:
+        parser.parse_args(
+            [
+                "jobs",
+                "run-once",
+                "/src/repo",
+                "--cache-dir",
+                "/src/repo/.codenib_index",
+                "--source-bm25",
+                *topology,
+            ]
+        )
+    assert mixed.value.code == 2
+
+
+@pytest.mark.parametrize(
+    "source_option",
+    (
+        ("language", ["python"]),
+        ("exclude_dir", ["generated"]),
+        ("clear_exclude_dirs", True),
+    ),
+)
+def test_cache_job_worker_rejects_source_only_options(source_option) -> None:
+    name, value = source_option
+    args = SimpleNamespace(
+        source_bm25=False,
+        language=[],
+        exclude_dir=None,
+        clear_exclude_dirs=False,
+    )
+    setattr(args, name, value)
+
+    with pytest.raises(cli.CLIError, match="require --source-bm25"):
+        cli._run_with_local_index_job_worker(
+            args,
+            lambda _worker: pytest.fail("worker must not be created"),
+        )
+
+
+def test_source_job_worker_pins_repository_before_provider_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    (repository / "sample.py").write_text("VALUE = 1\n", encoding="utf-8")
+    candidate = tmp_path / "candidate-repository"
+    candidate.mkdir()
+    (candidate / "sample.py").write_text("VALUE = 1\n", encoding="utf-8")
+    displaced = tmp_path / "displaced-repository"
+    catalog = tmp_path / "catalog.sqlite3"
+    catalog.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    args = SimpleNamespace(
+        repo=os.fspath(repository),
+        source_bm25=True,
+        cache_dir=None,
+        language=["python"],
+        exclude_dir=None,
+        clear_exclude_dirs=False,
+        catalog=os.fspath(catalog),
+        cas_root=os.fspath(cas_root),
+        workspace_root=os.fspath(workspace_root),
+        repository="owner/repo",
+        namespace="default",
+    )
+    authorities: list[object] = []
+    real_pin = source_fingerprint_module.pin_repository_source_root
+
+    def capture_pin(*values: object, **kwargs: object):
+        authority = real_pin(*values, **kwargs)
+        authorities.append(authority)
+        return authority
+
+    class Provider:
+        def __init__(self, root: Path) -> None:
+            assert root == workspace_root
+
+        def require_support(self) -> None:
+            repository.rename(displaced)
+            candidate.rename(repository)
+
+    def unexpected(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("replaced repository must fail before storage or worker setup")
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "pin_repository_source_root",
+        capture_pin,
+    )
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(
+        cli,
+        "_require_retained_materialization_topology",
+        unexpected,
+    )
+    monkeypatch.setattr(storage_module, "LocalCAS", unexpected)
+
+    with pytest.raises(cli.CLIError, match="repository root"):
+        cli._run_with_local_index_job_worker(
+            args,
+            lambda _worker: pytest.fail("worker operation must not run"),
+        )
+
+    assert len(authorities) == 1
+    assert authorities[0].closed  # type: ignore[attr-defined]
 
 
 def test_jobs_run_parser_exposes_continuous_scheduler_inputs() -> None:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -680,6 +680,64 @@ def test_source_job_worker_rejects_programmatic_cache_input() -> None:
         )
 
 
+def test_source_job_topology_loss_stops_continuous_scheduler_before_claim() -> None:
+    considered: list[object] = []
+    page_calls: list[tuple[object | None, object]] = []
+    waits: list[float | None] = []
+
+    def topology_lost() -> None:
+        raise cli.CLIError("workspace identity changed")
+
+    guard = cli._bm25_source_job_infrastructure_guard(topology_lost)
+    candidate_filter = cli._index_job_candidate_filter_with_guard(
+        guard,
+        lambda candidate: considered.append(candidate) or True,
+    )
+
+    class GuardedWorker:
+        def begin_cycle(self):
+            return storage_module.IndexJobRunnableCycle(1)
+
+        def run_page(self, *, cursor=None, cycle):
+            page_calls.append((cursor, cycle))
+            candidate_filter(object())
+            pytest.fail("topology loss must terminate the scheduler page")
+
+    class NeverStop:
+        def is_set(self) -> bool:
+            return False
+
+        def wait(self, timeout: float | None = None) -> bool:
+            waits.append(timeout)
+            return False
+
+    scheduler = storage_module.IndexJobWorkerScheduler(worker=GuardedWorker())
+
+    with pytest.raises(
+        storage_module.StorageIntegrityError,
+        match="retained topology changed",
+    ) as caught:
+        scheduler.run(NeverStop())
+
+    assert isinstance(caught.value.__cause__, cli.CLIError)
+    assert page_calls == [(None, storage_module.IndexJobRunnableCycle(1))]
+    assert considered == []
+    assert waits == []
+
+
+def test_source_job_worker_guard_preserves_healthy_candidate_filter() -> None:
+    verified: list[bool] = []
+    candidate = object()
+    guard = cli._bm25_source_job_infrastructure_guard(lambda: verified.append(True))
+    candidate_filter = cli._index_job_candidate_filter_with_guard(
+        guard,
+        lambda value: value is candidate,
+    )
+
+    assert candidate_filter(candidate) is True
+    assert verified == [True]
+
+
 def test_source_job_worker_pins_repository_before_provider_probe(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -667,6 +667,19 @@ def test_cache_job_worker_rejects_source_only_options(source_option) -> None:
         )
 
 
+def test_source_job_worker_rejects_programmatic_cache_input() -> None:
+    args = SimpleNamespace(
+        source_bm25=True,
+        cache_dir="/state/compiler-cache",
+    )
+
+    with pytest.raises(cli.CLIError, match="cannot be combined"):
+        cli._run_with_local_index_job_worker(
+            args,
+            lambda _worker: pytest.fail("worker must not be created"),
+        )
+
+
 def test_source_job_worker_pins_repository_before_provider_probe(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Expose the retained-source BM25 resolver through the explicit production `codenib jobs run-once` and `codenib jobs run` worker commands without changing default compiler, Web, MCP, or runtime routes. Advances #199.

## Changes

- make `--cache-dir` and `--source-bm25` explicit mutually exclusive worker inputs while preserving the existing cache adapter
- configure exact BM25 builder profiles from repeatable language and source-exclusion arguments
- pin the repository hierarchy before provider probing or repository reads and pass the exact authority into every attempt capture
- resolve and recheck Git display provenance per attempt so a long-running worker cannot stamp newer source with its startup HEAD
- bind every source attempt/view/context provision to the retained startup workspace identity and recheck the complete topology
- promote retained-topology loss to a worker integrity alarm and recheck it before candidate lease acquisition so continuous workers stop without consuming job retries
- reject mixed inputs, physical aliases, non-Git roots, source/profile drift, HEAD drift, and workspace replacement before publication
- cover parser isolation, hierarchy replacement, authority handoff, signature compatibility, cleanup, scheduler termination, and production-shaped source execution
- document the source worker contract and update the durable storage roadmap

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `pre-commit run --files codenib/cli.py codenib/compiler/job_resources.py codenib/compiler/source_job.py codenib/web/index_job_writes.py docs/development/local-workspace-provider.md docs/storage_backend_roadmap.md test/compiler/test_source_job.py test/test_cli.py`
- `pytest -q test/compiler/test_source_job.py test/test_cli.py --tb=short` (231 passed)
- `pytest -q test/compiler/test_cache_import.py test/storage/test_job_worker.py --tb=short` (317 passed)
- topology-loss worker/scheduler regression selection (4 passed)
- `pytest -q test/test_local_workspace_provider.py --tb=short` (35 passed)
- prior full unit tier excluding the three documented local baselines (8,478 passed, 35 skipped, 193 deselected); current-head CI reruns the unit tier
- Python compile and `git diff --check`

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
