### PR TITLE
feat(storage): add bounded reclaimer discovery

### DIFF
--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -72,6 +72,7 @@ _MAX_ORPHAN_NAME_ATTEMPTS = 128
 _MAX_ORDERED_ACTION_CANCELLATION_RETRIES = 8
 _MAX_PUBLICATION_CLEANUP_OWNERS = 64
 _MAX_PUBLICATION_EXCEPTION_LINKS = 64
+_MAX_QUIESCENT_DIRECTORY_CHILDREN = 4_096
 _OWNERSHIP_SORT_RUN_ENTRIES = 256
 _DURABLE_PUBLICATION_FSYNC_BACKENDS = frozenset(
     {"linux-native-workspace-owner", "linux-renameat2"}
@@ -2343,6 +2344,65 @@ class _ExactResourceCleanupOwner:
 
     def close(self) -> None:
         self.action()
+
+
+class _QuiescentDirectoryResourceOwner(Protocol):
+    """Small resource contract protected by the quiescent handoff boundary."""
+
+    @property
+    def closed(self) -> bool: ...
+
+    def close(self) -> None: ...
+
+
+class _ScandirIterator(Protocol):
+    """The bounded iterator surface needed from :func:`os.scandir`."""
+
+    def __iter__(self) -> Iterator[object]: ...
+
+    def __next__(self) -> object: ...
+
+    def close(self) -> None: ...
+
+
+class _ScandirIteratorCleanupOwner:
+    """Acquire and retry closure of one descriptor-backed directory iterator."""
+
+    __slots__ = ("_close_callback", "_closed", "_iterator")
+
+    def __init__(self) -> None:
+        self._iterator: _ScandirIterator | None = None
+        self._close_callback: Callable[[], None] | None = None
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def open(self, descriptor: int) -> _ScandirIterator:
+        if self._iterator is not None or self._close_callback is not None:
+            raise RuntimeError("directory snapshot iterator is already open")
+        if self._closed:
+            raise RuntimeError("directory snapshot iterator owner is closed")
+        # Publish the native result directly into the pre-owned object.  If an
+        # interruption lands before the bound close store, ``close`` derives it
+        # again from this retained iterator.
+        self._iterator = os.scandir(descriptor)
+        self._close_callback = self._iterator.close
+        return self._iterator
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        close_callback = self._close_callback
+        if close_callback is None:
+            iterator = self._iterator
+            if iterator is None:
+                self._closed = True
+                return
+            close_callback = iterator.close
+        close_callback()
+        self._closed = True
 
 
 class _PosixResourceOwner:
@@ -9096,7 +9156,7 @@ def _quiescent_reclaim_parent_descriptor(
 
 
 def _run_quiescent_directory_resource_scope(
-    resources: _PosixResourceOwner,
+    resources: _QuiescentDirectoryResourceOwner,
     callback: Callable[[], _T],
     *,
     label: str,
@@ -9127,7 +9187,7 @@ def _run_quiescent_directory_resource_scope(
 
 
 def _run_quiescent_directory_resource_scope_unprotected(
-    resources: _PosixResourceOwner,
+    resources: _QuiescentDirectoryResourceOwner,
     callback: Callable[[], _T],
     outcome: _QuiescentDirectoryLifecycleOutcome,
     *,
@@ -9163,7 +9223,7 @@ def _run_quiescent_directory_resource_scope_unprotected(
                         callback,
                         outcome,
                     )
-            except BaseException as primary_error:  # noqa: B036 - close exact fds
+            except BaseException as primary_error:  # noqa: B036 - close resource
                 try:
                     resources.close()
                 except BaseException as cleanup_error:  # noqa: B036 - keep primary
@@ -9465,6 +9525,9 @@ class QuiescentDirectoryReclaimer:
     limited to the originating thread after its owning public call has stopped
     executing.
 
+    ``snapshot_child_names`` returns one deterministic, bounded point-in-time
+    snapshot from the retained parent descriptor.  It supplies no name policy:
+    callers must decide which exact names belong to their own cleanup namespace.
     ``reclaim_orphan`` authenticates an existing verified isolation receipt
     and treats absence of that exact receipted child as idempotent completion
     only after synchronizing and rechecking its parent authority.
@@ -9473,14 +9536,18 @@ class QuiescentDirectoryReclaimer:
     returns ``False`` and carries no proof of earlier cleanup.  A present
     generic child is freshly captured and moved no-replace into an authenticated
     orphan before descriptor-bound removal begins.
+    ``reclaim_quarantined_child`` is the stronger caller-authorized form for a
+    child that policy has already quarantined: it freshly captures that exact
+    name and deletes it in place, without adding another quarantine-name layer.
 
-    Both reclaim methods return ``True`` after a present tree is fully removed
+    Every reclaim method returns ``True`` after a present tree is fully removed
     and its parent is synchronized.  An already-absent exact receipt also
-    returns ``True`` as idempotent completion; only an absent generic name
-    returns ``False``.  An interrupted operation remains installed on this
-    object; :meth:`retry` resumes it, and :meth:`close` must settle it before
-    releasing authority.  Recursive and concurrent lifecycle transitions fail
-    before they may inspect or change that installed operation.
+    returns ``True`` as idempotent completion; an absent name-authorized child
+    returns ``False`` without synchronization or proof of earlier cleanup.  An
+    interrupted operation remains installed on this object; :meth:`retry`
+    resumes it, and :meth:`close` must settle it before releasing authority.
+    Recursive and concurrent lifecycle transitions fail before they may inspect
+    or change that installed operation.
 
     This fail-fast boundary covers the supported public reclaimer methods and
     the ``closed``/``close()`` protocol on a published cleanup owner. Handed
@@ -10024,6 +10091,52 @@ class QuiescentDirectoryReclaimer:
             lambda: self._run_reclaim_call(lambda: self._reclaim_orphan(orphan))
         )
 
+    def _snapshot_child_names(self) -> tuple[str, ...]:
+        authority = self._require_open()
+        if self._active is not None:
+            raise RuntimeError("quiescent directory reclaimer owns another tree")
+        authority.verify_path_binding()
+        ordered: list[tuple[bytes, str]] = []
+        iterator_owner = _ScandirIteratorCleanupOwner()
+
+        def scan() -> None:
+            entries = iterator_owner.open(authority.resource)
+            for index, entry in enumerate(entries):
+                # Fetch exactly one entry past the budget to detect overflow,
+                # but do not inspect or retain that excess entry.
+                if index >= _MAX_QUIESCENT_DIRECTORY_CHILDREN:
+                    raise RuntimeError(
+                        "quiescent directory child snapshot exceeds its limit"
+                    )
+                name = entry.name
+                if type(name) is not str:
+                    raise RuntimeError("quiescent directory child snapshot is invalid")
+                validated = _simple_child_name(
+                    name,
+                    label="quiescent directory snapshot child",
+                )
+                ordered.append((os.fsencode(validated), validated))
+
+        _run_quiescent_directory_resource_scope(
+            iterator_owner,
+            scan,
+            label="quiescent directory snapshot iterator cleanup also failed",
+        )
+        authority.verify_path_binding()
+        ordered.sort(key=lambda item: item[0])
+        if any(
+            previous[0] == current[0]
+            for previous, current in zip(ordered, ordered[1:], strict=False)
+        ):
+            raise RuntimeError("quiescent directory child snapshot is invalid")
+        authority.verify_path_binding()
+        return tuple(name for _raw, name in ordered)
+
+    def snapshot_child_names(self) -> tuple[str, ...]:
+        """Return a bounded point-in-time snapshot from the retained parent fd."""
+
+        return self._run_lifecycle_transition(self._snapshot_child_names)
+
     def _reclaim_child(self, child_name: str) -> bool:
         authority = self._require_open()
         if type(child_name) is not str:
@@ -10063,6 +10176,61 @@ class QuiescentDirectoryReclaimer:
 
         return self._run_lifecycle_transition(
             lambda: self._run_reclaim_call(lambda: self._reclaim_child(child_name))
+        )
+
+    def _reclaim_quarantined_child(self, child_name: str) -> bool:
+        authority = self._require_open()
+        if type(child_name) is not str:
+            raise TypeError(
+                "quiescent directory quarantined child name must be an exact string"
+            )
+        name = _simple_child_name(
+            child_name,
+            label="quiescent directory quarantined child",
+        )
+        path = authority.display_parent / name
+        active = self._active
+        if active is not None:
+            if not active.matches_child(path):
+                raise RuntimeError("quiescent directory reclaimer owns another tree")
+            return self._resume()
+        parent_path_bytes = _bounded_directory_orphan_parent_path_bytes(
+            os.fsencode(authority.display_parent)
+        )
+        metadata = self._child_metadata(authority, path)
+        if metadata is None:
+            return False
+        self._require_owned_child(authority, path, metadata)
+        ownership = authority.capture_child(
+            name,
+            path=path,
+            label="quiescent directory quarantined child",
+            allow_empty_root=True,
+        )
+        _quiescent_reclaim_entries(ownership)
+        orphan = _orphan_metadata(
+            authority,
+            path,
+            ownership,
+            parent_path_bytes=parent_path_bytes,
+        )
+        operation = _QuiescentDirectoryReclaimOperation(
+            authority=authority,
+            requested_path=path,
+            ownership=orphan.locator.ownership,
+            isolation_owner=None,
+            orphan=orphan,
+        )
+        self._install_operation(operation)
+        return self._resume()
+
+    def reclaim_quarantined_child(self, child_name: str) -> bool:
+        """Reclaim one already-quarantined exact child without renaming it."""
+
+        return self._run_lifecycle_transition(
+            lambda: self._run_reclaim_call(
+                lambda: self._reclaim_quarantined_child(child_name)
+            )
         )
 
     def retry(self) -> bool:

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1317,10 +1317,18 @@ reclaimer now supplies the primitive cleanup boundary: it pins one exact
 same-euid `0700` parent, authenticates either an existing orphan receipt or one
 caller-authorized exact child, quarantines a generic child no-replace, and
 removes only the freshly matched bounded inventory through no-follow directory
-descriptors. An absent verified receipt is idempotent completion only after a
-fresh parent synchronization and binding recheck, including after response
-loss, while an absent generic name grants no cleanup authority and returns
-false without synchronization. A private receipt seal length-frames bounded
+descriptors. Under caller-enforced parent quiescence, its point-in-time snapshot
+incrementally reads through the retained descriptor only to its fixed child
+limit plus one, rejects overflow before inspecting or retaining the excess
+entry, and returns a bounded byte-sorted tuple of exact simple names without
+granting policy or deletion authority. A separate caller-authorized operation
+preflights bounded canonical parent receipt bytes, freshly captures an
+already-quarantined exact child, and enters descriptor removal without adding
+another `.discarded-*` layer. An absent verified receipt is idempotent
+completion only after a fresh parent synchronization and binding recheck,
+including after response loss, while an absent name-authorized child, whether
+generic or already quarantined, grants no cleanup authority and returns false
+without synchronization. A private receipt seal length-frames bounded
 canonical parent bytes, the hidden name, verification state, and complete exact
 ownership token. Fixed tuple arities, string and path lengths, and every root
 and entry identity's 128-bit scalar magnitude are checked before their
@@ -1457,9 +1465,10 @@ its local attempt resource factory, resolver, and explicit production CLI entry
 are implemented. Its three transient destinations now share one retained
 caller-owned path-build root whose authenticated cleanup receipt is accepted
 before ownership is released. The descriptor-owned quiescent directory
-reclamation primitive is implemented; BM25 attempt-name reconciliation,
-multi-target retry routing, worker-lifecycle quiescence, and CLI wiring remain
-pending.
+reclamation primitive, bounded descriptor child snapshot, and direct
+already-quarantined-child cleanup are implemented; BM25 attempt-name
+classification, multi-target retry routing, worker-lifecycle quiescence, and
+CLI wiring remain pending.
 Vector and graph source builders, generic builder routing, and remaining
 runtime wiring remain.
 
@@ -1549,15 +1558,16 @@ success-triggered refresh, MCP, UI controls, and default routing remain absent.
   worker and force a duplicate attempt.
 - The retained-source BM25 attempt resource factory/resolver, production CLI
   entry, and explicit Web planner are implemented. The generic descriptor-bound
-  quiescent directory reclamation primitive is also implemented without BM25
-  discovery or publication authority. The planner captures the same frozen
-  local target as the worker, revalidates source after planning, and uses a
-  separate least-authority catalog surface that can register only
-  content-addressed source/profile identities and read one ref generation. Add
-  the worker-lifecycle attempt-pool coordinator, then add vector and graph
-  source adapters and wire successful worker results into runtime, Web, MCP,
-  and default routes. Older self-publishing ingress APIs remain compatibility
-  paths and are never nested inside the worker.
+  quiescent directory reclamation primitive, bounded descriptor child snapshot,
+  and direct already-quarantined cleanup are also implemented without BM25 name
+  policy or publication authority. The planner captures the same frozen local
+  target as the worker, revalidates source after planning, and uses a separate
+  least-authority catalog surface that can register only content-addressed
+  source/profile identities and read one ref generation. Add the
+  worker-lifecycle attempt-pool coordinator, then add vector and graph source
+  adapters and wire successful worker results into runtime, Web, MCP, and
+  default routes. Older self-publishing ingress APIs remain compatibility paths
+  and are never nested inside the worker.
 - Complete the #266 job and update APIs with accurate incremental versus rebuild
   behavior; the first read-only status slice is described below.
 - `RepoRegistry.load_all()` now reconciles each complete registry snapshot,
@@ -1614,8 +1624,7 @@ success-triggered refresh, MCP, UI controls, and default routing remain absent.
   so the ref-writer fence spans the actual generation swap. It rejects
   ref-generation regression, same-generation snapshot/timestamp conflict,
   storage-binding drift, and legacy registry-file replacement of an active
-  durable generation. A guarded local loader/publisher and production server
-  loop remain separate gates.
+  durable generation. The production server loop remains a separate gate.
 - The concrete local retained-BM25 publisher binds each configured storage ref
   to one canonical repository root, private workspace authority, namespace,
   object store, and retained catalog. It performs fail-fast current-result

--- a/test/test_atomic_directory.py
+++ b/test/test_atomic_directory.py
@@ -1599,6 +1599,497 @@ def test_quiescent_reclaimer_reclaims_exact_child_and_reports_absence(
     assert list(parent.iterdir()) == []
 
 
+def test_quiescent_reclaimer_snapshots_sorted_descriptor_child_names(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent, parent_identity = _private_reclaimer_parent(tmp_path)
+    names = ("zeta", ".alpha", "middle", "café")
+    for name in names:
+        (parent / name).mkdir()
+    real_scandir = atomic_module.os.scandir
+    scanned: list[object] = []
+
+    def capture_scandir(descriptor: object) -> object:
+        scanned.append(descriptor)
+        return real_scandir(descriptor)
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(atomic_module.os, "scandir", capture_scandir)
+        with atomic_module.QuiescentDirectoryReclaimer(
+            parent,
+            expected_parent_identity=parent_identity,
+        ) as reclaimer:
+            assert reclaimer.snapshot_child_names() == tuple(
+                sorted(names, key=os.fsencode)
+            )
+            assert reclaimer.retry() is False
+
+    assert len(scanned) == 1
+    assert type(scanned[0]) is int
+    assert {path.name for path in parent.iterdir()} == set(names)
+
+
+def test_quiescent_reclaimer_child_snapshot_stops_at_incremental_bound(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent, parent_identity = _private_reclaimer_parent(tmp_path)
+
+    class PoisonEntry:
+        @property
+        def name(self) -> str:
+            raise AssertionError("snapshot inspected the limit-plus-one entry")
+
+    entries = (
+        SimpleNamespace(name="one"),
+        SimpleNamespace(name="two"),
+        PoisonEntry(),
+    )
+
+    class BoundedScandir:
+        def __init__(self) -> None:
+            self.index = 0
+            self.closed = False
+
+        def __iter__(self) -> BoundedScandir:
+            return self
+
+        def __next__(self) -> object:
+            if self.index >= len(entries):
+                raise AssertionError("snapshot read beyond limit plus one")
+            entry = entries[self.index]
+            self.index += 1
+            return entry
+
+        def close(self) -> None:
+            self.closed = True
+
+        def __enter__(self) -> BoundedScandir:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            self.close()
+
+    iterator = BoundedScandir()
+    scanned: list[object] = []
+
+    def bounded_scandir(descriptor: object) -> BoundedScandir:
+        scanned.append(descriptor)
+        return iterator
+
+    monkeypatch.setattr(atomic_module, "_MAX_QUIESCENT_DIRECTORY_CHILDREN", 2)
+    monkeypatch.setattr(atomic_module.os, "scandir", bounded_scandir)
+
+    with atomic_module.QuiescentDirectoryReclaimer(
+        parent,
+        expected_parent_identity=parent_identity,
+    ) as reclaimer:
+        with pytest.raises(RuntimeError, match="snapshot exceeds its limit"):
+            reclaimer.snapshot_child_names()
+        assert reclaimer.retry() is False
+
+    assert len(scanned) == 1
+    assert type(scanned[0]) is int
+    assert iterator.index == 3
+    assert iterator.closed
+
+
+def test_quiescent_reclaimer_child_snapshot_closes_iterator_on_scan_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent, parent_identity = _private_reclaimer_parent(tmp_path)
+    real_scandir = atomic_module.os.scandir
+    failure = OSError(errno.EIO, "injected snapshot scan failure")
+
+    class FailingScandir:
+        def __init__(self, descriptor: int) -> None:
+            self._entries = real_scandir(descriptor)
+            self.closed = False
+
+        def __iter__(self) -> FailingScandir:
+            return self
+
+        def __next__(self) -> object:
+            raise failure
+
+        def close(self) -> None:
+            self._entries.close()
+            self.closed = True
+
+        def __enter__(self) -> FailingScandir:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            self.close()
+
+    iterators: list[FailingScandir] = []
+
+    def failing_scandir(descriptor: int) -> FailingScandir:
+        assert type(descriptor) is int
+        iterator = FailingScandir(descriptor)
+        iterators.append(iterator)
+        return iterator
+
+    before_fds = (
+        len(os.listdir("/proc/self/fd")) if sys.platform.startswith("linux") else 0
+    )
+    monkeypatch.setattr(atomic_module.os, "scandir", failing_scandir)
+    reclaimer = atomic_module.QuiescentDirectoryReclaimer(
+        parent,
+        expected_parent_identity=parent_identity,
+    )
+
+    with pytest.raises(OSError) as caught:
+        reclaimer.snapshot_child_names()
+
+    assert caught.value is failure
+    assert len(iterators) == 1
+    assert iterators[0].closed
+    assert reclaimer.retry() is False
+    reclaimer.close()
+    if sys.platform.startswith("linux"):
+        assert len(os.listdir("/proc/self/fd")) <= before_fds
+
+
+def test_quiescent_reclaimer_child_snapshot_retries_interrupted_iterator_close(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent, parent_identity = _private_reclaimer_parent(tmp_path)
+    (parent / "attempt").mkdir()
+    real_scandir = atomic_module.os.scandir
+    interruption = KeyboardInterrupt("injected snapshot iterator close interruption")
+
+    class InterruptingScandir:
+        def __init__(self, descriptor: int) -> None:
+            self._entries = real_scandir(descriptor)
+            self.close_calls = 0
+            self.closed = False
+
+        def __iter__(self) -> InterruptingScandir:
+            return self
+
+        def __next__(self) -> object:
+            return next(self._entries)
+
+        def close(self) -> None:
+            self.close_calls += 1
+            self._entries.close()
+            if self.close_calls == 1:
+                raise interruption
+            self.closed = True
+
+        def __enter__(self) -> InterruptingScandir:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            self.close()
+
+    iterators: list[InterruptingScandir] = []
+
+    def interrupting_scandir(descriptor: int) -> InterruptingScandir:
+        assert type(descriptor) is int
+        iterator = InterruptingScandir(descriptor)
+        iterators.append(iterator)
+        return iterator
+
+    before_fds = (
+        len(os.listdir("/proc/self/fd")) if sys.platform.startswith("linux") else 0
+    )
+    monkeypatch.setattr(atomic_module.os, "scandir", interrupting_scandir)
+    reclaimer = atomic_module.QuiescentDirectoryReclaimer(
+        parent,
+        expected_parent_identity=parent_identity,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        reclaimer.snapshot_child_names()
+
+    assert caught.value is interruption
+    assert len(iterators) == 1
+    assert iterators[0].close_calls >= 2
+    assert iterators[0].closed
+    assert reclaimer.retry() is False
+    reclaimer.close()
+    if sys.platform.startswith("linux"):
+        assert len(os.listdir("/proc/self/fd")) <= before_fds
+
+
+def test_quiescent_reclaimer_retains_iterator_after_persistent_close_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent, parent_identity = _private_reclaimer_parent(tmp_path)
+    (parent / "attempt").mkdir()
+    before_fds = (
+        len(os.listdir("/proc/self/fd")) if sys.platform.startswith("linux") else 0
+    )
+    real_scope = atomic_module._run_quiescent_directory_resource_scope
+    real_close = atomic_module._ScandirIteratorCleanupOwner.close
+    iterator_owners: list[atomic_module._ScandirIteratorCleanupOwner] = []
+    close_failures: list[KeyboardInterrupt] = []
+    fail_close = True
+
+    def capture_scope(
+        resources: atomic_module._QuiescentDirectoryResourceOwner,
+        callback: object,
+        *,
+        label: str,
+    ) -> object:
+        if label == "quiescent directory snapshot iterator cleanup also failed":
+            assert isinstance(
+                resources,
+                atomic_module._ScandirIteratorCleanupOwner,
+            )
+            iterator_owners.append(resources)
+        return real_scope(resources, callback, label=label)
+
+    def interrupt_before_close(
+        owner: atomic_module._ScandirIteratorCleanupOwner,
+    ) -> None:
+        if iterator_owners and owner is iterator_owners[0] and fail_close:
+            failure = KeyboardInterrupt(
+                f"persistent snapshot iterator close {len(close_failures)}"
+            )
+            close_failures.append(failure)
+            raise failure
+        real_close(owner)
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_run_quiescent_directory_resource_scope",
+        capture_scope,
+    )
+    monkeypatch.setattr(
+        atomic_module._ScandirIteratorCleanupOwner,
+        "close",
+        interrupt_before_close,
+    )
+    reclaimer = atomic_module.QuiescentDirectoryReclaimer(
+        parent,
+        expected_parent_identity=parent_identity,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        reclaimer.snapshot_child_names()
+
+    assert len(iterator_owners) == 1
+    iterator_owner = iterator_owners[0]
+    assert iterator_owner._iterator is not None
+    assert not iterator_owner.closed
+    assert len(close_failures) > atomic_module._MAX_ORDERED_ACTION_CANCELLATION_RETRIES
+    top_owners = BaseException.__getattribute__(
+        caught.value,
+        "publication_cleanup_owners",
+    )
+    assert type(top_owners) is tuple
+    assert sum(owner is iterator_owner for owner in top_owners) == 1
+
+    fail_close = False
+    for owner in top_owners:
+        if not owner.closed:
+            owner.close()
+
+    assert iterator_owner.closed
+    _assert_quiescent_reclaimer_publicly_retryable(reclaimer)
+    reclaimer.close()
+    if sys.platform.startswith("linux"):
+        assert len(os.listdir("/proc/self/fd")) <= before_fds
+
+
+def test_quiescent_reclaimer_child_snapshot_rejects_recursive_entry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent, parent_identity = _private_reclaimer_parent(tmp_path)
+    (parent / "attempt").mkdir()
+    reclaimer = atomic_module.QuiescentDirectoryReclaimer(
+        parent,
+        expected_parent_identity=parent_identity,
+    )
+    real_scandir = atomic_module.os.scandir
+    nested_errors: list[BaseException] = []
+
+    def reenter(descriptor: int) -> object:
+        try:
+            reclaimer.snapshot_child_names()
+        except BaseException as error:  # noqa: B036 - inspect nested rejection
+            nested_errors.append(error)
+        return real_scandir(descriptor)
+
+    monkeypatch.setattr(atomic_module.os, "scandir", reenter)
+
+    assert reclaimer.snapshot_child_names() == ("attempt",)
+    assert len(nested_errors) == 1
+    assert isinstance(nested_errors[0], RuntimeError)
+    assert "lifecycle transition is already active" in str(nested_errors[0])
+    reclaimer.close()
+
+
+def test_quiescent_reclaimer_child_snapshot_serializes_threads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent, parent_identity = _private_reclaimer_parent(tmp_path)
+    (parent / "attempt").mkdir()
+    reclaimer = atomic_module.QuiescentDirectoryReclaimer(
+        parent,
+        expected_parent_identity=parent_identity,
+    )
+    entered = threading.Event()
+    release = threading.Event()
+    results: list[tuple[str, ...]] = []
+    failures: list[BaseException] = []
+    real_scandir = atomic_module.os.scandir
+
+    def blocked_scandir(descriptor: int) -> object:
+        entered.set()
+        assert release.wait(timeout=5)
+        return real_scandir(descriptor)
+
+    def snapshot_in_worker() -> None:
+        try:
+            results.append(reclaimer.snapshot_child_names())
+        except BaseException as error:  # noqa: B036 - report thread failure
+            failures.append(error)
+
+    monkeypatch.setattr(atomic_module.os, "scandir", blocked_scandir)
+    worker = threading.Thread(target=snapshot_in_worker)
+    worker.start()
+    assert entered.wait(timeout=5)
+    with pytest.raises(RuntimeError, match="lifecycle transition is already active"):
+        reclaimer.snapshot_child_names()
+    release.set()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert failures == []
+    assert results == [("attempt",)]
+    reclaimer.close()
+
+
+def test_quiescent_reclaimer_reclaims_quarantined_child_without_rename(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent, parent_identity = _private_reclaimer_parent(tmp_path)
+    quarantined = parent / ".attempt-a.discarded-0123456789abcdef"
+    _write_tree(quarantined, "payload.txt", "payload")
+    rename_calls = 0
+
+    def forbidden_rename(*_args: object, **_kwargs: object) -> None:
+        nonlocal rename_calls
+        rename_calls += 1
+        raise AssertionError("an already quarantined child must not be renamed")
+
+    monkeypatch.setattr(
+        atomic_module._PublicationAuthority,
+        "rename_noreplace",
+        forbidden_rename,
+    )
+
+    with atomic_module.QuiescentDirectoryReclaimer(
+        parent,
+        expected_parent_identity=parent_identity,
+    ) as reclaimer:
+        assert reclaimer.reclaim_quarantined_child(quarantined.name) is True
+        assert reclaimer.reclaim_quarantined_child(quarantined.name) is False
+
+    assert rename_calls == 0
+    assert list(parent.iterdir()) == []
+
+
+def test_quiescent_reclaimer_retries_quarantined_child_without_name_nesting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent, parent_identity = _private_reclaimer_parent(tmp_path)
+    quarantined = parent / ".attempt-a.discarded-0123456789abcdef"
+    _write_tree(quarantined, "payload.txt", "payload")
+    reclaimer = atomic_module.QuiescentDirectoryReclaimer(
+        parent,
+        expected_parent_identity=parent_identity,
+    )
+    real_unlink = atomic_module.os.unlink
+    interrupted = False
+
+    def interrupt_before_unlink(path: object, *, dir_fd: int | None = None) -> None:
+        nonlocal interrupted
+        if not interrupted:
+            interrupted = True
+            raise KeyboardInterrupt("quarantined unlink interruption")
+        real_unlink(path, dir_fd=dir_fd)
+
+    monkeypatch.setattr(atomic_module.os, "unlink", interrupt_before_unlink)
+
+    with pytest.raises(KeyboardInterrupt, match="quarantined unlink") as caught:
+        reclaimer.reclaim_quarantined_child(quarantined.name)
+    assert reclaimer in caught.value.publication_cleanup_owners
+    assert [path.name for path in parent.iterdir()] == [quarantined.name]
+    assert not list(parent.glob(f".{quarantined.name}.discarded-*"))
+
+    assert reclaimer.retry() is True
+    reclaimer.close()
+    assert list(parent.iterdir()) == []
+
+
+def test_quiescent_reclaimer_bounds_parent_before_quarantined_child_deletion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent, parent_identity = _private_reclaimer_parent(tmp_path)
+    quarantined = parent / ".attempt-a.discarded-0123456789abcdef"
+    _write_tree(quarantined, "payload.txt", "payload")
+    reclaimer = atomic_module.QuiescentDirectoryReclaimer(
+        parent,
+        expected_parent_identity=parent_identity,
+    )
+
+    class ParentPathTooLong(RuntimeError):
+        pass
+
+    def reject_parent_path(_value: object) -> bytes:
+        raise ParentPathTooLong("parent receipt path is too long")
+
+    def forbidden_removal(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("parent receipt validation must precede deletion")
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_bounded_directory_orphan_parent_path_bytes",
+        reject_parent_path,
+    )
+    monkeypatch.setattr(atomic_module.os, "unlink", forbidden_removal)
+    monkeypatch.setattr(atomic_module.os, "rmdir", forbidden_removal)
+
+    with pytest.raises(ParentPathTooLong):
+        reclaimer.reclaim_quarantined_child(quarantined.name)
+
+    assert (quarantined / "payload.txt").read_text(encoding="utf-8") == "payload"
+    assert reclaimer.retry() is False
+    reclaimer.close()
+
+
+def test_quiescent_reclaimer_rejects_non_directory_quarantined_child(
+    tmp_path: Path,
+) -> None:
+    parent, parent_identity = _private_reclaimer_parent(tmp_path)
+    ordinary_file = parent / ".attempt.discarded-file"
+    ordinary_file.write_text("preserve", encoding="utf-8")
+
+    with atomic_module.QuiescentDirectoryReclaimer(
+        parent,
+        expected_parent_identity=parent_identity,
+    ) as reclaimer:
+        with pytest.raises(ValueError, match="not a directory or is a link"):
+            reclaimer.reclaim_quarantined_child(ordinary_file.name)
+        assert reclaimer.reclaim_quarantined_child("missing") is False
+
+    assert ordinary_file.read_text(encoding="utf-8") == "preserve"
+
+
 def test_quiescent_reclaimer_reclaims_authenticated_orphan_idempotently(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Add the generic descriptor-bound primitives needed for a later quiescent BM25 attempt-pool coordinator: bounded child discovery and direct reclamation of already-quarantined children. This PR intentionally adds no BM25 name policy, CLI wiring, publication authority, or cross-process lease.

## Changes

- Add `snapshot_child_names()` to return a deterministic byte-sorted, point-in-time tuple from the retained parent descriptor.
- Enumerate incrementally through `scandir`, stop at the fixed child limit plus one, and retain exact iterator cleanup authority across interruption.
- Add `reclaim_quarantined_child()` to freshly capture and remove an exact caller-authorized quarantined child without adding another discard-name layer.
- Preflight bounded canonical parent receipt bytes before direct child lookup or deletion, then reuse the existing descriptor-bound retry and synchronization state machine.
- Add cross-version boundedness, lifecycle, topology, FD cleanup, retry, and pre-mutation regression coverage.
- Update the storage roadmap while keeping BM25 classification, worker quiescence, CLI coordination, and cross-process leasing pending.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- New discovery/direct-cleanup slice: 11 passed on Python 3.10, 3.12, and 3.14.
- Complete quiescent reclaimer slice: 158 passed on each supported interpreter.
- Full atomic-directory suite: 497 passed and 10 skipped on each supported interpreter.
- Persistent iterator-close retry-budget kill replay: passed on each supported interpreter.
- Black, isort, flake8 with bugbear, py_compile on all three interpreters, namespace checks, and git diff checks passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published