### PR TITLE
feat(web): retry current-result reconciliation

### DIFF
--- a/codenib/web/index_job_activation.py
+++ b/codenib/web/index_job_activation.py
@@ -87,6 +87,26 @@ class IndexJobRuntimeActivation:
         return self.snapshot_id, self.ref_generation
 
 
+class IndexJobReconciliationPassError(IndexJobActivationError):
+    """Report one failed pass together with its completed activation count."""
+
+    def __init__(
+        self,
+        failure: IndexJobActivationError,
+        *,
+        completed_activation_count: int,
+    ) -> None:
+        if type(failure) is not IndexJobActivationError:
+            raise TypeError("reconciliation pass failure must use the exact type")
+        if (
+            type(completed_activation_count) is not int
+            or not 0 <= completed_activation_count <= _CATALOG_INT64_MAX
+        ):
+            raise ValueError("completed activation count is invalid")
+        super().__init__(*failure.args)
+        self.completed_activation_count = completed_activation_count
+
+
 @runtime_checkable
 class IndexJobRuntimePublisher(Protocol):
     """Publish one exact snapshot with idempotent, monotonic retry semantics.
@@ -454,7 +474,10 @@ class CatalogIndexJobRuntimeReconciler:
                 if value is not None:
                     reconciled.append(value)
         if first_failure is not None:
-            raise first_failure
+            raise IndexJobReconciliationPassError(
+                first_failure,
+                completed_activation_count=len(reconciled),
+            ) from first_failure
         return tuple(reconciled)
 
     def on_worker_result(
@@ -493,6 +516,7 @@ class CatalogIndexJobRuntimeReconciler:
 __all__ = [
     "CatalogIndexJobRuntimeReconciler",
     "IndexJobActivationError",
+    "IndexJobReconciliationPassError",
     "IndexJobRuntimeActivation",
     "IndexJobRuntimePublisher",
 ]

--- a/codenib/web/index_job_runtime.py
+++ b/codenib/web/index_job_runtime.py
@@ -11,7 +11,11 @@ from threading import Lock
 from typing import Callable, Protocol, runtime_checkable
 
 from ..storage import IndexJobSchedulerStopSignal
-from .index_job_activation import IndexJobActivationError, IndexJobRuntimeActivation
+from .index_job_activation import (
+    IndexJobActivationError,
+    IndexJobReconciliationPassError,
+    IndexJobRuntimeActivation,
+)
 
 _MAX_LOOP_COUNT = 2**63 - 1
 _MAX_POLL_INTERVAL_MS = 86_400_000
@@ -23,10 +27,14 @@ def _positive_integer(value: object, label: str, *, maximum: int) -> int:
     return value
 
 
-def _increment(value: int, label: str) -> int:
-    if value >= _MAX_LOOP_COUNT:
+def _add_count(value: int, amount: int, label: str) -> int:
+    if type(amount) is not int or amount < 0 or amount > _MAX_LOOP_COUNT - value:
         raise IndexJobActivationError(f"{label} exhausted")
-    return value + 1
+    return value + amount
+
+
+def _increment(value: int, label: str) -> int:
+    return _add_count(value, 1, label)
 
 
 @runtime_checkable
@@ -178,6 +186,12 @@ class IndexJobRuntimeReconciliationLoop:
             try:
                 returned = self._reconciler.reconcile_all()
             except IndexJobActivationError as failure:
+                if type(failure) is IndexJobReconciliationPassError:
+                    activation_count = _add_count(
+                        activation_count,
+                        failure.completed_activation_count,
+                        "runtime activation count",
+                    )
                 failure_count = _increment(
                     failure_count,
                     "runtime reconciliation failure count",

--- a/codenib/web/index_job_runtime.py
+++ b/codenib/web/index_job_runtime.py
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Retrying runtime reconciliation loop for durable Web index results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import Lock
+from typing import Callable, Protocol, runtime_checkable
+
+from ..storage import IndexJobSchedulerStopSignal
+from .index_job_activation import IndexJobActivationError, IndexJobRuntimeActivation
+
+_MAX_LOOP_COUNT = 2**63 - 1
+_MAX_POLL_INTERVAL_MS = 86_400_000
+
+
+def _positive_integer(value: object, label: str, *, maximum: int) -> int:
+    if type(value) is not int or not 1 <= value <= maximum:
+        raise ValueError(f"{label} must be an exact integer between 1 and {maximum}")
+    return value
+
+
+def _increment(value: int, label: str) -> int:
+    if value >= _MAX_LOOP_COUNT:
+        raise IndexJobActivationError(f"{label} exhausted")
+    return value + 1
+
+
+@runtime_checkable
+class IndexJobRuntimeReconciler(Protocol):
+    """Reconcile every configured durable current result into Web runtime."""
+
+    def reconcile_all(self) -> tuple[IndexJobRuntimeActivation, ...]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class IndexJobRuntimeLoopSummary:
+    """Bounded reconciliation counters after cooperative loop shutdown."""
+
+    pass_count: int
+    failure_count: int
+    activation_count: int
+
+    def __post_init__(self) -> None:
+        if type(self) is not IndexJobRuntimeLoopSummary:
+            raise TypeError("runtime loop summary must use the exact type")
+        for value, label in (
+            (self.pass_count, "runtime reconciliation pass count"),
+            (self.failure_count, "runtime reconciliation failure count"),
+            (self.activation_count, "runtime activation count"),
+        ):
+            if type(value) is not int or not 0 <= value <= _MAX_LOOP_COUNT:
+                raise ValueError(f"{label} must be a non-negative integer")
+        if self.failure_count > self.pass_count:
+            raise ValueError("runtime reconciliation failures exceed passes")
+
+
+class IndexJobRuntimeReconciliationLoop:
+    """Poll durable current results and retry sanitized activation failures."""
+
+    def __init__(
+        self,
+        reconciler: IndexJobRuntimeReconciler,
+        *,
+        poll_interval_ms: int = 1_000,
+        on_failure: Callable[[IndexJobActivationError], None] | None = None,
+    ) -> None:
+        if not isinstance(reconciler, IndexJobRuntimeReconciler):
+            raise TypeError("runtime loop requires a current-result reconciler")
+        interval = _positive_integer(
+            poll_interval_ms,
+            "runtime reconciliation poll interval",
+            maximum=_MAX_POLL_INTERVAL_MS,
+        )
+        if on_failure is not None and not callable(on_failure):
+            raise TypeError("runtime reconciliation failure callback must be callable")
+        self._reconciler = reconciler
+        self._poll_interval_ms = interval
+        self._on_failure = on_failure
+        self._run_lock = Lock()
+
+    @staticmethod
+    def _is_stopped(stop_signal: IndexJobSchedulerStopSignal) -> bool:
+        try:
+            stopped = stop_signal.is_set()
+        except Exception as exc:
+            raise IndexJobActivationError(
+                "runtime reconciliation stop-state check failed"
+            ) from exc
+        if type(stopped) is not bool:
+            raise IndexJobActivationError(
+                "runtime reconciliation stop-state check returned an invalid result"
+            )
+        return stopped
+
+    @staticmethod
+    def _wait_for_stop(
+        stop_signal: IndexJobSchedulerStopSignal,
+        timeout: float,
+    ) -> bool:
+        try:
+            stopped = stop_signal.wait(timeout)
+        except Exception as exc:
+            raise IndexJobActivationError(
+                "runtime reconciliation stop wait failed"
+            ) from exc
+        if type(stopped) is not bool:
+            raise IndexJobActivationError(
+                "runtime reconciliation stop wait returned an invalid result"
+            )
+        return stopped
+
+    @staticmethod
+    def _attest_activations(
+        value: object,
+    ) -> tuple[IndexJobRuntimeActivation, ...]:
+        if type(value) is not tuple or any(
+            type(item) is not IndexJobRuntimeActivation for item in value
+        ):
+            raise IndexJobActivationError(
+                "runtime reconciler returned invalid activations"
+            )
+        return value
+
+    def _report_failure(self, failure: IndexJobActivationError) -> None:
+        callback = self._on_failure
+        if callback is None:
+            return
+        try:
+            result = callback(failure)
+        except Exception as exc:
+            raise IndexJobActivationError(
+                "runtime reconciliation failure callback failed"
+            ) from exc
+        if result is not None:
+            raise IndexJobActivationError(
+                "runtime reconciliation failure callback returned a value"
+            )
+
+    def run(
+        self,
+        stop_signal: IndexJobSchedulerStopSignal,
+        *,
+        max_passes: int | None = None,
+    ) -> IndexJobRuntimeLoopSummary:
+        """Run immediate and periodic reconciliation until cooperatively stopped."""
+
+        if not isinstance(stop_signal, IndexJobSchedulerStopSignal):
+            raise TypeError("runtime loop stop signal is invalid")
+        pass_limit = (
+            None
+            if max_passes is None
+            else _positive_integer(
+                max_passes,
+                "runtime reconciliation pass limit",
+                maximum=_MAX_LOOP_COUNT,
+            )
+        )
+        if not self._run_lock.acquire(blocking=False):
+            raise RuntimeError("runtime reconciliation loop is already running")
+        try:
+            return self._run_locked(stop_signal, pass_limit)
+        finally:
+            self._run_lock.release()
+
+    def _run_locked(
+        self,
+        stop_signal: IndexJobSchedulerStopSignal,
+        pass_limit: int | None,
+    ) -> IndexJobRuntimeLoopSummary:
+        pass_count = 0
+        failure_count = 0
+        activation_count = 0
+        while not self._is_stopped(stop_signal):
+            try:
+                returned = self._reconciler.reconcile_all()
+            except IndexJobActivationError as failure:
+                failure_count = _increment(
+                    failure_count,
+                    "runtime reconciliation failure count",
+                )
+                self._report_failure(failure)
+            else:
+                activations = self._attest_activations(returned)
+                for _activation in activations:
+                    activation_count = _increment(
+                        activation_count,
+                        "runtime activation count",
+                    )
+            pass_count = _increment(pass_count, "runtime reconciliation pass count")
+            if pass_limit is not None and pass_count >= pass_limit:
+                break
+            if self._wait_for_stop(
+                stop_signal,
+                self._poll_interval_ms / 1_000.0,
+            ):
+                break
+        return IndexJobRuntimeLoopSummary(
+            pass_count=pass_count,
+            failure_count=failure_count,
+            activation_count=activation_count,
+        )
+
+
+__all__ = [
+    "IndexJobRuntimeLoopSummary",
+    "IndexJobRuntimeReconciler",
+    "IndexJobRuntimeReconciliationLoop",
+]

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1638,7 +1638,12 @@ success-triggered refresh, MCP, UI controls, and default routing remain absent.
   writer-fenced transfer. Reconciliation re-attests even an already reported
   fence, so removal or reload cannot leave a permanent false success. Newer
   incumbents and conflicting equal generations are rejected before
-  materialization. The production server loop remains a separate gate.
+  materialization. The production runtime's cooperative polling loop reconciles
+  once immediately, retries sanitized transient activation failures, and
+  periodically replays current durable results with exact return and stop-signal
+  validation.
+  Server lifespan ownership and explicit local storage configuration remain
+  separate gates.
 - An explicitly injected Web reader can now project authorized durable jobs and
   at most 64 events without exposing worker owner IDs, fencing tokens, or raw
   executor errors or event keys. Each event is rebound to the exact job, a

--- a/test/web/test_index_job_activation.py
+++ b/test/web/test_index_job_activation.py
@@ -23,6 +23,7 @@ from codenib.web.config import QAConfig
 from codenib.web.index_job_activation import (
     CatalogIndexJobRuntimeReconciler,
     IndexJobActivationError,
+    IndexJobReconciliationPassError,
     IndexJobRuntimeActivation,
 )
 from codenib.web.index_jobs import IndexJobRepoBinding
@@ -490,16 +491,20 @@ def test_reconcile_all_does_not_starve_later_repositories_after_failure() -> Non
         publisher,
     )
 
-    with pytest.raises(IndexJobActivationError, match="publication failed") as error:
+    with pytest.raises(
+        IndexJobReconciliationPassError,
+        match="publication failed",
+    ) as error:
         reconciler.reconcile_all()
 
     assert "private" not in str(error.value)
+    assert error.value.completed_activation_count == 1
     assert [binding.repo_id for binding, _activation in publisher.calls] == [
         "alpha",
         "beta",
     ]
 
-    with pytest.raises(IndexJobActivationError, match="publication failed"):
+    with pytest.raises(IndexJobReconciliationPassError, match="publication failed"):
         reconciler.reconcile_all()
     assert [binding.repo_id for binding, _activation in publisher.calls] == [
         "alpha",

--- a/test/web/test_index_job_runtime.py
+++ b/test/web/test_index_job_runtime.py
@@ -10,6 +10,7 @@ import pytest
 
 from codenib.web.index_job_activation import (
     IndexJobActivationError,
+    IndexJobReconciliationPassError,
     IndexJobRuntimeActivation,
 )
 from codenib.web.index_job_runtime import (
@@ -92,6 +93,27 @@ def test_runtime_loop_retries_sanitized_activation_failures() -> None:
     assert loop.run(stop) == IndexJobRuntimeLoopSummary(2, 1, 1)
     assert failures == [failure]
     assert stop.waits == [0.1, 0.1]
+
+
+def test_runtime_loop_counts_activations_completed_during_failed_pass() -> None:
+    failure = IndexJobActivationError("durable current result unavailable")
+
+    class Reconciler:
+        def reconcile_all(self):
+            raise IndexJobReconciliationPassError(
+                failure,
+                completed_activation_count=2,
+            )
+
+    failures = []
+    loop = IndexJobRuntimeReconciliationLoop(
+        Reconciler(),
+        on_failure=failures.append,
+    )
+
+    assert loop.run(Event(), max_passes=1) == IndexJobRuntimeLoopSummary(1, 1, 2)
+    assert len(failures) == 1
+    assert type(failures[0]) is IndexJobReconciliationPassError
 
 
 def test_runtime_loop_stops_before_catalog_access() -> None:

--- a/test/web/test_index_job_runtime.py
+++ b/test/web/test_index_job_runtime.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from threading import Barrier, Event, Thread
+
+import pytest
+
+from codenib.web.index_job_activation import (
+    IndexJobActivationError,
+    IndexJobRuntimeActivation,
+)
+from codenib.web.index_job_runtime import (
+    IndexJobRuntimeLoopSummary,
+    IndexJobRuntimeReconciliationLoop,
+)
+
+
+def _activation(generation: int) -> IndexJobRuntimeActivation:
+    return IndexJobRuntimeActivation(
+        repo_id="demo",
+        repository_id="repo_" + "a" * 64,
+        ref_name="main",
+        job_id="job_" + chr(ord("a") + generation) * 64,
+        attempt_count=1,
+        snapshot_id="snapshot_" + chr(ord("d") + generation) * 64,
+        ref_generation=generation,
+        ref_updated_at=f"2026-08-27T00:00:0{generation}+00:00",
+        finished_at_ms=generation,
+    )
+
+
+class _StopSignal:
+    def __init__(self, *, stop_after_waits: int) -> None:
+        self.stop_after_waits = stop_after_waits
+        self.waits: list[float | None] = []
+
+    def is_set(self) -> bool:
+        return False
+
+    def wait(self, timeout: float | None = None) -> bool:
+        self.waits.append(timeout)
+        return len(self.waits) >= self.stop_after_waits
+
+
+def test_runtime_loop_reconciles_immediately_and_periodically() -> None:
+    class Reconciler:
+        calls = 0
+
+        def reconcile_all(self):
+            self.calls += 1
+            return (_activation(self.calls),)
+
+    reconciler = Reconciler()
+    stop = _StopSignal(stop_after_waits=2)
+    loop = IndexJobRuntimeReconciliationLoop(
+        reconciler,
+        poll_interval_ms=250,
+    )
+
+    assert loop.run(stop) == IndexJobRuntimeLoopSummary(
+        pass_count=2,
+        failure_count=0,
+        activation_count=2,
+    )
+    assert reconciler.calls == 2
+    assert stop.waits == [0.25, 0.25]
+
+
+def test_runtime_loop_retries_sanitized_activation_failures() -> None:
+    failure = IndexJobActivationError("durable current result unavailable")
+
+    class Reconciler:
+        calls = 0
+
+        def reconcile_all(self):
+            self.calls += 1
+            if self.calls == 1:
+                raise failure
+            return (_activation(1),)
+
+    failures = []
+    stop = _StopSignal(stop_after_waits=2)
+    loop = IndexJobRuntimeReconciliationLoop(
+        Reconciler(),
+        poll_interval_ms=100,
+        on_failure=failures.append,
+    )
+
+    assert loop.run(stop) == IndexJobRuntimeLoopSummary(2, 1, 1)
+    assert failures == [failure]
+    assert stop.waits == [0.1, 0.1]
+
+
+def test_runtime_loop_stops_before_catalog_access() -> None:
+    class Reconciler:
+        def reconcile_all(self):
+            pytest.fail("stopped runtime loop reached the catalog")
+
+    stop = Event()
+    stop.set()
+
+    assert IndexJobRuntimeReconciliationLoop(Reconciler()).run(stop) == (
+        IndexJobRuntimeLoopSummary(0, 0, 0)
+    )
+
+
+@pytest.mark.parametrize("returned", (None, [], (object(),)))
+def test_runtime_loop_rejects_invalid_reconciler_results(returned) -> None:
+    class Reconciler:
+        def reconcile_all(self):
+            return returned
+
+    with pytest.raises(IndexJobActivationError, match="invalid activations"):
+        IndexJobRuntimeReconciliationLoop(Reconciler()).run(
+            Event(),
+            max_passes=1,
+        )
+
+
+def test_runtime_loop_rejects_concurrent_runs() -> None:
+    entered = Barrier(2)
+    release = Event()
+
+    class Reconciler:
+        def reconcile_all(self):
+            entered.wait()
+            release.wait()
+            return ()
+
+    loop = IndexJobRuntimeReconciliationLoop(Reconciler())
+    errors = []
+
+    def run() -> None:
+        try:
+            loop.run(Event(), max_passes=1)
+        except BaseException as exc:  # noqa: B036 - asserted by the test
+            errors.append(exc)
+
+    thread = Thread(target=run)
+    thread.start()
+    entered.wait()
+    try:
+        with pytest.raises(RuntimeError, match="already running"):
+            loop.run(Event(), max_passes=1)
+    finally:
+        release.set()
+        thread.join()
+    assert errors == []


### PR DESCRIPTION
## Summary
Add the production-quality cooperative loop that immediately and periodically reconciles configured durable current results into the Web runtime. Sanitized activation failures are reported and retried without weakening exact return, stop-signal, or single-run contracts. Server lifespan ownership and storage configuration remain a separate explicit gate.

## Changes
- add a runtime reconciler protocol and exact bounded loop summary
- reconcile immediately, then poll cooperatively until stopped or a bounded pass limit is reached
- retry only sanitized `IndexJobActivationError` failures through an optional no-return callback
- preserve bounded activation counts when one repository succeeds during a partially failed pass
- reject malformed reconciliation outputs, stop decisions, wait results, callbacks, intervals, and pass limits
- serialize ownership so one loop instance cannot run concurrently
- document the runtime retry boundary and the remaining lifespan/configuration gate in the storage roadmap

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- latest-main retained context, registry, activation, and runtime-loop files (`283 passed`)
- latest-main non-slow/non-integration tier with the three documented local baselines excluded (`8803 passed, 35 skipped, 193 deselected`)
- relevant pre-commit hooks

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
