### PR TITLE
feat(storage): own BM25 source attempt roots

### DIFF
--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -6023,14 +6023,26 @@ class OwnedPathBuildDirectory:
         destination: Path,
         *,
         require_private_parent: bool,
+        expected_parent_identity: tuple[int, ...] | None = None,
     ) -> None:
         if type(self) is not OwnedPathBuildDirectory:
             raise TypeError(
                 "owned path build directory does not support subclass construction"
             )
+        if expected_parent_identity is not None and (
+            type(expected_parent_identity) is not tuple
+            or len(expected_parent_identity) < 2
+            or any(type(value) is not int for value in expected_parent_identity)
+        ):
+            raise TypeError("owned path build parent identity is invalid")
         self._destination = destination
         self._path = destination
         self._require_private_parent = require_private_parent
+        self._expected_parent_identity = (
+            None
+            if expected_parent_identity is None
+            else tuple(expected_parent_identity)
+        )
         self._authority_owner = _PublicationAuthorityOwner()
         self._stage: OwnedDirectoryStage | None = None
         self._isolation_owner: _OwnedDirectoryIsolationOwner | None = None
@@ -6047,8 +6059,13 @@ class OwnedPathBuildDirectory:
         *,
         create_parent: bool = False,
         require_private_parent: bool = True,
+        expected_parent_identity: tuple[int, ...] | None = None,
     ) -> OwnedPathBuildDirectory:
-        """Create a fresh private build root under one retained authority."""
+        """Create a fresh private build root under one retained authority.
+
+        An optional parent identity binds the retained path to a caller-pinned
+        attempt pool before the first root mutation.
+        """
 
         if cls is not OwnedPathBuildDirectory:
             raise TypeError(
@@ -6060,6 +6077,12 @@ class OwnedPathBuildDirectory:
             raise TypeError("owned path build create_parent must be a boolean")
         if type(require_private_parent) is not bool:
             raise TypeError("owned path build require_private_parent must be a boolean")
+        if expected_parent_identity is not None and (
+            type(expected_parent_identity) is not tuple
+            or len(expected_parent_identity) < 2
+            or any(type(value) is not int for value in expected_parent_identity)
+        ):
+            raise TypeError("owned path build parent identity is invalid")
         _require_owned_path_build_support()
         lexical = lexical_directory_path(destination)
         # Validate the exact derived component length before constructing the
@@ -6069,6 +6092,7 @@ class OwnedPathBuildDirectory:
         resource = cls(
             lexical,
             require_private_parent=require_private_parent,
+            expected_parent_identity=expected_parent_identity,
         )
         cleanup = _OrderedAction(
             label="owned path build preparation cleanup also failed",
@@ -6088,7 +6112,7 @@ class OwnedPathBuildDirectory:
         authority = _open_publication_authority(
             self._destination.parent,
             parent_resource=None,
-            expected_parent_identity=None,
+            expected_parent_identity=self._expected_parent_identity,
             create_missing=create_parent,
             missing_parent_mode=0o700,
             authority_owner=self._authority_owner,

--- a/codenib/compiler/job_resources.py
+++ b/codenib/compiler/job_resources.py
@@ -19,10 +19,14 @@ from .._atomic_directory import (
     _attach_publication_cleanup_owner,
     _OrderedAction,
     _run_context_with_cleanup_actions,
+    directory_ownership_root_identity,
     discard_owned_directory,
     lexical_directory_path,
 )
-from .._captured_directory import PublishedWorkspaceReceiptOwner
+from .._captured_directory import (
+    OwnedPathBuildDirectory,
+    PublishedWorkspaceReceiptOwner,
+)
 from .._local_workspace_provider import LocalWorkspaceProvider
 from .._workspace_provider import StrictWorkspaceRequest, StrictWorkspaceSession
 from ..artifacts.runtime import SourceBindingCleanupOwner
@@ -240,7 +244,13 @@ class LocalCompilerCacheJobTarget:
 
 @dataclass(frozen=True, slots=True)
 class LocalBM25SourceJobTarget:
-    """One explicitly trusted source-builder and local workspace binding."""
+    """One explicitly trusted source-builder and local attempt-pool binding.
+
+    ``attempt_orphan_sink`` accepts authenticated cleanup receipts at least
+    once.  A configured sink must therefore be idempotent and non-reentrant.
+    Without one, receipts are logged for the owning pool's later quiescent
+    reaper.
+    """
 
     repository_root: Path
     workspace_provider: LocalWorkspaceProvider
@@ -269,6 +279,11 @@ class LocalBM25SourceJobTarget:
         compare=False,
     )
     topology_verifier: Callable[[], None] | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    attempt_orphan_sink: Callable[[DirectoryOrphan], None] | None = field(
         default=None,
         repr=False,
         compare=False,
@@ -327,6 +342,9 @@ class LocalBM25SourceJobTarget:
         topology_verifier = self.topology_verifier
         if topology_verifier is not None and not callable(topology_verifier):
             raise TypeError("BM25 source target topology verifier is invalid")
+        attempt_orphan_sink = self.attempt_orphan_sink
+        if attempt_orphan_sink is not None and not callable(attempt_orphan_sink):
+            raise TypeError("BM25 source target orphan sink is invalid")
         namespace = NamespaceIdentity(self.namespace_name)
         repository = RepositoryIdentity(
             namespace_id=namespace.namespace_id,
@@ -377,6 +395,12 @@ class LocalBM25SourceJobTarget:
 
     @property
     def workspace_root(self) -> Path:
+        return self.workspace_provider.allowed_root
+
+    @property
+    def attempt_pool_root(self) -> Path:
+        """Return the private parent that owns source-job attempt roots."""
+
         return self.workspace_provider.allowed_root
 
     @property
@@ -434,15 +458,35 @@ class LocalBM25SourceJobTarget:
         self.verify_topology()
         return source
 
+    def accept_attempt_orphan(self, orphan: DirectoryOrphan) -> None:
+        """Persist or log one authenticated attempt-root cleanup receipt."""
+
+        if type(orphan) is not DirectoryOrphan:
+            raise TypeError("BM25 source target orphan receipt is invalid")
+        sink = self.attempt_orphan_sink
+        if sink is not None:
+            sink(orphan)
+            return
+        logger.warning(
+            "BM25 source job retained an attempt-root orphan for quiescent GC: "
+            "path=%s digest=%s entries=%d bytes=%d verified=%s",
+            orphan.path,
+            orphan.ownership_digest,
+            orphan.entries,
+            orphan.byte_count,
+            orphan.verified_at_isolation,
+        )
+
 
 @dataclass(slots=True)
 class _AttemptWorkspaceCleanupOwner:
-    """Close one receipt authority, then isolate its exact published tree."""
+    """Close a receipt and optionally isolate its exact published tree."""
 
     owner: PublishedWorkspaceReceiptOwner
-    destination: Path
+    destination: Path | None
     label: str
     job_label: str = "Compiler-cache job"
+    isolate_destination: bool = True
     _ownership: object | None = field(default=None, init=False, repr=False)
     _closed: bool = field(default=False, init=False, repr=False)
 
@@ -476,8 +520,13 @@ class _AttemptWorkspaceCleanupOwner:
         if self._ownership is None:
             state = self.owner.state
             if state == "active":
+                destination = self.destination
+                if destination is None:
+                    raise StorageIntegrityError(
+                        f"{self.job_label} workspace destination is not installed"
+                    )
                 binding = self.owner.destination_binding
-                if binding.destination != self.destination:
+                if binding.destination != destination:
                     raise StorageIntegrityError(
                         f"{self.job_label} workspace receipt changed destination"
                     )
@@ -493,9 +542,58 @@ class _AttemptWorkspaceCleanupOwner:
         self.owner.close()
         if not self.owner.closed:
             raise RuntimeError(f"{self.job_label} workspace receipt did not close")
-        if self._ownership is not None:
-            orphan = discard_owned_directory(self.destination, self._ownership)
+        if self._ownership is not None and self.isolate_destination:
+            destination = self.destination
+            if destination is None:  # pragma: no cover - active state checked above
+                raise AssertionError("workspace cleanup destination is absent")
+            orphan = discard_owned_directory(destination, self._ownership)
             self._record_orphan(orphan, label=self.label)
+        self._closed = True
+
+
+@dataclass(slots=True)
+class _BM25AttemptRootCleanupOwner:
+    """Deliver one outer attempt receipt after every child receipt closes."""
+
+    child_owners: tuple[_AttemptWorkspaceCleanupOwner, ...]
+    accept_orphan: Callable[[DirectoryOrphan], None]
+    owner: OwnedPathBuildDirectory | None = field(default=None, init=False)
+    orphan: DirectoryOrphan | None = field(default=None, init=False)
+    accepted: bool = field(default=False, init=False)
+    _closed: bool = field(default=False, init=False, repr=False)
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def install(self, owner: OwnedPathBuildDirectory) -> None:
+        if type(owner) is not OwnedPathBuildDirectory:
+            raise TypeError("BM25 attempt root requires an exact owned path")
+        if self.owner is not None:
+            raise RuntimeError("BM25 attempt root owner is already installed")
+        self.owner = owner
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        owner = self.owner
+        if owner is None:
+            self._closed = True
+            return
+        if any(not child.closed for child in self.child_owners):
+            raise StorageIntegrityError(
+                "BM25 source job child receipts remain active before root isolation"
+            )
+        orphan = self.orphan
+        if orphan is None:
+            orphan = owner.isolate()
+            self.orphan = orphan
+        if not self.accepted:
+            self.accept_orphan(orphan)
+            self.accepted = True
+        owner.close()
+        if not owner.closed:
+            raise RuntimeError("BM25 source job attempt root did not close")
         self._closed = True
 
 
@@ -916,36 +1014,40 @@ class LocalBM25SourceJobResourceFactory:
         if check_cancelled is None:  # pragma: no cover - context invariant
             raise AssertionError("BM25 source job context has no stop check")
         nonce = _attempt_nonce()
-        prefix = f".codenib-source-job-{nonce}"
-        attempt_destination = target.workspace_root / f"{prefix}-attempt"
-        view_destination = target.workspace_root / f"{prefix}-bm25"
-        context_destination = target.workspace_root / f"{prefix}-context"
+        prefix = f"codenib-source-job-{nonce}"
         attempt_owner = PublishedWorkspaceReceiptOwner()
         view_owner = PublishedWorkspaceReceiptOwner()
         context_owner = PublishedWorkspaceReceiptOwner()
         attempt_cleanup = _AttemptWorkspaceCleanupOwner(
             attempt_owner,
-            attempt_destination,
+            None,
             "source attempt",
             job_label="BM25 source job",
+            isolate_destination=False,
         )
         view_cleanup = _AttemptWorkspaceCleanupOwner(
             view_owner,
-            view_destination,
+            None,
             "source BM25",
             job_label="BM25 source job",
+            isolate_destination=False,
         )
         context_cleanup = _AttemptWorkspaceCleanupOwner(
             context_owner,
-            context_destination,
+            None,
             "source context",
             job_label="BM25 source job",
+            isolate_destination=False,
+        )
+        child_cleanups = (context_cleanup, view_cleanup, attempt_cleanup)
+        attempt_root_cleanup = _BM25AttemptRootCleanupOwner(
+            child_cleanups,
+            target.accept_attempt_orphan,
         )
         source_owner = SourceBindingCleanupOwner()
         cleanup_owners = (
-            context_cleanup,
-            view_cleanup,
-            attempt_cleanup,
+            *child_cleanups,
+            attempt_root_cleanup,
             source_owner,
         )
         cleanup_actions = tuple(
@@ -956,8 +1058,15 @@ class LocalBM25SourceJobResourceFactory:
                 retry_incomplete="cancellation",
                 incomplete_owner=cleanup,
             )
-            for cleanup in (context_cleanup, view_cleanup, attempt_cleanup)
+            for cleanup in child_cleanups
         ) + (
+            _OrderedAction(
+                label="BM25 source job attempt root cleanup also failed",
+                action=attempt_root_cleanup.close,
+                complete=lambda: attempt_root_cleanup.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=attempt_root_cleanup,
+            ),
             _OrderedAction(
                 label="BM25 source job source cleanup also failed",
                 action=source_owner.close,
@@ -990,42 +1099,59 @@ class LocalBM25SourceJobResourceFactory:
                     raise StorageValidationError(
                         "BM25 source job Git HEAD changed during source capture"
                     )
-                workspace_provider = (
-                    target.workspace_provider
-                    if target.workspace_parent_identity is None
-                    and target.topology_verifier is None
-                    else _RetainedBM25WorkspaceProvider(
-                        delegate=target.workspace_provider,
-                        parent_identity=target.workspace_parent_identity,
-                        topology_verifier=target.topology_verifier,
-                    )
-                )
                 check_cancelled()
-                yield BM25SourceJobExecutor(
-                    attempt_generation=attempt_destination,
-                    display_commit=display_commit,
-                    builder=target._builder.builder(),
-                    attempt_output_owner=attempt_owner,
-                    attempt_workspace_provider=target.workspace_provider,
-                    repository_source=repository_source,
-                    view_output_owner=view_owner,
-                    context_output_owner=context_owner,
-                    view_destination=view_destination,
-                    context_destination=context_destination,
-                    workspace_provider=workspace_provider,
-                    repository_key=target.repository_key,
-                    object_store=object_store,
-                    namespace_name=target.namespace_name,
-                    environ=target.environ,
-                    attempt_parent_identity=target.workspace_parent_identity,
-                    attempt_topology_verifier=target.topology_verifier,
+                target.verify_topology()
+                attempt_root = OwnedPathBuildDirectory.prepare(
+                    target.attempt_pool_root / prefix,
+                    expected_parent_identity=target.workspace_parent_identity,
                 )
-                check_cancelled()
-                repository_source.verify_snapshot(check_cancelled=check_cancelled)
-                if target.current_display_commit() != display_commit:
-                    raise StorageValidationError(
-                        "BM25 source job Git HEAD changed before publication"
+                attempt_root_cleanup.install(attempt_root)
+                target.verify_topology()
+                attempt_root_identity = directory_ownership_root_identity(
+                    attempt_root.capture_ownership()
+                )
+                nested_provider = LocalWorkspaceProvider(
+                    attempt_root.path,
+                    provision_timeout_ns=target.workspace_provider.provision_timeout_ns,
+                )
+                attempt_destination = attempt_root.path / "attempt"
+                view_destination = attempt_root.path / "bm25"
+                context_destination = attempt_root.path / "context"
+                attempt_cleanup.destination = attempt_destination
+                view_cleanup.destination = view_destination
+                context_cleanup.destination = context_destination
+                workspace_provider = _RetainedBM25WorkspaceProvider(
+                    delegate=nested_provider,
+                    parent_identity=attempt_root_identity,
+                    topology_verifier=target.topology_verifier,
+                )
+                with attempt_root.path_operation("BM25 source job execution"):
+                    check_cancelled()
+                    yield BM25SourceJobExecutor(
+                        attempt_generation=attempt_destination,
+                        display_commit=display_commit,
+                        builder=target._builder.builder(),
+                        attempt_output_owner=attempt_owner,
+                        attempt_workspace_provider=nested_provider,
+                        repository_source=repository_source,
+                        view_output_owner=view_owner,
+                        context_output_owner=context_owner,
+                        view_destination=view_destination,
+                        context_destination=context_destination,
+                        workspace_provider=workspace_provider,
+                        repository_key=target.repository_key,
+                        object_store=object_store,
+                        namespace_name=target.namespace_name,
+                        environ=target.environ,
+                        attempt_parent_identity=attempt_root_identity,
+                        attempt_topology_verifier=target.topology_verifier,
                     )
+                    check_cancelled()
+                    repository_source.verify_snapshot(check_cancelled=check_cancelled)
+                    if target.current_display_commit() != display_commit:
+                        raise StorageValidationError(
+                            "BM25 source job Git HEAD changed before publication"
+                        )
         except BaseException as error:  # noqa: B036 - retain cleanup authority
             pending = tuple(
                 owner for owner in cleanup_owners if _cleanup_owner_pending(owner)

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1293,8 +1293,8 @@ factory, resolver, and production CLI wiring are described below; Web binding,
 vector source building, and graph source building remain absent.
 
 A general caller-owned path-build directory now supplies a retained attempt
-boundary for arbitrary path writers and the next cleanup hardening of the
-implemented source-job resource factory. It creates under a retained no-follow
+boundary for arbitrary path writers and the implemented source-job resource
+factory. It creates under a retained no-follow
 owner-controlled parent, captures the completed tree, atomically isolates that
 exact tree, retains
 interrupted cleanup for an explicit quiescent retry that delivers authenticated
@@ -1306,14 +1306,17 @@ interrupted public return can be redelivered by the process-local retry. That
 retry is serialized through callback acknowledgement; its sink must not
 recursively invoke the boundary. The native `mkdir`-to-first-identity handoff
 is intentionally fail-closed: if the hidden name cannot be authenticated, it
-is left untouched and never becomes cleanup authority. A follow-up must place
-the implemented source-job factory's attempt, BM25, and context destinations
-under one such outer owner, preserve its exact job/source/profile and
-worker-only binding, release all inner receipt authorities before isolation,
-and add an attempt-pool reaper that reconciles stale names only at a quiescent
-boundary. The legacy one-shot directory-discard and plain stage-construction
-return contracts remain unchanged; cancellation-safe integrations must use the
-retained owner and explicit receipt acknowledgement.
+is left untouched and never becomes cleanup authority. The retained-source
+BM25 factory now places its attempt, BM25, and context destinations under one
+such outer owner. It preserves the exact pool and nested-root identities,
+releases all three inner receipt authorities before isolation, delivers one
+authenticated outer receipt at least once to an idempotent target sink, and
+only then acknowledges the retained owner. Source validation still finishes
+before the attempt root is created. The remaining follow-up is an attempt-pool
+reaper that reconciles stale names only at a quiescent boundary. The legacy
+one-shot directory-discard and plain stage-construction return contracts remain
+unchanged; cancellation-safe integrations must use the retained owner and
+explicit receipt acknowledgement.
 
 The compiler-cache bridge now also has a resource-scoped resolver seam. It
 attests the canonical running request before opening attempt resources, accepts
@@ -1348,11 +1351,14 @@ accepts only that target's single required `full` BM25 profile. Scope
 declaration is side-effect free; entry authenticates lexical and physical
 repository/workspace separation before source capture, binds the worker's exact
 retained object store, recaptures the current dirty fingerprint, and creates
-fresh nonce-scoped attempt, BM25, and context destinations. Ordered exit closes
-source and receipt authorities and isolates only their receipt-owned trees for
-quiescent GC. A changed source fails before build or CAS mutation, and worker
-integration coverage proves the previous published ref remains unchanged. The
-production CLI now selects this binding explicitly. It resolves one stable Git
+one fresh nonce-scoped outer attempt root containing missing `attempt`, `bm25`,
+and `context` children. Ordered exit closes all child receipt authorities,
+atomically isolates the complete outer tree, delivers its authenticated receipt
+to the target sink, acknowledges that delivery, and then closes the source.
+Sink failure keeps the same receipt retained for at-least-once redelivery. A
+changed source fails before build or CAS mutation, and worker integration
+coverage proves the previous published ref remains unchanged. The production
+CLI now selects this binding explicitly. It resolves one stable Git
 HEAD around each fresh source capture and again before returning the prepared
 result, and binds every attempt/view/context provision to the retained startup
 workspace identity while rechecking the complete storage topology. No Web
@@ -1398,9 +1404,10 @@ retained-source BM25 builder and its prepare-only source-job adapter now publish
 and ingest a unique private generation under an exact retained parent and
 generation receipt, without final publication authority or a cache-path reopen;
 its local attempt resource factory, resolver, and explicit production CLI entry
-are implemented. The general caller-owned path-build cleanup primitive intended
-to enclose that factory's three transient destinations is also implemented but
-not yet adopted there.
+are implemented. Its three transient destinations now share one retained
+caller-owned path-build root whose authenticated cleanup receipt is accepted
+before ownership is released; the quiescent attempt-pool reaper remains
+pending.
 Vector and graph source builders, generic builder routing, and remaining
 runtime wiring remain.
 
@@ -1488,13 +1495,12 @@ MCP, UI controls, and default routing remain absent.
   final fenced heartbeat, and then publishes before releasing receipt
   retention. Slow object hashing therefore cannot expire an otherwise healthy
   worker and force a duplicate attempt.
-- The retained-source BM25 attempt resource factory/resolver is implemented;
-  add its production worker entry, then add vector and graph source adapters and
-  wire successful worker results into runtime, Web, MCP, and default routes.
-  The existing continuous CLI still selects only the trusted local
-  compiler-cache factory and can recapture an already-current single BM25 or
-  vector cache view. Older self-publishing ingress APIs remain compatibility
-  paths and are never nested inside the worker.
+- The retained-source BM25 attempt resource factory/resolver and explicit
+  production worker entry are implemented. Add the quiescent attempt-pool
+  reaper, then add vector and graph source adapters and wire successful worker
+  results into runtime, Web, MCP, and default routes. Older self-publishing
+  ingress APIs remain compatibility paths and are never nested inside the
+  worker.
 - Complete the #266 job and update APIs with accurate incremental versus rebuild
   behavior; the first read-only status slice is described below.
 - `RepoRegistry.load_all()` now reconciles each complete registry snapshot,

--- a/test/compiler/test_source_job.py
+++ b/test/compiler/test_source_job.py
@@ -26,7 +26,7 @@ import codenib.compiler.job_resolver as job_resolver_module
 import codenib.compiler.job_resources as job_resources_module
 import codenib.compiler.source_job as source_job_module
 from codenib import LocalWorkspaceProvider
-from codenib._atomic_directory import publication_parent_identity
+from codenib._atomic_directory import DirectoryOrphan, publication_parent_identity
 from codenib._captured_directory import (
     PublishedWorkspaceReceiptOwner,
     UnsupportedWorkspaceCreation,
@@ -1455,6 +1455,7 @@ def test_local_bm25_source_target_binds_exact_repository_root_authority(
         )
         assert positional_target.environ == positional_environment
         assert positional_target.repository_root_authority is None
+        assert positional_target.attempt_pool_root == fixture.workspace
 
         with pin_repository_source_root(fixture.repository) as authority:
             target = LocalBM25SourceJobTarget(
@@ -1493,6 +1494,16 @@ def test_local_bm25_source_target_binds_exact_repository_root_authority(
                 repository_root_authority=object(),  # type: ignore[arg-type]
                 environ={},
             )
+        with pytest.raises(TypeError, match="orphan sink is invalid"):
+            LocalBM25SourceJobTarget(
+                repository_root=fixture.repository,
+                workspace_provider=fixture.provider,
+                repository_key=_REPOSITORY_KEY,
+                display_commit=_COMMIT,
+                builder=BM25IndexBuilder(),
+                attempt_orphan_sink=object(),  # type: ignore[arg-type]
+                environ={},
+            )
         assert not tuple(fixture.workspace.iterdir())
     finally:
         fixture.close()
@@ -1500,12 +1511,14 @@ def test_local_bm25_source_target_binds_exact_repository_root_authority(
 
 def test_local_bm25_source_job_factory_runs_worker_and_cleans_attempt(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     builder = BM25IndexBuilder(languages=["python"], max_k=17)
     profile = bm25_source_job_profile(builder)
     fixture = _source_fixture(tmp_path)
     catalog_path = tmp_path / "catalog.sqlite"
     environment = {"CODENIB_SOURCE_RESOURCE_TEST": "before"}
+    accepted_orphans: list[DirectoryOrphan] = []
     target = LocalBM25SourceJobTarget(
         repository_root=fixture.repository,
         workspace_provider=fixture.provider,
@@ -1513,6 +1526,7 @@ def test_local_bm25_source_job_factory_runs_worker_and_cleans_attempt(
         display_commit=_COMMIT,
         builder=builder,
         environ=environment,
+        attempt_orphan_sink=accepted_orphans.append,
     )
     assert target.profile_id == profile.profile_id
     assert target.environ == environment
@@ -1555,6 +1569,13 @@ def test_local_bm25_source_job_factory_runs_worker_and_cleans_attempt(
             )
 
         with LocalCAS(tmp_path / "cas") as cas:
+            monkeypatch.setattr(
+                job_resources_module,
+                "discard_owned_directory",
+                lambda *_args, **_kwargs: pytest.fail(
+                    "BM25 cleanup used the legacy per-directory discard path"
+                ),
+            )
             resources = LocalBM25SourceJobResourceFactory((target,))
             assert resources.accepts_candidate(queued)
             worker = IndexJobWorker(
@@ -1576,8 +1597,15 @@ def test_local_bm25_source_job_factory_runs_worker_and_cleans_attempt(
             assert outcome.job_id == queued.job_id
             assert not tuple(fixture.workspace.glob(".codenib-source-job-*"))
             orphans = tuple(fixture.workspace.glob(".*.discarded-*"))
-            assert len(orphans) == 3
-            assert all(orphan.is_dir() for orphan in orphans)
+            assert len(orphans) == 1
+            assert len(accepted_orphans) == 1
+            assert accepted_orphans[0].path == orphans[0]
+            inventory = accepted_orphans[0].reopen(lambda reader: reader.inventory())
+            assert {entry for entry in inventory if "/" not in entry[0]} == {
+                ("attempt", "directory"),
+                ("bm25", "directory"),
+                ("context", "directory"),
+            }
             with SQLiteCatalog(catalog_path, create=False) as catalog:
                 completed = catalog.get_job(queued.job_id)
                 assert completed.status is IndexJobStatus.SUCCEEDED
@@ -1587,6 +1615,222 @@ def test_local_bm25_source_job_factory_runs_worker_and_cleans_attempt(
                     json.loads(event.payload_json).get("adapter") == "bm25_source"
                     for event in events
                 )
+    finally:
+        fixture.close()
+
+
+def test_local_bm25_source_scope_nests_outputs_and_orders_outer_ack(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    accepted_orphans: list[DirectoryOrphan] = []
+    order: list[str] = []
+
+    def accept(orphan: DirectoryOrphan) -> None:
+        order.append("accept outer orphan")
+        accepted_orphans.append(orphan)
+
+    target = LocalBM25SourceJobTarget(
+        repository_root=fixture.repository,
+        workspace_provider=fixture.provider,
+        repository_key=_REPOSITORY_KEY,
+        display_commit=_COMMIT,
+        builder=builder,
+        attempt_orphan_sink=accept,
+        environ={},
+    )
+    real_receipt_close = job_resources_module._AttemptWorkspaceCleanupOwner.close
+    real_isolate = job_resources_module.OwnedPathBuildDirectory.isolate
+    real_root_close = job_resources_module.OwnedPathBuildDirectory.close
+
+    def close_receipt(cleanup) -> None:
+        order.append(f"close {cleanup.label}")
+        real_receipt_close(cleanup)
+
+    def isolate_root(owner):
+        order.append("isolate outer root")
+        return real_isolate(owner)
+
+    def close_root(owner) -> None:
+        order.append("ack outer orphan")
+        real_root_close(owner)
+
+    monkeypatch.setattr(
+        job_resources_module._AttemptWorkspaceCleanupOwner,
+        "close",
+        close_receipt,
+    )
+    monkeypatch.setattr(
+        job_resources_module.OwnedPathBuildDirectory,
+        "isolate",
+        isolate_root,
+    )
+    monkeypatch.setattr(
+        job_resources_module.OwnedPathBuildDirectory,
+        "close",
+        close_root,
+    )
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+
+            with resources.create_scope(
+                context,
+                object_store=cas,
+            ).resources as executor:
+                attempt_root = executor.attempt_workspace_provider.allowed_root
+                assert attempt_root.parent == fixture.workspace
+                assert executor.attempt_generation == attempt_root / "attempt"
+                assert executor.view_destination == attempt_root / "bm25"
+                assert executor.context_destination == attempt_root / "context"
+                descriptor = os.open(attempt_root, os.O_RDONLY | os.O_DIRECTORY)
+                try:
+                    assert executor.attempt_parent_identity == (
+                        publication_parent_identity(descriptor)
+                    )
+                finally:
+                    os.close(descriptor)
+
+        assert order == [
+            "close source context",
+            "close source BM25",
+            "close source attempt",
+            "isolate outer root",
+            "accept outer orphan",
+            "ack outer orphan",
+        ]
+        assert len(accepted_orphans) == 1
+        assert accepted_orphans[0].reopen(lambda reader: reader.inventory()) == ()
+    finally:
+        fixture.close()
+
+
+def test_local_bm25_source_scope_redelivers_outer_orphan_until_sink_ack(
+    tmp_path: Path,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    accepted_orphans: list[DirectoryOrphan] = []
+    rejection = RuntimeError("attempt orphan sink rejected receipt")
+
+    def reject_once(orphan: DirectoryOrphan) -> None:
+        accepted_orphans.append(orphan)
+        if len(accepted_orphans) == 1:
+            raise rejection
+
+    target = LocalBM25SourceJobTarget(
+        repository_root=fixture.repository,
+        workspace_provider=fixture.provider,
+        repository_key=_REPOSITORY_KEY,
+        display_commit=_COMMIT,
+        builder=builder,
+        attempt_orphan_sink=reject_once,
+        environ={},
+    )
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+
+            with pytest.raises(
+                StorageIntegrityError,
+                match="attempt resource cleanup did not settle",
+            ) as caught:
+                with resources.create_scope(
+                    context,
+                    object_store=cas,
+                ).resources:
+                    pass
+
+        assert len(accepted_orphans) == 1
+        orphan = accepted_orphans[0]
+        cleanup_owners = getattr(
+            caught.value,
+            "publication_cleanup_owners",
+            (),
+        )
+        attempt_root_cleanup = next(
+            owner
+            for owner in cleanup_owners
+            if isinstance(
+                owner,
+                job_resources_module._BM25AttemptRootCleanupOwner,
+            )
+        )
+        assert not attempt_root_cleanup.closed
+        assert attempt_root_cleanup.orphan is orphan
+
+        attempt_root_cleanup.close()
+
+        assert attempt_root_cleanup.closed
+        assert accepted_orphans == [orphan, orphan]
+        assert orphan.reopen(lambda reader: reader.inventory()) == ()
+    finally:
+        fixture.close()
+
+
+def test_local_bm25_source_scope_retries_cancelled_orphan_sink_before_ack(
+    tmp_path: Path,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    accepted_orphans: list[DirectoryOrphan] = []
+    interruption = KeyboardInterrupt("attempt orphan sink was interrupted")
+
+    def interrupt_once(orphan: DirectoryOrphan) -> None:
+        accepted_orphans.append(orphan)
+        if len(accepted_orphans) == 1:
+            raise interruption
+
+    target = LocalBM25SourceJobTarget(
+        repository_root=fixture.repository,
+        workspace_provider=fixture.provider,
+        repository_key=_REPOSITORY_KEY,
+        display_commit=_COMMIT,
+        builder=builder,
+        attempt_orphan_sink=interrupt_once,
+        environ={},
+    )
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+
+            with pytest.raises(KeyboardInterrupt) as caught:
+                with resources.create_scope(
+                    context,
+                    object_store=cas,
+                ).resources:
+                    pass
+
+        assert caught.value is interruption
+        assert len(accepted_orphans) == 2
+        assert accepted_orphans[0] is accepted_orphans[1]
+        assert accepted_orphans[0].reopen(lambda reader: reader.inventory()) == ()
     finally:
         fixture.close()
 
@@ -1673,8 +1917,8 @@ def test_jobs_run_once_source_bm25_executes_matching_catalog_job(
         assert not tuple(fixture.workspace.glob(".codenib-source-job-*"))
         assert not tuple(fixture.workspace.glob(".codenib-source-worker-topology-*"))
         orphans = tuple(fixture.workspace.glob(".*.discarded-*"))
-        assert len(orphans) == 3
-        assert all(orphan.is_dir() for orphan in orphans)
+        assert len(orphans) == 1
+        assert orphans[0].is_dir()
         with SQLiteCatalog(catalog_path, create=False) as catalog:
             completed = catalog.get_job(queued.job_id)
             assert completed.status is IndexJobStatus.SUCCEEDED
@@ -1930,6 +2174,7 @@ def test_local_bm25_source_scope_threads_repository_root_authority(
     builder = BM25IndexBuilder()
     fixture = _source_fixture(tmp_path)
     observed: list[object] = []
+    accepted_orphans: list[DirectoryOrphan] = []
     real_capture = job_resources_module.capture_repository_source
     try:
         with (
@@ -1944,6 +2189,7 @@ def test_local_bm25_source_scope_threads_repository_root_authority(
                 display_commit=_COMMIT,
                 builder=builder,
                 repository_root_authority=authority,
+                attempt_orphan_sink=accepted_orphans.append,
                 environ={},
             )
             context = _execution_context(
@@ -1969,7 +2215,8 @@ def test_local_bm25_source_scope_threads_repository_root_authority(
                 assert type(executor) is BM25SourceJobExecutor
 
             assert observed == [authority]
-            assert not tuple(fixture.workspace.iterdir())
+            assert len(accepted_orphans) == 1
+            assert accepted_orphans[0].reopen(lambda reader: reader.inventory()) == ()
     finally:
         fixture.close()
 
@@ -1980,6 +2227,7 @@ def test_local_bm25_source_scope_resolves_display_commit_per_attempt(
     builder = BM25IndexBuilder(languages=["python"])
     fixture = _source_fixture(tmp_path, git_checkout=True)
     initial_commit = _git_head(fixture.repository)
+    accepted_orphans: list[DirectoryOrphan] = []
     target = LocalBM25SourceJobTarget(
         repository_root=fixture.repository,
         workspace_provider=fixture.provider,
@@ -1987,6 +2235,7 @@ def test_local_bm25_source_scope_resolves_display_commit_per_attempt(
         display_commit=initial_commit,
         builder=builder,
         display_commit_resolver=lambda: _git_head(fixture.repository),
+        attempt_orphan_sink=accepted_orphans.append,
         environ={},
     )
     try:
@@ -2016,7 +2265,8 @@ def test_local_bm25_source_scope_resolves_display_commit_per_attempt(
             ).resources as executor:
                 assert executor.display_commit == current_commit
 
-        assert not tuple(fixture.workspace.iterdir())
+        assert len(accepted_orphans) == 1
+        assert accepted_orphans[0].reopen(lambda reader: reader.inventory()) == ()
     finally:
         fixture.close()
 
@@ -2061,12 +2311,132 @@ def test_local_bm25_source_scope_rejects_replaced_retained_workspace(
 
             with pytest.raises(
                 RuntimeError,
-                match="attempt parent differs from retained topology",
+                match="publication parent identity does not match authority",
             ):
                 resolved.execute(context)
 
             assert not tuple(fixture.workspace.iterdir())
             assert not tuple(displaced.iterdir())
+    finally:
+        fixture.close()
+
+
+def test_local_bm25_source_scope_rechecks_topology_before_attempt_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = BM25IndexBuilder(languages=["python"])
+    fixture = _source_fixture(tmp_path)
+    revoked = False
+    display_commit_calls = 0
+    displaced_workspace = tmp_path / "displaced-workspace"
+    accepted_orphans: list[DirectoryOrphan] = []
+
+    def verify_topology() -> None:
+        if revoked:
+            raise StorageValidationError("BM25 source worker topology was revoked")
+
+    target = LocalBM25SourceJobTarget(
+        repository_root=fixture.repository,
+        workspace_provider=fixture.provider,
+        repository_key=_REPOSITORY_KEY,
+        display_commit=_COMMIT,
+        builder=builder,
+        topology_verifier=verify_topology,
+        attempt_orphan_sink=accepted_orphans.append,
+        environ={},
+    )
+    real_current_display_commit = LocalBM25SourceJobTarget.current_display_commit
+
+    def current_display_commit(candidate: LocalBM25SourceJobTarget) -> str:
+        nonlocal display_commit_calls, revoked
+        display_commit = real_current_display_commit(candidate)
+        display_commit_calls += 1
+        if display_commit_calls == 2:
+            fixture.workspace.rename(displaced_workspace)
+            fixture.workspace.mkdir(mode=0o700)
+            revoked = True
+        return display_commit
+
+    monkeypatch.setattr(
+        LocalBM25SourceJobTarget,
+        "current_display_commit",
+        current_display_commit,
+    )
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+
+            with pytest.raises(
+                StorageValidationError,
+                match="worker topology was revoked",
+            ):
+                with resources.create_scope(context, object_store=cas).resources:
+                    pass
+
+        assert display_commit_calls == 2
+        assert not tuple(fixture.workspace.iterdir())
+        assert not tuple(displaced_workspace.iterdir())
+        assert accepted_orphans == []
+    finally:
+        fixture.close()
+
+
+def test_local_bm25_source_scope_preserves_workspace_timeout(
+    tmp_path: Path,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    provision_timeout_ns = 123_456_789
+    provider = LocalWorkspaceProvider(
+        fixture.workspace,
+        provision_timeout_ns=provision_timeout_ns,
+    )
+    accepted_orphans: list[DirectoryOrphan] = []
+    target = LocalBM25SourceJobTarget(
+        repository_root=fixture.repository,
+        workspace_provider=provider,
+        repository_key=_REPOSITORY_KEY,
+        display_commit=_COMMIT,
+        builder=builder,
+        attempt_orphan_sink=accepted_orphans.append,
+        environ={},
+    )
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+
+            with resources.create_scope(
+                context,
+                object_store=cas,
+            ).resources as executor:
+                assert (
+                    executor.attempt_workspace_provider.provision_timeout_ns
+                    == provision_timeout_ns
+                )
+                assert (
+                    executor.workspace_provider.delegate
+                    is executor.attempt_workspace_provider
+                )
+
+        assert len(accepted_orphans) == 1
+        assert accepted_orphans[0].reopen(lambda reader: reader.inventory()) == ()
     finally:
         fixture.close()
 

--- a/test/test_captured_directory.py
+++ b/test/test_captured_directory.py
@@ -1377,6 +1377,41 @@ def test_owned_path_build_requires_a_missing_destination(tmp_path: Path) -> None
     assert not tuple(parent.glob(".attempt.normalize-*"))
 
 
+def test_owned_path_build_binds_expected_parent_identity_before_root_creation(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    descriptor = os.open(parent, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        expected = atomic_directory.publication_parent_identity(descriptor)
+    finally:
+        os.close(descriptor)
+    displaced = tmp_path / "displaced"
+    parent.rename(displaced)
+    parent.mkdir(mode=0o700)
+
+    with pytest.raises(
+        RuntimeError,
+        match="publication parent identity does not match authority",
+    ):
+        OwnedPathBuildDirectory.prepare(
+            parent / "attempt",
+            expected_parent_identity=expected,
+        )
+
+    assert not tuple(parent.iterdir())
+    missing_parent = tmp_path / "missing"
+    with pytest.raises(TypeError, match="parent identity is invalid"):
+        OwnedPathBuildDirectory.prepare(
+            missing_parent / "attempt",
+            create_parent=True,
+            expected_parent_identity=(1,),
+        )
+    assert not missing_parent.exists()
+    assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+
+
 def test_owned_path_build_isolate_return_handoff_redelivers_retained_orphan(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Adopt the retained OwnedPath build primitive from #714 for local BM25 source jobs. Each job now owns one authenticated outer attempt root and durably delivers its orphan receipt before acknowledging cleanup ownership.

## Changes

- place attempt, BM25 view, and context workspaces under one private retained attempt root
- bind the exact configured pool identity and captured nested-root identity before writer mutation
- verify caller-retained topology immediately before attempt-root creation
- preserve the configured local workspace provisioning timeout for all nested writers
- add an optional idempotent, non-reentrant attempt orphan sink with at-least-once redelivery on failure or cancellation
- close all child receipt owners before outer isolation, then accept the receipt before owner acknowledgement
- preserve existing target positional compatibility and compiler-cache cleanup behavior
- update the storage roadmap to mark BM25 OwnedPath adoption complete while leaving the quiescent pool reaper pending

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Python 3.10, 3.12, and 3.14: 318 passed in `test/compiler/test_source_job.py` plus `test/test_captured_directory.py`
- Python 3.10, 3.12, and 3.14: 90 source-job tests passed
- Python 3.10, 3.12, and 3.14: 66 OwnedPath tests passed
- the two review regressions fail the superseded head and pass the replacement on all three runtimes
- black, isort, flake8, py_compile, and diff-check passed

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published