### PR TITLE
fix(storage): preserve scoped job failure priority

### DIFF
--- a/codenib/compiler/job_resolver.py
+++ b/codenib/compiler/job_resolver.py
@@ -6,8 +6,10 @@
 
 from __future__ import annotations
 
+import sys
+from collections.abc import Callable
 from contextlib import AbstractContextManager
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import Protocol, runtime_checkable
 
 from ..storage.job_worker import (
@@ -125,14 +127,25 @@ def _add_cleanup_exception_note(
     *,
     label: str,
 ) -> None:
-    """Best-effort note cleanup failure without replacing the primary error."""
+    """Best-effort note one cleanup failure without replacing the primary."""
 
     try:
         message = f"{label} cleanup also failed: {type(secondary).__name__}"
         add_note = getattr(BaseException, "add_note", None)
         if add_note is not None:
-            add_note(primary, message)
-            return
+            notes_missing = False
+            try:
+                notes = BaseException.__getattribute__(primary, "__notes__")
+            except AttributeError:
+                notes_missing = True
+                notes = None
+            if notes_missing or type(notes) is list:
+                if type(notes) is list and any(
+                    type(note) is str and note == message for note in notes
+                ):
+                    return
+                add_note(primary, message)
+                return
         try:
             notes = BaseException.__getattribute__(
                 primary,
@@ -140,21 +153,23 @@ def _add_cleanup_exception_note(
             )
         except AttributeError:
             notes = ()
-        if not isinstance(notes, tuple):
+        if type(notes) is not tuple:
             notes = ()
+        if any(type(note) is str and note == message for note in notes):
+            return
         BaseException.__setattr__(
             primary,
             "_codenib_cleanup_notes",
             (*notes, message),
         )
-    except BaseException:  # noqa: B036 - notes must not replace execution failure
-        pass
+    except BaseException:  # noqa: B036 - diagnostics cannot replace execution
+        return
 
 
 def _inherit_cleanup_owners(
     primary: BaseException,
     secondary: BaseException,
-) -> None:
+) -> bool:
     """Keep exact cleanup recovery handles reachable from the primary error."""
 
     try:
@@ -164,9 +179,9 @@ def _inherit_cleanup_owners(
                 "publication_cleanup_owners",
             )
         except AttributeError:
-            return
+            return True
         if type(inherited) is not tuple:
-            return
+            return True
         try:
             existing = BaseException.__getattribute__(
                 primary,
@@ -185,8 +200,491 @@ def _inherit_cleanup_owners(
             "publication_cleanup_owners",
             retained,
         )
-    except BaseException:  # noqa: B036 - recovery metadata is best effort
-        pass
+        installed = BaseException.__getattribute__(
+            primary,
+            "publication_cleanup_owners",
+        )
+        return type(installed) is tuple and all(
+            any(candidate is owner for candidate in installed) for owner in inherited
+        )
+    except BaseException:  # noqa: B036 - caller retries interrupted metadata
+        return False
+
+
+@dataclass(slots=True)
+class _ScopedJobExecutionOutcome:
+    """Durable operation and resource-exit state for one scoped executor."""
+
+    result: object = _MISSING_EXECUTION_RESULT
+    operation_error: BaseException | None = None
+    scope_error: BaseException | None = None
+    boundary_errors: list[BaseException] = field(default_factory=list)
+    settled_primary: BaseException | None = None
+    settlement_started: bool = False
+    settlement_complete: bool = False
+
+
+class _ScopedJobOperationCapture:
+    """Store one operation failure before it crosses the resource boundary."""
+
+    __slots__ = ("outcome",)
+
+    def __init__(self, outcome: _ScopedJobExecutionOutcome) -> None:
+        self.outcome = outcome
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, _exc_type, error, _traceback) -> bool:
+        if error is None:
+            return False
+        self.outcome.operation_error = error
+        return False
+
+
+class _ScopedJobResourceExitCapture:
+    """Store one final resource-exit error for post-scope settlement."""
+
+    __slots__ = ("outcome",)
+
+    def __init__(self, outcome: _ScopedJobExecutionOutcome) -> None:
+        self.outcome = outcome
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, _exc_type, error, _traceback) -> bool:
+        if error is None:
+            return False
+        self.outcome.scope_error = error
+        return True
+
+
+def _raw_exception_context(error: BaseException) -> BaseException | None:
+    """Read ``__context__`` without invoking exception-subclass dispatch."""
+
+    try:
+        context = vars(BaseException)["__context__"].__get__(error, type(error))
+    except BaseException:  # noqa: B036 - inspection cannot replace failure
+        return None
+    if not issubclass(type(context), BaseException):
+        return None
+    return context
+
+
+def _has_scoped_job_provenance(
+    error: BaseException,
+    provenance: Callable[..., object],
+    outcome: _ScopedJobExecutionOutcome,
+) -> bool:
+    """Require one exact outcome-bound frame in an exception traceback."""
+
+    try:
+        traceback = vars(BaseException)["__traceback__"].__get__(
+            error,
+            type(error),
+        )
+        while traceback is not None:
+            frame = traceback.tb_frame
+            if (
+                frame.f_code is provenance.__code__
+                and frame.f_locals.get("outcome") is outcome
+            ):
+                return True
+            traceback = traceback.tb_next
+    except BaseException:  # noqa: B036 - inspection cannot replace failure
+        return False
+    return False
+
+
+def _has_current_scoped_job_execution_provenance(
+    error: BaseException,
+    outcome: _ScopedJobExecutionOutcome,
+) -> bool:
+    """Require the current execute frame without swallowing classification."""
+
+    traceback = BaseException.__traceback__.__get__(error, type(error))
+    while traceback is not None:
+        frame = traceback.tb_frame
+        if (
+            frame.f_code is _execute_scoped_job_resource.__code__
+            and frame.f_locals.get("outcome") is outcome
+        ):
+            return True
+        traceback = traceback.tb_next
+    return False
+
+
+def _is_inherited_scoped_job_ambient(
+    error: BaseException | None,
+    ambient_error: BaseException | None,
+    ambient_traceback: object,
+    outcome: _ScopedJobExecutionOutcome,
+) -> bool:
+    """Reject caller exception state that never escaped this execution frame."""
+
+    if error is not ambient_error or ambient_error is None:
+        return False
+    current_traceback = BaseException.__traceback__.__get__(
+        error,
+        type(error),
+    )
+    if current_traceback is ambient_traceback:
+        return True
+    return not _has_current_scoped_job_execution_provenance(error, outcome)
+
+
+def _captured_exception_context(
+    error: BaseException,
+    capture: Callable[..., object],
+    *,
+    provenance: Callable[..., object] | None = None,
+    outcome: _ScopedJobExecutionOutcome | None = None,
+) -> BaseException | None:
+    """Recover an interrupted handler's exact error from one capture frame."""
+
+    context = _raw_exception_context(error)
+    if context is None:
+        return None
+    try:
+        error_traceback = vars(BaseException)["__traceback__"].__get__(
+            error,
+            type(error),
+        )
+        capture_frames = []
+        while error_traceback is not None:
+            frame = error_traceback.tb_frame
+            if frame.f_code is capture.__code__:
+                capture_frames.append(frame)
+            error_traceback = error_traceback.tb_next
+        if not capture_frames:
+            return None
+        context_traceback = vars(BaseException)["__traceback__"].__get__(
+            context,
+            type(context),
+        )
+        while context_traceback is not None:
+            frame = context_traceback.tb_frame
+            if any(frame is capture_frame for capture_frame in capture_frames):
+                return context
+            context_traceback = context_traceback.tb_next
+        if (
+            provenance is not None
+            and outcome is not None
+            and _has_scoped_job_provenance(context, provenance, outcome)
+        ):
+            return context
+    except BaseException:  # noqa: B036 - inspection cannot replace failure
+        return None
+    return None
+
+
+def _call_scoped_job_operation(
+    executor: object,
+    operation: Callable[[object], IndexJobExecutionResult],
+    outcome: _ScopedJobExecutionOutcome,
+) -> IndexJobExecutionResult:
+    """Bind one operation failure to its exact preinstalled outcome."""
+
+    return operation(executor)
+
+
+def _capture_scoped_job_execution(
+    executor: object,
+    operation: Callable[[object], IndexJobExecutionResult],
+    outcome: _ScopedJobExecutionOutcome,
+) -> None:
+    """Capture one executor result without crossing the resource boundary."""
+
+    with _ScopedJobOperationCapture(outcome):
+        outcome.result = _call_scoped_job_operation(executor, operation, outcome)
+
+
+def _invoke_scoped_job_execution(
+    executor: object,
+    operation: Callable[[object], IndexJobExecutionResult],
+    outcome: _ScopedJobExecutionOutcome,
+) -> None:
+    """Commit an interrupted capture, then rethrow inside the native scope."""
+
+    boundary_error: BaseException | None = None
+    try:
+        _capture_scoped_job_execution(executor, operation, outcome)
+    except BaseException as error:  # noqa: B036 - one-shot capture recovery
+        boundary_error = error
+    if (
+        outcome.operation_error is None
+        and outcome.result is _MISSING_EXECUTION_RESULT
+        and boundary_error is not None
+    ):
+        recovered = _captured_exception_context(
+            boundary_error,
+            _capture_scoped_job_execution,
+        )
+        if recovered is not None:
+            outcome.operation_error = recovered
+    if boundary_error is not None:
+        outcome.boundary_errors.append(boundary_error)
+    if outcome.operation_error is not None:
+        raise outcome.operation_error
+    if boundary_error is not None:
+        raise boundary_error
+
+
+def _run_scoped_job_resource(
+    resources: AbstractContextManager[object],
+    operation: Callable[[object], IndexJobExecutionResult],
+    outcome: _ScopedJobExecutionOutcome,
+) -> None:
+    """Recover operation provenance before leaving its resource scope."""
+
+    with resources as executor:
+        try:
+            _invoke_scoped_job_execution(executor, operation, outcome)
+        except BaseException as boundary_error:  # noqa: B036 - exact recovery
+            if outcome.operation_error is None:
+                outcome.operation_error = boundary_error
+            if outcome.result is _MISSING_EXECUTION_RESULT:
+                recovered = _captured_exception_context(
+                    boundary_error,
+                    _capture_scoped_job_execution,
+                    provenance=_call_scoped_job_operation,
+                    outcome=outcome,
+                )
+                if recovered is not None:
+                    outcome.operation_error = recovered
+            if outcome.operation_error is boundary_error:
+                raise
+            raise outcome.operation_error from boundary_error
+
+
+def _capture_scoped_job_resource_exit(
+    resources: AbstractContextManager[object],
+    operation: Callable[[object], IndexJobExecutionResult],
+    outcome: _ScopedJobExecutionOutcome,
+) -> None:
+    """Capture one native resource scope's final exit outcome."""
+
+    with _ScopedJobResourceExitCapture(outcome):
+        _run_scoped_job_resource(resources, operation, outcome)
+
+
+def _invoke_scoped_job_resource_exit(
+    resources: AbstractContextManager[object],
+    operation: Callable[[object], IndexJobExecutionResult],
+    outcome: _ScopedJobExecutionOutcome,
+) -> None:
+    """Recover one interrupted resource-exit capture after cleanup finished."""
+
+    boundary_error: BaseException | None = None
+    try:
+        _capture_scoped_job_resource_exit(resources, operation, outcome)
+    except BaseException as error:  # noqa: B036 - one-shot capture recovery
+        boundary_error = error
+    if outcome.scope_error is None and boundary_error is not None:
+        recovered = _captured_exception_context(
+            boundary_error,
+            _capture_scoped_job_resource_exit,
+        )
+        if recovered is not None:
+            outcome.scope_error = recovered
+    if boundary_error is not None:
+        outcome.boundary_errors.append(boundary_error)
+        if outcome.scope_error is None:
+            raise boundary_error
+
+
+def _recover_scoped_job_resource_exit(
+    resources: AbstractContextManager[object],
+    operation: Callable[[object], IndexJobExecutionResult],
+    outcome: _ScopedJobExecutionOutcome,
+) -> None:
+    """Recover provenance after one interrupted resource capture has unwound."""
+
+    boundary_error: BaseException | None = None
+    try:
+        _invoke_scoped_job_resource_exit(resources, operation, outcome)
+    except BaseException as error:  # noqa: B036 - deferred capture recovery
+        boundary_error = error
+    if outcome.scope_error is None and boundary_error is not None:
+        recovered = _captured_exception_context(
+            boundary_error,
+            _capture_scoped_job_resource_exit,
+            provenance=_run_scoped_job_resource,
+            outcome=outcome,
+        )
+        outcome.scope_error = recovered if recovered is not None else boundary_error
+    if outcome.operation_error is None:
+        outcome.operation_error = _scoped_job_operation_context(outcome)
+
+
+def _iter_exception_contexts(error: BaseException):
+    """Yield one raw exception-context chain without following cycles."""
+
+    current: BaseException | None = error
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = _raw_exception_context(current)
+
+
+def _scoped_job_operation_context(
+    outcome: _ScopedJobExecutionOutcome,
+) -> BaseException | None:
+    """Recover one exact operation error after the resource scope unwinds."""
+
+    roots = (
+        (outcome.scope_error, *outcome.boundary_errors)
+        if outcome.scope_error is not None
+        else tuple(outcome.boundary_errors)
+    )
+    seen: set[int] = set()
+    for root in roots:
+        for error in _iter_exception_contexts(root):
+            if id(error) in seen:
+                continue
+            seen.add(id(error))
+            if _has_scoped_job_provenance(
+                error,
+                _call_scoped_job_operation,
+                outcome,
+            ):
+                return error
+    return None
+
+
+def _settle_scoped_job_execution_once(
+    outcome: _ScopedJobExecutionOutcome,
+    *,
+    label: str,
+) -> None:
+    """Idempotently commit priority and recovery metadata without raising."""
+
+    if outcome.settlement_complete:
+        return
+
+    primary = outcome.operation_error
+    if primary is None:
+        primary = outcome.scope_error
+    if primary is None and outcome.boundary_errors:
+        primary = outcome.boundary_errors[0]
+    outcome.settled_primary = primary
+    retained_secondary_ids: set[int] = set()
+    secondary_roots = (
+        (outcome.scope_error, *outcome.boundary_errors)
+        if outcome.scope_error is not None
+        else tuple(outcome.boundary_errors)
+    )
+    for secondary_root in secondary_roots:
+        if secondary_root is None:
+            continue
+        for secondary in _iter_exception_contexts(secondary_root):
+            if secondary is primary:
+                break
+            if id(secondary) in retained_secondary_ids:
+                continue
+            retained_secondary_ids.add(id(secondary))
+            if not _inherit_cleanup_owners(primary, secondary):
+                # Retry one interrupted attachment inline.  A hostile primary
+                # can still reject the attribute permanently; in that case the
+                # exact secondary and its owner remain reachable from outcome.
+                _inherit_cleanup_owners(primary, secondary)
+            _add_cleanup_exception_note(primary, secondary, label=label)
+    outcome.settlement_complete = True
+
+
+def _settle_scoped_job_execution(
+    outcome: _ScopedJobExecutionOutcome,
+    active_error: BaseException | None,
+    *,
+    label: str,
+) -> None:
+    """Retry one interrupted non-raising settlement before final delivery."""
+
+    if active_error is not None and not any(
+        active_error is candidate for candidate in outcome.boundary_errors
+    ):
+        outcome.boundary_errors.append(active_error)
+    try:
+        _settle_scoped_job_execution_once(outcome, label=label)
+    except BaseException as settlement_error:  # noqa: B036 - retry once
+        if not any(
+            settlement_error is candidate for candidate in outcome.boundary_errors
+        ):
+            outcome.boundary_errors.append(settlement_error)
+        _settle_scoped_job_execution_once(outcome, label=label)
+
+
+def _execute_scoped_job_resource(
+    resources: AbstractContextManager[object],
+    operation: Callable[[object], IndexJobExecutionResult],
+    *,
+    label: str,
+    missing_result_message: str,
+) -> IndexJobExecutionResult:
+    """Execute and settle one scope using a preinstalled outcome carrier."""
+
+    outcome = _ScopedJobExecutionOutcome()
+    ambient_error = sys.exc_info()[1]
+    ambient_traceback = (
+        None
+        if ambient_error is None
+        else BaseException.__traceback__.__get__(
+            ambient_error,
+            type(ambient_error),
+        )
+    )
+    try:
+        try:
+            _recover_scoped_job_resource_exit(resources, operation, outcome)
+        finally:
+            active_error = sys.exc_info()[1]
+            if _is_inherited_scoped_job_ambient(
+                active_error,
+                ambient_error,
+                ambient_traceback,
+                outcome,
+            ):
+                active_error = None
+            elif (
+                active_error is not None
+                and outcome.operation_error is None
+                and outcome.scope_error is None
+            ):
+                outcome.operation_error = active_error
+            outcome.settlement_started = True
+            _settle_scoped_job_execution(outcome, active_error, label=label)
+    finally:
+        if not outcome.settlement_complete:
+            active_error = sys.exc_info()[1]
+            if _is_inherited_scoped_job_ambient(
+                active_error,
+                ambient_error,
+                ambient_traceback,
+                outcome,
+            ):
+                active_error = None
+            elif (
+                not outcome.settlement_started
+                and active_error is not None
+                and outcome.operation_error is None
+            ):
+                outcome.operation_error = active_error
+            outcome.settlement_started = True
+            _settle_scoped_job_execution(outcome, active_error, label=label)
+        # This is the outermost Python delivery boundary.  Settlement above is
+        # complete before a primary reaches it: exact cleanup owners and notes
+        # are already attached, and ``outcome`` remains reachable from the
+        # traceback if a later asynchronous exception supersedes this raise.
+        # No finite Python helper/finally can protect its own last opcode.
+        if outcome.settled_primary is not None and sys.exc_info()[1] is not None:
+            raise outcome.settled_primary
+    if outcome.settled_primary is not None:
+        raise outcome.settled_primary
+    if type(outcome.result) is not IndexJobExecutionResult:
+        raise StorageIntegrityError(missing_result_message)
+    return outcome.result
 
 
 def _execute_in_resource_scope(
@@ -195,48 +693,34 @@ def _execute_in_resource_scope(
 ) -> IndexJobExecutionResult:
     """Execute without permitting hostile cleanup to suppress the primary error."""
 
-    result: object = _MISSING_EXECUTION_RESULT
-    primary: BaseException | None = None
-    try:
-        with scope.resources as executor:
-            try:
-                if type(executor) is not CompilerCacheJobExecutor:
-                    raise TypeError(
-                        "compiler cache resource factory returned an invalid executor"
-                    )
-                if executor.object_store is not scope.object_store:
-                    raise StorageIntegrityError(
-                        "compiler cache executor differs from its declared object store"
-                    )
-                if executor.view_type != scope.view_type:
-                    raise StorageIntegrityError(
-                        "compiler cache executor differs from its declared job view"
-                    )
-                result = executor.execute(context)
-                if type(result) is not IndexJobExecutionResult:
-                    raise StorageIntegrityError(
-                        "compiler cache executor returned an invalid result"
-                    )
-            except BaseException as exc:  # noqa: B036 - rethrown after cleanup
-                primary = exc
-                raise
-    except BaseException as cleanup_exc:  # noqa: B036 - preserve primary failure
-        if primary is None:
-            raise
-        if cleanup_exc is not primary:
-            _inherit_cleanup_owners(primary, cleanup_exc)
-            _add_cleanup_exception_note(
-                primary,
-                cleanup_exc,
-                label="compiler cache resource",
+    def execute(executor: object) -> IndexJobExecutionResult:
+        if type(executor) is not CompilerCacheJobExecutor:
+            raise TypeError(
+                "compiler cache resource factory returned an invalid executor"
             )
-    if primary is not None:
-        raise primary
-    if type(result) is not IndexJobExecutionResult:
-        raise StorageIntegrityError(
+        if executor.object_store is not scope.object_store:
+            raise StorageIntegrityError(
+                "compiler cache executor differs from its declared object store"
+            )
+        if executor.view_type != scope.view_type:
+            raise StorageIntegrityError(
+                "compiler cache executor differs from its declared job view"
+            )
+        result = executor.execute(context)
+        if type(result) is not IndexJobExecutionResult:
+            raise StorageIntegrityError(
+                "compiler cache executor returned an invalid result"
+            )
+        return result
+
+    return _execute_scoped_job_resource(
+        scope.resources,
+        execute,
+        label="compiler cache resource",
+        missing_result_message=(
             "compiler cache resource scope returned no execution result"
-        )
-    return result
+        ),
+    )
 
 
 def _execute_in_bm25_source_resource_scope(
@@ -245,42 +729,26 @@ def _execute_in_bm25_source_resource_scope(
 ) -> IndexJobExecutionResult:
     """Execute a source build without letting cleanup suppress its failure."""
 
-    result: object = _MISSING_EXECUTION_RESULT
-    primary: BaseException | None = None
-    try:
-        with scope.resources as executor:
-            try:
-                if type(executor) is not BM25SourceJobExecutor:
-                    raise TypeError(
-                        "BM25 source resource factory returned an invalid executor"
-                    )
-                if executor.object_store is not scope.object_store:
-                    raise StorageIntegrityError(
-                        "BM25 source executor differs from its declared object store"
-                    )
-                result = executor.execute(context)
-                if type(result) is not IndexJobExecutionResult:
-                    raise StorageIntegrityError(
-                        "BM25 source executor returned an invalid result"
-                    )
-            except BaseException as exc:  # noqa: B036 - rethrown after cleanup
-                primary = exc
-                raise
-    except BaseException as cleanup_exc:  # noqa: B036 - preserve primary failure
-        if primary is None:
-            raise
-        if cleanup_exc is not primary:
-            _inherit_cleanup_owners(primary, cleanup_exc)
-            _add_cleanup_exception_note(
-                primary,
-                cleanup_exc,
-                label="BM25 source resource",
+    def execute(executor: object) -> IndexJobExecutionResult:
+        if type(executor) is not BM25SourceJobExecutor:
+            raise TypeError("BM25 source resource factory returned an invalid executor")
+        if executor.object_store is not scope.object_store:
+            raise StorageIntegrityError(
+                "BM25 source executor differs from its declared object store"
             )
-    if primary is not None:
-        raise primary
-    if type(result) is not IndexJobExecutionResult:
-        raise StorageIntegrityError("BM25 source resource scope returned no result")
-    return result
+        result = executor.execute(context)
+        if type(result) is not IndexJobExecutionResult:
+            raise StorageIntegrityError(
+                "BM25 source executor returned an invalid result"
+            )
+        return result
+
+    return _execute_scoped_job_resource(
+        scope.resources,
+        execute,
+        label="BM25 source resource",
+        missing_result_message="BM25 source resource scope returned no result",
+    )
 
 
 def _detach_resolved_job(value: object) -> IndexJobRecord:

--- a/test/compiler/test_source_job.py
+++ b/test/compiler/test_source_job.py
@@ -5,11 +5,14 @@
 from __future__ import annotations
 
 import builtins
+import dis
 import inspect
 import json
 import os
 import subprocess
+import sys
 import threading
+from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -19,6 +22,7 @@ import pytest
 import codenib.cli as cli_module
 import codenib.compiler as compiler_module
 import codenib.compiler.cache_import as cache_import_module
+import codenib.compiler.job_resolver as job_resolver_module
 import codenib.compiler.job_resources as job_resources_module
 import codenib.compiler.source_job as source_job_module
 from codenib import LocalWorkspaceProvider
@@ -34,6 +38,7 @@ from codenib.compiler.job_resolver import (
     BM25SourceJobResolver,
     BM25SourceJobResourceFactory,
     BM25SourceJobResourceScope,
+    CompilerCacheJobResourceScope,
 )
 from codenib.compiler.job_resources import (
     LocalBM25SourceJobResourceFactory,
@@ -2066,15 +2071,18 @@ def test_local_bm25_source_scope_rejects_replaced_retained_workspace(
         fixture.close()
 
 
+@pytest.mark.parametrize("malformed_notes", ((), None))
 def test_bm25_source_scope_cleanup_cannot_replace_executor_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    malformed_notes: object,
 ) -> None:
     builder = BM25IndexBuilder()
     fixture = _source_fixture(tmp_path)
     view_owner = PublishedWorkspaceReceiptOwner()
     context_owner = PublishedWorkspaceReceiptOwner()
     primary = StorageIntegrityError("primary BM25 source failure")
+    BaseException.__setattr__(primary, "__notes__", malformed_notes)
     cleanup = OSError("injected BM25 source cleanup failure")
     try:
         with (
@@ -2128,10 +2136,10 @@ def test_bm25_source_scope_cleanup_cannot_replace_executor_failure(
                 resolved.execute(context)
 
             assert caught.value is primary
-            notes = (
-                *getattr(primary, "__notes__", ()),
-                *getattr(primary, "_codenib_cleanup_notes", ()),
-            )
+            native_notes = getattr(primary, "__notes__", ())
+            if type(native_notes) is not list:
+                native_notes = ()
+            notes = (*native_notes, *getattr(primary, "_codenib_cleanup_notes", ()))
             assert any(
                 "BM25 source resource cleanup also failed: OSError" in note
                 for note in notes
@@ -2140,6 +2148,1045 @@ def test_bm25_source_scope_cleanup_cannot_replace_executor_failure(
         context_owner.close()
         view_owner.close()
         fixture.close()
+
+
+def _run_in_isolated_thread(callback: Callable[[], None]) -> None:
+    """Keep trace-raised exception state out of the pytest worker thread."""
+
+    failures: list[str] = []
+
+    def run() -> None:
+        try:
+            callback()
+        except (Exception, KeyboardInterrupt) as failure:
+            failures.append(type(failure).__name__)
+
+    worker = threading.Thread(target=run)
+    worker.start()
+    worker.join()
+    assert not worker.is_alive()
+    assert failures == []
+
+
+def _warm_scoped_job_capture_tracing(capture: Callable[..., object]) -> None:
+    """Warm one handler under tracing without injecting an exception."""
+
+    warm_error = RuntimeError("warm scoped capture tracing")
+    warm_outcome = job_resolver_module._ScopedJobExecutionOutcome()
+
+    @contextmanager
+    def warm_resources():
+        yield object()
+
+    def fail_warm_operation(_executor):
+        raise warm_error
+
+    def warm_trace(frame, _event, _arg):
+        if frame.f_code is capture.__code__:
+            frame.f_trace_opcodes = True
+        return warm_trace
+
+    sys.settrace(warm_trace)
+    try:
+        job_resolver_module._capture_scoped_job_resource_exit(
+            warm_resources(),
+            fail_warm_operation,
+            warm_outcome,
+        )
+    finally:
+        sys.settrace(None)
+    assert warm_outcome.operation_error is warm_error
+    assert warm_outcome.scope_error is warm_error
+
+
+def _native_handler_offset(capture: Callable[..., object]) -> int:
+    instructions = tuple(dis.get_instructions(capture))
+    return next(
+        instruction.offset
+        for instruction in instructions
+        if instruction.opname in {"PUSH_EXC_INFO", "WITH_EXCEPT_START"}
+    )
+
+
+@pytest.mark.parametrize("scope_kind", ("cache", "source"))
+@pytest.mark.parametrize(
+    ("capture_name", "trace_point", "cleanup_mode"),
+    (
+        ("_capture_scoped_job_execution", "handler-entry", "raise"),
+        ("_capture_scoped_job_execution", "handler-after-store", "raise"),
+        ("_capture_scoped_job_execution", "handler-entry", "suppress"),
+        ("_capture_scoped_job_execution", "handler-after-store", "suppress"),
+        ("_capture_scoped_job_resource_exit", "handler-entry", "raise"),
+        ("_capture_scoped_job_resource_exit", "handler-after-store", "raise"),
+    ),
+)
+def test_scoped_job_handler_interruption_preserves_executor_primary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    scope_kind: str,
+    capture_name: str,
+    trace_point: str,
+    cleanup_mode: str,
+) -> None:
+    primary = StorageIntegrityError("primary scoped executor failure")
+    cleanup = OSError("scoped resource cleanup failure")
+    injected = KeyboardInterrupt("handler interrupted")
+    cleanup_owner = object()
+    BaseException.__setattr__(
+        cleanup,
+        "publication_cleanup_owners",
+        (cleanup_owner,),
+    )
+    exits: list[str] = []
+
+    class FakeExecutor:
+        def __init__(self, object_store) -> None:
+            self.object_store = object_store
+            self.view_type = "bm25"
+
+        def execute(self, _context):
+            raise primary
+
+    if capture_name == "_capture_scoped_job_execution":
+        capture_type = job_resolver_module._ScopedJobOperationCapture
+        captured_attribute = "operation_error"
+    else:
+        capture_type = job_resolver_module._ScopedJobResourceExitCapture
+        captured_attribute = "scope_error"
+    capture = capture_type.__exit__
+    instructions = tuple(dis.get_instructions(capture))
+    error_store_index = next(
+        index
+        for index, instruction in enumerate(instructions)
+        if instruction.opname == "STORE_ATTR"
+        and instruction.argval == captured_attribute
+    )
+    if trace_point == "handler-entry":
+        handler_offset = next(
+            instruction.offset
+            for instruction in instructions[:error_store_index]
+            if instruction.opname not in {"CACHE", "COPY_FREE_VARS", "NOP", "RESUME"}
+        )
+    else:
+        handler_offset = instructions[error_store_index + 1].offset
+    hit = False
+
+    def trace(frame, event, _arg):
+        nonlocal hit
+        if frame.f_code is capture.__code__:
+            frame.f_trace_opcodes = True
+            if event == "opcode" and frame.f_lasti == handler_offset and not hit:
+                hit = True
+                sys.settrace(None)
+                raise injected
+        return trace
+
+    with LocalCAS(tmp_path / "cas") as cas:
+        executor = FakeExecutor(cas)
+
+        @contextmanager
+        def failing_cleanup():
+            try:
+                yield executor
+            except BaseException as exiting:  # noqa: B036 - inspect scope exit
+                exits.append("exit")
+                assert exiting is primary
+                if cleanup_mode == "raise":
+                    raise cleanup
+
+        if scope_kind == "cache":
+            monkeypatch.setattr(
+                job_resolver_module,
+                "CompilerCacheJobExecutor",
+                FakeExecutor,
+            )
+            scope = CompilerCacheJobResourceScope(
+                object_store=cas,
+                view_type="bm25",
+                resources=failing_cleanup(),
+            )
+            execute = job_resolver_module._execute_in_resource_scope
+            expected_note = "compiler cache resource cleanup also failed: OSError"
+        else:
+            monkeypatch.setattr(
+                job_resolver_module,
+                "BM25SourceJobExecutor",
+                FakeExecutor,
+            )
+            scope = BM25SourceJobResourceScope(
+                object_store=cas,
+                resources=failing_cleanup(),
+            )
+            execute = job_resolver_module._execute_in_bm25_source_resource_scope
+            expected_note = "BM25 source resource cleanup also failed: OSError"
+
+        def run_traced_execute() -> None:
+            _warm_scoped_job_capture_tracing(capture)
+            sys.settrace(trace)
+            try:
+                with pytest.raises(StorageIntegrityError) as caught:
+                    execute(scope, object())
+            finally:
+                sys.settrace(None)
+            assert caught.value is primary
+
+        _run_in_isolated_thread(run_traced_execute)
+
+    assert hit
+    assert exits == ["exit"]
+    retained_owners = getattr(primary, "publication_cleanup_owners", ())
+    if cleanup_mode == "raise":
+        assert retained_owners == (cleanup_owner,)
+    else:
+        assert retained_owners == ()
+    notes = (
+        *getattr(primary, "__notes__", ()),
+        *getattr(primary, "_codenib_cleanup_notes", ()),
+    )
+    assert (expected_note in notes) is (cleanup_mode == "raise")
+
+
+@pytest.mark.parametrize("cleanup_mode", ("raise", "suppress", "propagate"))
+@pytest.mark.parametrize("primary_context", ("none", "internal", "ambient"))
+def test_scoped_job_native_operation_handler_preserves_provenance(
+    cleanup_mode: str,
+    primary_context: str,
+) -> None:
+    primary = StorageIntegrityError("primary scoped executor failure")
+    internal = ValueError("operation-internal context")
+    ambient = RuntimeError("caller ambient context")
+    cleanup = OSError("scoped resource cleanup failure")
+    injected = KeyboardInterrupt("native operation handler interrupted")
+    cleanup_owner = object()
+    BaseException.__setattr__(
+        cleanup,
+        "publication_cleanup_owners",
+        (cleanup_owner,),
+    )
+    capture = job_resolver_module._capture_scoped_job_execution
+    handler_offset = _native_handler_offset(capture)
+    hit = False
+    exits: list[BaseException] = []
+
+    def trace(frame, event, _arg):
+        nonlocal hit
+        if frame.f_code is capture.__code__:
+            frame.f_trace_opcodes = True
+            if event == "opcode" and frame.f_lasti == handler_offset and not hit:
+                hit = True
+                sys.settrace(None)
+                raise injected
+        return trace
+
+    @contextmanager
+    def resources():
+        try:
+            yield object()
+        except BaseException as exiting:  # noqa: B036 - inspect scope exit
+            exits.append(exiting)
+            if cleanup_mode == "raise":
+                raise cleanup from exiting
+            if cleanup_mode == "propagate":
+                raise
+
+    def operation(_executor):
+        if primary_context == "internal":
+            try:
+                raise internal
+            except ValueError as internal_error:
+                raise primary from internal_error
+        raise primary
+
+    def execute_once() -> None:
+        _warm_scoped_job_capture_tracing(capture)
+        sys.settrace(trace)
+        try:
+            with pytest.raises(StorageIntegrityError) as caught:
+                job_resolver_module._execute_scoped_job_resource(
+                    resources(),
+                    operation,
+                    label="test resource",
+                    missing_result_message="test resource returned no result",
+                )
+        finally:
+            sys.settrace(None)
+        assert caught.value is primary
+
+    def run_traced_execute() -> None:
+        if primary_context == "ambient":
+            try:
+                raise ambient
+            except RuntimeError as active_error:
+                assert active_error is ambient
+                execute_once()
+        else:
+            execute_once()
+
+    _run_in_isolated_thread(run_traced_execute)
+
+    assert hit
+    assert exits == [primary]
+    retained_owners = getattr(primary, "publication_cleanup_owners", ())
+    if cleanup_mode == "raise":
+        assert retained_owners == (cleanup_owner,)
+        notes = (
+            *getattr(primary, "__notes__", ()),
+            *getattr(primary, "_codenib_cleanup_notes", ()),
+        )
+        assert "test resource cleanup also failed: OSError" in notes
+    else:
+        assert retained_owners == ()
+
+
+@pytest.mark.parametrize("caller_ambient", (False, True))
+def test_scoped_job_native_resource_handler_preserves_cleanup_failure(
+    caller_ambient: bool,
+) -> None:
+    class HostileCleanupError(OSError):
+        def __bool__(self) -> bool:
+            raise AssertionError("cleanup exception truthiness was evaluated")
+
+    cleanup = HostileCleanupError("scoped resource cleanup failure")
+    injected = KeyboardInterrupt("native resource handler interrupted")
+    cleanup_owner = object()
+    BaseException.__setattr__(
+        cleanup,
+        "publication_cleanup_owners",
+        (cleanup_owner,),
+    )
+    ambient = RuntimeError("caller ambient context")
+    capture = job_resolver_module._capture_scoped_job_resource_exit
+    handler_offset = _native_handler_offset(capture)
+    hit = False
+    exits = 0
+
+    def trace(frame, event, _arg):
+        nonlocal hit
+        if frame.f_code is capture.__code__:
+            frame.f_trace_opcodes = True
+            if event == "opcode" and frame.f_lasti == handler_offset and not hit:
+                hit = True
+                sys.settrace(None)
+                raise injected
+        return trace
+
+    @contextmanager
+    def resources():
+        nonlocal exits
+        try:
+            yield object()
+        finally:
+            exits += 1
+            raise cleanup
+
+    def execute_once() -> None:
+        _warm_scoped_job_capture_tracing(capture)
+        sys.settrace(trace)
+        try:
+            with pytest.raises(OSError) as caught:
+                job_resolver_module._execute_scoped_job_resource(
+                    resources(),
+                    lambda _executor: object(),
+                    label="test resource",
+                    missing_result_message="test resource returned no result",
+                )
+        finally:
+            sys.settrace(None)
+        assert caught.value is cleanup
+
+    def run_traced_execute() -> None:
+        if caller_ambient:
+            try:
+                raise ambient
+            except RuntimeError as active_error:
+                assert active_error is ambient
+                execute_once()
+        else:
+            execute_once()
+
+    _run_in_isolated_thread(run_traced_execute)
+
+    assert hit
+    assert exits == 1
+    assert getattr(cleanup, "publication_cleanup_owners", ()) == (cleanup_owner,)
+
+
+def test_scoped_job_resource_recovery_entry_preserves_boundary_error() -> None:
+    injected = KeyboardInterrupt("scoped resource recovery interrupted")
+    recover = job_resolver_module._recover_scoped_job_resource_exit
+    target_offset = next(
+        instruction.offset
+        for instruction in dis.get_instructions(recover)
+        if instruction.argval == "_invoke_scoped_job_resource_exit"
+    )
+    hit = False
+    resource_enters = 0
+    operation_calls = 0
+
+    def trace(frame, event, _arg):
+        nonlocal hit
+        if frame.f_code is recover.__code__:
+            frame.f_trace_opcodes = True
+            if event == "opcode" and frame.f_lasti == target_offset and not hit:
+                hit = True
+                sys.settrace(None)
+                raise injected
+        return trace
+
+    @contextmanager
+    def resources():
+        nonlocal resource_enters
+        resource_enters += 1
+        yield object()
+
+    def operation(_executor):
+        nonlocal operation_calls
+        operation_calls += 1
+        return object()
+
+    def run_traced_execute() -> None:
+        warm_outcome = job_resolver_module._ScopedJobExecutionOutcome()
+
+        def warm_trace(frame, _event, _arg):
+            if frame.f_code is recover.__code__:
+                frame.f_trace_opcodes = True
+            return warm_trace
+
+        sys.settrace(warm_trace)
+        try:
+            recover(resources(), operation, warm_outcome)
+        finally:
+            sys.settrace(None)
+        resource_enters_before = resource_enters
+        operation_calls_before = operation_calls
+
+        sys.settrace(trace)
+        try:
+            with pytest.raises(KeyboardInterrupt) as caught:
+                job_resolver_module._execute_scoped_job_resource(
+                    resources(),
+                    operation,
+                    label="test resource",
+                    missing_result_message="test resource returned no result",
+                )
+        finally:
+            sys.settrace(None)
+        assert caught.value is injected
+        assert resource_enters == resource_enters_before
+        assert operation_calls == operation_calls_before
+
+    _run_in_isolated_thread(run_traced_execute)
+
+    assert hit
+
+
+def test_scoped_job_same_ambient_instance_remains_local_primary() -> None:
+    execute = job_resolver_module._execute_scoped_job_resource
+    sys_loads = tuple(
+        instruction.offset
+        for instruction in dis.get_instructions(execute)
+        if instruction.opname == "LOAD_GLOBAL" and instruction.argval == "sys"
+    )
+    target_offset = sys_loads[1]
+    ambient = RuntimeError("caller and local scoped failure")
+    cleanup = OSError("scoped resource cleanup failure")
+    cleanup_owner = object()
+    BaseException.__setattr__(
+        cleanup,
+        "publication_cleanup_owners",
+        (cleanup_owner,),
+    )
+    hit = False
+    exits = 0
+    operation_calls = 0
+
+    def trace(frame, event, _arg):
+        nonlocal hit
+        if frame.f_code is execute.__code__:
+            frame.f_trace_opcodes = True
+            if event == "opcode" and frame.f_lasti == target_offset and not hit:
+                hit = True
+                sys.settrace(None)
+                raise ambient
+        return trace
+
+    @contextmanager
+    def resources():
+        nonlocal exits
+        try:
+            yield object()
+        finally:
+            exits += 1
+            raise cleanup
+
+    def operation(_executor):
+        nonlocal operation_calls
+        operation_calls += 1
+        return object()
+
+    def run_traced_execute() -> None:
+        def warm_trace(frame, _event, _arg):
+            if frame.f_code is execute.__code__:
+                frame.f_trace_opcodes = True
+            return warm_trace
+
+        warm_primary = RuntimeError("warm scoped execution")
+        sys.settrace(warm_trace)
+        try:
+            with pytest.raises(RuntimeError) as warm_caught:
+                execute(
+                    resources(),
+                    lambda _executor: (_ for _ in ()).throw(warm_primary),
+                    label="test resource",
+                    missing_result_message="test resource returned no result",
+                )
+        finally:
+            sys.settrace(None)
+        assert warm_caught.value is warm_primary
+        exits_before = exits
+
+        try:
+            raise ambient
+        except RuntimeError as active_error:
+            assert active_error is ambient
+            sys.settrace(trace)
+            try:
+                with pytest.raises(RuntimeError) as caught:
+                    execute(
+                        resources(),
+                        operation,
+                        label="test resource",
+                        missing_result_message="test resource returned no result",
+                    )
+            finally:
+                sys.settrace(None)
+            assert caught.value is ambient
+        assert exits == exits_before + 1
+
+    _run_in_isolated_thread(run_traced_execute)
+
+    assert hit
+    assert exits == 2
+    assert operation_calls == 1
+    assert getattr(ambient, "publication_cleanup_owners", ()) == (cleanup_owner,)
+    notes = (
+        *getattr(ambient, "__notes__", ()),
+        *getattr(ambient, "_codenib_cleanup_notes", ()),
+    )
+    assert "test resource cleanup also failed: OSError" in notes
+
+
+@pytest.mark.parametrize("cleanup_mode", ("success", "raise"))
+def test_scoped_job_caught_ambient_reuse_does_not_become_primary(
+    monkeypatch: pytest.MonkeyPatch,
+    cleanup_mode: str,
+) -> None:
+    class FakeResult:
+        pass
+
+    monkeypatch.setattr(job_resolver_module, "IndexJobExecutionResult", FakeResult)
+    result = FakeResult()
+    ambient = RuntimeError("caller ambient reused inside operation")
+    cleanup = OSError("scoped resource cleanup failure")
+    cleanup_owner = object()
+    BaseException.__setattr__(
+        cleanup,
+        "publication_cleanup_owners",
+        (cleanup_owner,),
+    )
+    exits = 0
+
+    @contextmanager
+    def resources():
+        nonlocal exits
+        try:
+            yield object()
+        finally:
+            exits += 1
+            if cleanup_mode == "raise":
+                raise cleanup
+
+    def operation(_executor):
+        try:
+            raise ambient
+        except RuntimeError as caught:
+            assert caught is ambient
+        return result
+
+    try:
+        raise ambient
+    except RuntimeError as active_error:
+        assert active_error is ambient
+        if cleanup_mode == "success":
+            assert (
+                job_resolver_module._execute_scoped_job_resource(
+                    resources(),
+                    operation,
+                    label="test resource",
+                    missing_result_message="test resource returned no result",
+                )
+                is result
+            )
+        else:
+            with pytest.raises(OSError) as caught:
+                job_resolver_module._execute_scoped_job_resource(
+                    resources(),
+                    operation,
+                    label="test resource",
+                    missing_result_message="test resource returned no result",
+                )
+            assert caught.value is cleanup
+
+    assert exits == 1
+    assert getattr(ambient, "publication_cleanup_owners", ()) == ()
+    assert getattr(cleanup, "publication_cleanup_owners", ()) == (cleanup_owner,)
+
+
+def test_scoped_job_ambient_classification_interruption_becomes_primary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResult:
+        pass
+
+    monkeypatch.setattr(job_resolver_module, "IndexJobExecutionResult", FakeResult)
+    result = FakeResult()
+    ambient = RuntimeError("caller ambient reused inside operation")
+    injected = KeyboardInterrupt("ambient classification interrupted")
+    classify = job_resolver_module._has_current_scoped_job_execution_provenance
+    target_offset = next(
+        instruction.offset
+        for instruction in dis.get_instructions(classify)
+        if instruction.argval == "__traceback__"
+    )
+    hit = False
+    exits = 0
+    operation_calls = 0
+
+    def trace(frame, event, _arg):
+        nonlocal hit
+        if frame.f_code is classify.__code__:
+            frame.f_trace_opcodes = True
+            if event == "opcode" and frame.f_lasti == target_offset and not hit:
+                hit = True
+                sys.settrace(None)
+                raise injected
+        return trace
+
+    @contextmanager
+    def resources():
+        nonlocal exits
+        try:
+            yield object()
+        finally:
+            exits += 1
+
+    def operation(active_ambient):
+        def run(_executor):
+            nonlocal operation_calls
+            operation_calls += 1
+            try:
+                raise active_ambient
+            except RuntimeError as caught:
+                assert caught is active_ambient
+            return result
+
+        return run
+
+    def execute_with_ambient(active_ambient) -> FakeResult:
+        try:
+            raise active_ambient
+        except RuntimeError as caught:
+            assert caught is active_ambient
+            return job_resolver_module._execute_scoped_job_resource(
+                resources(),
+                operation(active_ambient),
+                label="test resource",
+                missing_result_message="test resource returned no result",
+            )
+
+    def run_traced_execute() -> None:
+        def warm_trace(frame, _event, _arg):
+            if frame.f_code is classify.__code__:
+                frame.f_trace_opcodes = True
+            return warm_trace
+
+        sys.settrace(warm_trace)
+        try:
+            assert execute_with_ambient(RuntimeError("warm ambient")) is result
+        finally:
+            sys.settrace(None)
+
+        sys.settrace(trace)
+        try:
+            with pytest.raises(KeyboardInterrupt) as caught:
+                execute_with_ambient(ambient)
+        finally:
+            sys.settrace(None)
+        assert caught.value is injected
+
+    _run_in_isolated_thread(run_traced_execute)
+
+    assert hit
+    assert exits == 2
+    assert operation_calls == 2
+
+
+def test_scoped_job_final_delivery_interruption_retains_settled_outcome() -> None:
+    execute = job_resolver_module._execute_scoped_job_resource
+    instructions = tuple(dis.get_instructions(execute))
+    target_offset = next(
+        instruction.offset
+        for index, instruction in enumerate(instructions[:-1])
+        if instruction.opname == "RAISE_VARARGS"
+        and instructions[index + 1].opname == "LOAD_GLOBAL"
+        and instructions[index + 1].argval == "type"
+    )
+    primary = StorageIntegrityError("primary scoped executor failure")
+    cleanup = OSError("scoped resource cleanup failure")
+    injected = KeyboardInterrupt("final scoped delivery interrupted")
+    cleanup_owner = object()
+    BaseException.__setattr__(
+        cleanup,
+        "publication_cleanup_owners",
+        (cleanup_owner,),
+    )
+    hit = False
+    exits = 0
+    observed_outcomes: list[object] = []
+
+    def trace(frame, event, _arg):
+        nonlocal hit
+        if frame.f_code is execute.__code__:
+            frame.f_trace_opcodes = True
+            if event == "opcode" and frame.f_lasti == target_offset and not hit:
+                hit = True
+                sys.settrace(None)
+                raise injected
+        return trace
+
+    @contextmanager
+    def resources():
+        nonlocal exits
+        try:
+            yield object()
+        finally:
+            exits += 1
+            raise cleanup
+
+    def operation(_executor):
+        raise primary
+
+    def run_traced_execute() -> None:
+        def warm_trace(frame, _event, _arg):
+            if frame.f_code is execute.__code__:
+                frame.f_trace_opcodes = True
+            return warm_trace
+
+        warm_primary = RuntimeError("warm scoped primary")
+
+        @contextmanager
+        def warm_resources():
+            try:
+                yield object()
+            finally:
+                raise OSError("warm scoped cleanup")
+
+        sys.settrace(warm_trace)
+        try:
+            with pytest.raises(RuntimeError) as warm_caught:
+                execute(
+                    warm_resources(),
+                    lambda _executor: (_ for _ in ()).throw(warm_primary),
+                    label="test resource",
+                    missing_result_message="test resource returned no result",
+                )
+        finally:
+            sys.settrace(None)
+        assert warm_caught.value is warm_primary
+
+        sys.settrace(trace)
+        try:
+            with pytest.raises(KeyboardInterrupt) as caught:
+                execute(
+                    resources(),
+                    operation,
+                    label="test resource",
+                    missing_result_message="test resource returned no result",
+                )
+        finally:
+            sys.settrace(None)
+        assert caught.value is injected
+        traceback = BaseException.__traceback__.__get__(injected, type(injected))
+        while traceback is not None:
+            frame = traceback.tb_frame
+            if frame.f_code is execute.__code__:
+                observed_outcomes.append(frame.f_locals["outcome"])
+                break
+            traceback = traceback.tb_next
+
+    _run_in_isolated_thread(run_traced_execute)
+
+    assert hit
+    assert exits == 1
+    assert len(observed_outcomes) == 1
+    outcome = observed_outcomes[0]
+    assert type(outcome) is job_resolver_module._ScopedJobExecutionOutcome
+    assert outcome.settlement_started
+    assert outcome.settlement_complete
+    assert outcome.operation_error is primary
+    assert outcome.scope_error is cleanup
+    assert outcome.settled_primary is primary
+    assert getattr(primary, "publication_cleanup_owners", ()) == (cleanup_owner,)
+    assert getattr(cleanup, "publication_cleanup_owners", ()) == (cleanup_owner,)
+    notes = (
+        *getattr(primary, "__notes__", ()),
+        *getattr(primary, "_codenib_cleanup_notes", ()),
+    )
+    assert "test resource cleanup also failed: OSError" in notes
+
+
+def test_scoped_job_unattachable_primary_retains_cleanup_owner_in_outcome() -> None:
+    class UnattachablePrimary(StorageIntegrityError):
+        @property
+        def publication_cleanup_owners(self):
+            return ()
+
+        @publication_cleanup_owners.setter
+        def publication_cleanup_owners(self, _value):
+            raise RuntimeError("primary rejects cleanup-owner attachment")
+
+    execute = job_resolver_module._execute_scoped_job_resource
+    primary = UnattachablePrimary("primary scoped executor failure")
+    cleanup = OSError("scoped resource cleanup failure")
+    cleanup_owner = object()
+    BaseException.__setattr__(
+        cleanup,
+        "publication_cleanup_owners",
+        (cleanup_owner,),
+    )
+    exits = 0
+
+    @contextmanager
+    def resources():
+        nonlocal exits
+        try:
+            yield object()
+        finally:
+            exits += 1
+            raise cleanup
+
+    with pytest.raises(UnattachablePrimary) as caught:
+        execute(
+            resources(),
+            lambda _executor: (_ for _ in ()).throw(primary),
+            label="test resource",
+            missing_result_message="test resource returned no result",
+        )
+
+    assert caught.value is primary
+    assert exits == 1
+    observed_outcome = None
+    traceback = BaseException.__traceback__.__get__(primary, type(primary))
+    while traceback is not None:
+        frame = traceback.tb_frame
+        if frame.f_code is execute.__code__:
+            observed_outcome = frame.f_locals["outcome"]
+            break
+        traceback = traceback.tb_next
+    assert type(observed_outcome) is job_resolver_module._ScopedJobExecutionOutcome
+    assert observed_outcome.settlement_complete
+    assert observed_outcome.settled_primary is primary
+    assert observed_outcome.scope_error is cleanup
+    assert cleanup.publication_cleanup_owners == (cleanup_owner,)
+    notes = (
+        *getattr(primary, "__notes__", ()),
+        *getattr(primary, "_codenib_cleanup_notes", ()),
+    )
+    assert "test resource cleanup also failed: OSError" in notes
+
+
+def test_scoped_job_post_invoke_handler_keeps_captured_primary() -> None:
+    invoke = job_resolver_module._invoke_scoped_job_execution
+    instructions = tuple(dis.get_instructions(invoke))
+    boundary_store_indices = tuple(
+        index
+        for index, instruction in enumerate(instructions)
+        if instruction.opname == "STORE_FAST" and instruction.argval == "boundary_error"
+    )
+    handler_store_index = boundary_store_indices[-1]
+    pop_except_index = next(
+        index
+        for index in range(handler_store_index + 1, len(instructions))
+        if instructions[index].opname == "POP_EXCEPT"
+    )
+    target_offset = instructions[pop_except_index + 1].offset
+    primary = StorageIntegrityError("primary scoped executor failure")
+    cleanup = OSError("scoped resource cleanup failure")
+    injected = KeyboardInterrupt("post-handler interruption")
+    cleanup_owner = object()
+    BaseException.__setattr__(
+        cleanup,
+        "publication_cleanup_owners",
+        (cleanup_owner,),
+    )
+    hit = False
+    exits: list[BaseException] = []
+
+    def trace(frame, event, _arg):
+        nonlocal hit
+        if frame.f_code is invoke.__code__:
+            frame.f_trace_opcodes = True
+            if event == "opcode" and frame.f_lasti == target_offset and not hit:
+                hit = True
+                sys.settrace(None)
+                raise injected
+        return trace
+
+    @contextmanager
+    def resources():
+        try:
+            yield object()
+        except BaseException as exiting:  # noqa: B036 - inspect exact primary
+            exits.append(exiting)
+            raise cleanup
+
+    def run_traced_execute() -> None:
+        def warm_trace(frame, _event, _arg):
+            if frame.f_code is invoke.__code__:
+                frame.f_trace_opcodes = True
+            return warm_trace
+
+        warm_primary = RuntimeError("warm invoke handler")
+        warm_outcome = job_resolver_module._ScopedJobExecutionOutcome()
+        sys.settrace(warm_trace)
+        try:
+            with pytest.raises(RuntimeError) as warm_caught:
+                invoke(
+                    object(),
+                    lambda _executor: (_ for _ in ()).throw(warm_primary),
+                    warm_outcome,
+                )
+        finally:
+            sys.settrace(None)
+        assert warm_caught.value is warm_primary
+
+        sys.settrace(trace)
+        try:
+            with pytest.raises(StorageIntegrityError) as caught:
+                job_resolver_module._execute_scoped_job_resource(
+                    resources(),
+                    lambda _executor: (_ for _ in ()).throw(primary),
+                    label="test resource",
+                    missing_result_message="test resource returned no result",
+                )
+        finally:
+            sys.settrace(None)
+        assert caught.value is primary
+
+    _run_in_isolated_thread(run_traced_execute)
+
+    assert hit
+    assert exits == [primary]
+    assert getattr(primary, "publication_cleanup_owners", ()) == (cleanup_owner,)
+    notes = (
+        *getattr(primary, "__notes__", ()),
+        *getattr(primary, "_codenib_cleanup_notes", ()),
+    )
+    assert "test resource cleanup also failed: OSError" in notes
+
+
+def test_scoped_job_recovery_interruption_keeps_captured_scope_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResult:
+        pass
+
+    monkeypatch.setattr(job_resolver_module, "IndexJobExecutionResult", FakeResult)
+    result = FakeResult()
+    cleanup = OSError("scoped resource cleanup failure")
+    injected = KeyboardInterrupt("operation-context recovery interrupted")
+    cleanup_owner = object()
+    BaseException.__setattr__(
+        cleanup,
+        "publication_cleanup_owners",
+        (cleanup_owner,),
+    )
+    recover_operation = job_resolver_module._scoped_job_operation_context
+    target_offset = next(
+        instruction.offset
+        for instruction in dis.get_instructions(recover_operation)
+        if instruction.opname not in {"CACHE", "COPY_FREE_VARS", "NOP", "RESUME"}
+    )
+    hit = False
+    exits = 0
+    operation_calls = 0
+
+    def trace(frame, event, _arg):
+        nonlocal hit
+        if frame.f_code is recover_operation.__code__:
+            frame.f_trace_opcodes = True
+            if event == "opcode" and frame.f_lasti == target_offset and not hit:
+                hit = True
+                sys.settrace(None)
+                raise injected
+        return trace
+
+    @contextmanager
+    def resources():
+        nonlocal exits
+        try:
+            yield object()
+        finally:
+            exits += 1
+            raise cleanup
+
+    def operation(_executor):
+        nonlocal operation_calls
+        operation_calls += 1
+        return result
+
+    def run_traced_execute() -> None:
+        def warm_trace(frame, _event, _arg):
+            if frame.f_code is recover_operation.__code__:
+                frame.f_trace_opcodes = True
+            return warm_trace
+
+        sys.settrace(warm_trace)
+        try:
+            with pytest.raises(OSError) as warm_caught:
+                job_resolver_module._execute_scoped_job_resource(
+                    resources(),
+                    operation,
+                    label="test resource",
+                    missing_result_message="test resource returned no result",
+                )
+        finally:
+            sys.settrace(None)
+        assert warm_caught.value is cleanup
+        exits_before = exits
+        operation_calls_before = operation_calls
+
+        sys.settrace(trace)
+        try:
+            with pytest.raises(OSError) as caught:
+                job_resolver_module._execute_scoped_job_resource(
+                    resources(),
+                    operation,
+                    label="test resource",
+                    missing_result_message="test resource returned no result",
+                )
+        finally:
+            sys.settrace(None)
+        assert caught.value is cleanup
+        assert exits == exits_before + 1
+        assert operation_calls == operation_calls_before + 1
+
+    _run_in_isolated_thread(run_traced_execute)
+
+    assert hit
+    assert exits == 2
+    assert operation_calls == 2
+    assert getattr(cleanup, "publication_cleanup_owners", ()) == (cleanup_owner,)
 
 
 def test_local_bm25_source_scope_rejects_physical_workspace_overlap_before_capture(


### PR DESCRIPTION
## Summary
Preserve the exact scoped job execution failure when asynchronous interruption lands in exception capture or cleanup settlement paths.

## Changes
- Capture executor and resource-scope outcomes before cleanup crosses the scope boundary.
- Preserve an already captured operation failure across post-handler interruption.
- Keep a captured scope failure ahead of later recovery interruption.
- Settle cleanup owners and diagnostic notes idempotently across Python 3.10+ without letting permanently unavailable metadata replace the primary.
- Authenticate ambient and handler provenance without swallowing cancellation.
- Cover cache and retained-source scopes with version-portable interruption regressions.
- Document and test the fully settled outermost Python delivery boundary.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- Python 3.10, 3.12, and 3.14: test/compiler/test_source_job.py test/compiler/test_cache_import.py (203 passed per interpreter).
- Python 3.12: full test/compiler suite (1,052 passed).
- Cross-version ambient, strict-provenance, handler, settlement, final-delivery, topology, and vector cross-order adversarial gates.
- Reachable-opcode sweeps for post-handler preservation, resource recovery, owner inheritance, and hostile settlement.
- black, isort, flake8, py_compile, and git diff checks.

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published