### PR TITLE
feat(web): publish guarded retained BM25 snapshots

### DIFF
--- a/codenib/web/index_job_activation.py
+++ b/codenib/web/index_job_activation.py
@@ -304,8 +304,7 @@ class CatalogIndexJobRuntimeReconciler:
         activation = _attest_current_result(binding, value)
         storage_key = (binding.repository_id, binding.ref_name)
         published = self._published.get(storage_key)
-        if published == activation.publication_fence:
-            return None
+        already_published = published == activation.publication_fence
         if published is not None and (
             activation.ref_generation < published[1]
             or (
@@ -412,7 +411,7 @@ class CatalogIndexJobRuntimeReconciler:
                 "runtime snapshot publisher skipped guarded runtime transfer"
             )
         self._published[storage_key] = activation.publication_fence
-        return activation
+        return None if already_published else activation
 
     def reconcile(self, repo_id: str) -> IndexJobRuntimeActivation | None:
         """Publish the current durable result for one configured repository."""

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -42,7 +42,10 @@ if TYPE_CHECKING:
     from ..index.embedding.vector_store import CodeVectorStore
     from ..index.sparse_idx.bm25_index import BM25CodeIndexer
     from ..llm.litellm_chat import LiteLLMChat
-    from ..mcp.retained_context import RetainedServerContextOwner
+    from ..mcp.retained_context import (
+        RetainedServerContextOwner,
+        RetainedServerContextResult,
+    )
     from ..native_index_authorization import NativeIndexAuthorization
     from ..source_fingerprint import RepositorySourceBinding, RepositorySourceReader
     from .index_job_activation import IndexJobRuntimeActivation
@@ -1381,6 +1384,108 @@ class RepoRegistry:
 
         self._run_serialized_reload(operation)
 
+    def attest_retained_bm25_snapshot_if_equivalent(
+        self,
+        binding: "IndexJobRepoBinding",
+        activation: "IndexJobRuntimeActivation",
+        *,
+        transfer_if_current: Callable[[Callable[[], None]], None],
+    ) -> bool:
+        """Guard-attest an equivalent incumbent under the reload fence.
+
+        The reload lock is acquired before the durable current-result guard,
+        matching the lock order used by full snapshot publication. A normal
+        registry reload therefore cannot retire the incumbent between the
+        runtime proof and the durable guarded transfer.
+        """
+
+        from .index_job_activation import (
+            IndexJobActivationError,
+            IndexJobRuntimeActivation,
+        )
+        from .index_jobs import IndexJobRepoBinding
+
+        if type(binding) is not IndexJobRepoBinding:
+            raise TypeError("binding must be an exact IndexJobRepoBinding")
+        if type(activation) is not IndexJobRuntimeActivation:
+            raise TypeError("activation must be an exact IndexJobRuntimeActivation")
+        if (
+            activation.repo_id != binding.repo_id
+            or activation.repository_id != binding.repository_id
+            or activation.ref_name != binding.ref_name
+        ):
+            raise ValueError("retained BM25 activation binding differs")
+        if not callable(transfer_if_current):
+            raise TypeError("retained BM25 guarded transfer must be callable")
+
+        instance_id = binding.repo_id
+
+        def operation() -> bool:
+            with self._generation_lock:
+                bundle = self._bundles.get(instance_id)
+                if bundle is None:
+                    raise IndexJobActivationError(
+                        "Web repository has no active runtime generation"
+                    )
+                incumbent = bundle.index_job_activation
+                if incumbent is None:
+                    return False
+                if type(incumbent) is not IndexJobRuntimeActivation:
+                    raise IndexJobActivationError(
+                        "active Web runtime activation identity is invalid"
+                    )
+                if (
+                    incumbent.repo_id != binding.repo_id
+                    or incumbent.repository_id != binding.repository_id
+                    or incumbent.ref_name != binding.ref_name
+                ):
+                    raise IndexJobActivationError(
+                        "active Web runtime activation binding changed"
+                    )
+                if incumbent.ref_generation > activation.ref_generation:
+                    raise IndexJobActivationError(
+                        "active Web runtime generation is newer than publication"
+                    )
+                if incumbent.ref_generation < activation.ref_generation:
+                    return False
+                if (
+                    incumbent.snapshot_id != activation.snapshot_id
+                    or incumbent.ref_updated_at != activation.ref_updated_at
+                ):
+                    raise IndexJobActivationError(
+                        "active Web runtime generation conflicts with publication"
+                    )
+
+            def require_incumbent() -> None:
+                with self._generation_lock:
+                    current = self._bundles.get(instance_id)
+                    if current is not bundle:
+                        raise IndexJobActivationError(
+                            "active Web runtime changed during guarded attestation"
+                        )
+                    current_activation = current.index_job_activation
+                    if (
+                        type(current_activation) is not IndexJobRuntimeActivation
+                        or current_activation.repo_id != binding.repo_id
+                        or current_activation.repository_id != binding.repository_id
+                        or current_activation.ref_name != binding.ref_name
+                        or current_activation.ref_generation
+                        != activation.ref_generation
+                        or current_activation.snapshot_id != activation.snapshot_id
+                        or current_activation.ref_updated_at
+                        != activation.ref_updated_at
+                    ):
+                        raise IndexJobActivationError(
+                            "active Web runtime changed during guarded attestation"
+                        )
+
+            result = transfer_if_current(require_incumbent)
+            if result is not None:
+                raise RuntimeError("retained BM25 guarded transfer returned a value")
+            return True
+
+        return self._run_serialized_reload(operation)
+
     def replace_retained_bm25_snapshot(
         self,
         binding: "IndexJobRepoBinding",
@@ -1453,6 +1558,71 @@ class RepoRegistry:
         except BaseException as primary:  # noqa: B036 - retain accepted owner
             try:
                 cleanup_failure = self._retain_cleanup_owner(
+                    instance_id,
+                    runtime_owner,
+                )
+            except BaseException as settlement_failure:  # noqa: B036
+                _raise_with_cleanup_failure(primary, settlement_failure)
+            if cleanup_failure is not None:
+                _raise_with_cleanup_failure(primary, cleanup_failure)
+            raise
+
+    def load_and_replace_retained_bm25_snapshot(
+        self,
+        binding: "IndexJobRepoBinding",
+        activation: "IndexJobRuntimeActivation",
+        *,
+        loader: Callable[
+            ["RetainedServerContextOwner"],
+            "RetainedServerContextResult",
+        ],
+        transfer_if_current: Callable[[Callable[[], None]], None],
+    ) -> None:
+        """Own one retained loader through its guarded runtime publication."""
+
+        from ..mcp.retained_context import (
+            RetainedServerContextOwner,
+            RetainedServerContextResult,
+        )
+        from .index_job_activation import IndexJobRuntimeActivation
+        from .index_jobs import IndexJobRepoBinding
+
+        if type(binding) is not IndexJobRepoBinding:
+            raise TypeError("binding must be an exact IndexJobRepoBinding")
+        if type(activation) is not IndexJobRuntimeActivation:
+            raise TypeError("activation must be an exact IndexJobRuntimeActivation")
+        if (
+            activation.repo_id != binding.repo_id
+            or activation.repository_id != binding.repository_id
+            or activation.ref_name != binding.ref_name
+        ):
+            raise ValueError("retained BM25 activation binding differs")
+        if not callable(loader):
+            raise TypeError("retained BM25 runtime loader must be callable")
+        if not callable(transfer_if_current):
+            raise TypeError("retained BM25 guarded transfer must be callable")
+
+        runtime_owner = RetainedServerContextOwner()
+        instance_id = binding.repo_id
+        try:
+            result = loader(runtime_owner)
+            if (
+                type(result) is not RetainedServerContextResult
+                or runtime_owner.state != "active"
+                or runtime_owner.result is not result
+            ):
+                raise RuntimeError(
+                    "retained BM25 runtime loader returned an invalid result"
+                )
+            self.replace_retained_bm25_snapshot(
+                binding,
+                activation,
+                runtime_owner,
+                transfer_if_current=transfer_if_current,
+            )
+        except BaseException as primary:  # noqa: B036 - retain acquired owner
+            try:
+                cleanup_failure = self._settle_unpublished_cleanup_owner(
                     instance_id,
                     runtime_owner,
                 )
@@ -1923,6 +2093,57 @@ class RepoRegistry:
             else:
                 self._orphan_cleanup_owners.append(owner)
         return self._drain_orphan_cleanup() if closed else None
+
+    def _settle_unpublished_cleanup_owner(
+        self,
+        instance_id: str,
+        owner: Any,
+    ) -> Optional[BaseException]:
+        """Immediately settle a rejected owner, retaining only pending cleanup."""
+
+        from ..artifacts.runtime import _source_cleanup_owner_is_pending
+
+        instance_id = _plain_repo_instance_id(instance_id)
+        cleanup_failure = self._retain_cleanup_owner(instance_id, owner)
+        if not _source_cleanup_owner_is_pending(owner):
+            return cleanup_failure
+
+        with self._generation_lock:
+            if self._closed:
+                return cleanup_failure
+            generation_owned = any(
+                (
+                    self._source_cleanup_owners.get(candidate_id) is owner
+                    or self._source_bindings.get(candidate_id) is owner
+                )
+                and candidate_id in self._bundles
+                for candidate_id in (
+                    set(self._source_cleanup_owners) | set(self._source_bindings)
+                )
+            ) or any(
+                retired.source_cleanup_owner is owner or retired.source_binding is owner
+                for retired in self._retired_bundles.values()
+            )
+            if generation_owned:
+                return cleanup_failure
+
+            if not any(candidate is owner for candidate in self._orphan_cleanup_owners):
+                # Publish retry ownership before removing any owner-only map
+                # alias so interruption cannot make the authority unreachable.
+                self._orphan_cleanup_owners.append(owner)
+            for candidate_id, candidate in tuple(self._source_cleanup_owners.items()):
+                if candidate is owner and candidate_id not in self._bundles:
+                    self._source_cleanup_owners.pop(candidate_id, None)
+            for candidate_id, candidate in tuple(self._source_bindings.items()):
+                if candidate is owner and candidate_id not in self._bundles:
+                    self._source_bindings.pop(candidate_id, None)
+
+        orphan_failure = self._drain_orphan_cleanup()
+        if orphan_failure is None:
+            return cleanup_failure
+        if cleanup_failure is None:
+            return orphan_failure
+        return _retain_cleanup_failure(cleanup_failure, orphan_failure)
 
     def _retain_exception_cleanup(
         self,

--- a/codenib/web/retained_bm25_activation.py
+++ b/codenib/web/retained_bm25_activation.py
@@ -1,0 +1,407 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Guarded local retained-BM25 publication for durable Web activations."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import secrets
+import sqlite3
+import stat
+from contextlib import AbstractContextManager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Mapping, Protocol, runtime_checkable
+
+from .._atomic_directory import lexical_directory_path
+from .._workspace_provider import StrictWorkspaceProvider
+from ..compiler.manifest_import import _snapshot_environment
+from ..compiler.snapshot_store import normalize_repo
+from ..mcp.retained_context import (
+    RetainedServerContextOwner,
+    RetainedServerContextResult,
+    load_retained_server_context_snapshot,
+)
+from ..source_fingerprint import lexical_repository_path, pin_repository_source_root
+from ..storage import (
+    DEFAULT_NAMESPACE_NAME,
+    JobResultCatalog,
+    NamespaceIdentity,
+    ReceiptRetainingObjectStore,
+    RepositoryIdentity,
+    RetainedSnapshotCatalog,
+    StorageError,
+    StorageValidationError,
+)
+from .index_job_activation import (
+    IndexJobActivationError,
+    IndexJobRuntimeActivation,
+    _attest_current_result,
+)
+from .index_jobs import IndexJobRepoBinding
+from .repo_registry import RepoRegistry
+
+_RUNTIME_NONCE_RE = re.compile(r"[0-9a-f]{32}\Z")
+_MAX_LOCAL_TARGETS = 4_096
+
+
+def _runtime_nonce() -> str:
+    return secrets.token_hex(16)
+
+
+def _paths_overlap(first: Path, second: Path) -> bool:
+    return first == second or first in second.parents or second in first.parents
+
+
+def _require_disjoint_runtime_paths(
+    repository_root: Path,
+    workspace_root: Path,
+) -> None:
+    """Reject lexical, resolved, or symlink-traversing runtime layouts."""
+
+    resolved_repository = repository_root.resolve(strict=False)
+    resolved_workspace = workspace_root.resolve(strict=False)
+    if _paths_overlap(repository_root, workspace_root) or _paths_overlap(
+        resolved_repository,
+        resolved_workspace,
+    ):
+        raise ValueError("retained BM25 workspace must not overlap the repository")
+    if resolved_workspace != workspace_root:
+        raise ValueError("retained BM25 workspace must not traverse symbolic links")
+
+
+def _require_private_runtime_root(path: Path) -> None:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise RuntimeError("retained BM25 runtime root is unavailable") from exc
+    effective_uid = getattr(os, "geteuid", None)
+    wrong_owner = callable(effective_uid) and metadata.st_uid != effective_uid()
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or wrong_owner
+        or stat.S_IMODE(metadata.st_mode) & 0o077
+        or stat.S_IMODE(metadata.st_mode) & 0o700 != 0o700
+    ):
+        raise RuntimeError(
+            "retained BM25 runtime root must be a private owner-only directory"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class LocalRetainedBm25RuntimeTarget:
+    """One explicit Web binding and its local materialization authority."""
+
+    binding: IndexJobRepoBinding
+    repository_key: str
+    repository_root: Path
+    workspace_root: Path
+    workspace_provider: StrictWorkspaceProvider
+    namespace_name: str = DEFAULT_NAMESPACE_NAME
+    environ: Mapping[str, str] | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        if type(self) is not LocalRetainedBm25RuntimeTarget:
+            raise TypeError("retained BM25 runtime target must use the exact type")
+        if type(self.binding) is not IndexJobRepoBinding:
+            raise TypeError("retained BM25 runtime target binding must be exact")
+        if not isinstance(self.repository_root, Path):
+            raise TypeError("retained BM25 repository root must be a Path")
+        if not isinstance(self.workspace_root, Path):
+            raise TypeError("retained BM25 workspace root must be a Path")
+        if type(self.repository_key) is not str or type(self.namespace_name) is not str:
+            raise TypeError(
+                "retained BM25 namespace and repository key must be exact text"
+            )
+        if not callable(getattr(self.workspace_provider, "require_support", None)) or (
+            not callable(getattr(self.workspace_provider, "run_workspace", None))
+        ):
+            raise TypeError("retained BM25 workspace provider is invalid")
+
+        repository_root = lexical_repository_path(self.repository_root)
+        workspace_root = lexical_directory_path(self.workspace_root)
+        if repository_root == repository_root.parent:
+            raise ValueError("retained BM25 repository cannot be a filesystem root")
+        if workspace_root == workspace_root.parent:
+            raise ValueError("retained BM25 workspace cannot be a filesystem root")
+        _require_private_runtime_root(workspace_root)
+        _require_disjoint_runtime_paths(repository_root, workspace_root)
+
+        provider_root = getattr(self.workspace_provider, "allowed_root", None)
+        if provider_root is not None and (
+            not isinstance(provider_root, Path)
+            or lexical_directory_path(provider_root) != workspace_root
+        ):
+            raise ValueError(
+                "retained BM25 workspace differs from its provider authority"
+            )
+
+        namespace = NamespaceIdentity(self.namespace_name)
+        repository = RepositoryIdentity(
+            namespace_id=namespace.namespace_id,
+            repository_key=self.repository_key,
+        )
+        try:
+            normalized_repository = normalize_repo(repository.repository_key)
+        except ValueError as exc:
+            raise StorageValidationError(
+                "retained BM25 repository key is not canonical"
+            ) from exc
+        if (
+            namespace.name != self.namespace_name
+            or repository.repository_key != self.repository_key
+            or normalized_repository != repository.repository_key
+            or repository.repository_id != self.binding.repository_id
+        ):
+            raise StorageValidationError(
+                "retained BM25 target storage identity is inconsistent"
+            )
+
+        object.__setattr__(self, "repository_root", repository_root)
+        object.__setattr__(self, "workspace_root", workspace_root)
+        object.__setattr__(self, "repository_key", repository.repository_key)
+        object.__setattr__(self, "namespace_name", namespace.name)
+        object.__setattr__(self, "environ", _snapshot_environment(self.environ))
+
+
+@runtime_checkable
+class RetainedBm25SnapshotLoader(Protocol):
+    """Load one exact snapshot into a caller-owned one-shot runtime owner."""
+
+    def load(
+        self,
+        binding: IndexJobRepoBinding,
+        activation: IndexJobRuntimeActivation,
+        runtime_owner: RetainedServerContextOwner,
+    ) -> RetainedServerContextResult: ...
+
+
+class LocalRetainedBm25SnapshotLoader:
+    """Materialize one exact successful snapshot into a fresh private output."""
+
+    def __init__(
+        self,
+        catalog_factory: Callable[
+            [],
+            AbstractContextManager[RetainedSnapshotCatalog],
+        ],
+        object_store: ReceiptRetainingObjectStore,
+        targets: tuple[LocalRetainedBm25RuntimeTarget, ...],
+        *,
+        nonce_factory: Callable[[], str] = _runtime_nonce,
+    ) -> None:
+        if not callable(catalog_factory):
+            raise TypeError("retained BM25 catalog factory must be callable")
+        if not isinstance(object_store, ReceiptRetainingObjectStore):
+            raise TypeError("retained BM25 object store lacks receipt retention")
+        if (
+            type(targets) is not tuple
+            or not targets
+            or len(targets) > _MAX_LOCAL_TARGETS
+        ):
+            raise ValueError("retained BM25 loader requires 1 to 4096 local targets")
+        if any(
+            type(target) is not LocalRetainedBm25RuntimeTarget for target in targets
+        ):
+            raise TypeError("retained BM25 loader targets must use exact values")
+        if not callable(nonce_factory):
+            raise TypeError("retained BM25 runtime nonce factory must be callable")
+
+        by_storage: dict[
+            tuple[str, str],
+            LocalRetainedBm25RuntimeTarget,
+        ] = {}
+        for target in targets:
+            key = (target.binding.repository_id, target.binding.ref_name)
+            if key in by_storage:
+                raise ValueError("retained BM25 loader targets must be unique")
+            by_storage[key] = target
+        self._catalog_factory = catalog_factory
+        self._object_store = object_store
+        self._by_storage = by_storage
+        self._nonce_factory = nonce_factory
+
+    @staticmethod
+    def _require_catalog(value: object) -> RetainedSnapshotCatalog:
+        if not isinstance(value, RetainedSnapshotCatalog):
+            raise TypeError("catalog does not implement retained snapshot reads")
+        return value
+
+    def load(
+        self,
+        binding: IndexJobRepoBinding,
+        activation: IndexJobRuntimeActivation,
+        runtime_owner: RetainedServerContextOwner,
+    ) -> RetainedServerContextResult:
+        if type(binding) is not IndexJobRepoBinding:
+            raise TypeError("retained BM25 loader binding must use the exact type")
+        if type(activation) is not IndexJobRuntimeActivation:
+            raise TypeError("retained BM25 loader activation must use the exact type")
+        if type(runtime_owner) is not RetainedServerContextOwner:
+            raise TypeError("retained BM25 loader owner must use the exact type")
+        if runtime_owner.state != "empty":
+            raise RuntimeError("retained BM25 loader owner must be empty")
+        if (
+            activation.repo_id != binding.repo_id
+            or activation.repository_id != binding.repository_id
+            or activation.ref_name != binding.ref_name
+        ):
+            raise ValueError("retained BM25 loader activation binding differs")
+
+        target = self._by_storage.get((binding.repository_id, binding.ref_name))
+        if target is None or target.binding != binding:
+            raise ValueError("retained BM25 loader has no exact local target")
+        _require_private_runtime_root(target.workspace_root)
+        _require_disjoint_runtime_paths(
+            target.repository_root,
+            target.workspace_root,
+        )
+        target.workspace_provider.require_support()
+
+        nonce = self._nonce_factory()
+        if type(nonce) is not str or _RUNTIME_NONCE_RE.fullmatch(nonce) is None:
+            raise RuntimeError("retained BM25 runtime nonce is invalid")
+        job_token = hashlib.sha256(activation.job_id.encode("utf-8")).hexdigest()[:16]
+        destination = target.workspace_root / (
+            ".codenib-bm25-runtime-" f"{activation.ref_generation}-{job_token}-{nonce}"
+        )
+
+        with pin_repository_source_root(target.repository_root) as root_authority:
+            with self._catalog_factory() as value:
+                catalog = self._require_catalog(value)
+                return load_retained_server_context_snapshot(
+                    target.repository_key,
+                    activation.snapshot_id,
+                    destination,
+                    catalog=catalog,
+                    object_store=self._object_store,
+                    workspace_provider=target.workspace_provider,
+                    runtime_owner=runtime_owner,
+                    namespace_name=target.namespace_name,
+                    repo_path=target.repository_root,
+                    expected_root_authority=root_authority,
+                    environ=target.environ,
+                )
+
+
+class RepoRegistryIndexJobRuntimePublisher:
+    """Guard and transfer one retained snapshot through the registry RCU."""
+
+    def __init__(
+        self,
+        registry: RepoRegistry,
+        catalog_factory: Callable[[], AbstractContextManager[JobResultCatalog]],
+        loader: RetainedBm25SnapshotLoader,
+    ) -> None:
+        if type(registry) is not RepoRegistry:
+            raise TypeError("runtime publisher requires an exact RepoRegistry")
+        if not callable(catalog_factory):
+            raise TypeError("runtime publisher catalog factory must be callable")
+        if not isinstance(loader, RetainedBm25SnapshotLoader):
+            raise TypeError("runtime publisher requires a retained BM25 loader")
+        self._registry = registry
+        self._catalog_factory = catalog_factory
+        self._loader = loader
+
+    @staticmethod
+    def _require_binding(
+        binding: object,
+        activation: object,
+    ) -> tuple[IndexJobRepoBinding, IndexJobRuntimeActivation]:
+        if type(binding) is not IndexJobRepoBinding:
+            raise TypeError("runtime publisher binding must use the exact type")
+        if type(activation) is not IndexJobRuntimeActivation:
+            raise TypeError("runtime publisher activation must use the exact type")
+        if (
+            activation.repo_id != binding.repo_id
+            or activation.repository_id != binding.repository_id
+            or activation.ref_name != binding.ref_name
+        ):
+            raise ValueError("runtime publisher activation binding differs")
+        return binding, activation
+
+    def _require_current(
+        self,
+        binding: IndexJobRepoBinding,
+        expected: IndexJobRuntimeActivation,
+    ) -> None:
+        try:
+            with self._catalog_factory() as value:
+                if not isinstance(value, JobResultCatalog):
+                    raise IndexJobActivationError(
+                        "catalog does not implement durable current-result reads"
+                    )
+                current = value.find_current_successful_job(
+                    binding.repository_id,
+                    binding.ref_name,
+                )
+                actual = (
+                    None
+                    if current is None
+                    else _attest_current_result(binding, current)
+                )
+        except IndexJobActivationError:
+            raise
+        except (OSError, sqlite3.Error, StorageError) as exc:
+            raise IndexJobActivationError(
+                "durable current-result publication check is unavailable"
+            ) from exc
+        except Exception as exc:
+            raise IndexJobActivationError(
+                "durable current-result publication check failed"
+            ) from exc
+        if actual != expected:
+            raise IndexJobActivationError(
+                "durable current result changed during runtime publication"
+            )
+
+    def publish(
+        self,
+        binding: IndexJobRepoBinding,
+        activation: IndexJobRuntimeActivation,
+        *,
+        transfer_if_current: Callable[[Callable[[], None]], None],
+    ) -> None:
+        binding, activation = self._require_binding(binding, activation)
+        if not callable(transfer_if_current):
+            raise TypeError("runtime publisher guarded transfer is not callable")
+
+        self._require_current(binding, activation)
+        if self._registry.attest_retained_bm25_snapshot_if_equivalent(
+            binding,
+            activation,
+            transfer_if_current=transfer_if_current,
+        ):
+            return
+
+        def load(
+            runtime_owner: RetainedServerContextOwner,
+        ) -> RetainedServerContextResult:
+            self._require_current(binding, activation)
+            result = self._loader.load(binding, activation, runtime_owner)
+            self._require_current(binding, activation)
+            return result
+
+        self._registry.load_and_replace_retained_bm25_snapshot(
+            binding,
+            activation,
+            loader=load,
+            transfer_if_current=transfer_if_current,
+        )
+
+
+__all__ = [
+    "LocalRetainedBm25RuntimeTarget",
+    "LocalRetainedBm25SnapshotLoader",
+    "RepoRegistryIndexJobRuntimePublisher",
+    "RetainedBm25SnapshotLoader",
+]

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1605,8 +1605,8 @@ success-triggered refresh, MCP, UI controls, and default routing remain absent.
   ref-writer exclusion until that transfer returns. Only that guarded transfer
   can advance reconciliation state; missing, repeated, out-of-scope, skipped,
   or failed guard/transfer calls fail closed. Publication failures remain
-  retryable and secret-free. A concrete generation publisher, server wiring,
-  and the final runtime refresh callback remain separate gates.
+  retryable and secret-free. Server wiring and the final runtime refresh
+  callback remain separate gates.
 - The retained BM25 registry boundary now accepts one exact snapshot-loaded
   runtime owner together with its full job activation and prepares the complete
   sparse runtime. It exposes the source-revalidated, lock-protected RCU pointer
@@ -1616,6 +1616,20 @@ success-triggered refresh, MCP, UI controls, and default routing remain absent.
   storage-binding drift, and legacy registry-file replacement of an active
   durable generation. A guarded local loader/publisher and production server
   loop remain separate gates.
+- The concrete local retained-BM25 publisher binds each configured storage ref
+  to one canonical repository root, private workspace authority, namespace,
+  object store, and retained catalog. It performs fail-fast current-result
+  checks before and after materialization, then submits the actual source-checked
+  RCU transfer to the reconciler's writer-fenced activation guard. An
+  intervening ref or job-result change preserves the incumbent and settles the
+  candidate owner, while ref publication cannot cross the generation swap.
+  Rejected loader owners are closed immediately and only unfinished cleanup is
+  retained for retry. Exact active publication fences are idempotent only after
+  the incumbent is proved under the registry reload fence and again inside the
+  writer-fenced transfer. Reconciliation re-attests even an already reported
+  fence, so removal or reload cannot leave a permanent false success. Newer
+  incumbents and conflicting equal generations are rejected before
+  materialization. The production server loop remains a separate gate.
 - An explicitly injected Web reader can now project authorized durable jobs and
   at most 64 events without exposing worker owner IDs, fencing tokens, or raw
   executor errors or event keys. Each event is rebound to the exact job, a

--- a/test/compiler/test_retained_context.py
+++ b/test/compiler/test_retained_context.py
@@ -4,10 +4,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 import select
 import signal
 import threading
+from contextlib import contextmanager
 from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
@@ -25,12 +27,16 @@ from codenib.mcp.retained_context import (
     load_retained_server_context_snapshot,
 )
 from codenib.source_fingerprint import pin_repository_source_root
-from codenib.storage import PublishConflict
+from codenib.storage import DEFAULT_NAMESPACE_NAME, PublishConflict
 from codenib.storage.models import NamespaceIdentity, RepositoryIdentity
 from codenib.web.config import QAConfig, RepoEntry
 from codenib.web.index_job_activation import IndexJobRuntimeActivation
 from codenib.web.index_jobs import IndexJobRepoBinding
 from codenib.web.repo_registry import RepoBundle, RepoRegistry
+from codenib.web.retained_bm25_activation import (
+    LocalRetainedBm25RuntimeTarget,
+    LocalRetainedBm25SnapshotLoader,
+)
 
 from .test_manifest_export import _retained_fixture
 from .test_manifest_import import _TestWorkspaceProvider
@@ -424,6 +430,301 @@ def test_registry_rechecks_source_after_runtime_preparation(
         finally:
             registry.close()
         assert owner.closed
+
+
+def test_registry_owns_retained_loader_through_guarded_publication(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (fixture, imported, object_store, catalog):
+        entry = RepoEntry(
+            instance_id="demo",
+            repo="owner/repo",
+            base_commit="0" * 40,
+            language="python",
+            repo_dir=str(fixture.repository),
+            manifest_path=str(fixture.context / "repo_manifest.json"),
+        )
+        previous_manifest = RepoManifest.load(entry.manifest_path)
+        previous_manifest.repo_path = str(fixture.repository)
+        previous = RepoBundle(entry=entry, manifest=previous_manifest)
+        binding = IndexJobRepoBinding(entry.instance_id, imported.repository_id)
+        ref = catalog.resolve_ref(imported.repository_id)
+        activation = _runtime_activation(
+            binding,
+            imported.snapshot_id,
+            generation=imported.generation,
+            updated_at=ref["updated_at"],
+        )
+        registry = RepoRegistry(QAConfig())
+        registry._bundles[entry.instance_id] = previous
+        loaded: list[RetainedServerContextOwner] = []
+        guarded: list[IndexJobRuntimeActivation] = []
+
+        def load(value: RetainedServerContextOwner) -> RetainedServerContextResult:
+            result = load_retained_server_context_snapshot(
+                "owner/repo",
+                imported.snapshot_id,
+                tmp_path / "context",
+                catalog=catalog,
+                object_store=object_store,
+                workspace_provider=_TestWorkspaceProvider(),
+                runtime_owner=value,
+                repo_path=fixture.repository,
+            )
+            loaded.append(value)
+            return result
+
+        def transfer_current(transfer) -> None:
+            assert len(loaded) == 1
+            assert loaded[0].state == "active"
+            result = transfer()
+            assert result is None
+            guarded.append(activation)
+
+        owner: RetainedServerContextOwner | None = None
+        try:
+            registry.load_and_replace_retained_bm25_snapshot(
+                binding,
+                activation,
+                loader=load,
+                transfer_if_current=transfer_current,
+            )
+
+            assert guarded == [activation]
+            assert len(loaded) == 1
+            owner = loaded[0]
+            assert owner.state == "active"
+            with registry.pin(entry.instance_id) as current:
+                assert current is not None
+                assert current is not previous
+                assert current.index_job_activation is activation
+                assert current.bm25 is owner.context.bm25
+        finally:
+            registry.close()
+        assert owner is not None
+        assert owner.closed
+
+
+def test_registry_closes_owner_when_retained_loader_is_interrupted(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (fixture, imported, object_store, catalog):
+        entry = RepoEntry(
+            instance_id="demo",
+            repo="owner/repo",
+            base_commit="0" * 40,
+            language="python",
+            repo_dir=str(fixture.repository),
+            manifest_path=str(fixture.context / "repo_manifest.json"),
+        )
+        previous_manifest = RepoManifest.load(entry.manifest_path)
+        previous_manifest.repo_path = str(fixture.repository)
+        previous = RepoBundle(entry=entry, manifest=previous_manifest)
+        binding = IndexJobRepoBinding(entry.instance_id, imported.repository_id)
+        ref = catalog.resolve_ref(imported.repository_id)
+        activation = _runtime_activation(
+            binding,
+            imported.snapshot_id,
+            generation=imported.generation,
+            updated_at=ref["updated_at"],
+        )
+        registry = RepoRegistry(QAConfig())
+        registry._bundles[entry.instance_id] = previous
+        loaded: list[RetainedServerContextOwner] = []
+        owner: RetainedServerContextOwner | None = None
+        interruption = KeyboardInterrupt("after retained runtime activation")
+
+        def load(value: RetainedServerContextOwner) -> RetainedServerContextResult:
+            load_retained_server_context_snapshot(
+                "owner/repo",
+                imported.snapshot_id,
+                tmp_path / "context",
+                catalog=catalog,
+                object_store=object_store,
+                workspace_provider=_TestWorkspaceProvider(),
+                runtime_owner=value,
+                repo_path=fixture.repository,
+            )
+            loaded.append(value)
+            raise interruption
+
+        def forbidden(_transfer) -> None:
+            pytest.fail("interrupted retained loader reached publication")
+
+        try:
+            with pytest.raises(KeyboardInterrupt) as raised:
+                registry.load_and_replace_retained_bm25_snapshot(
+                    binding,
+                    activation,
+                    loader=load,
+                    transfer_if_current=forbidden,
+                )
+
+            assert raised.value is interruption
+            assert registry.get(entry.instance_id) is previous
+            assert len(loaded) == 1
+            owner = loaded[0]
+            assert owner.closed
+            assert registry._orphan_cleanup_owners == []
+        finally:
+            registry.close()
+        assert owner is not None
+        assert owner.closed
+
+
+def test_local_retained_bm25_loader_materializes_exact_snapshot(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (fixture, imported, object_store, catalog):
+        binding = IndexJobRepoBinding("demo", imported.repository_id)
+        workspace_root = tmp_path / "runtime"
+        workspace_root.mkdir(mode=0o700)
+        provider = _TestWorkspaceProvider()
+        target = LocalRetainedBm25RuntimeTarget(
+            binding=binding,
+            repository_key="owner/repo",
+            repository_root=fixture.repository,
+            workspace_root=workspace_root,
+            workspace_provider=provider,
+            environ={},
+        )
+
+        @contextmanager
+        def catalog_factory():
+            yield catalog
+
+        loader = LocalRetainedBm25SnapshotLoader(
+            catalog_factory,
+            object_store,
+            (target,),
+            nonce_factory=lambda: "d" * 32,
+        )
+        ref = catalog.resolve_ref(imported.repository_id)
+        activation = _runtime_activation(
+            binding,
+            imported.snapshot_id,
+            generation=imported.generation,
+            updated_at=ref["updated_at"],
+        )
+        job_token = hashlib.sha256(activation.job_id.encode("utf-8")).hexdigest()[:16]
+        owner = RetainedServerContextOwner()
+        try:
+            result = loader.load(binding, activation, owner)
+
+            assert result is owner.result
+            assert owner.state == "active"
+            assert owner.context.source_verified is True
+            assert owner.context.bm25 is not None
+            assert provider.run_count == 1
+            assert result.materialization.artifact.output_dir == (
+                workspace_root
+                / (
+                    ".codenib-bm25-runtime-"
+                    f"{activation.ref_generation}-{job_token}-{'d' * 32}"
+                )
+            )
+        finally:
+            owner.close()
+        assert owner.closed
+        assert result.materialization.artifact.output_dir.is_dir()
+
+
+def test_local_retained_bm25_target_rejects_symlinked_workspace_parent(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    workspace_parent = tmp_path / "workspace-parent"
+    workspace_parent.mkdir(mode=0o700)
+    (workspace_parent / "runtime").mkdir(mode=0o700)
+    workspace_alias = tmp_path / "workspace-alias"
+    try:
+        workspace_alias.symlink_to(workspace_parent, target_is_directory=True)
+    except OSError:
+        pytest.skip("symbolic links are unavailable")
+
+    namespace = NamespaceIdentity(DEFAULT_NAMESPACE_NAME)
+    repository_identity = RepositoryIdentity(
+        namespace_id=namespace.namespace_id,
+        repository_key="owner/repo",
+    )
+    with pytest.raises(ValueError, match="must not traverse symbolic links"):
+        LocalRetainedBm25RuntimeTarget(
+            binding=IndexJobRepoBinding("demo", repository_identity.repository_id),
+            repository_key=repository_identity.repository_key,
+            repository_root=repository,
+            workspace_root=workspace_alias / "runtime",
+            workspace_provider=_TestWorkspaceProvider(),
+            environ={},
+        )
+
+
+def test_local_retained_bm25_loader_rechecks_runtime_topology(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (fixture, imported, object_store, _catalog):
+        binding = IndexJobRepoBinding("demo", imported.repository_id)
+        workspace_parent = tmp_path / "workspace-parent"
+        workspace_parent.mkdir(mode=0o700)
+        workspace_root = workspace_parent / "runtime"
+        workspace_root.mkdir(mode=0o700)
+        target = LocalRetainedBm25RuntimeTarget(
+            binding=binding,
+            repository_key="owner/repo",
+            repository_root=fixture.repository,
+            workspace_root=workspace_root,
+            workspace_provider=_TestWorkspaceProvider(),
+            environ={},
+        )
+        activation = _runtime_activation(
+            binding,
+            imported.snapshot_id,
+            generation=imported.generation,
+            updated_at="2026-08-27T00:00:01+00:00",
+        )
+
+        (fixture.repository / "runtime").mkdir(mode=0o700)
+        workspace_parent.rename(tmp_path / "retired-workspace-parent")
+        try:
+            workspace_parent.symlink_to(
+                fixture.repository,
+                target_is_directory=True,
+            )
+        except OSError:
+            pytest.skip("symbolic links are unavailable")
+
+        @contextmanager
+        def catalog_factory():
+            pytest.fail("retargeted runtime root reached catalog access")
+            yield
+
+        loader = LocalRetainedBm25SnapshotLoader(
+            catalog_factory,
+            object_store,
+            (target,),
+        )
+        owner = RetainedServerContextOwner()
+        try:
+            with pytest.raises(
+                ValueError,
+                match="workspace must not overlap the repository",
+            ):
+                loader.load(binding, activation, owner)
+            assert owner.state == "empty"
+        finally:
+            owner.close()
 
 
 def test_retained_loader_threads_expected_root_authority_to_capture(

--- a/test/web/test_index_job_activation.py
+++ b/test/web/test_index_job_activation.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from dataclasses import replace
+from types import SimpleNamespace
 
 import pytest
 
@@ -17,11 +19,15 @@ from codenib.storage import (
     IndexJobWorkerDisposition,
     IndexJobWorkerRunResult,
 )
+from codenib.web.config import QAConfig
 from codenib.web.index_job_activation import (
     CatalogIndexJobRuntimeReconciler,
     IndexJobActivationError,
+    IndexJobRuntimeActivation,
 )
 from codenib.web.index_jobs import IndexJobRepoBinding
+from codenib.web.repo_registry import RepoBundle, RepoRegistry
+from codenib.web.retained_bm25_activation import RepoRegistryIndexJobRuntimePublisher
 
 _FIRST_REF_TIME = "2026-08-27T00:00:01+00:00"
 _SECOND_REF_TIME = "2026-08-27T00:00:02+00:00"
@@ -125,7 +131,27 @@ def _reconciler(binding, catalog, publisher):
     return CatalogIndexJobRuntimeReconciler(factory, (binding,), publisher)
 
 
-def test_reconcile_all_replays_current_result_once_per_process() -> None:
+def _activation(
+    binding: IndexJobRepoBinding,
+    current: IndexJobCurrentResult,
+) -> IndexJobRuntimeActivation:
+    job = current.job
+    assert job.finished_at_ms is not None
+    assert job.result_snapshot_id is not None
+    return IndexJobRuntimeActivation(
+        repo_id=binding.repo_id,
+        repository_id=binding.repository_id,
+        ref_name=binding.ref_name,
+        job_id=job.job_id,
+        attempt_count=job.attempt_count,
+        snapshot_id=job.result_snapshot_id,
+        ref_generation=current.ref_generation,
+        ref_updated_at=current.ref_updated_at,
+        finished_at_ms=job.finished_at_ms,
+    )
+
+
+def test_reconcile_all_reports_current_result_once_but_reattests_runtime() -> None:
     binding = IndexJobRepoBinding("demo", "repo_" + "a" * 64)
     job = _successful_job(
         binding,
@@ -149,11 +175,50 @@ def test_reconcile_all_replays_current_result_once_per_process() -> None:
     assert first[0].ref_generation == 1
     assert first[0].ref_updated_at == _FIRST_REF_TIME
     assert reconciler.reconcile_all() == ()
-    assert len(publisher.calls) == 1
+    assert len(publisher.calls) == 2
 
     restarted = _reconciler(binding, catalog, publisher)
     assert restarted.reconcile("demo") is not None
-    assert len(publisher.calls) == 2
+    assert len(publisher.calls) == 3
+
+
+def test_reconcile_repairs_runtime_presence_for_an_already_reported_fence() -> None:
+    binding = IndexJobRepoBinding("demo", "repo_" + "a" * 64)
+    job = _successful_job(
+        binding,
+        idempotency_key="request-1",
+        snapshot_value="d",
+        finished_at_ms=3,
+    )
+    current = _current(job, generation=1, updated_at=_FIRST_REF_TIME)
+    catalog = _ResultCatalog(
+        {job.job_id: job},
+        {(binding.repository_id, binding.ref_name): current},
+    )
+
+    class PresencePublisher:
+        present = True
+        calls = 0
+
+        def publish(self, binding, activation, *, transfer_if_current):
+            self.calls += 1
+
+            def require_runtime() -> None:
+                if not self.present:
+                    raise RuntimeError("runtime generation is absent")
+
+            transfer_if_current(require_runtime)
+
+    publisher = PresencePublisher()
+    reconciler = _reconciler(binding, catalog, publisher)
+
+    assert reconciler.reconcile("demo") is not None
+    publisher.present = False
+    with pytest.raises(IndexJobActivationError, match="publication failed"):
+        reconciler.reconcile("demo")
+    publisher.present = True
+    assert reconciler.reconcile("demo") is None
+    assert publisher.calls == 3
 
 
 def test_reconcile_deduplicates_job_replays_by_snapshot_and_generation() -> None:
@@ -198,7 +263,7 @@ def test_reconcile_deduplicates_job_replays_by_snapshot_and_generation() -> None
         updated_at=_FIRST_REF_TIME,
     )
     assert reconciler.reconcile("demo") is None
-    assert len(publisher.calls) == 1
+    assert len(publisher.calls) == 2
 
     catalog.current[(binding.repository_id, binding.ref_name)] = _current(
         advanced,
@@ -209,7 +274,7 @@ def test_reconcile_deduplicates_job_replays_by_snapshot_and_generation() -> None
     assert activated is not None
     assert activated.job_id == advanced.job_id
     assert activated.publication_fence == (advanced.result_snapshot_id, 2)
-    assert len(publisher.calls) == 2
+    assert len(publisher.calls) == 3
 
     catalog.current[(binding.repository_id, binding.ref_name)] = _current(
         first,
@@ -218,7 +283,7 @@ def test_reconcile_deduplicates_job_replays_by_snapshot_and_generation() -> None
     )
     with pytest.raises(IndexJobActivationError, match="regressed"):
         reconciler.reconcile("demo")
-    assert len(publisher.calls) == 2
+    assert len(publisher.calls) == 3
 
 
 def test_worker_callback_attests_attempt_then_reconciles_current_result() -> None:
@@ -440,6 +505,7 @@ def test_reconcile_all_does_not_starve_later_repositories_after_failure() -> Non
         "alpha",
         "beta",
         "alpha",
+        "beta",
     ]
 
 
@@ -557,3 +623,298 @@ def test_reconciler_rejects_invalid_catalog_and_publisher_results() -> None:
     with pytest.raises(IndexJobActivationError, match="skipped guarded"):
         reconciler.reconcile("demo")
     assert len(repeated.calls) == 1
+
+
+def test_registry_publisher_routes_transfer_through_guarded_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binding = IndexJobRepoBinding("demo", "repo_" + "a" * 64)
+    job = _successful_job(
+        binding,
+        idempotency_key="request-1",
+        snapshot_value="d",
+        finished_at_ms=3,
+    )
+    current = _current(job, generation=1, updated_at=_FIRST_REF_TIME)
+
+    class CountingCatalog(_ResultCatalog):
+        reads = 0
+
+        def find_current_successful_job(self, repository_id, ref_name="main"):
+            self.reads += 1
+            return super().find_current_successful_job(repository_id, ref_name)
+
+    catalog = CountingCatalog(
+        {job.job_id: job},
+        {(binding.repository_id, binding.ref_name): current},
+    )
+
+    @contextmanager
+    def factory():
+        yield catalog
+
+    calls = []
+    guarded_transfers = []
+
+    class Loader:
+        def load(self, observed_binding, observed_activation, runtime_owner):
+            calls.append((observed_binding, observed_activation, runtime_owner))
+            return object()
+
+    registry = RepoRegistry(QAConfig())
+    registry._bundles[binding.repo_id] = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+    )
+
+    def handoff(
+        observed_binding,
+        observed_activation,
+        *,
+        loader,
+        transfer_if_current,
+    ):
+        assert observed_binding is binding
+        loader_owner = object()
+        assert loader(loader_owner) is not None
+        transfer_if_current(lambda: None)
+
+    monkeypatch.setattr(
+        registry,
+        "load_and_replace_retained_bm25_snapshot",
+        handoff,
+    )
+    try:
+        activation = _activation(binding, current)
+        publisher = RepoRegistryIndexJobRuntimePublisher(
+            registry,
+            factory,
+            Loader(),
+        )
+
+        def guard(transfer) -> None:
+            guarded_transfers.append(activation)
+            result = transfer()
+            assert result is None
+
+        assert (
+            publisher.publish(
+                binding,
+                activation,
+                transfer_if_current=guard,
+            )
+            is None
+        )
+    finally:
+        registry.close()
+
+    assert len(calls) == 1
+    assert calls[0][:2] == (binding, activation)
+    assert guarded_transfers == [activation]
+    assert catalog.reads == 3
+
+
+def test_registry_publisher_rejects_result_advance_after_materialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binding = IndexJobRepoBinding("demo", "repo_" + "a" * 64)
+    first_job = _successful_job(
+        binding,
+        idempotency_key="request-1",
+        snapshot_value="d",
+        finished_at_ms=3,
+    )
+    second_job = _successful_job(
+        binding,
+        idempotency_key="request-2",
+        snapshot_value="e",
+        finished_at_ms=4,
+        expected_ref_generation=1,
+    )
+    first = _current(first_job, generation=1, updated_at=_FIRST_REF_TIME)
+    second = _current(second_job, generation=2, updated_at=_SECOND_REF_TIME)
+    key = (binding.repository_id, binding.ref_name)
+    catalog = _ResultCatalog(
+        {first_job.job_id: first_job, second_job.job_id: second_job},
+        {key: first},
+    )
+
+    @contextmanager
+    def factory():
+        yield catalog
+
+    class AdvancingLoader:
+        calls = 0
+
+        def load(self, observed_binding, observed_activation, runtime_owner):
+            self.calls += 1
+            catalog.current[key] = second
+            return object()
+
+    registry = RepoRegistry(QAConfig())
+    registry._bundles[binding.repo_id] = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+    )
+
+    def handoff(
+        observed_binding,
+        observed_activation,
+        *,
+        loader,
+        transfer_if_current,
+    ):
+        loader(object())
+        pytest.fail("advanced result reached the guarded registry transfer")
+
+    monkeypatch.setattr(
+        registry,
+        "load_and_replace_retained_bm25_snapshot",
+        handoff,
+    )
+    loader = AdvancingLoader()
+    try:
+        publisher = RepoRegistryIndexJobRuntimePublisher(
+            registry,
+            factory,
+            loader,
+        )
+        with pytest.raises(IndexJobActivationError, match="current result changed"):
+            publisher.publish(
+                binding,
+                _activation(binding, first),
+                transfer_if_current=lambda transfer: pytest.fail(
+                    "advanced result reached the durable transfer guard"
+                ),
+            )
+    finally:
+        registry.close()
+    assert loader.calls == 1
+
+
+def test_registry_publisher_treats_active_publication_fence_idempotently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binding = IndexJobRepoBinding("demo", "repo_" + "a" * 64)
+    job = _successful_job(
+        binding,
+        idempotency_key="request-1",
+        snapshot_value="d",
+        finished_at_ms=3,
+    )
+    current = _current(job, generation=1, updated_at=_FIRST_REF_TIME)
+    activation = _activation(binding, current)
+    catalog = _ResultCatalog(
+        {job.job_id: job},
+        {(binding.repository_id, binding.ref_name): current},
+    )
+
+    @contextmanager
+    def factory():
+        yield catalog
+
+    class ForbiddenLoader:
+        def load(self, binding, activation, runtime_owner):
+            pytest.fail("an active publication fence was materialized again")
+
+    registry = RepoRegistry(QAConfig())
+    registry._bundles[binding.repo_id] = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+        index_job_activation=replace(
+            activation,
+            job_id="job_" + "f" * 64,
+            finished_at_ms=2,
+        ),
+    )
+    monkeypatch.setattr(
+        registry,
+        "load_and_replace_retained_bm25_snapshot",
+        lambda *args, **kwargs: pytest.fail("idempotent fence reached handoff"),
+    )
+    guarded_transfers = []
+    try:
+        publisher = RepoRegistryIndexJobRuntimePublisher(
+            registry,
+            factory,
+            ForbiddenLoader(),
+        )
+
+        def guard(transfer) -> None:
+            guarded_transfers.append(activation)
+            result = transfer()
+            assert result is None
+
+        assert (
+            publisher.publish(
+                binding,
+                activation,
+                transfer_if_current=guard,
+            )
+            is None
+        )
+    finally:
+        registry.close()
+    assert guarded_transfers == [activation]
+
+
+def test_registry_publisher_rechecks_equivalent_runtime_inside_guard() -> None:
+    binding = IndexJobRepoBinding("demo", "repo_" + "a" * 64)
+    job = _successful_job(
+        binding,
+        idempotency_key="request-1",
+        snapshot_value="d",
+        finished_at_ms=3,
+    )
+    current = _current(job, generation=1, updated_at=_FIRST_REF_TIME)
+    activation = _activation(binding, current)
+    catalog = _ResultCatalog(
+        {job.job_id: job},
+        {(binding.repository_id, binding.ref_name): current},
+    )
+
+    @contextmanager
+    def factory():
+        yield catalog
+
+    class ForbiddenLoader:
+        def load(self, binding, activation, runtime_owner):
+            pytest.fail("an equivalent runtime was materialized again")
+
+    registry = RepoRegistry(QAConfig())
+    incumbent = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+        index_job_activation=activation,
+    )
+    registry._bundles[binding.repo_id] = incumbent
+    publisher = RepoRegistryIndexJobRuntimePublisher(
+        registry,
+        factory,
+        ForbiddenLoader(),
+    )
+
+    def remove_before_transfer(transfer) -> None:
+        with registry._generation_lock:
+            assert registry._bundles.pop(binding.repo_id) is incumbent
+        transfer()
+
+    try:
+        with pytest.raises(
+            IndexJobActivationError,
+            match="changed during guarded attestation",
+        ):
+            publisher.publish(
+                binding,
+                activation,
+                transfer_if_current=remove_before_transfer,
+            )
+
+        registry._bundles[binding.repo_id] = incumbent
+        publisher.publish(
+            binding,
+            activation,
+            transfer_if_current=lambda transfer: transfer(),
+        )
+    finally:
+        registry.close()

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -348,6 +348,39 @@ def test_registry_later_publish_preserves_failed_owner_for_retry():
     assert registry._orphan_cleanup_owners == []
 
 
+def test_registry_immediately_retries_only_unsettled_rejected_owner():
+    cleanup = RuntimeError("retry rejected owner")
+
+    class Owner:
+        def __init__(self):
+            self.close_calls = 0
+
+        @property
+        def closed(self):
+            return self.close_calls >= 2
+
+        def close(self):
+            self.close_calls += 1
+            if self.close_calls == 1:
+                raise cleanup
+
+    owner = Owner()
+    registry = RepoRegistry(QAConfig())
+    registry._bundles["repo"] = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+    )
+    try:
+        assert registry._settle_unpublished_cleanup_owner("repo", owner) is cleanup
+        assert owner.close_calls == 1
+        assert registry._orphan_cleanup_owners == [owner]
+    finally:
+        registry.close()
+
+    assert owner.close_calls == 2
+    assert registry._orphan_cleanup_owners == []
+
+
 def test_registry_complete_snapshot_retires_owner_without_bundle(monkeypatch):
     class Owner:
         def __init__(self):


### PR DESCRIPTION
## Summary
Materialize one exact current retained BM25 snapshot into a fresh private runtime and publish it through the guarded RepoRegistry generation boundary. The concrete publisher performs fail-fast current checks, while the actual RCU transfer remains inside the durable ref-writer fence. This advances #199 and #266 without enabling default storage or runtime routing.

## Changes
- add explicit local runtime targets bound to one Web repo, storage repository/ref, namespace, repository root, and private workspace authority
- reject non-canonical storage identities, unsafe workspace permissions, provider-root drift, and lexical or physical repository/workspace overlap
- pin the repository source and materialize the exact snapshot through a receipt-retaining object store into a fresh nonce-scoped output
- keep one exact runtime owner from loader acquisition through guarded publication; immediately settle rejected owners and retain only unfinished cleanup
- revalidate the durable current result before and after materialization, then submit the actual source-checked RCU transfer to the reconciler guard
- serialize equivalent-incumbent proof under the registry reload fence before entering the durable guarded no-op transfer
- re-attest already reported durable fences on every reconciliation pass so runtime removal cannot become a permanent false success
- reject newer incumbents or equal-generation conflicts without replacing them
- add guarded-handoff, runtime-loss recovery, incumbent-removal, and immediate-cleanup regressions
- document the concrete guarded loader/publisher boundary in the storage roadmap

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- exact retained context, RepoRegistry, and reconciler files after the final rebase (`275 passed`)
- downstream publisher/runtime composition on the final rebased stack (`282 passed`)
- downstream full non-slow/non-integration unit tier with the three documented local baselines excluded (`8791 passed, 35 skipped, 193 deselected`)
- GitHub unit job on exact head `5fdc0eeae3` (`8779 passed, 43 skipped`)
- relevant pre-commit and commit hooks

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
