### PR TITLE
feat(web): publish retained BM25 generations

### DIFF
--- a/codenib/mcp/context.py
+++ b/codenib/mcp/context.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from ..index.sparse_idx import BM25CodeIndexer
     from ..index.trigram import ZoektSearcher
     from ..native_index_authorization import NativeIndexAuthorization
-    from ..source_fingerprint import RepositorySourceBinding
+    from ..source_fingerprint import RepositorySourceBinding, RepositorySourceReader
     from .explore_session import ExploreSessionRuntime
 
 logger = logging.getLogger(__name__)
@@ -379,6 +379,15 @@ class ServerContext:
         except Exception as exc:
             self.source_error = str(exc)
             raise
+
+    def borrow_source_reader(self) -> RepositorySourceReader:
+        """Borrow the exact source reader retained by this context owner."""
+
+        if self._source_binding is None or not self._source_binding.usable:
+            raise RuntimeError(
+                f"source reads are unavailable: {self.source_error or 'unverified'}"
+            )
+        return self._source_binding.borrow_reader()
 
     def verify_source_status(self) -> bool:
         """Refresh whole-tree source truth before publishing verified status."""

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import os
 import re
 from contextlib import contextmanager
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from functools import partial
 from importlib.util import find_spec
 from threading import Lock, RLock, local
@@ -42,8 +42,11 @@ if TYPE_CHECKING:
     from ..index.embedding.vector_store import CodeVectorStore
     from ..index.sparse_idx.bm25_index import BM25CodeIndexer
     from ..llm.litellm_chat import LiteLLMChat
+    from ..mcp.retained_context import RetainedServerContextOwner
     from ..native_index_authorization import NativeIndexAuthorization
     from ..source_fingerprint import RepositorySourceBinding, RepositorySourceReader
+    from .index_job_activation import IndexJobRuntimeActivation
+    from .index_jobs import IndexJobRepoBinding
 
 logger = get_logger(__name__)
 _REGISTRY_CLEANUP_CONTEXT = local()
@@ -439,6 +442,25 @@ def _require_authenticated_documents(
     _require_authenticated_source_paths(paths, source_reader, subject=subject)
 
 
+def _load_retained_bm25_view(
+    bundle: "RepoBundle",
+    *,
+    runtime_owner: Any,
+) -> None:
+    """Reborrow one retained BM25 view without reopening its published path."""
+
+    if runtime_owner.state != "active":
+        raise RuntimeError("retained BM25 runtime owner is not active")
+    context = runtime_owner.context
+    if context.manifest is not bundle.manifest:
+        raise RuntimeError("retained BM25 runtime manifest identity changed")
+    if not context.verify_source_status():
+        raise RuntimeError("retained BM25 repository source changed")
+    if context.bm25 is None or context.loaded_views != frozenset({"bm25"}):
+        raise RuntimeError("retained BM25 runtime view is unavailable")
+    bundle.bm25 = context.bm25
+
+
 @dataclass
 class RepoBundle:
     """Everything needed to answer questions about one repo."""
@@ -455,8 +477,17 @@ class RepoBundle:
     # Borrowed exact source reader. Its creator retains and closes the owning
     # binding; escaped readers become unusable when that owner closes it.
     source_reader: Optional["RepositorySourceReader"] = None
+    index_job_activation: Optional["IndexJobRuntimeActivation"] = field(
+        default=None,
+        repr=False,
+    )
 
     def __post_init__(self) -> None:
+        if self.index_job_activation is not None:
+            from .index_job_activation import IndexJobRuntimeActivation
+
+            if type(self.index_job_activation) is not IndexJobRuntimeActivation:
+                raise TypeError("repo bundle index-job activation is invalid")
         self._views_lock = Lock()
         self._runtime_lock = Lock()
         self._views_loaded = self.view_loader is None
@@ -851,6 +882,44 @@ def _plain_repo_instance_id(value: Any) -> str:
     if not instance_id:
         raise ValueError("repository instance_id must be non-empty text")
     return instance_id
+
+
+def _require_monotonic_index_job_activation(
+    instance_id: str,
+    previous: object,
+    candidate: object,
+) -> None:
+    """Reject runtime publication regressions and non-durable replacement."""
+
+    from .index_job_activation import IndexJobRuntimeActivation
+
+    for value in (previous, candidate):
+        if value is not None and type(value) is not IndexJobRuntimeActivation:
+            raise RuntimeError("repository runtime activation identity is invalid")
+    if previous is not None and previous.repo_id != instance_id:
+        raise RuntimeError(
+            "active repository runtime activation targets another Web repo"
+        )
+    if candidate is not None and candidate.repo_id != instance_id:
+        raise RuntimeError("repository runtime activation targets another Web repo")
+    if previous is None:
+        return
+    if candidate is None:
+        raise RuntimeError(
+            "registry metadata cannot replace a durable runtime generation"
+        )
+    if (
+        candidate.repository_id != previous.repository_id
+        or candidate.ref_name != previous.ref_name
+    ):
+        raise RuntimeError("repository runtime activation storage binding changed")
+    if candidate.ref_generation < previous.ref_generation:
+        raise RuntimeError("repository runtime activation generation regressed")
+    if candidate.ref_generation == previous.ref_generation and (
+        candidate.snapshot_id != previous.snapshot_id
+        or candidate.ref_updated_at != previous.ref_updated_at
+    ):
+        raise RuntimeError("repository runtime activation fence conflicts")
 
 
 _REPO_LOOKUP_MISS = object()
@@ -1312,6 +1381,87 @@ class RepoRegistry:
 
         self._run_serialized_reload(operation)
 
+    def replace_retained_bm25_snapshot(
+        self,
+        binding: "IndexJobRepoBinding",
+        activation: "IndexJobRuntimeActivation",
+        runtime_owner: "RetainedServerContextOwner",
+        *,
+        transfer_if_current: Callable[[Callable[[], None]], None],
+    ) -> None:
+        """Publish one current retained BM25 result as a pinned generation.
+
+        Validation leaves the caller's owner untouched. Once an active owner
+        passes that boundary, the registry retains it through publication or
+        retryable cleanup. After all runtime preparation, the caller-supplied
+        durable guard invokes the complete source-checked RCU transfer while
+        retaining its ref-writer fence.
+        """
+
+        from ..mcp.retained_context import RetainedServerContextOwner
+        from .index_job_activation import IndexJobRuntimeActivation
+        from .index_jobs import IndexJobRepoBinding
+
+        if type(binding) is not IndexJobRepoBinding:
+            raise TypeError("binding must be an exact IndexJobRepoBinding")
+        if type(activation) is not IndexJobRuntimeActivation:
+            raise TypeError("activation must be an exact IndexJobRuntimeActivation")
+        if (
+            activation.repo_id != binding.repo_id
+            or activation.repository_id != binding.repository_id
+            or activation.ref_name != binding.ref_name
+        ):
+            raise ValueError("retained BM25 activation binding differs")
+        if type(runtime_owner) is not RetainedServerContextOwner:
+            raise TypeError("runtime_owner must be an exact RetainedServerContextOwner")
+        if runtime_owner.state != "active":
+            raise RuntimeError("retained BM25 runtime owner must be active")
+        if not callable(transfer_if_current):
+            raise TypeError("retained BM25 guarded transfer must be callable")
+
+        instance_id = binding.repo_id
+
+        def guard_source_checked_publish(publish: Callable[[], None]) -> None:
+            def transfer() -> None:
+                if not runtime_owner.context.verify_source_status():
+                    raise RuntimeError("retained BM25 repository source changed")
+                result = publish()
+                if result is not None:
+                    raise RuntimeError(
+                        "retained BM25 runtime transfer returned a value"
+                    )
+
+            result = transfer_if_current(transfer)
+            if result is not None:
+                raise RuntimeError("retained BM25 guarded transfer returned a value")
+
+        def operation() -> None:
+            owned = self._build_retained_bm25_snapshot(
+                binding,
+                activation,
+                runtime_owner,
+            )
+            self._prepare_and_publish_owned(
+                instance_id,
+                owned,
+                prepare_runtime=True,
+                guarded_publish=guard_source_checked_publish,
+            )
+
+        try:
+            self._run_serialized_reload(operation)
+        except BaseException as primary:  # noqa: B036 - retain accepted owner
+            try:
+                cleanup_failure = self._retain_cleanup_owner(
+                    instance_id,
+                    runtime_owner,
+                )
+            except BaseException as settlement_failure:  # noqa: B036
+                _raise_with_cleanup_failure(primary, settlement_failure)
+            if cleanup_failure is not None:
+                _raise_with_cleanup_failure(primary, cleanup_failure)
+            raise
+
     def _raise_if_closed_after_cleanup(
         self,
         cleanup_failure: Optional[BaseException] = None,
@@ -1395,10 +1545,35 @@ class RepoRegistry:
             except BaseException as cleanup_failure:  # noqa: B036
                 _raise_with_cleanup_failure(primary, cleanup_failure)
             raise
+        return self._prepare_and_publish_owned(
+            instance_id,
+            owned,
+            prepare_runtime=prepare_runtime,
+        )
+
+    def _prepare_and_publish_owned(
+        self,
+        instance_id: str,
+        owned: _OwnedRepoBundle,
+        *,
+        prepare_runtime: bool,
+        guarded_publish: Callable[[Callable[[], None]], None] | None = None,
+    ) -> RepoBundle:
+        """Prepare a complete candidate and transfer its cleanup ownership."""
+
         try:
             if prepare_runtime:
                 self._prepare_runtime_bundle(owned.bundle)
-            self._publish_owned(instance_id, owned)
+            if guarded_publish is None:
+                self._publish_owned(instance_id, owned)
+            else:
+                result = guarded_publish(
+                    partial(self._publish_owned, instance_id, owned)
+                )
+                if result is not None:
+                    raise RuntimeError(
+                        "guarded repository publication returned a value"
+                    )
             return owned.bundle
         except BaseException as primary:  # noqa: B036 - retain candidate owner
             cleanup_failure: BaseException | None = None
@@ -1433,6 +1608,164 @@ class RepoRegistry:
             # swap prevents the first post-refresh request from observing a
             # partially initialized bundle.
             bundle.hierarchical_graph()
+
+    def _build_retained_bm25_snapshot(
+        self,
+        binding: "IndexJobRepoBinding",
+        activation: "IndexJobRuntimeActivation",
+        runtime_owner: "RetainedServerContextOwner",
+    ) -> _OwnedRepoBundle:
+        """Bind an exact retained snapshot to one complete sparse Web bundle."""
+
+        from ..artifacts.context import CONTEXT_ARTIFACT_SCHEMA, ContextArtifactResult
+        from ..compiler.manifest_export import RepoManifestExportReceipt
+        from ..compiler.manifest_materialization import (
+            RepoManifestMaterializationResult,
+        )
+        from ..mcp.context import ServerContext
+        from ..mcp.retained_context import (
+            RetainedServerContextOwner,
+            RetainedServerContextResult,
+        )
+        from ..source_fingerprint import lexical_repository_path
+        from .index_job_activation import IndexJobRuntimeActivation
+        from .index_jobs import IndexJobRepoBinding
+
+        if type(binding) is not IndexJobRepoBinding:
+            raise TypeError("binding must be an exact IndexJobRepoBinding")
+        if type(activation) is not IndexJobRuntimeActivation:
+            raise TypeError("activation must be an exact IndexJobRuntimeActivation")
+        if type(runtime_owner) is not RetainedServerContextOwner:
+            raise TypeError("runtime_owner must be an exact RetainedServerContextOwner")
+        if (
+            activation.repo_id != binding.repo_id
+            or activation.repository_id != binding.repository_id
+            or activation.ref_name != binding.ref_name
+        ):
+            raise ValueError("retained BM25 activation binding differs")
+        if tuple(self._config.index_types()) != ("bm25",):
+            raise ValueError("retained BM25 publication requires sparse Web mode")
+
+        instance_id = binding.repo_id
+        with self._generation_lock:
+            current = self._bundles.get(instance_id)
+        if type(current) is not RepoBundle:
+            raise ValueError(
+                f"Web repository {instance_id!r} has no active exact generation"
+            )
+        entry = current.entry
+        current_manifest = current.manifest
+        if type(entry) is not RepoEntry or type(current_manifest) is not RepoManifest:
+            raise TypeError("active Web repository metadata uses an invalid type")
+        if entry.instance_id != instance_id:
+            raise RuntimeError("active Web repository identity changed")
+        if set(current_manifest.indexes) != {"bm25"} or not (
+            current_manifest.index_is_current("bm25")
+        ):
+            raise ValueError(
+                "retained BM25 publication cannot replace a non-BM25 generation"
+            )
+
+        result = runtime_owner.result
+        context = runtime_owner.context
+        if type(result) is not RetainedServerContextResult:
+            raise TypeError("retained BM25 result uses an invalid type")
+        if type(context) is not ServerContext:
+            raise TypeError("retained BM25 context uses an invalid type")
+        materialization = result.materialization
+        if type(materialization) is not RepoManifestMaterializationResult:
+            raise TypeError("retained BM25 materialization uses an invalid type")
+        artifact = materialization.artifact
+        receipt = materialization.export_receipt
+        if type(artifact) is not ContextArtifactResult:
+            raise TypeError("retained BM25 artifact uses an invalid type")
+        if type(receipt) is not RepoManifestExportReceipt:
+            raise TypeError("retained BM25 export receipt uses an invalid type")
+        manifest = context.manifest
+        if type(manifest) is not RepoManifest:
+            raise TypeError("retained BM25 manifest uses an invalid type")
+
+        if (
+            receipt.repository_id != binding.repository_id
+            or receipt.repository_key != artifact.repository
+            or receipt.repository_key != entry.repo
+            or receipt.snapshot_id != activation.snapshot_id
+            or receipt.ref_name is not None
+            or receipt.ref_generation is not None
+            or receipt.ref_updated_at is not None
+        ):
+            raise ValueError("retained BM25 snapshot identity is inconsistent")
+        if (
+            receipt.views != ("bm25",)
+            or receipt.skipped_items != ()
+            or artifact.views != ("bm25",)
+            or result.loaded_views != ("bm25",)
+            or result.view_error_items != ()
+            or context.loaded_views != frozenset({"bm25"})
+            or context.errors
+            or context.bm25 is None
+        ):
+            raise ValueError("retained BM25 snapshot is not a complete BM25 view")
+        if (
+            runtime_owner.context is not context
+            or runtime_owner.result is not result
+            or artifact.commit != manifest.commit
+            or set(manifest.indexes) != {"bm25"}
+            or not manifest.index_is_current("bm25")
+            or context.artifact
+            != {
+                "verified": True,
+                "schema": CONTEXT_ARTIFACT_SCHEMA,
+                "repository": artifact.repository,
+                "commit": artifact.commit,
+                "views": ["bm25"],
+            }
+        ):
+            raise ValueError("retained BM25 manifest identity is inconsistent")
+
+        entry_repo = lexical_repository_path(entry.repo_dir)
+        active_repo = lexical_repository_path(current_manifest.repo_path)
+        retained_repo = lexical_repository_path(manifest.repo_path)
+        if entry_repo != active_repo or entry_repo != retained_repo:
+            raise ValueError("retained BM25 repository path differs from Web source")
+        try:
+            physical_paths = {
+                entry_repo.resolve(strict=True),
+                active_repo.resolve(strict=True),
+                retained_repo.resolve(strict=True),
+            }
+        except (OSError, RuntimeError) as exc:
+            raise ValueError("retained BM25 repository path is unavailable") from exc
+        if len(physical_paths) != 1 or not next(iter(physical_paths)).is_dir():
+            raise ValueError("retained BM25 repository path identity changed")
+        if not context.verify_source_status():
+            raise ValueError("retained BM25 repository source changed")
+        source_reader = context.borrow_source_reader()
+        _require_authenticated_documents(
+            context.bm25.documents,
+            source_reader,
+            subject="retained BM25 view",
+        )
+
+        retained_entry = replace(
+            entry,
+            base_commit=manifest.commit,
+            manifest_path=os.fspath(artifact.manifest_path),
+        )
+        bundle = RepoBundle(
+            entry=retained_entry,
+            manifest=manifest,
+            bm25=context.bm25,
+            chat_available=current.chat_available,
+            view_loader=partial(
+                _load_retained_bm25_view,
+                runtime_owner=runtime_owner,
+            ),
+            runtime_loader=self._load_repo_runtime,
+            source_reader=source_reader,
+            index_job_activation=activation,
+        )
+        return _OwnedRepoBundle(bundle, None, runtime_owner)
 
     def _build_repo_metadata(self, entry: RepoEntry) -> _OwnedRepoBundle:
         """Authenticate an unpublished candidate and retain all cleanup owners."""
@@ -1549,13 +1882,53 @@ class RepoRegistry:
 
         return self._run_serialized_reload(operation)
 
+    def _retain_cleanup_owner(
+        self,
+        instance_id: str,
+        owner: Any,
+    ) -> Optional[BaseException]:
+        """Retain one unpublished authority and settle it during shutdown."""
+
+        from ..artifacts.runtime import _source_cleanup_owner_is_pending
+
+        instance_id = _plain_repo_instance_id(instance_id)
+        if not _source_cleanup_owner_is_pending(owner):
+            return None
+        with self._generation_lock:
+            if (
+                any(
+                    candidate is owner
+                    for candidate in self._source_cleanup_owners.values()
+                )
+                or any(
+                    candidate is owner for candidate in self._source_bindings.values()
+                )
+                or any(candidate is owner for candidate in self._orphan_cleanup_owners)
+                or any(
+                    retired.source_cleanup_owner is owner
+                    or retired.source_binding is owner
+                    for retired in self._retired_bundles.values()
+                )
+            ):
+                return None
+            closed = self._closed
+            if closed:
+                self._orphan_cleanup_owners.append(owner)
+            elif (
+                instance_id not in self._source_cleanup_owners
+                and instance_id not in self._source_bindings
+                and instance_id not in self._bundles
+            ):
+                self._source_cleanup_owners[instance_id] = owner
+            else:
+                self._orphan_cleanup_owners.append(owner)
+        return self._drain_orphan_cleanup() if closed else None
+
     def _retain_exception_cleanup(
         self,
         instance_id: str,
         error: BaseException,
     ) -> None:
-        from ..artifacts.runtime import _source_cleanup_owner_is_pending
-
         try:
             attributes = BaseException.__getattribute__(error, "__dict__")
             owner = (
@@ -1565,32 +1938,14 @@ class RepoRegistry:
             )
         except BaseException:  # noqa: B036 - inspection cannot replace primary
             owner = None
-        if not _source_cleanup_owner_is_pending(owner):
-            return
-        with self._generation_lock:
-            if any(
-                candidate is owner for candidate in self._source_cleanup_owners.values()
-            ) or any(candidate is owner for candidate in self._orphan_cleanup_owners):
-                return
-            closed = self._closed
-            if closed:
-                self._orphan_cleanup_owners.append(owner)
-            elif (
-                instance_id not in self._source_cleanup_owners
-                and instance_id not in self._bundles
-            ):
-                self._source_cleanup_owners[instance_id] = owner
-            else:
-                self._orphan_cleanup_owners.append(owner)
-        if closed:
-            cleanup_failure = self._drain_orphan_cleanup()
-            if cleanup_failure is not None:
-                if not issubclass(type(cleanup_failure), Exception):
-                    _raise_with_cleanup_failure(error, cleanup_failure)
-                _log_cleanup_failure(
-                    "Unpublished repository cleanup remains pending: %s",
-                    cleanup_failure,
-                )
+        cleanup_failure = self._retain_cleanup_owner(instance_id, owner)
+        if cleanup_failure is not None:
+            if not issubclass(type(cleanup_failure), Exception):
+                _raise_with_cleanup_failure(error, cleanup_failure)
+            _log_cleanup_failure(
+                "Unpublished repository cleanup remains pending: %s",
+                cleanup_failure,
+            )
 
     def _publish_owned(
         self,
@@ -1651,6 +2006,15 @@ class RepoRegistry:
                     "repository source cleanup authority is already closed"
                 )
             previous_bundle = self._bundles.get(instance_id)
+            _require_monotonic_index_job_activation(
+                instance_id,
+                (
+                    None
+                    if previous_bundle is None
+                    else previous_bundle.index_job_activation
+                ),
+                owned.bundle.index_job_activation,
+            )
             previous_binding = self._source_bindings.get(instance_id)
             previous_owner = self._source_cleanup_owners.get(instance_id)
             previous = (

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1556,6 +1556,15 @@ success-triggered refresh, MCP, UI controls, and default routing remain absent.
   or failed guard/transfer calls fail closed. Publication failures remain
   retryable and secret-free. A concrete generation publisher, server wiring,
   and the final runtime refresh callback remain separate gates.
+- The retained BM25 registry boundary now accepts one exact snapshot-loaded
+  runtime owner together with its full job activation and prepares the complete
+  sparse runtime. It exposes the source-revalidated, lock-protected RCU pointer
+  and cleanup-ownership transfer only through the caller-supplied durable guard,
+  so the ref-writer fence spans the actual generation swap. It rejects
+  ref-generation regression, same-generation snapshot/timestamp conflict,
+  storage-binding drift, and legacy registry-file replacement of an active
+  durable generation. A guarded local loader/publisher and production server
+  loop remain separate gates.
 - An explicitly injected Web reader can now project authorized durable jobs and
   at most 64 events without exposing worker owner IDs, fencing tokens, or raw
   executor errors or event keys. Each event is rebound to the exact job, a

--- a/test/compiler/test_retained_context.py
+++ b/test/compiler/test_retained_context.py
@@ -27,9 +27,33 @@ from codenib.mcp.retained_context import (
 from codenib.source_fingerprint import pin_repository_source_root
 from codenib.storage import PublishConflict
 from codenib.storage.models import NamespaceIdentity, RepositoryIdentity
+from codenib.web.config import QAConfig, RepoEntry
+from codenib.web.index_job_activation import IndexJobRuntimeActivation
+from codenib.web.index_jobs import IndexJobRepoBinding
+from codenib.web.repo_registry import RepoBundle, RepoRegistry
 
 from .test_manifest_export import _retained_fixture
 from .test_manifest_import import _TestWorkspaceProvider
+
+
+def _runtime_activation(
+    binding: IndexJobRepoBinding,
+    snapshot_id: str,
+    *,
+    generation: int,
+    updated_at: str,
+) -> IndexJobRuntimeActivation:
+    return IndexJobRuntimeActivation(
+        repo_id=binding.repo_id,
+        repository_id=binding.repository_id,
+        ref_name=binding.ref_name,
+        job_id="job_" + "f" * 64,
+        attempt_count=1,
+        snapshot_id=snapshot_id,
+        ref_generation=generation,
+        ref_updated_at=updated_at,
+        finished_at_ms=1,
+    )
 
 
 def test_loads_retained_ref_with_bm25_inside_exact_reader(
@@ -163,6 +187,243 @@ def test_loads_retained_ref_with_reader_bound_source(
         assert owner.closed
         assert owner._source_owner.closed
         assert captured_sources and captured_sources[0].closed
+
+
+def test_registry_publishes_current_retained_bm25_as_rcu_generation(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (fixture, imported, object_store, catalog):
+        owner = RetainedServerContextOwner()
+        result = load_retained_server_context_snapshot(
+            "owner/repo",
+            imported.snapshot_id,
+            tmp_path / "context",
+            catalog=catalog,
+            object_store=object_store,
+            workspace_provider=_TestWorkspaceProvider(),
+            runtime_owner=owner,
+            repo_path=fixture.repository,
+        )
+        entry = RepoEntry(
+            instance_id="demo",
+            repo="owner/repo",
+            base_commit="0" * 40,
+            language="python",
+            repo_dir=str(fixture.repository),
+            manifest_path=str(fixture.context / "repo_manifest.json"),
+        )
+        previous_manifest = RepoManifest.load(entry.manifest_path)
+        previous_manifest.repo_path = str(fixture.repository)
+        previous = RepoBundle(entry=entry, manifest=previous_manifest)
+        binding = IndexJobRepoBinding("demo", imported.repository_id)
+        ref = catalog.resolve_ref(imported.repository_id)
+        activation = _runtime_activation(
+            binding,
+            imported.snapshot_id,
+            generation=imported.generation,
+            updated_at=ref["updated_at"],
+        )
+
+        class PreviousOwner:
+            closed = False
+
+            def close(self) -> None:
+                self.closed = True
+
+        previous_owner = PreviousOwner()
+        verified: list[IndexJobRuntimeActivation] = []
+
+        def transfer_current(transfer) -> None:
+            result = transfer()
+            assert result is None
+            verified.append(activation)
+
+        registry = RepoRegistry(QAConfig())
+        registry._bundles[entry.instance_id] = previous
+        registry._source_cleanup_owners[entry.instance_id] = previous_owner
+        try:
+            with registry.pin(entry.instance_id) as pinned_previous:
+                registry.replace_retained_bm25_snapshot(
+                    binding,
+                    activation,
+                    owner,
+                    transfer_if_current=transfer_current,
+                )
+
+                assert pinned_previous is previous
+                assert previous_owner.closed is False
+                assert verified == [activation]
+                assert owner.state == "active"
+                with registry.pin(entry.instance_id) as current:
+                    assert current is not None
+                    assert current is not previous
+                    assert current.index_job_activation is activation
+                    assert current.manifest is owner.context.manifest
+                    assert current.entry.base_commit == "a" * 40
+                    assert current.entry.manifest_path == str(
+                        result.materialization.artifact.manifest_path
+                    )
+                    assert current.source_reader is not None
+                    assert (
+                        current.source_reader.read_prefix(
+                            "sample.py",
+                            max_bytes=1024,
+                        )
+                        == b"VALUE = 1\n"
+                    )
+                    assert current.bm25 is owner.context.bm25
+                    hits = current.bm25.search(
+                        "VALUE",
+                        return_code_content=True,
+                    )
+                    assert hits and hits[0].node_id == "sample.VALUE"
+                    assert current.release_views() is True
+                    assert current.bm25 is None
+                    current.ensure_views()
+                    assert current.bm25 is owner.context.bm25
+
+            assert previous_owner.closed is True
+            assert owner.state == "active"
+        finally:
+            registry.close()
+        assert owner.closed
+
+
+def test_registry_enters_current_result_guard_after_runtime_preparation(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (fixture, imported, object_store, catalog):
+        owner = RetainedServerContextOwner()
+        load_retained_server_context_snapshot(
+            "owner/repo",
+            imported.snapshot_id,
+            tmp_path / "context",
+            catalog=catalog,
+            object_store=object_store,
+            workspace_provider=_TestWorkspaceProvider(),
+            runtime_owner=owner,
+            repo_path=fixture.repository,
+        )
+        entry = RepoEntry(
+            instance_id="demo",
+            repo="owner/repo",
+            base_commit="a" * 40,
+            language="python",
+            repo_dir=str(fixture.repository),
+            manifest_path=str(fixture.context / "repo_manifest.json"),
+        )
+        previous_manifest = RepoManifest.load(entry.manifest_path)
+        previous_manifest.repo_path = str(fixture.repository)
+        previous = RepoBundle(entry=entry, manifest=previous_manifest)
+        binding = IndexJobRepoBinding("demo", imported.repository_id)
+        ref = catalog.resolve_ref(imported.repository_id)
+        activation = _runtime_activation(
+            binding,
+            imported.snapshot_id,
+            generation=imported.generation,
+            updated_at=ref["updated_at"],
+        )
+        registry = RepoRegistry(QAConfig())
+        registry._bundles[entry.instance_id] = previous
+
+        def stale_after_prepare(transfer) -> None:
+            assert owner.context.bm25 is not None
+            raise RuntimeError("durable ref advanced during preparation")
+
+        try:
+            with pytest.raises(RuntimeError, match="ref advanced"):
+                registry.replace_retained_bm25_snapshot(
+                    binding,
+                    activation,
+                    owner,
+                    transfer_if_current=stale_after_prepare,
+                )
+
+            assert registry.get(entry.instance_id) is previous
+            assert owner.closed
+            assert registry._orphan_cleanup_owners == []
+        finally:
+            registry.close()
+        assert owner.closed
+
+
+def test_registry_rechecks_source_after_runtime_preparation(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (fixture, imported, object_store, catalog):
+        owner = RetainedServerContextOwner()
+        load_retained_server_context_snapshot(
+            "owner/repo",
+            imported.snapshot_id,
+            tmp_path / "context",
+            catalog=catalog,
+            object_store=object_store,
+            workspace_provider=_TestWorkspaceProvider(),
+            runtime_owner=owner,
+            repo_path=fixture.repository,
+        )
+        entry = RepoEntry(
+            instance_id="demo",
+            repo="owner/repo",
+            base_commit="a" * 40,
+            language="python",
+            repo_dir=str(fixture.repository),
+            manifest_path=str(fixture.context / "repo_manifest.json"),
+        )
+        previous_manifest = RepoManifest.load(entry.manifest_path)
+        previous_manifest.repo_path = str(fixture.repository)
+        previous = RepoBundle(entry=entry, manifest=previous_manifest)
+        binding = IndexJobRepoBinding("demo", imported.repository_id)
+        ref = catalog.resolve_ref(imported.repository_id)
+        activation = _runtime_activation(
+            binding,
+            imported.snapshot_id,
+            generation=imported.generation,
+            updated_at=ref["updated_at"],
+        )
+        registry = RepoRegistry(QAConfig())
+        registry._bundles[entry.instance_id] = previous
+        prepare_runtime = registry._prepare_runtime_bundle
+        verified: list[IndexJobRuntimeActivation] = []
+
+        def transfer_current(transfer) -> None:
+            result = transfer()
+            assert result is None
+            verified.append(activation)
+
+        def prepare_then_mutate(bundle: RepoBundle) -> None:
+            prepare_runtime(bundle)
+            (fixture.repository / "sample.py").write_text(
+                "VALUE = 2\n",
+                encoding="utf-8",
+            )
+
+        registry._prepare_runtime_bundle = prepare_then_mutate
+        try:
+            with pytest.raises(RuntimeError, match="repository source changed"):
+                registry.replace_retained_bm25_snapshot(
+                    binding,
+                    activation,
+                    owner,
+                    transfer_if_current=transfer_current,
+                )
+
+            assert verified == []
+            assert registry.get(entry.instance_id) is previous
+            assert owner.closed
+            assert registry._orphan_cleanup_owners == []
+        finally:
+            registry.close()
+        assert owner.closed
 
 
 def test_retained_loader_threads_expected_root_authority_to_capture(

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -10,6 +10,7 @@ import inspect
 import pickle
 import sys
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 from threading import Barrier, Event, Lock, Thread
 from types import CodeType, SimpleNamespace
 from weakref import ref as weakref_ref
@@ -37,6 +38,7 @@ from codenib.web.config import (
     load_registry,
     save_registry,
 )
+from codenib.web.index_job_activation import IndexJobRuntimeActivation
 from codenib.web.repo_registry import (
     _DEMO_SYSTEM_PROMPT,
     _REGISTRY_CLEANUP_CONTEXT,
@@ -78,6 +80,25 @@ def _repo_entry(repo, manifest_path, *, instance_id="owner__repo-1"):
         language="python",
         repo_dir=str(repo),
         manifest_path=str(manifest_path),
+    )
+
+
+def _index_job_activation(
+    *,
+    generation: int,
+    snapshot_value: str,
+    updated_at: str,
+) -> IndexJobRuntimeActivation:
+    return IndexJobRuntimeActivation(
+        repo_id="repo",
+        repository_id="repo_" + "a" * 64,
+        ref_name="main",
+        job_id="job_" + "b" * 64,
+        attempt_count=1,
+        snapshot_id="snapshot_" + snapshot_value * 64,
+        ref_generation=generation,
+        ref_updated_at=updated_at,
+        finished_at_ms=generation,
     )
 
 
@@ -3414,6 +3435,117 @@ def test_registry_publish_does_not_close_active_shared_owner():
 
     registry.close()
     assert owner.close_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("candidate_activation", "message"),
+    (
+        (None, "cannot replace a durable"),
+        (
+            _index_job_activation(
+                generation=1,
+                snapshot_value="c",
+                updated_at="2026-08-27T00:00:01+00:00",
+            ),
+            "generation regressed",
+        ),
+        (
+            _index_job_activation(
+                generation=2,
+                snapshot_value="e",
+                updated_at="2026-08-27T00:00:02+00:00",
+            ),
+            "fence conflicts",
+        ),
+    ),
+)
+def test_registry_rejects_runtime_generation_regressions(
+    candidate_activation,
+    message,
+):
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls > 0
+
+        def close(self):
+            self.close_calls += 1
+
+    previous_owner = Owner()
+    candidate_owner = Owner()
+    previous = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+        index_job_activation=_index_job_activation(
+            generation=2,
+            snapshot_value="d",
+            updated_at="2026-08-27T00:00:02+00:00",
+        ),
+    )
+    candidate = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+        index_job_activation=candidate_activation,
+    )
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = previous
+    registry._source_cleanup_owners["repo"] = previous_owner
+
+    try:
+        with pytest.raises(RuntimeError, match=message):
+            registry._publish_owned(
+                "repo",
+                _OwnedRepoBundle(candidate, None, candidate_owner),
+            )
+
+        assert registry.get("repo") is previous
+        assert previous_owner.close_calls == 0
+        assert candidate_owner.close_calls == 0
+    finally:
+        candidate_owner.close()
+        registry.close()
+
+    assert previous_owner.close_calls == 1
+    assert candidate_owner.close_calls == 1
+
+
+def test_registry_rejects_misbound_active_runtime_generation():
+    previous = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+        index_job_activation=replace(
+            _index_job_activation(
+                generation=2,
+                snapshot_value="d",
+                updated_at="2026-08-27T00:00:02+00:00",
+            ),
+            repo_id="other",
+        ),
+    )
+    candidate = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+        index_job_activation=_index_job_activation(
+            generation=3,
+            snapshot_value="e",
+            updated_at="2026-08-27T00:00:03+00:00",
+        ),
+    )
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = previous
+
+    try:
+        with pytest.raises(RuntimeError, match="targets another Web repo"):
+            registry._publish_owned(
+                "repo",
+                _OwnedRepoBundle(candidate, None, None),
+            )
+        assert registry.get("repo") is previous
+    finally:
+        registry.close()
 
 
 def test_registry_retired_claim_interruption_keeps_retry_state():


### PR DESCRIPTION
## Summary
Publish one exact retained BM25 snapshot as a fully prepared, pinned RepoRegistry generation. Source revalidation plus the actual RCU pointer and cleanup-ownership transfer run only through the reconciler supplied durable guard. This advances #199 and #266 without enabling default storage or runtime routing.

## Changes
- let a retained server context lend its exact authenticated source reader to the owning runtime generation
- bind each retained BM25 generation to the exact Web/storage/job activation identity
- validate complete sparse manifest, artifact, source path, document, and view closure before publication
- prepare retrieval, Ask, and graph-facing runtime state before the guarded pointer swap
- reject ref-generation regression, equal-generation conflicts, storage-binding drift, and legacy registry replacement of a durable generation
- retain candidate and retired-generation cleanup authority through publication failure, request pins, and shutdown
- document the retained BM25 RCU generation boundary in the storage roadmap

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- retained context, RepoRegistry, and reconciler tests (`264 passed`)
- full non-slow/non-integration unit tier (`8620 passed, 35 skipped, 193 deselected`), excluding only the three documented unrelated local baselines
- relevant pre-commit hooks

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published