### PR TITLE
fix(storage): retain cleanup notes on Python 3.10

### DIFF
--- a/codenib/compiler/job_resolver.py
+++ b/codenib/compiler/job_resolver.py
@@ -128,9 +128,25 @@ def _add_cleanup_exception_note(
     """Best-effort note cleanup failure without replacing the primary error."""
 
     try:
-        add_note = getattr(primary, "add_note", None)
-        if callable(add_note):
-            add_note(f"{label} cleanup also failed: {type(secondary).__name__}")
+        message = f"{label} cleanup also failed: {type(secondary).__name__}"
+        add_note = getattr(BaseException, "add_note", None)
+        if add_note is not None:
+            add_note(primary, message)
+            return
+        try:
+            notes = BaseException.__getattribute__(
+                primary,
+                "_codenib_cleanup_notes",
+            )
+        except AttributeError:
+            notes = ()
+        if not isinstance(notes, tuple):
+            notes = ()
+        BaseException.__setattr__(
+            primary,
+            "_codenib_cleanup_notes",
+            (*notes, message),
+        )
     except BaseException:  # noqa: B036 - notes must not replace execution failure
         pass
 

--- a/test/compiler/test_source_job.py
+++ b/test/compiler/test_source_job.py
@@ -1783,9 +1783,13 @@ def test_bm25_source_scope_cleanup_cannot_replace_executor_failure(
                 resolved.execute(context)
 
             assert caught.value is primary
+            notes = (
+                *getattr(primary, "__notes__", ()),
+                *getattr(primary, "_codenib_cleanup_notes", ()),
+            )
             assert any(
                 "BM25 source resource cleanup also failed: OSError" in note
-                for note in getattr(primary, "__notes__", ())
+                for note in notes
             )
     finally:
         context_owner.close()


### PR DESCRIPTION
## Summary

Preserves BM25 source-resource cleanup diagnostics on Python 3.10 while keeping the original executor failure as the exact primary exception.

## Changes

- Use the repository fallback cleanup-note tuple when BaseException.add_note is unavailable.
- Call BaseException methods directly so exception subclass overrides cannot replace the primary failure.
- Verify cleanup diagnostics through both standard exception notes and the Python 3.10 fallback.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Full source-job test file: 47 passed on Python 3.10, 3.12, and 3.14.
- Compiler-cache cleanup selection: 2 passed on each supported Python version.
- Black, isort, flake8, py_compile on all three versions, and git diff --check passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published