### PR TITLE
feat(storage): coordinate quiescent BM25 cleanup

### DIFF
--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -3881,7 +3881,17 @@ def _run_with_local_index_job_worker(args: argparse.Namespace, operation):
 
     if not callable(operation):
         raise TypeError("local index job worker operation must be callable")
-    if bool(getattr(args, "source_bm25", False)):
+    source_bm25 = bool(getattr(args, "source_bm25", False))
+    reclaim_quiescent_attempts = getattr(
+        args,
+        "reclaim_quiescent_attempts",
+        False,
+    )
+    if type(reclaim_quiescent_attempts) is not bool:
+        raise CLIError("--reclaim-quiescent-attempts state must be an exact boolean")
+    if reclaim_quiescent_attempts and not source_bm25:
+        raise CLIError("--reclaim-quiescent-attempts requires --source-bm25")
+    if source_bm25:
         if getattr(args, "cache_dir", None) is not None:
             raise CLIError("--cache-dir cannot be combined with --source-bm25")
         return _run_with_local_bm25_source_job_worker(args, operation)
@@ -3984,6 +3994,44 @@ def _run_with_local_compiler_cache_job_worker(
             _inherit_publication_cleanup_owners(wrapped, primary_error)
             raise wrapped from primary_error
         raise
+
+
+def _reclaim_local_bm25_source_attempt_pool(target) -> None:
+    """Run one count-only explicit-quiescent sweep and report it on stderr."""
+
+    from .compiler.job_resources import LocalBM25AttemptPoolCoordinator
+
+    reclamation = LocalBM25AttemptPoolCoordinator(target).reclaim(
+        caller_asserts_quiescence=True,
+    )
+    print(
+        "BM25 attempt-pool reclamation: "
+        f"scanned={reclamation.scanned_children} "
+        f"reclaimed={reclamation.reclaimed_children} "
+        f"current={reclamation.current_children} "
+        f"legacy={reclamation.legacy_children} "
+        f"discarded={reclamation.discarded_children} "
+        f"retained={reclamation.retained_unrelated_children}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def _run_local_bm25_source_worker_operation(
+    args: argparse.Namespace,
+    operation,
+    worker,
+    target,
+    topology_verifier: Callable[[], None],
+):
+    """Run once, then optionally sweep only after worker resources settle."""
+
+    result = operation(worker)
+    topology_verifier()
+    if getattr(args, "reclaim_quiescent_attempts", False):
+        _reclaim_local_bm25_source_attempt_pool(target)
+        topology_verifier()
+    return result
 
 
 def _run_with_local_bm25_source_job_worker(
@@ -4114,8 +4162,13 @@ def _run_with_local_bm25_source_job_worker(
                 ),
             )
             topology.verify()
-            result = operation(worker)
-            topology.verify()
+            result = _run_local_bm25_source_worker_operation(
+                args,
+                operation,
+                worker,
+                target,
+                topology.verify,
+            )
         if result is missing_result:  # pragma: no cover - callback always returns
             raise RuntimeError("index job worker operation returned no result")
         return result
@@ -6027,6 +6080,14 @@ def _add_jobs_worker_arguments(parser: argparse.ArgumentParser) -> None:
         "--source-bm25",
         action="store_true",
         help="build matching FULL BM25 jobs directly from retained source",
+    )
+    parser.add_argument(
+        "--reclaim-quiescent-attempts",
+        action="store_true",
+        help=(
+            "after a successful source-worker run, reclaim recognized stale "
+            "attempts while asserting that no other process can enter the pool"
+        ),
     )
     parser.add_argument(
         "--language",

--- a/codenib/compiler/__init__.py
+++ b/codenib/compiler/__init__.py
@@ -56,6 +56,8 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
         CompilerCacheJobResourceScope,
     )
     from codenib.compiler.job_resources import (
+        BM25AttemptPoolReclamation,
+        LocalBM25AttemptPoolCoordinator,
         LocalBM25SourceJobResourceFactory,
         LocalBM25SourceJobTarget,
         LocalCompilerCacheJobResourceFactory,
@@ -105,6 +107,10 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
     )
 
 _EXPORTS = {
+    "BM25AttemptPoolReclamation": (
+        "codenib.compiler.job_resources",
+        "BM25AttemptPoolReclamation",
+    ),
     "BM25SourceJobResolver": (
         "codenib.compiler.job_resolver",
         "BM25SourceJobResolver",
@@ -204,6 +210,10 @@ _EXPORTS = {
     "LocalCompilerCacheJobTarget": (
         "codenib.compiler.job_resources",
         "LocalCompilerCacheJobTarget",
+    ),
+    "LocalBM25AttemptPoolCoordinator": (
+        "codenib.compiler.job_resources",
+        "LocalBM25AttemptPoolCoordinator",
     ),
     "LocalBM25SourceJobResourceFactory": (
         "codenib.compiler.job_resources",
@@ -319,6 +329,7 @@ _EXPORTS = {
 }
 
 __all__ = [
+    "BM25AttemptPoolReclamation",
     "BM25SourceJobResolver",
     "BM25SourceJobResourceFactory",
     "BM25SourceJobResourceScope",
@@ -333,6 +344,7 @@ __all__ = [
     "CompilerCacheJobResourceScope",
     "LocalCompilerCacheJobResourceFactory",
     "LocalCompilerCacheJobTarget",
+    "LocalBM25AttemptPoolCoordinator",
     "LocalBM25SourceJobResourceFactory",
     "LocalBM25SourceJobTarget",
     "CompilerCacheMultiViewImportResult",

--- a/codenib/compiler/job_resources.py
+++ b/codenib/compiler/job_resources.py
@@ -7,6 +7,8 @@
 from __future__ import annotations
 
 import logging
+import os
+import re
 import secrets
 from contextlib import contextmanager
 from dataclasses import InitVar, dataclass, field
@@ -16,8 +18,10 @@ from typing import Callable, Iterator, Mapping
 
 from .._atomic_directory import (
     DirectoryOrphan,
+    QuiescentDirectoryReclaimer,
     _attach_publication_cleanup_owner,
     _OrderedAction,
+    _run_callback_with_post_validations,
     _run_context_with_cleanup_actions,
     directory_ownership_root_identity,
     discard_owned_directory,
@@ -76,6 +80,91 @@ logger = logging.getLogger(__name__)
 _MAX_LOCAL_TARGETS = 4_096
 _NONCE_BYTES = 16
 _SUPPORTED_CACHE_VIEWS = frozenset({"bm25", "vector"})
+_BM25_ATTEMPT_NONCE = rb"[0-9a-f]{32}"
+_BM25_STAGE_NONCE = rb"[0-9a-f]{24}"
+_BM25_ATTEMPT_ROLE = rb"(?:attempt|bm25|context)"
+_BM25_ATTEMPT_POOL_PATTERNS = (
+    (
+        re.compile(
+            rb"\.codenib-source-job-"
+            + _BM25_ATTEMPT_NONCE
+            + rb"\.normalize-"
+            + _BM25_STAGE_NONCE
+            + rb"\Z"
+        ),
+        "current",
+        False,
+    ),
+    (
+        re.compile(
+            rb"\.\.codenib-source-job-"
+            + _BM25_ATTEMPT_NONCE
+            + rb"\.normalize-"
+            + _BM25_STAGE_NONCE
+            + rb"\.discarded-"
+            + _BM25_ATTEMPT_NONCE
+            + rb"\Z"
+        ),
+        "current",
+        True,
+    ),
+    (
+        re.compile(
+            rb"\.codenib-source-job-"
+            + _BM25_ATTEMPT_NONCE
+            + rb"-"
+            + _BM25_ATTEMPT_ROLE
+            + rb"\Z"
+        ),
+        "legacy",
+        False,
+    ),
+    (
+        re.compile(
+            rb"\.\.codenib-source-job-"
+            + _BM25_ATTEMPT_NONCE
+            + rb"-"
+            + _BM25_ATTEMPT_ROLE
+            + rb"\.normalize-"
+            + _BM25_STAGE_NONCE
+            + rb"\Z"
+        ),
+        "legacy",
+        False,
+    ),
+    (
+        re.compile(
+            rb"\.\.codenib-source-job-"
+            + _BM25_ATTEMPT_NONCE
+            + rb"-"
+            + _BM25_ATTEMPT_ROLE
+            + rb"\.discarded-"
+            + _BM25_ATTEMPT_NONCE
+            + rb"\Z"
+        ),
+        "legacy",
+        True,
+    ),
+    (
+        re.compile(
+            rb"\.\.\.codenib-source-job-"
+            + _BM25_ATTEMPT_NONCE
+            + rb"-"
+            + _BM25_ATTEMPT_ROLE
+            + rb"\.normalize-"
+            + _BM25_STAGE_NONCE
+            + rb"\.discarded-"
+            + _BM25_ATTEMPT_NONCE
+            + rb"\Z"
+        ),
+        "legacy",
+        True,
+    ),
+)
+_BM25_ATTEMPT_POOL_RESERVED_PREFIXES = (
+    b"codenib-source-job-",
+    b"codenib-discarded-",
+)
 
 
 def _paths_overlap(first: Path, second: Path) -> bool:
@@ -406,6 +495,12 @@ class LocalBM25SourceJobTarget:
         return self.workspace_provider.allowed_root
 
     @property
+    def attempt_pool_identity(self) -> tuple[int, ...] | None:
+        """Return the retained identity for the source-job attempt parent."""
+
+        return self.workspace_parent_identity
+
+    @property
     def profile_id(self) -> str:
         return self._profile_id
 
@@ -491,6 +586,174 @@ class LocalBM25SourceJobTarget:
             orphan.entries,
             orphan.byte_count,
             orphan.verified_at_isolation,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _BM25AttemptPoolChild:
+    """One exact, policy-recognized source-job attempt child."""
+
+    lineage: str
+    discarded: bool
+
+
+def _classify_bm25_attempt_pool_child_name(
+    name: str,
+) -> _BM25AttemptPoolChild | None:
+    """Classify one bounded snapshot name without granting broad discovery."""
+
+    if type(name) is not str:
+        raise TypeError("BM25 attempt-pool child name must be exact text")
+    raw_name = os.fsencode(name)
+    for pattern, lineage, discarded in _BM25_ATTEMPT_POOL_PATTERNS:
+        if pattern.fullmatch(raw_name) is not None:
+            return _BM25AttemptPoolChild(
+                lineage=lineage,
+                discarded=discarded,
+            )
+    reserved = raw_name.lstrip(b".").lower()
+    if reserved.startswith(_BM25_ATTEMPT_POOL_RESERVED_PREFIXES):
+        raise StorageValidationError(
+            "BM25 attempt pool contains an unrecognized reserved child"
+        )
+    return None
+
+
+@dataclass(frozen=True, slots=True)
+class BM25AttemptPoolReclamation:
+    """Bounded count-only result from one explicit-quiescent attempt sweep."""
+
+    scanned_children: int
+    reclaimed_children: int
+    current_children: int
+    legacy_children: int
+    discarded_children: int
+    retained_unrelated_children: int
+
+
+@dataclass(frozen=True, slots=True)
+class LocalBM25AttemptPoolCoordinator:
+    """Apply exact BM25 name policy under a caller-asserted quiescent boundary."""
+
+    target: LocalBM25SourceJobTarget
+
+    def __post_init__(self) -> None:
+        if type(self) is not LocalBM25AttemptPoolCoordinator:
+            raise TypeError("local BM25 attempt-pool coordinator must use exact type")
+        if type(self.target) is not LocalBM25SourceJobTarget:
+            raise TypeError(
+                "local BM25 attempt-pool coordinator requires an exact target"
+            )
+
+    def _require_target(self) -> tuple[Path, tuple[int, ...]]:
+        target = self.target
+        if target.topology_verifier is None:
+            raise StorageValidationError(
+                "BM25 attempt-pool reclamation requires retained topology"
+            )
+        attempt_pool_root = target.attempt_pool_root
+        if attempt_pool_root != target.workspace_root:
+            raise StorageValidationError(
+                "BM25 attempt-pool reclamation target changed its workspace root"
+            )
+        identity = target.attempt_pool_identity
+        if (
+            type(identity) is not tuple
+            or len(identity) != 4
+            or any(type(value) is not int for value in identity)
+        ):
+            raise StorageValidationError(
+                "BM25 attempt-pool reclamation requires an exact parent identity"
+            )
+        return attempt_pool_root, identity
+
+    def reclaim(
+        self,
+        *,
+        caller_asserts_quiescence: bool = False,
+    ) -> BM25AttemptPoolReclamation:
+        """Reclaim recognized stale attempts after an exact caller assertion."""
+
+        if type(caller_asserts_quiescence) is not bool:
+            raise TypeError("BM25 attempt-pool quiescence assertion must be exact bool")
+        if caller_asserts_quiescence is not True:
+            raise StorageValidationError(
+                "BM25 attempt-pool reclamation requires caller-asserted quiescence"
+            )
+        attempt_pool_root, identity = self._require_target()
+        target = self.target
+
+        def run_with_topology(label: str, callback):
+            target.verify_topology()
+            return _run_callback_with_post_validations(
+                callback,
+                (
+                    (
+                        f"BM25 attempt-pool {label} topology validation also failed",
+                        target.verify_topology,
+                    ),
+                ),
+            )
+
+        def sweep() -> BM25AttemptPoolReclamation:
+            with QuiescentDirectoryReclaimer(
+                attempt_pool_root,
+                expected_parent_identity=identity,
+            ) as reclaimer:
+                child_names = run_with_topology(
+                    "snapshot",
+                    reclaimer.snapshot_child_names,
+                )
+
+                classified = tuple(
+                    (name, _classify_bm25_attempt_pool_child_name(name))
+                    for name in child_names
+                )
+                candidates = tuple(
+                    (name, child) for name, child in classified if child is not None
+                )
+                retained = tuple(name for name, child in classified if child is None)
+
+                for name, child in candidates:
+                    if child.discarded:
+                        reclaim = reclaimer.reclaim_quarantined_child
+                    else:
+                        reclaim = reclaimer.reclaim_child
+                    reclaimed = run_with_topology(
+                        "child reclamation",
+                        lambda name=name, reclaim=reclaim: reclaim(name),
+                    )
+                    if reclaimed is not True:
+                        raise StorageIntegrityError(
+                            "BM25 attempt-pool child disappeared despite quiescence"
+                        )
+
+                final_names = run_with_topology(
+                    "final snapshot",
+                    reclaimer.snapshot_child_names,
+                )
+                if final_names != retained:
+                    raise StorageIntegrityError(
+                        "BM25 attempt pool changed during quiescent reclamation"
+                    )
+
+            current_children = sum(
+                child.lineage == "current" for _name, child in candidates
+            )
+            legacy_children = len(candidates) - current_children
+            discarded_children = sum(child.discarded for _name, child in candidates)
+            return BM25AttemptPoolReclamation(
+                scanned_children=len(child_names),
+                reclaimed_children=len(candidates),
+                current_children=current_children,
+                legacy_children=legacy_children,
+                discarded_children=discarded_children,
+                retained_unrelated_children=len(retained),
+            )
+
+        return run_with_topology(
+            "reclaimer lifetime",
+            sweep,
         )
 
 
@@ -1184,6 +1447,8 @@ class LocalBM25SourceJobResourceFactory:
 
 
 __all__ = [
+    "BM25AttemptPoolReclamation",
+    "LocalBM25AttemptPoolCoordinator",
     "LocalBM25SourceJobResourceFactory",
     "LocalBM25SourceJobTarget",
     "LocalCompilerCacheJobResourceFactory",

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1289,8 +1289,9 @@ separately supplied full Git SHA remains display provenance only. The returned
 `IndexJobExecutionResult` carries no catalog, lease, fencing, ref, or final
 generation publication authority; the worker remains the sole publisher and
 the caller retains cleanup ownership for every attempt. Source-job resource
-factory, resolver, and production CLI wiring are described below; Web binding,
-vector source building, and graph source building remain absent.
+factory, resolver, production CLI wiring, and the explicit injected Web planner
+are described below; default Web installation, vector source building, and
+graph source building remain absent.
 
 A general caller-owned path-build directory now supplies a retained attempt
 boundary for arbitrary path writers and the implemented source-job resource
@@ -1366,12 +1367,19 @@ directory descriptor directly
 and fail closed on any name under the declared quiescence contract, without
 claiming a hostile-writer allocation budget. Interrupted rename, removal, and
 synchronization likewise retain an explicit retry owner. It acquires no
-cross-process lease and contains no BM25 name discovery or policy; the remaining
-follow-up is the attempt-pool coordinator that invokes it only after worker
-quiescence. The
-legacy one-shot directory-discard and plain stage-construction return contracts
-remain unchanged; cancellation-safe integrations must use the retained owner
-and explicit receipt acknowledgement.
+cross-process lease and contains no BM25 name discovery or policy. A separate
+target-bound BM25 coordinator now supplies that policy only after successful
+worker settlement and an exact caller assertion that no other cooperative
+process can enter the pool. It snapshots and classifies the complete bounded
+parent before mutation, recognizes only the fixed current and legacy
+source-attempt lineages, rejects malformed reserved and provenance-free hashed
+fallback names, routes only already-discarded lineage to direct cleanup, and
+requires the final snapshot to contain exactly the original unrelated names.
+It carries no catalog, publication, or global retained-owner routing authority;
+automatic multi-target cleanup and a cross-process writer/reaper lease remain
+pending. The legacy one-shot directory-discard and plain stage-construction
+return contracts remain unchanged; cancellation-safe integrations must use the
+retained owner and explicit receipt acknowledgement.
 
 The compiler-cache bridge now also has a resource-scoped resolver seam. It
 attests the canonical running request before opening attempt resources, accepts
@@ -1419,8 +1427,10 @@ returning the prepared result, and binds every attempt/view/context provision
 to the retained startup workspace identity while rechecking the complete
 storage topology. The planner captures that same topology-guarded retained
 source and registers only its content-addressed planning identities through a
-least-authority catalog surface. No default Web installation, runtime refresh
-trigger, or default route selects either production binding yet.
+least-authority catalog surface. The guarded result reconciler, retained
+publisher, and polling loop remain dependency-injected; no default Web lifespan
+installation, local storage configuration, or default route selects either
+production binding yet.
 
 The production CLI binding exposes both trusted local adapters through
 `codenib jobs run-once` and `codenib jobs run`, with an explicit mutually
@@ -1436,6 +1446,13 @@ publication rather than stamping later source bytes with the startup commit.
 The source candidate filter rechecks retained topology before lease acquisition,
 and every later attempt verifier promotes topology loss to a storage-integrity
 alarm, so a continuous scheduler terminates instead of consuming job retries.
+A default-off `--reclaim-quiescent-attempts` source-mode flag runs the bounded
+coordinator exactly once after a successful `run-once` worker return or
+continuous-scheduler shutdown, while retained topology and CAS owners are still
+open. The flag is an operator assertion that no other cooperative process can
+enter that workspace through the post-worker sweep; exceptional worker unwind
+never invokes it, cache mode rejects it before path or storage setup, stdout
+remains unchanged, and stderr receives only bounded count diagnostics.
 A trusted candidate filter runs on a detached canonical job before owner
 allocation or lease acquisition, so foreign repositories and unsupported view
 requests remain untouched. `run-once`
@@ -1466,9 +1483,10 @@ are implemented. Its three transient destinations now share one retained
 caller-owned path-build root whose authenticated cleanup receipt is accepted
 before ownership is released. The descriptor-owned quiescent directory
 reclamation primitive, bounded descriptor child snapshot, and direct
-already-quarantined-child cleanup are implemented; BM25 attempt-name
-classification, multi-target retry routing, worker-lifecycle quiescence, and
-CLI wiring remain pending.
+already-quarantined-child cleanup are implemented. Exact BM25 attempt-name
+classification, the caller-asserted post-worker coordinator, and default-off
+CLI wiring are also implemented; automatic multi-target retry routing and a
+cross-process writer/reaper lease remain pending.
 Vector and graph source builders, generic builder routing, and remaining
 runtime wiring remain.
 
@@ -1506,9 +1524,11 @@ bundle before atomically publishing it, pins the exact generation for each
 in-flight request, defers old vector/source cleanup until the final pin exits,
 and invalidates bundle-bound Wiki, edge-label, and commit-window caches by
 generation identity.
-The first #266 status, durable-read, explicitly injected one-view write, and
-retained-source BM25 planning slices are present; a default Web binding,
-success-triggered refresh, MCP, UI controls, and default routing remain absent.
+The first #266 status, durable-read, explicitly injected one-view write,
+retained-source BM25 planning, guarded reconciliation, retained publication,
+and polling slices are present. The success callback exists but is not installed
+by the default server; Web lifespan ownership, local storage configuration,
+MCP, UI controls, and default routing remain absent.
 
 - The backend-neutral worker now owns advisory scan/claim, per-attempt task
   authority, independent heartbeat sessions, cancellation precedence, bounded
@@ -1559,15 +1579,19 @@ success-triggered refresh, MCP, UI controls, and default routing remain absent.
 - The retained-source BM25 attempt resource factory/resolver, production CLI
   entry, and explicit Web planner are implemented. The generic descriptor-bound
   quiescent directory reclamation primitive, bounded descriptor child snapshot,
-  and direct already-quarantined cleanup are also implemented without BM25 name
-  policy or publication authority. The planner captures the same frozen local
-  target as the worker, revalidates source after planning, and uses a separate
-  least-authority catalog surface that can register only content-addressed
-  source/profile identities and read one ref generation. Add the
-  worker-lifecycle attempt-pool coordinator, then add vector and graph source
-  adapters and wire successful worker results into runtime, Web, MCP, and
-  default routes. Older self-publishing ingress APIs remain compatibility paths
-  and are never nested inside the worker.
+  and direct already-quarantined cleanup remain policy-free and carry no
+  publication authority. A separate exact-target coordinator and default-off
+  CLI flag now add bounded BM25 attempt-name policy only after successful worker
+  settlement under caller-asserted process quiescence. The planner captures the
+  same frozen local target as the worker, revalidates source after planning, and
+  uses a separate least-authority catalog surface that can register only
+  content-addressed source/profile identities and read one ref generation. Add
+  a cooperative cross-process writer/reaper lease and automatic multi-target
+  routing, then add vector and graph source adapters, install the existing
+  reconciler and polling loop in the production server lifespan, invoke its
+  callback from attested worker success, and wire MCP, UI, and default routes.
+  Older self-publishing ingress APIs remain compatibility paths and are never
+  nested inside the worker.
 - Complete the #266 job and update APIs with accurate incremental versus rebuild
   behavior; the first read-only status slice is described below.
 - `RepoRegistry.load_all()` now reconciles each complete registry snapshot,
@@ -1584,8 +1608,9 @@ success-triggered refresh, MCP, UI controls, and default routing remain absent.
   cancellation-class cleanup failures never demoted behind ordinary errors.
   Bundle-derived Wiki, edge-label, and commit-window helpers are generation
   keyed and stale entries are pruned after replacement, removal, and shutdown.
-  The remaining #266 work is to invoke this refresh boundary only after an
-  attested update job succeeds and expose its status/results to the UI.
+  The remaining #266 work is to own the existing reconciliation loop in the
+  production server lifespan, invoke its existing callback only after an
+  attested update job succeeds, and expose its status/results to the UI.
 - The first #266 read slice exposes one pinned, detached status snapshot for
   exactly BM25, vector, and symbol-graph surfaces. It reports manifest/current
   commit drift and retained incremental metrics without exposing mutable bundle

--- a/test/compiler/test_bm25_attempt_pool.py
+++ b/test/compiler/test_bm25_attempt_pool.py
@@ -1,0 +1,449 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+import codenib.compiler as compiler_module
+import codenib.compiler.job_resources as job_resources_module
+from codenib import LocalWorkspaceProvider
+from codenib._atomic_directory import publication_parent_identity
+from codenib.compiler.index_builders import BM25IndexBuilder
+from codenib.compiler.job_resources import (
+    BM25AttemptPoolReclamation,
+    LocalBM25AttemptPoolCoordinator,
+    LocalBM25SourceJobTarget,
+)
+from codenib.storage import StorageIntegrityError, StorageValidationError
+
+_ATTEMPT = "a" * 32
+_STAGE = "b" * 24
+_DISCARD = "c" * 32
+
+
+def _cleanup_notes(error: BaseException) -> tuple[str, ...]:
+    return (
+        *tuple(getattr(error, "__notes__", ())),
+        *tuple(getattr(error, "_codenib_cleanup_notes", ())),
+    )
+
+
+def _attempt_pool_target(
+    tmp_path: Path,
+    *,
+    topology_verifier=None,
+    workspace_parent_identity: tuple[int, ...] | None = None,
+) -> tuple[LocalBM25SourceJobTarget, Path, list[bool]]:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700, parents=True)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    provider = LocalWorkspaceProvider(workspace)
+    if workspace_parent_identity is None:
+        descriptor = os.open(workspace, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            workspace_parent_identity = publication_parent_identity(descriptor)
+        finally:
+            os.close(descriptor)
+    topology_checks: list[bool] = []
+    if topology_verifier is None:
+
+        def topology_verifier() -> None:
+            topology_checks.append(True)
+
+    target = LocalBM25SourceJobTarget(
+        repository_root=repository,
+        workspace_provider=provider,
+        repository_key="owner/repository",
+        display_commit="d" * 40,
+        builder=BM25IndexBuilder(),
+        workspace_parent_identity=workspace_parent_identity,
+        topology_verifier=topology_verifier,
+    )
+    return target, workspace, topology_checks
+
+
+@pytest.mark.parametrize(
+    ("name", "lineage", "discarded"),
+    (
+        (f".codenib-source-job-{_ATTEMPT}.normalize-{_STAGE}", "current", False),
+        (
+            f"..codenib-source-job-{_ATTEMPT}.normalize-{_STAGE}"
+            f".discarded-{_DISCARD}",
+            "current",
+            True,
+        ),
+        (f".codenib-source-job-{_ATTEMPT}-attempt", "legacy", False),
+        (
+            f"..codenib-source-job-{_ATTEMPT}-bm25.normalize-{_STAGE}",
+            "legacy",
+            False,
+        ),
+        (
+            f"..codenib-source-job-{_ATTEMPT}-context.discarded-{_DISCARD}",
+            "legacy",
+            True,
+        ),
+        (
+            f"...codenib-source-job-{_ATTEMPT}-attempt.normalize-{_STAGE}"
+            f".discarded-{_DISCARD}",
+            "legacy",
+            True,
+        ),
+    ),
+)
+def test_bm25_attempt_pool_name_policy_accepts_exact_lineage(
+    name: str,
+    lineage: str,
+    discarded: bool,
+) -> None:
+    child = job_resources_module._classify_bm25_attempt_pool_child_name(name)
+
+    assert child is not None
+    assert child.lineage == lineage
+    assert child.discarded is discarded
+
+
+@pytest.mark.parametrize(
+    "name",
+    (
+        f"codenib-source-job-{_ATTEMPT}",
+        f".CODENIB-SOURCE-JOB-{_ATTEMPT}.NORMALIZE-{_STAGE}",
+        f".codenib-source-job-{_ATTEMPT}-vector",
+        f".codenib-source-job-{'a' * 31}.normalize-{_STAGE}",
+        f".codenib-source-job-{_ATTEMPT}.normalize-{_STAGE}.extra",
+        f"....codenib-source-job-{_ATTEMPT}.normalize-{_STAGE}",
+        ".codenib-discarded-0123456789abcdef-" + _DISCARD,
+    ),
+)
+def test_bm25_attempt_pool_name_policy_rejects_ambiguous_reserved_names(
+    name: str,
+) -> None:
+    with pytest.raises(StorageValidationError, match="unrecognized reserved child"):
+        job_resources_module._classify_bm25_attempt_pool_child_name(name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    (
+        "unrelated",
+        ".other.normalize-" + _STAGE,
+        ".codenib-source-worker-topology-" + _ATTEMPT,
+        "unrelated-µ",
+    ),
+)
+def test_bm25_attempt_pool_name_policy_retains_unrelated_names(name: str) -> None:
+    assert job_resources_module._classify_bm25_attempt_pool_child_name(name) is None
+
+
+def test_bm25_attempt_pool_coordinator_reclaims_exact_mixed_lineage(
+    tmp_path: Path,
+) -> None:
+    target, workspace, topology_checks = _attempt_pool_target(tmp_path)
+    current = f".codenib-source-job-{_ATTEMPT}.normalize-{_STAGE}"
+    current_discarded = (
+        f"..codenib-source-job-{_ATTEMPT}.normalize-{_STAGE}" f".discarded-{_DISCARD}"
+    )
+    legacy = f".codenib-source-job-{_ATTEMPT}-attempt"
+    legacy_stage = f"..codenib-source-job-{_ATTEMPT}-bm25.normalize-{_STAGE}"
+    legacy_discarded = f"..codenib-source-job-{_ATTEMPT}-context.discarded-{_DISCARD}"
+    legacy_discarded_stage = (
+        f"...codenib-source-job-{_ATTEMPT}-attempt.normalize-{_STAGE}"
+        f".discarded-{_DISCARD}"
+    )
+    attempts = (
+        current,
+        current_discarded,
+        legacy,
+        legacy_stage,
+        legacy_discarded,
+        legacy_discarded_stage,
+    )
+    for name in attempts:
+        child = workspace / name
+        child.mkdir(mode=0o700)
+        (child / "payload.txt").write_text(name, encoding="utf-8")
+    unrelated = workspace / "retain-me"
+    unrelated.mkdir(mode=0o700)
+
+    result = LocalBM25AttemptPoolCoordinator(target).reclaim(
+        caller_asserts_quiescence=True,
+    )
+
+    assert result == BM25AttemptPoolReclamation(
+        scanned_children=7,
+        reclaimed_children=6,
+        current_children=2,
+        legacy_children=4,
+        discarded_children=3,
+        retained_unrelated_children=1,
+    )
+    assert tuple(workspace.iterdir()) == (unrelated,)
+    assert len(topology_checks) >= 18
+
+
+def test_bm25_attempt_pool_coordinator_preflights_every_name_before_mutation(
+    tmp_path: Path,
+) -> None:
+    target, workspace, _topology_checks = _attempt_pool_target(tmp_path)
+    recognized = workspace / (f".codenib-source-job-{_ATTEMPT}.normalize-{_STAGE}")
+    recognized.mkdir(mode=0o700)
+    malformed = workspace / (f".codenib-source-job-{_ATTEMPT}.normalize-{'B' * 24}")
+    malformed.mkdir(mode=0o700)
+
+    with pytest.raises(StorageValidationError, match="unrecognized reserved child"):
+        LocalBM25AttemptPoolCoordinator(target).reclaim(
+            caller_asserts_quiescence=True,
+        )
+
+    assert recognized.is_dir()
+    assert malformed.is_dir()
+
+
+def test_bm25_attempt_pool_coordinator_requires_exact_quiescence_and_topology(
+    tmp_path: Path,
+) -> None:
+    target, workspace, _topology_checks = _attempt_pool_target(tmp_path)
+    coordinator = LocalBM25AttemptPoolCoordinator(target)
+
+    with pytest.raises(StorageValidationError, match="caller-asserted quiescence"):
+        coordinator.reclaim()
+    with pytest.raises(TypeError, match="exact bool"):
+        coordinator.reclaim(caller_asserts_quiescence=1)  # type: ignore[arg-type]
+
+    no_topology_target = LocalBM25SourceJobTarget(
+        repository_root=target.repository_root,
+        workspace_provider=target.workspace_provider,
+        repository_key=target.repository_key,
+        display_commit=target.display_commit,
+        builder=BM25IndexBuilder(),
+        workspace_parent_identity=target.attempt_pool_identity,
+    )
+    with pytest.raises(StorageValidationError, match="requires retained topology"):
+        LocalBM25AttemptPoolCoordinator(no_topology_target).reclaim(
+            caller_asserts_quiescence=True,
+        )
+
+    short_identity_target, _workspace, _checks = _attempt_pool_target(
+        tmp_path / "short-identity",
+        workspace_parent_identity=(1, 2),
+    )
+    with pytest.raises(StorageValidationError, match="exact parent identity"):
+        LocalBM25AttemptPoolCoordinator(short_identity_target).reclaim(
+            caller_asserts_quiescence=True,
+        )
+    assert not tuple(workspace.iterdir())
+
+
+def test_bm25_attempt_pool_coordinator_rejects_quiescence_contradiction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target, _workspace, _topology_checks = _attempt_pool_target(tmp_path)
+    child_name = f".codenib-source-job-{_ATTEMPT}.normalize-{_STAGE}"
+
+    class Reclaimer:
+        def __init__(self, parent: Path, *, expected_parent_identity) -> None:
+            assert parent == target.attempt_pool_root
+            assert expected_parent_identity == target.attempt_pool_identity
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            return None
+
+        def snapshot_child_names(self) -> tuple[str, ...]:
+            return (child_name,)
+
+        def reclaim_child(self, name: str) -> bool:
+            assert name == child_name
+            return False
+
+    monkeypatch.setattr(job_resources_module, "QuiescentDirectoryReclaimer", Reclaimer)
+
+    with pytest.raises(StorageIntegrityError, match="despite quiescence"):
+        LocalBM25AttemptPoolCoordinator(target).reclaim(
+            caller_asserts_quiescence=True,
+        )
+
+
+def test_bm25_attempt_pool_coordinator_routes_only_discarded_lineage_directly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target, _workspace, _topology_checks = _attempt_pool_target(tmp_path)
+    live = f".codenib-source-job-{_ATTEMPT}.normalize-{_STAGE}"
+    discarded = f"..codenib-source-job-{_ATTEMPT}-context.discarded-{_DISCARD}"
+    snapshots = iter(((discarded, live, "retain-me"), ("retain-me",)))
+    calls: list[tuple[str, str]] = []
+
+    class Reclaimer:
+        def __init__(self, _parent: Path, *, expected_parent_identity) -> None:
+            assert expected_parent_identity == target.attempt_pool_identity
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            return None
+
+        def snapshot_child_names(self) -> tuple[str, ...]:
+            return next(snapshots)
+
+        def reclaim_child(self, name: str) -> bool:
+            calls.append(("live", name))
+            return True
+
+        def reclaim_quarantined_child(self, name: str) -> bool:
+            calls.append(("discarded", name))
+            return True
+
+    monkeypatch.setattr(job_resources_module, "QuiescentDirectoryReclaimer", Reclaimer)
+
+    result = LocalBM25AttemptPoolCoordinator(target).reclaim(
+        caller_asserts_quiescence=True,
+    )
+
+    assert calls == [("discarded", discarded), ("live", live)]
+    assert result.reclaimed_children == 2
+    assert result.discarded_children == 1
+
+
+def test_bm25_attempt_pool_coordinator_rejects_final_snapshot_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target, _workspace, _topology_checks = _attempt_pool_target(tmp_path)
+    snapshots = iter((("retain-me",), ("retain-me", "raced-child")))
+
+    class Reclaimer:
+        def __init__(self, _parent: Path, *, expected_parent_identity) -> None:
+            assert expected_parent_identity == target.attempt_pool_identity
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            return None
+
+        def snapshot_child_names(self) -> tuple[str, ...]:
+            return next(snapshots)
+
+    monkeypatch.setattr(job_resources_module, "QuiescentDirectoryReclaimer", Reclaimer)
+
+    with pytest.raises(StorageIntegrityError, match="changed during"):
+        LocalBM25AttemptPoolCoordinator(target).reclaim(
+            caller_asserts_quiescence=True,
+        )
+
+
+def test_bm25_attempt_pool_coordinator_rechecks_topology_before_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verification_count = 0
+    topology_lost = StorageIntegrityError("topology changed")
+
+    def verify_topology() -> None:
+        nonlocal verification_count
+        verification_count += 1
+        if verification_count == 4:
+            raise topology_lost
+
+    target, _workspace, _topology_checks = _attempt_pool_target(
+        tmp_path,
+        topology_verifier=verify_topology,
+    )
+    live = f".codenib-source-job-{_ATTEMPT}.normalize-{_STAGE}"
+
+    class Reclaimer:
+        def __init__(self, _parent: Path, *, expected_parent_identity) -> None:
+            assert expected_parent_identity == target.attempt_pool_identity
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            return None
+
+        def snapshot_child_names(self) -> tuple[str, ...]:
+            return (live,)
+
+        def reclaim_child(self, _name: str) -> bool:
+            pytest.fail("topology loss must precede attempt mutation")
+
+    monkeypatch.setattr(job_resources_module, "QuiescentDirectoryReclaimer", Reclaimer)
+
+    with pytest.raises(StorageIntegrityError) as caught:
+        LocalBM25AttemptPoolCoordinator(target).reclaim(
+            caller_asserts_quiescence=True,
+        )
+
+    assert caught.value is topology_lost
+    assert verification_count == 5
+
+
+def test_bm25_attempt_pool_coordinator_rechecks_topology_after_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verification_count = 0
+    topology_lost = StorageIntegrityError("topology changed after failure")
+    reclaim_failure = OSError("reclaim failed")
+
+    def verify_topology() -> None:
+        nonlocal verification_count
+        verification_count += 1
+        if verification_count == 5:
+            raise topology_lost
+
+    target, _workspace, _topology_checks = _attempt_pool_target(
+        tmp_path,
+        topology_verifier=verify_topology,
+    )
+    live = f".codenib-source-job-{_ATTEMPT}.normalize-{_STAGE}"
+
+    class Reclaimer:
+        def __init__(self, _parent: Path, *, expected_parent_identity) -> None:
+            assert expected_parent_identity == target.attempt_pool_identity
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            return None
+
+        def snapshot_child_names(self) -> tuple[str, ...]:
+            return (live,)
+
+        def reclaim_child(self, _name: str) -> bool:
+            raise reclaim_failure
+
+    monkeypatch.setattr(job_resources_module, "QuiescentDirectoryReclaimer", Reclaimer)
+
+    with pytest.raises(OSError) as caught:
+        LocalBM25AttemptPoolCoordinator(target).reclaim(
+            caller_asserts_quiescence=True,
+        )
+
+    assert caught.value is reclaim_failure
+    assert verification_count >= 6
+    assert any(
+        "BM25 attempt-pool child reclamation topology validation also failed" in note
+        and "topology changed after failure" in note
+        for note in _cleanup_notes(reclaim_failure)
+    )
+
+
+def test_bm25_attempt_pool_types_are_lazy_compiler_exports() -> None:
+    assert compiler_module.BM25AttemptPoolReclamation is BM25AttemptPoolReclamation
+    assert (
+        compiler_module.LocalBM25AttemptPoolCoordinator
+        is LocalBM25AttemptPoolCoordinator
+    )

--- a/test/compiler/test_source_job.py
+++ b/test/compiler/test_source_job.py
@@ -1835,9 +1835,11 @@ def test_local_bm25_source_scope_retries_cancelled_orphan_sink_before_ack(
         fixture.close()
 
 
+@pytest.mark.parametrize("reclaim_quiescent_attempts", (False, True))
 def test_jobs_run_once_source_bm25_executes_matching_catalog_job(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
+    reclaim_quiescent_attempts: bool,
 ) -> None:
     builder = BM25IndexBuilder(languages=["python"])
     profile = bm25_source_job_profile(builder)
@@ -1882,33 +1884,35 @@ def test_jobs_run_once_source_bm25_executes_matching_catalog_job(
                 },
             )
 
-        args = cli_module.build_parser().parse_args(
-            [
-                "jobs",
-                "run-once",
-                os.fspath(fixture.repository),
-                "--source-bm25",
-                "--language",
-                "python",
-                "--catalog",
-                os.fspath(catalog_path),
-                "--cas-root",
-                os.fspath(cas_root),
-                "--workspace-root",
-                os.fspath(fixture.workspace),
-                "--repository",
-                _REPOSITORY_KEY,
-                "--lease-duration-ms",
-                "60000",
-                "--heartbeat-interval-ms",
-                "5",
-                "--json",
-            ]
-        )
+        command = [
+            "jobs",
+            "run-once",
+            os.fspath(fixture.repository),
+            "--source-bm25",
+            "--language",
+            "python",
+            "--catalog",
+            os.fspath(catalog_path),
+            "--cas-root",
+            os.fspath(cas_root),
+            "--workspace-root",
+            os.fspath(fixture.workspace),
+            "--repository",
+            _REPOSITORY_KEY,
+            "--lease-duration-ms",
+            "60000",
+            "--heartbeat-interval-ms",
+            "5",
+            "--json",
+        ]
+        if reclaim_quiescent_attempts:
+            command.append("--reclaim-quiescent-attempts")
+        args = cli_module.build_parser().parse_args(command)
 
         assert args.handler(args) == 0
 
-        payload = json.loads(capsys.readouterr().out)
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
         assert payload == {
             "attempt_count": 1,
             "disposition": "succeeded",
@@ -1917,8 +1921,16 @@ def test_jobs_run_once_source_bm25_executes_matching_catalog_job(
         assert not tuple(fixture.workspace.glob(".codenib-source-job-*"))
         assert not tuple(fixture.workspace.glob(".codenib-source-worker-topology-*"))
         orphans = tuple(fixture.workspace.glob(".*.discarded-*"))
-        assert len(orphans) == 1
-        assert orphans[0].is_dir()
+        if reclaim_quiescent_attempts:
+            assert orphans == ()
+            assert captured.err.endswith(
+                "BM25 attempt-pool reclamation: scanned=1 reclaimed=1 "
+                "current=1 legacy=0 discarded=1 retained=0\n"
+            )
+        else:
+            assert len(orphans) == 1
+            assert orphans[0].is_dir()
+            assert "BM25 attempt-pool reclamation:" not in captured.err
         with SQLiteCatalog(catalog_path, create=False) as catalog:
             completed = catalog.get_job(queued.job_id)
             assert completed.status is IndexJobStatus.SUCCEEDED

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -577,6 +577,7 @@ def test_jobs_run_once_parser_exposes_bounded_worker_inputs() -> None:
     assert defaults.json is False
     assert defaults.cache_dir == "/src/repo/.codenib_index"
     assert defaults.source_bm25 is False
+    assert defaults.reclaim_quiescent_attempts is False
     assert defaults.language == []
     assert defaults.exclude_dir is None
     assert defaults.clear_exclude_dirs is False
@@ -610,6 +611,7 @@ def test_jobs_worker_parser_requires_one_explicit_input_mode() -> None:
             "run-once",
             "/src/repo",
             "--source-bm25",
+            "--reclaim-quiescent-attempts",
             "--language",
             "python,go",
             "--exclude-dir",
@@ -620,6 +622,7 @@ def test_jobs_worker_parser_requires_one_explicit_input_mode() -> None:
 
     assert source.cache_dir is None
     assert source.source_bm25 is True
+    assert source.reclaim_quiescent_attempts is True
     assert source.language == ["python,go"]
     assert source.exclude_dir == ["generated"]
     assert source.clear_exclude_dirs is False
@@ -648,6 +651,7 @@ def test_jobs_worker_parser_requires_one_explicit_input_mode() -> None:
         ("language", ["python"]),
         ("exclude_dir", ["generated"]),
         ("clear_exclude_dirs", True),
+        ("reclaim_quiescent_attempts", True),
     ),
 )
 def test_cache_job_worker_rejects_source_only_options(source_option) -> None:
@@ -660,7 +664,7 @@ def test_cache_job_worker_rejects_source_only_options(source_option) -> None:
     )
     setattr(args, name, value)
 
-    with pytest.raises(cli.CLIError, match="require --source-bm25"):
+    with pytest.raises(cli.CLIError, match="requires? --source-bm25"):
         cli._run_with_local_index_job_worker(
             args,
             lambda _worker: pytest.fail("worker must not be created"),
@@ -678,6 +682,125 @@ def test_source_job_worker_rejects_programmatic_cache_input() -> None:
             args,
             lambda _worker: pytest.fail("worker must not be created"),
         )
+
+
+def test_jobs_worker_rejects_nonboolean_reclamation_state() -> None:
+    args = SimpleNamespace(
+        source_bm25=True,
+        reclaim_quiescent_attempts=1,
+        cache_dir=None,
+    )
+
+    with pytest.raises(cli.CLIError, match="state must be an exact boolean"):
+        cli._run_with_local_index_job_worker(
+            args,
+            lambda _worker: pytest.fail("worker must not be created"),
+        )
+
+
+@pytest.mark.parametrize("reclaim", (False, True))
+def test_bm25_source_operation_reclaims_once_only_after_successful_return(
+    monkeypatch: pytest.MonkeyPatch,
+    reclaim: bool,
+) -> None:
+    events: list[str] = []
+    result = object()
+
+    def operation(worker: object) -> object:
+        assert worker == "worker"
+        events.extend(("page-one", "page-two", "operation-return"))
+        return result
+
+    monkeypatch.setattr(
+        cli,
+        "_reclaim_local_bm25_source_attempt_pool",
+        lambda target: events.append(f"reclaim:{target}"),
+    )
+
+    observed = cli._run_local_bm25_source_worker_operation(
+        SimpleNamespace(reclaim_quiescent_attempts=reclaim),
+        operation,
+        "worker",
+        "target",
+        lambda: events.append("verify"),
+    )
+
+    assert observed is result
+    assert events == [
+        "page-one",
+        "page-two",
+        "operation-return",
+        "verify",
+        *(("reclaim:target", "verify") if reclaim else ()),
+    ]
+
+
+def test_bm25_source_operation_does_not_reclaim_exceptional_unwind(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failure = RuntimeError("worker failed")
+    events: list[str] = []
+
+    def fail(_worker: object) -> None:
+        events.append("operation")
+        raise failure
+
+    monkeypatch.setattr(
+        cli,
+        "_reclaim_local_bm25_source_attempt_pool",
+        lambda _target: pytest.fail("exceptional worker must not reclaim"),
+    )
+
+    with pytest.raises(RuntimeError) as caught:
+        cli._run_local_bm25_source_worker_operation(
+            SimpleNamespace(reclaim_quiescent_attempts=True),
+            fail,
+            object(),
+            object(),
+            lambda: events.append("verify"),
+        )
+
+    assert caught.value is failure
+    assert events == ["operation"]
+
+
+def test_bm25_attempt_pool_summary_is_bounded_stderr_only(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.compiler.job_resources as job_resources_module
+
+    target = object()
+
+    class Coordinator:
+        def __init__(self, candidate: object) -> None:
+            assert candidate is target
+
+        def reclaim(self, *, caller_asserts_quiescence: bool):
+            assert caller_asserts_quiescence is True
+            return job_resources_module.BM25AttemptPoolReclamation(
+                scanned_children=7,
+                reclaimed_children=5,
+                current_children=3,
+                legacy_children=2,
+                discarded_children=4,
+                retained_unrelated_children=2,
+            )
+
+    monkeypatch.setattr(
+        job_resources_module,
+        "LocalBM25AttemptPoolCoordinator",
+        Coordinator,
+    )
+
+    cli._reclaim_local_bm25_source_attempt_pool(target)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == (
+        "BM25 attempt-pool reclamation: scanned=7 reclaimed=5 "
+        "current=3 legacy=2 discarded=4 retained=2\n"
+    )
 
 
 def test_source_job_topology_loss_stops_continuous_scheduler_before_claim() -> None:
@@ -849,6 +972,7 @@ def test_jobs_run_parser_exposes_continuous_scheduler_inputs() -> None:
     assert defaults.max_cycles is None
     assert defaults.scan_limit == 64
     assert defaults.json is False
+    assert defaults.reclaim_quiescent_attempts is False
     assert configured.initial_idle_delay_ms == 100
     assert configured.max_idle_delay_ms == 2_000
     assert configured.max_cycles == 3


### PR DESCRIPTION
## Summary

Add a default-off, caller-asserted quiescent cleanup path for stale local BM25 source-job attempts. The coordinator applies exact bounded name policy after successful worker settlement without claiming automatic cross-process safety.

## Changes

- Add a target-bound `LocalBM25AttemptPoolCoordinator` and count-only result type with exact current and legacy attempt-name classification.
- Preflight the complete bounded snapshot before mutation, reject malformed reserved or provenance-free fallback names, and route only already-discarded lineage to direct cleanup.
- Revalidate retained topology before and after snapshot, child reclamation, and reclaimer lifetime boundaries while preserving the first operation failure.
- Add `--reclaim-quiescent-attempts` for source mode only; run one sweep after a successful worker or scheduler return, never during exceptional unwind, and keep stdout unchanged.
- Export the coordinator types, add cross-version and end-to-end coverage, and reconcile the storage roadmap with the injected Web runtime milestones while leaving automatic multi-target routing and the writer/reaper lease pending.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Exact coordinator policy suite: 26 passed on Python 3.10, 3.12, and 3.14.
- Coordinator and CLI focused selection: 40 passed on Python 3.10; 38 passed on Python 3.12 and 3.14.
- Affected source-job, CLI, and coordinator suites: 302 passed on Python 3.10.
- Full atomic-directory suite: 497 passed and 10 skipped on Python 3.10, 3.12, and 3.14.
- Broad Python 3.10 unit marker tier, excluding only the unavailable local Docker module: 8,799 passed, 35 skipped, 190 deselected.
- New-base Web runtime reconciliation slice: 57 passed.
- Black, isort, flake8 with bugbear, namespace checks, py_compile on all three interpreters, and git diff checks passed.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published