### PR TITLE
feat(web): own index background loops

### DIFF
--- a/codenib/web/index_job_service.py
+++ b/codenib/web/index_job_service.py
@@ -66,6 +66,13 @@ class _LoopOutcome:
     failure: BaseException | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class _CloseResult:
+    owned: bool = False
+    summary: IndexJobBackgroundServiceSummary | None = None
+    failure: BaseException | None = None
+
+
 class _ThreadLaunch:
     """Gate one non-daemon start behind a cancellation-safe daemon launcher."""
 
@@ -470,11 +477,14 @@ class IndexJobBackgroundService:
 
     def _begin_close_locked(self) -> tuple[bool, tuple[_ThreadLaunch, ...]]:
         if self._state == "new":
+            if self._summary is None:
+                self._summary = IndexJobBackgroundServiceSummary(
+                    worker=IndexJobSchedulerRunSummary(0, 0, 0),
+                    runtime=IndexJobRuntimeLoopSummary(0, 0, 0),
+                )
+            # The summary is recoverable before the terminal state becomes
+            # visible, so an interrupted transition remains idempotent.
             self._state = "closed"
-            self._summary = IndexJobBackgroundServiceSummary(
-                worker=IndexJobSchedulerRunSummary(0, 0, 0),
-                runtime=IndexJobRuntimeLoopSummary(0, 0, 0),
-            )
             return False, ()
         if self._state in {"running", "starting", "stopping"}:
             self._state = "stopping"
@@ -548,20 +558,70 @@ class IndexJobBackgroundService:
             raise interruption
         return self._lifecycle_lock.run(self._closed_result_locked)
 
-    def _called_from_owned_thread(self) -> bool:
-        current = current_thread()
-        return self._lifecycle_lock.run(
-            lambda: any(launch.thread is current for launch in self._threads)
-        )
+    def _close_entry_serialized(self) -> _CloseResult:
+        first_failure: BaseException | None = None
+
+        def remember(candidate: BaseException) -> None:
+            nonlocal first_failure
+            if first_failure is None:
+                first_failure = candidate
+
+        while True:
+            try:
+                summary = self._close_serialized()
+            except BaseException as close_failure:  # noqa: B036 - prove terminal
+                remember(close_failure)
+                while True:
+                    try:
+                        state = self._lifecycle_lock.run(lambda: self._state)
+                        break
+                    except BaseException as state_failure:  # noqa: B036 - retry read
+                        remember(state_failure)
+                if state == "closed":
+                    return _CloseResult(failure=first_failure)
+                continue
+            return _CloseResult(summary=summary, failure=first_failure)
 
     def close(self) -> IndexJobBackgroundServiceSummary:
         """Stop and join both loops before shared resources may be released."""
 
-        if self._called_from_owned_thread():
+        first_failure: BaseException | None = None
+
+        def remember(candidate: BaseException) -> None:
+            nonlocal first_failure
+            if first_failure is None:
+                first_failure = candidate
+
+        # Ownership lookup must precede settlement acquisition so an owned
+        # callback can reject self-close while an external close is joining it.
+        # The whole entry is replayed after interruption; an external caller
+        # cannot observe a failure until close has proven the service terminal.
+        while True:
+            try:
+                current = current_thread()
+                owned = self._lifecycle_lock.run(
+                    lambda current=current: any(
+                        launch.thread is current for launch in self._threads
+                    )
+                )
+                if owned:
+                    result = _CloseResult(owned=True)
+                else:
+                    result = self._settlement_lock.run(self._close_entry_serialized)
+                break
+            except BaseException as entry_failure:  # noqa: B036 - replay entry
+                remember(entry_failure)
+
+        if result.owned:
             raise IndexJobBackgroundServiceError(
                 "background index service cannot close from an owned loop"
             )
-        return self._settlement_lock.run(self._close_serialized)
+        failure = first_failure if first_failure is not None else result.failure
+        if failure is not None:
+            raise failure
+        if result.summary is None:
+            raise RuntimeError("background index service close result is incomplete")
+        return result.summary
 
 
 __all__ = [

--- a/codenib/web/index_job_service.py
+++ b/codenib/web/index_job_service.py
@@ -66,24 +66,75 @@ class _LoopOutcome:
     failure: BaseException | None = None
 
 
-@dataclass(slots=True)
 class _ThreadLaunch:
-    """Retain one candidate before launch and its child-entry handshake."""
+    """Gate one non-daemon start behind a cancellation-safe daemon launcher."""
 
-    thread: Thread
-    entered: Event
-    attempted: bool = False
-    start_returned: bool = False
-    start_failure: BaseException | None = None
+    def __init__(self, thread: Thread) -> None:
+        self.thread = thread
+        self._lock = _CancellationSafeRLock()
+        self._complete = Event()
+        self._state = "pending"
+        self._failure: BaseException | None = None
 
-    def start(self) -> None:
-        self.attempted = True
+    def _resolve_locked(self) -> None:
+        if self._state != "pending":
+            return
         try:
             self.thread.start()
-        except BaseException as failure:  # noqa: B036 - retain ambiguous launch
-            self.start_failure = failure
-            raise
-        self.start_returned = True
+        except BaseException as failure:  # noqa: B036 - publish launch result
+            self._failure = failure
+            self._state = "failed"
+        else:
+            self._state = "launched"
+
+    def _launch(self) -> None:
+        # SIGINT is delivered to the main thread, so the actual non-daemon
+        # Thread.start runs to a definite result here. The lock spans that call:
+        # cancellation either changes pending to cancelled first, or waits for
+        # the launched/failed result before shared resources can be released.
+        while True:
+            try:
+                self._lock.run(self._resolve_locked)
+                break
+            except BaseException:  # noqa: B036 - retry internal publication
+                continue
+        while True:
+            try:
+                self._complete.set()
+                return
+            except BaseException:  # noqa: B036 - retry internal publication
+                continue
+
+    def start(self) -> None:
+        launcher = Thread(
+            target=self._launch,
+            name=f"{self.thread.name}-launcher",
+            daemon=True,
+        )
+        launcher.start()
+        completed = self._complete.wait()
+        if type(completed) is not bool or not completed:
+            raise IndexJobBackgroundServiceError(
+                "thread launcher returned an invalid completion decision"
+            )
+        state, failure = self._lock.run(lambda: (self._state, self._failure))
+        if state == "launched":
+            return
+        if state == "failed" and failure is not None:
+            raise failure
+        raise IndexJobBackgroundServiceError(
+            "thread launcher completed without transferring ownership"
+        )
+
+    def cancel_and_was_launched(self) -> bool:
+        """Cancel a pending launch or wait for an in-progress launch result."""
+
+        def cancel() -> bool:
+            if self._state == "pending":
+                self._state = "cancelled"
+            return self._state == "launched"
+
+        return self._lock.run(cancel)
 
 
 class IndexJobBackgroundService:
@@ -213,103 +264,37 @@ class IndexJobBackgroundService:
             # is best effort.
             pass
 
-    def _stop_and_join(self, launches: tuple[_ThreadLaunch, ...]) -> None:
-        """Settle every started thread before rethrowing an interruption."""
+    def _stop_and_join(
+        self,
+        launches: tuple[_ThreadLaunch, ...],
+    ) -> BaseException | None:
+        """Replay settlement until every transferred non-daemon thread joins."""
 
         first_failure: BaseException | None = None
         while True:
             try:
-                stopped = self._stop.is_set()
-            except BaseException as failure:  # noqa: B036 - retry state read
-                if first_failure is None:
-                    first_failure = failure
-                continue
-            if stopped:
-                break
-            try:
                 self._stop.set()
-            except BaseException as failure:  # noqa: B036 - settle before rethrow
+                owned_current = current_thread()
+                for launch in reversed(launches):
+                    thread = launch.thread
+                    if thread is owned_current:
+                        raise IndexJobBackgroundServiceError(
+                            "an owned index loop cannot join itself"
+                        )
+                    if not launch.cancel_and_was_launched():
+                        continue
+                    thread.join()
+                    if thread.is_alive():
+                        raise IndexJobBackgroundServiceError(
+                            "an owned index loop remained active after join"
+                        )
+                return first_failure
+            except BaseException as failure:  # noqa: B036 - replay whole settle
                 if first_failure is None:
                     first_failure = failure
-        owned_current = current_thread()
-        for launch in reversed(launches):
-            thread = launch.thread
-            if thread is owned_current:
-                raise IndexJobBackgroundServiceError(
-                    "an owned index loop cannot join itself"
-                )
-            if not launch.attempted:
-                continue
 
-            launched = False
-            while True:
-                try:
-                    entered = launch.entered.is_set()
-                except BaseException as failure:  # noqa: B036 - retry state read
-                    if first_failure is None:
-                        first_failure = failure
-                    continue
-                if entered or launch.start_returned:
-                    launched = True
-                    break
-                try:
-                    identified = thread.ident is not None
-                except BaseException as failure:  # noqa: B036 - retry state read
-                    if first_failure is None:
-                        first_failure = failure
-                    continue
-                try:
-                    alive = thread.is_alive()
-                except BaseException as failure:  # noqa: B036 - retry state read
-                    if first_failure is None:
-                        first_failure = failure
-                    continue
-                if identified or alive:
-                    launched = True
-                    break
-                start_failure = launch.start_failure
-                if start_failure is not None and isinstance(start_failure, Exception):
-                    # CPython's ordinary start failures occur before ownership
-                    # transfers to an OS thread. Cancellation-class failures
-                    # remain ambiguous and must wait for the child handshake.
-                    break
-                try:
-                    signaled = launch.entered.wait(0.05)
-                except BaseException as failure:  # noqa: B036 - await ownership
-                    if first_failure is None:
-                        first_failure = failure
-                    continue
-                if type(signaled) is not bool:
-                    if first_failure is None:
-                        first_failure = IndexJobBackgroundServiceError(
-                            "thread launch handshake returned an invalid decision"
-                        )
-                    continue
-                if signaled:
-                    launched = True
-                    break
-            if not launched:
-                continue
-            while True:
-                try:
-                    alive = thread.is_alive()
-                except BaseException as failure:  # noqa: B036 - retry state read
-                    if first_failure is None:
-                        first_failure = failure
-                    continue
-                if not alive:
-                    break
-                try:
-                    thread.join()
-                except BaseException as failure:  # noqa: B036 - settle all loops
-                    if first_failure is None:
-                        first_failure = failure
-        if first_failure is not None:
-            raise first_failure
-
-    def _run_worker(self, entered: Event) -> None:
+    def _run_worker(self) -> None:
         try:
-            entered.set()
             summary = self._worker.run(self._stop)
             if type(summary) is not IndexJobSchedulerRunSummary:
                 raise IndexJobBackgroundServiceError(
@@ -324,9 +309,8 @@ class IndexJobBackgroundService:
         else:
             self._record_outcome("worker", summary=summary)
 
-    def _run_runtime(self, entered: Event) -> None:
+    def _run_runtime(self) -> None:
         try:
-            entered.set()
             summary = self._runtime.run(self._stop)
             if type(summary) is not IndexJobRuntimeLoopSummary:
                 raise IndexJobBackgroundServiceError(
@@ -342,21 +326,19 @@ class IndexJobBackgroundService:
             self._record_outcome("runtime", summary=summary)
 
     def _build_launches(self) -> tuple[_ThreadLaunch, ...]:
-        runtime_entered = Event()
-        worker_entered = Event()
         runtime_thread = Thread(
-            target=lambda: self._run_runtime(runtime_entered),
+            target=self._run_runtime,
             name="codenib-index-runtime",
             daemon=False,
         )
         worker_thread = Thread(
-            target=lambda: self._run_worker(worker_entered),
+            target=self._run_worker,
             name="codenib-index-worker",
             daemon=False,
         )
         return (
-            _ThreadLaunch(runtime_thread, runtime_entered),
-            _ThreadLaunch(worker_thread, worker_entered),
+            _ThreadLaunch(runtime_thread),
+            _ThreadLaunch(worker_thread),
         )
 
     def _claim_start_locked(
@@ -436,9 +418,8 @@ class IndexJobBackgroundService:
         if not owned:
             return False
         if needs_join:
-            try:
-                self._stop_and_join(launches)
-            except BaseException as cleanup_failure:  # noqa: B036 - keep primary
+            cleanup_failure = self._stop_and_join(launches)
+            if cleanup_failure is not None:
                 self._add_cleanup_note(primary, cleanup_failure)
             self._lifecycle_retry(
                 lambda: self._finish_failed_start_locked(token),
@@ -554,10 +535,9 @@ class IndexJobBackgroundService:
             except BaseException as state_failure:  # noqa: B036 - retry transition
                 remember(state_failure)
         if needs_join:
-            try:
-                self._stop_and_join(launches)
-            except BaseException as failure:  # noqa: B036 - settled before rethrow
-                remember(failure)
+            settlement_failure = self._stop_and_join(launches)
+            if settlement_failure is not None:
+                remember(settlement_failure)
             while True:
                 try:
                     self._lifecycle_lock.run(self._finish_close_locked)

--- a/codenib/web/index_job_service.py
+++ b/codenib/web/index_job_service.py
@@ -7,8 +7,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from threading import Event, Thread
-from typing import Protocol, runtime_checkable
+from threading import Event, Thread, current_thread
+from typing import Callable, Protocol, TypeVar, runtime_checkable
 
 from .._owned_file_publication import _CancellationSafeRLock
 from ..log_utils import get_logger
@@ -16,6 +16,7 @@ from ..storage import IndexJobSchedulerRunSummary, IndexJobSchedulerStopSignal
 from .index_job_runtime import IndexJobRuntimeLoopSummary
 
 logger = get_logger(__name__)
+_LifecycleResult = TypeVar("_LifecycleResult")
 
 
 class IndexJobBackgroundServiceError(RuntimeError):
@@ -60,8 +61,29 @@ class IndexJobBackgroundServiceSummary:
 
 @dataclass(frozen=True, slots=True)
 class _LoopOutcome:
+    token: object
     summary: object | None = None
     failure: BaseException | None = None
+
+
+@dataclass(slots=True)
+class _ThreadLaunch:
+    """Retain one candidate before launch and its child-entry handshake."""
+
+    thread: Thread
+    entered: Event
+    attempted: bool = False
+    start_returned: bool = False
+    start_failure: BaseException | None = None
+
+    def start(self) -> None:
+        self.attempted = True
+        try:
+            self.thread.start()
+        except BaseException as failure:  # noqa: B036 - retain ambiguous launch
+            self.start_failure = failure
+            raise
+        self.start_returned = True
 
 
 class IndexJobBackgroundService:
@@ -85,10 +107,14 @@ class IndexJobBackgroundService:
         self._runtime = runtime
         self._stop = Event()
         self._lifecycle_lock = _CancellationSafeRLock()
+        # Start and close serialize here, but background health/state reads do
+        # not. Joins therefore never hold the lifecycle lock a loop may read.
+        self._settlement_lock = _CancellationSafeRLock()
         self._outcome_lock = _CancellationSafeRLock()
         self._state = "new"
         self._outcomes: dict[str, _LoopOutcome] = {}
-        self._threads: tuple[Thread, ...] = ()
+        self._threads: tuple[_ThreadLaunch, ...] = ()
+        self._start_token: object | None = None
         self._summary: IndexJobBackgroundServiceSummary | None = None
         self._terminal_failure: BaseException | None = None
 
@@ -120,34 +146,74 @@ class IndexJobBackgroundService:
         summary: object | None = None,
         failure: BaseException | None = None,
     ) -> None:
+        token = object()
+        handoff_failure: BaseException | None = None
+
+        def remember_handoff_failure(candidate: BaseException) -> None:
+            nonlocal handoff_failure
+            if handoff_failure is None:
+                handoff_failure = candidate
+
+        # A clean summary is only valid after the shared stop was already
+        # observed. Reasserting it for every terminal outcome closes the
+        # fault-to-peer handoff before any interruptible outcome bookkeeping.
+        while True:
+            try:
+                self._stop.set()
+                break
+            except BaseException as stop_failure:  # noqa: B036 - retry handoff
+                remember_handoff_failure(stop_failure)
+
         def record() -> bool:
-            if name in self._outcomes:
+            effective_failure = failure if failure is not None else handoff_failure
+            outcome = _LoopOutcome(
+                token=token,
+                summary=None if effective_failure is not None else summary,
+                failure=effective_failure,
+            )
+            existing = self._outcomes.get(name)
+            if existing is not None and existing.token is not token:
                 self._outcomes[name] = _LoopOutcome(
+                    token=object(),
                     failure=IndexJobBackgroundServiceError(
                         "background index loop reported more than one outcome"
-                    )
+                    ),
                 )
                 return False
-            self._outcomes[name] = _LoopOutcome(summary=summary, failure=failure)
+            # Replacing our own token is idempotent when lock release was
+            # interrupted after the first callback committed. It also upgrades
+            # a clean summary to the bookkeeping interruption on retry.
+            self._outcomes[name] = outcome
             return True
 
-        recorded = self._outcome_lock.run(record)
-        if not recorded:
-            self._stop.set()
-            return
-        if failure is not None:
-            self._stop.set()
+        while True:
             try:
-                logger.error(
-                    "Durable index %s loop failed",
-                    name,
-                    exc_info=(type(failure), failure, failure.__traceback__),
-                )
-            except Exception:
-                # The shared stop is authoritative; logging is best effort.
-                pass
+                recorded = self._outcome_lock.run(record)
+                break
+            except BaseException as record_failure:  # noqa: B036 - retry commit
+                remember_handoff_failure(record_failure)
 
-    def _stop_and_join(self, threads: tuple[Thread, ...]) -> None:
+        if not recorded:
+            return
+        effective_failure = failure if failure is not None else handoff_failure
+        if effective_failure is None:
+            return
+        try:
+            logger.error(
+                "Durable index %s loop failed",
+                name,
+                exc_info=(
+                    type(effective_failure),
+                    effective_failure,
+                    effective_failure.__traceback__,
+                ),
+            )
+        except Exception:
+            # The shared stop and retained outcome are authoritative; logging
+            # is best effort.
+            pass
+
+    def _stop_and_join(self, launches: tuple[_ThreadLaunch, ...]) -> None:
         """Settle every started thread before rethrowing an interruption."""
 
         first_failure: BaseException | None = None
@@ -165,16 +231,66 @@ class IndexJobBackgroundService:
             except BaseException as failure:  # noqa: B036 - settle before rethrow
                 if first_failure is None:
                     first_failure = failure
-        for thread in reversed(threads):
+        owned_current = current_thread()
+        for launch in reversed(launches):
+            thread = launch.thread
+            if thread is owned_current:
+                raise IndexJobBackgroundServiceError(
+                    "an owned index loop cannot join itself"
+                )
+            if not launch.attempted:
+                continue
+
+            launched = False
             while True:
                 try:
-                    started = thread.ident is not None
+                    entered = launch.entered.is_set()
                 except BaseException as failure:  # noqa: B036 - retry state read
                     if first_failure is None:
                         first_failure = failure
                     continue
-                if not started:
+                if entered or launch.start_returned:
+                    launched = True
                     break
+                try:
+                    identified = thread.ident is not None
+                except BaseException as failure:  # noqa: B036 - retry state read
+                    if first_failure is None:
+                        first_failure = failure
+                    continue
+                try:
+                    alive = thread.is_alive()
+                except BaseException as failure:  # noqa: B036 - retry state read
+                    if first_failure is None:
+                        first_failure = failure
+                    continue
+                if identified or alive:
+                    launched = True
+                    break
+                start_failure = launch.start_failure
+                if start_failure is not None and isinstance(start_failure, Exception):
+                    # CPython's ordinary start failures occur before ownership
+                    # transfers to an OS thread. Cancellation-class failures
+                    # remain ambiguous and must wait for the child handshake.
+                    break
+                try:
+                    signaled = launch.entered.wait(0.05)
+                except BaseException as failure:  # noqa: B036 - await ownership
+                    if first_failure is None:
+                        first_failure = failure
+                    continue
+                if type(signaled) is not bool:
+                    if first_failure is None:
+                        first_failure = IndexJobBackgroundServiceError(
+                            "thread launch handshake returned an invalid decision"
+                        )
+                    continue
+                if signaled:
+                    launched = True
+                    break
+            if not launched:
+                continue
+            while True:
                 try:
                     alive = thread.is_alive()
                 except BaseException as failure:  # noqa: B036 - retry state read
@@ -191,8 +307,9 @@ class IndexJobBackgroundService:
         if first_failure is not None:
             raise first_failure
 
-    def _run_worker(self) -> None:
+    def _run_worker(self, entered: Event) -> None:
         try:
+            entered.set()
             summary = self._worker.run(self._stop)
             if type(summary) is not IndexJobSchedulerRunSummary:
                 raise IndexJobBackgroundServiceError(
@@ -207,8 +324,9 @@ class IndexJobBackgroundService:
         else:
             self._record_outcome("worker", summary=summary)
 
-    def _run_runtime(self) -> None:
+    def _run_runtime(self, entered: Event) -> None:
         try:
+            entered.set()
             summary = self._runtime.run(self._stop)
             if type(summary) is not IndexJobRuntimeLoopSummary:
                 raise IndexJobBackgroundServiceError(
@@ -223,67 +341,168 @@ class IndexJobBackgroundService:
         else:
             self._record_outcome("runtime", summary=summary)
 
-    def _start_locked(self) -> None:
-        if self._state != "new":
-            raise RuntimeError("background index service can start only once")
-        self._state = "starting"
+    def _build_launches(self) -> tuple[_ThreadLaunch, ...]:
+        runtime_entered = Event()
+        worker_entered = Event()
         runtime_thread = Thread(
-            target=self._run_runtime,
+            target=lambda: self._run_runtime(runtime_entered),
             name="codenib-index-runtime",
             daemon=False,
         )
         worker_thread = Thread(
-            target=self._run_worker,
+            target=lambda: self._run_worker(worker_entered),
             name="codenib-index-worker",
             daemon=False,
         )
-        # Retain both candidate threads before the first launch. If an
-        # asynchronous exception lands after ``Thread.start`` launches a
-        # thread, cleanup must not depend on interruptible post-start
-        # bookkeeping to remember that ownership.
-        self._threads = (runtime_thread, worker_thread)
-        try:
-            runtime_thread.start()
-            worker_thread.start()
-        except BaseException as failure:  # noqa: B036 - join partial start
-            self._terminal_failure = failure
-            try:
-                self._stop_and_join(self._threads)
-            except BaseException as cleanup_failure:  # noqa: B036
-                if cleanup_failure is not failure:
-                    add_note = getattr(failure, "add_note", None)
-                    if callable(add_note):
-                        add_note(
-                            "background service startup cleanup also failed: "
-                            f"{type(cleanup_failure).__name__}"
-                        )
-            self._state = "closed"
-            raise IndexJobBackgroundServiceError(
-                "background index service could not start"
-            ) from failure
+        return (
+            _ThreadLaunch(runtime_thread, runtime_entered),
+            _ThreadLaunch(worker_thread, worker_entered),
+        )
+
+    def _claim_start_locked(
+        self,
+        token: object,
+        launches: tuple[_ThreadLaunch, ...],
+    ) -> bool:
+        if self._state != "new" or self._start_token is not None:
+            return False
+        # Retain the candidates before publishing ownership. An interruption
+        # before the token write is harmless because no launch was attempted;
+        # after it, the caller can identify and settle this exact start call.
+        self._threads = launches
+        self._start_token = token
+        self._state = "starting"
+        return True
+
+    def _finish_start_locked(self, token: object) -> bool:
+        if self._start_token is not token:
+            return False
+        if self._state == "running":
+            return True
+        if self._state != "starting":
+            return False
         self._state = "running"
+        return True
+
+    def _begin_failed_start_locked(
+        self,
+        token: object,
+        failure: BaseException,
+    ) -> tuple[bool, bool, tuple[_ThreadLaunch, ...]]:
+        if self._start_token is not token:
+            return False, False, ()
+        if self._terminal_failure is None:
+            self._terminal_failure = failure
+        if self._state == "closed":
+            return True, False, ()
+        self._state = "stopping"
+        return True, True, self._threads
+
+    def _finish_failed_start_locked(self, token: object) -> None:
+        if self._start_token is token:
+            self._state = "closed"
+
+    @staticmethod
+    def _add_cleanup_note(primary: BaseException, cleanup: BaseException) -> None:
+        if cleanup is primary:
+            return
+        add_note = getattr(primary, "add_note", None)
+        if callable(add_note):
+            add_note(
+                "background service startup cleanup also failed: "
+                f"{type(cleanup).__name__}"
+            )
+
+    def _lifecycle_retry(
+        self,
+        callback: Callable[[], _LifecycleResult],
+        primary: BaseException,
+    ) -> _LifecycleResult:
+        while True:
+            try:
+                return self._lifecycle_lock.run(callback)
+            except BaseException as transition_failure:  # noqa: B036 - retry state
+                self._add_cleanup_note(primary, transition_failure)
+
+    def _settle_owned_start_failure(
+        self,
+        token: object,
+        primary: BaseException,
+    ) -> bool:
+        owned, needs_join, launches = self._lifecycle_retry(
+            lambda: self._begin_failed_start_locked(token, primary),
+            primary,
+        )
+        if not owned:
+            return False
+        if needs_join:
+            try:
+                self._stop_and_join(launches)
+            except BaseException as cleanup_failure:  # noqa: B036 - keep primary
+                self._add_cleanup_note(primary, cleanup_failure)
+            self._lifecycle_retry(
+                lambda: self._finish_failed_start_locked(token),
+                primary,
+            )
+        return True
+
+    def _start_serialized(self, token: object) -> None:
+        launches = self._build_launches()
+        try:
+            claimed = self._lifecycle_lock.run(
+                lambda: self._claim_start_locked(token, launches)
+            )
+            if not claimed:
+                raise RuntimeError("background index service can start only once")
+            for launch in launches:
+                launch.start()
+            published = self._lifecycle_lock.run(
+                lambda: self._finish_start_locked(token)
+            )
+            if not published:
+                raise RuntimeError("background index service start state changed")
+        except BaseException as failure:  # noqa: B036 - join partial start
+            self._settle_owned_start_failure(token, failure)
+            raise
 
     def start(self) -> None:
         """Start the runtime thread before the worker execution thread."""
 
-        self._lifecycle_lock.run(self._start_locked)
+        token = object()
+        try:
+            self._settlement_lock.run(lambda: self._start_serialized(token))
+        except BaseException as failure:  # noqa: B036 - recover lock-release window
+            primary = failure
+            while True:
+                try:
+                    owned = self._settlement_lock.run(
+                        lambda: self._settle_owned_start_failure(token, primary)
+                    )
+                    break
+                except BaseException as cleanup_failure:  # noqa: B036 - retry settle
+                    self._add_cleanup_note(primary, cleanup_failure)
+            if not owned:
+                raise
+            raise IndexJobBackgroundServiceError(
+                "background index service could not start"
+            ) from primary
 
-    def _close_locked(self) -> IndexJobBackgroundServiceSummary:
+    def _begin_close_locked(self) -> tuple[bool, tuple[_ThreadLaunch, ...]]:
         if self._state == "new":
             self._state = "closed"
             self._summary = IndexJobBackgroundServiceSummary(
                 worker=IndexJobSchedulerRunSummary(0, 0, 0),
                 runtime=IndexJobRuntimeLoopSummary(0, 0, 0),
             )
-        elif self._state in {"running", "starting"}:
+            return False, ()
+        if self._state in {"running", "starting", "stopping"}:
             self._state = "stopping"
-            try:
-                self._stop_and_join(self._threads)
-            finally:
-                self._state = "closed"
-        elif self._state not in {"stopping", "closed"}:
+            return True, self._threads
+        if self._state != "closed":
             raise RuntimeError("background index service state is invalid")
+        return False, ()
 
+    def _closed_result_locked(self) -> IndexJobBackgroundServiceSummary:
         if self._summary is not None:
             return self._summary
         if self._terminal_failure is not None:
@@ -315,10 +534,54 @@ class IndexJobBackgroundService:
         )
         return self._summary
 
+    def _finish_close_locked(self) -> None:
+        self._state = "closed"
+
+    def _close_serialized(self) -> IndexJobBackgroundServiceSummary:
+        interruption: BaseException | None = None
+
+        def remember(candidate: BaseException) -> None:
+            nonlocal interruption
+            if interruption is None:
+                interruption = candidate
+
+        while True:
+            try:
+                needs_join, launches = self._lifecycle_lock.run(
+                    self._begin_close_locked
+                )
+                break
+            except BaseException as state_failure:  # noqa: B036 - retry transition
+                remember(state_failure)
+        if needs_join:
+            try:
+                self._stop_and_join(launches)
+            except BaseException as failure:  # noqa: B036 - settled before rethrow
+                remember(failure)
+            while True:
+                try:
+                    self._lifecycle_lock.run(self._finish_close_locked)
+                    break
+                except BaseException as state_failure:  # noqa: B036 - retry publish
+                    remember(state_failure)
+        if interruption is not None:
+            raise interruption
+        return self._lifecycle_lock.run(self._closed_result_locked)
+
+    def _called_from_owned_thread(self) -> bool:
+        current = current_thread()
+        return self._lifecycle_lock.run(
+            lambda: any(launch.thread is current for launch in self._threads)
+        )
+
     def close(self) -> IndexJobBackgroundServiceSummary:
         """Stop and join both loops before shared resources may be released."""
 
-        return self._lifecycle_lock.run(self._close_locked)
+        if self._called_from_owned_thread():
+            raise IndexJobBackgroundServiceError(
+                "background index service cannot close from an owned loop"
+            )
+        return self._settlement_lock.run(self._close_serialized)
 
 
 __all__ = [

--- a/codenib/web/index_job_service.py
+++ b/codenib/web/index_job_service.py
@@ -1,0 +1,312 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Owned background lifecycle for durable Web index-job loops."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import Event, Thread
+from typing import Protocol, runtime_checkable
+
+from .._owned_file_publication import _CancellationSafeRLock
+from ..log_utils import get_logger
+from ..storage import IndexJobSchedulerRunSummary, IndexJobSchedulerStopSignal
+from .index_job_runtime import IndexJobRuntimeLoopSummary
+
+logger = get_logger(__name__)
+
+
+class IndexJobBackgroundServiceError(RuntimeError):
+    """The owned worker/runtime background service failed safely."""
+
+
+@runtime_checkable
+class IndexJobWorkerLoop(Protocol):
+    """Run the configured durable job worker until cooperatively stopped."""
+
+    def run(
+        self,
+        stop_signal: IndexJobSchedulerStopSignal,
+    ) -> IndexJobSchedulerRunSummary: ...
+
+
+@runtime_checkable
+class IndexJobActivationLoop(Protocol):
+    """Run current-result reconciliation until cooperatively stopped."""
+
+    def run(
+        self,
+        stop_signal: IndexJobSchedulerStopSignal,
+    ) -> IndexJobRuntimeLoopSummary: ...
+
+
+@dataclass(frozen=True, slots=True)
+class IndexJobBackgroundServiceSummary:
+    """Terminal summaries from both cooperatively stopped loops."""
+
+    worker: IndexJobSchedulerRunSummary
+    runtime: IndexJobRuntimeLoopSummary
+
+    def __post_init__(self) -> None:
+        if type(self) is not IndexJobBackgroundServiceSummary:
+            raise TypeError("background service summary must use the exact type")
+        if type(self.worker) is not IndexJobSchedulerRunSummary:
+            raise TypeError("background service worker summary is invalid")
+        if type(self.runtime) is not IndexJobRuntimeLoopSummary:
+            raise TypeError("background service runtime summary is invalid")
+
+
+@dataclass(frozen=True, slots=True)
+class _LoopOutcome:
+    summary: object | None = None
+    failure: BaseException | None = None
+
+
+class IndexJobBackgroundService:
+    """Own one worker loop and one runtime loop through ordered shutdown.
+
+    Either loop fault stops its peer. ``close`` joins both non-daemon threads
+    before returning or reporting a sanitized failure, so callers may then
+    release the shared catalog, object store, and repository registry.
+    """
+
+    def __init__(
+        self,
+        worker: IndexJobWorkerLoop,
+        runtime: IndexJobActivationLoop,
+    ) -> None:
+        if not isinstance(worker, IndexJobWorkerLoop):
+            raise TypeError("background service requires a worker loop")
+        if not isinstance(runtime, IndexJobActivationLoop):
+            raise TypeError("background service requires a runtime loop")
+        self._worker = worker
+        self._runtime = runtime
+        self._stop = Event()
+        self._lifecycle_lock = _CancellationSafeRLock()
+        self._outcome_lock = _CancellationSafeRLock()
+        self._state = "new"
+        self._outcomes: dict[str, _LoopOutcome] = {}
+        self._threads: tuple[Thread, ...] = ()
+        self._summary: IndexJobBackgroundServiceSummary | None = None
+        self._terminal_failure: BaseException | None = None
+
+    @property
+    def state(self) -> str:
+        """Return the exact lifecycle state for health and tests."""
+
+        return self._lifecycle_lock.run(lambda: self._state)
+
+    @property
+    def healthy(self) -> bool:
+        """Return whether no owned loop has reported a terminal fault."""
+
+        def read() -> bool:
+            terminal_failure = self._terminal_failure
+            return self._outcome_lock.run(
+                lambda: terminal_failure is None
+                and not any(
+                    outcome.failure is not None for outcome in self._outcomes.values()
+                )
+            )
+
+        return self._lifecycle_lock.run(read)
+
+    def _record_outcome(
+        self,
+        name: str,
+        *,
+        summary: object | None = None,
+        failure: BaseException | None = None,
+    ) -> None:
+        def record() -> bool:
+            if name in self._outcomes:
+                self._outcomes[name] = _LoopOutcome(
+                    failure=IndexJobBackgroundServiceError(
+                        "background index loop reported more than one outcome"
+                    )
+                )
+                return False
+            self._outcomes[name] = _LoopOutcome(summary=summary, failure=failure)
+            return True
+
+        recorded = self._outcome_lock.run(record)
+        if not recorded:
+            self._stop.set()
+            return
+        if failure is not None:
+            self._stop.set()
+            try:
+                logger.error(
+                    "Durable index %s loop failed",
+                    name,
+                    exc_info=(type(failure), failure, failure.__traceback__),
+                )
+            except Exception:
+                # The shared stop is authoritative; logging is best effort.
+                pass
+
+    def _stop_and_join(self, threads: tuple[Thread, ...]) -> None:
+        """Settle every started thread before rethrowing an interruption."""
+
+        first_failure: BaseException | None = None
+        while not self._stop.is_set():
+            try:
+                self._stop.set()
+            except BaseException as failure:  # noqa: B036 - settle before rethrow
+                if first_failure is None:
+                    first_failure = failure
+        for thread in reversed(threads):
+            while thread.is_alive():
+                try:
+                    thread.join()
+                except BaseException as failure:  # noqa: B036 - settle all loops
+                    if first_failure is None:
+                        first_failure = failure
+        if first_failure is not None:
+            raise first_failure
+
+    def _run_worker(self) -> None:
+        try:
+            summary = self._worker.run(self._stop)
+            if type(summary) is not IndexJobSchedulerRunSummary:
+                raise IndexJobBackgroundServiceError(
+                    "background worker returned an invalid summary"
+                )
+            if not self._stop.is_set():
+                raise IndexJobBackgroundServiceError(
+                    "background worker exited before shutdown"
+                )
+        except BaseException as failure:  # noqa: B036 - retain thread fault
+            self._record_outcome("worker", failure=failure)
+        else:
+            self._record_outcome("worker", summary=summary)
+
+    def _run_runtime(self) -> None:
+        try:
+            summary = self._runtime.run(self._stop)
+            if type(summary) is not IndexJobRuntimeLoopSummary:
+                raise IndexJobBackgroundServiceError(
+                    "background runtime returned an invalid summary"
+                )
+            if not self._stop.is_set():
+                raise IndexJobBackgroundServiceError(
+                    "background runtime exited before shutdown"
+                )
+        except BaseException as failure:  # noqa: B036 - retain thread fault
+            self._record_outcome("runtime", failure=failure)
+        else:
+            self._record_outcome("runtime", summary=summary)
+
+    def _start_locked(self) -> None:
+        if self._state != "new":
+            raise RuntimeError("background index service can start only once")
+        self._state = "starting"
+        runtime_thread = Thread(
+            target=self._run_runtime,
+            name="codenib-index-runtime",
+            daemon=False,
+        )
+        worker_thread = Thread(
+            target=self._run_worker,
+            name="codenib-index-worker",
+            daemon=False,
+        )
+        started: list[Thread] = []
+        try:
+            try:
+                runtime_thread.start()
+            finally:
+                if runtime_thread.ident is not None:
+                    started.append(runtime_thread)
+            try:
+                worker_thread.start()
+            finally:
+                if worker_thread.ident is not None:
+                    started.append(worker_thread)
+        except BaseException as failure:  # noqa: B036 - join partial start
+            self._threads = tuple(started)
+            self._terminal_failure = failure
+            try:
+                self._stop_and_join(self._threads)
+            except BaseException as cleanup_failure:  # noqa: B036
+                if cleanup_failure is not failure:
+                    add_note = getattr(failure, "add_note", None)
+                    if callable(add_note):
+                        add_note(
+                            "background service startup cleanup also failed: "
+                            f"{type(cleanup_failure).__name__}"
+                        )
+            self._state = "closed"
+            raise IndexJobBackgroundServiceError(
+                "background index service could not start"
+            ) from failure
+        self._threads = tuple(started)
+        self._state = "running"
+
+    def start(self) -> None:
+        """Start the runtime thread before the worker execution thread."""
+
+        self._lifecycle_lock.run(self._start_locked)
+
+    def _close_locked(self) -> IndexJobBackgroundServiceSummary:
+        if self._state == "new":
+            self._state = "closed"
+            self._summary = IndexJobBackgroundServiceSummary(
+                worker=IndexJobSchedulerRunSummary(0, 0, 0),
+                runtime=IndexJobRuntimeLoopSummary(0, 0, 0),
+            )
+        elif self._state in {"running", "starting"}:
+            self._state = "stopping"
+            try:
+                self._stop_and_join(self._threads)
+            finally:
+                self._state = "closed"
+        elif self._state not in {"stopping", "closed"}:
+            raise RuntimeError("background index service state is invalid")
+
+        if self._summary is not None:
+            return self._summary
+        if self._terminal_failure is not None:
+            raise IndexJobBackgroundServiceError(
+                "background index service failed"
+            ) from self._terminal_failure
+        outcomes = self._outcome_lock.run(lambda: dict(self._outcomes))
+        failure = next(
+            (
+                outcome.failure
+                for name in ("runtime", "worker")
+                if (outcome := outcomes.get(name)) is not None
+                and outcome.failure is not None
+            ),
+            None,
+        )
+        if failure is not None:
+            self._terminal_failure = failure
+            raise IndexJobBackgroundServiceError(
+                "background index service failed"
+            ) from failure
+        worker = outcomes.get("worker")
+        runtime = outcomes.get("runtime")
+        if worker is None or runtime is None:
+            raise RuntimeError("background index service outcome is incomplete")
+        self._summary = IndexJobBackgroundServiceSummary(
+            worker=worker.summary,  # type: ignore[arg-type]
+            runtime=runtime.summary,  # type: ignore[arg-type]
+        )
+        return self._summary
+
+    def close(self) -> IndexJobBackgroundServiceSummary:
+        """Stop and join both loops before shared resources may be released."""
+
+        return self._lifecycle_lock.run(self._close_locked)
+
+
+__all__ = [
+    "IndexJobActivationLoop",
+    "IndexJobBackgroundService",
+    "IndexJobBackgroundServiceError",
+    "IndexJobBackgroundServiceSummary",
+    "IndexJobWorkerLoop",
+]

--- a/codenib/web/index_job_service.py
+++ b/codenib/web/index_job_service.py
@@ -151,14 +151,38 @@ class IndexJobBackgroundService:
         """Settle every started thread before rethrowing an interruption."""
 
         first_failure: BaseException | None = None
-        while not self._stop.is_set():
+        while True:
+            try:
+                stopped = self._stop.is_set()
+            except BaseException as failure:  # noqa: B036 - retry state read
+                if first_failure is None:
+                    first_failure = failure
+                continue
+            if stopped:
+                break
             try:
                 self._stop.set()
             except BaseException as failure:  # noqa: B036 - settle before rethrow
                 if first_failure is None:
                     first_failure = failure
         for thread in reversed(threads):
-            while thread.is_alive():
+            while True:
+                try:
+                    started = thread.ident is not None
+                except BaseException as failure:  # noqa: B036 - retry state read
+                    if first_failure is None:
+                        first_failure = failure
+                    continue
+                if not started:
+                    break
+                try:
+                    alive = thread.is_alive()
+                except BaseException as failure:  # noqa: B036 - retry state read
+                    if first_failure is None:
+                        first_failure = failure
+                    continue
+                if not alive:
+                    break
                 try:
                     thread.join()
                 except BaseException as failure:  # noqa: B036 - settle all loops
@@ -213,20 +237,15 @@ class IndexJobBackgroundService:
             name="codenib-index-worker",
             daemon=False,
         )
-        started: list[Thread] = []
+        # Retain both candidate threads before the first launch. If an
+        # asynchronous exception lands after ``Thread.start`` launches a
+        # thread, cleanup must not depend on interruptible post-start
+        # bookkeeping to remember that ownership.
+        self._threads = (runtime_thread, worker_thread)
         try:
-            try:
-                runtime_thread.start()
-            finally:
-                if runtime_thread.ident is not None:
-                    started.append(runtime_thread)
-            try:
-                worker_thread.start()
-            finally:
-                if worker_thread.ident is not None:
-                    started.append(worker_thread)
+            runtime_thread.start()
+            worker_thread.start()
         except BaseException as failure:  # noqa: B036 - join partial start
-            self._threads = tuple(started)
             self._terminal_failure = failure
             try:
                 self._stop_and_join(self._threads)
@@ -242,7 +261,6 @@ class IndexJobBackgroundService:
             raise IndexJobBackgroundServiceError(
                 "background index service could not start"
             ) from failure
-        self._threads = tuple(started)
         self._state = "running"
 
     def start(self) -> None:

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1666,9 +1666,13 @@ MCP, UI controls, and default routing remain absent.
   materialization. The production runtime's cooperative polling loop reconciles
   once immediately, retries sanitized transient activation failures, and
   periodically replays current durable results with exact return and stop-signal
-  validation.
-  Server lifespan ownership and explicit local storage configuration remain
-  separate gates.
+  validation. A shared background owner starts that runtime thread before the
+  worker thread, uses one cooperative stop signal, stops the peer after either
+  loop faults, and joins both non-daemon threads before shared storage or registry
+  resources may be released. Partial thread start and interrupted shutdown still
+  settle every thread before reporting a sanitized lifecycle failure.
+  Explicit local storage composition, configuration, and server lifespan
+  installation remain separate gates.
 - An explicitly injected Web reader can now project authorized durable jobs and
   at most 64 events without exposing worker owner IDs, fencing tokens, or raw
   executor errors or event keys. Each event is rebound to the exact job, a

--- a/test/web/test_index_job_service.py
+++ b/test/web/test_index_job_service.py
@@ -128,6 +128,80 @@ def test_partial_thread_start_failure_stops_and_joins_started_runtime(
         service.close()
 
 
+def test_interrupted_post_start_bookkeeping_still_joins_launched_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _Loop(_runtime_summary())
+
+    class InterruptingThread(Thread):
+        _interrupt_ident = False
+
+        @property
+        def ident(self):
+            if self._interrupt_ident:
+                self._interrupt_ident = False
+                raise KeyboardInterrupt
+            return super().ident
+
+        def start(self) -> None:
+            super().start()
+            if self.name == "codenib-index-runtime":
+                self._interrupt_ident = True
+                raise KeyboardInterrupt
+
+    monkeypatch.setattr(service_module, "Thread", InterruptingThread)
+    service = IndexJobBackgroundService(_Loop(_worker_summary()), runtime)
+
+    with pytest.raises(IndexJobBackgroundServiceError, match="could not start"):
+        service.start()
+
+    assert service.state == "closed"
+    assert runtime.exited.is_set()
+    with pytest.raises(IndexJobBackgroundServiceError, match="service failed"):
+        service.close()
+
+
+def test_close_retries_interrupted_stop_and_thread_state_checks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    worker = _Loop(_worker_summary())
+    runtime = _Loop(_runtime_summary())
+    service = IndexJobBackgroundService(worker, runtime)
+    service.start()
+    assert runtime.entered.wait(1)
+    assert worker.entered.wait(1)
+    real_is_set = service._stop.is_set
+    real_is_alive = Thread.is_alive
+    interruptions = {"stop": False, "thread": False}
+
+    def is_set() -> bool:
+        if not interruptions["stop"]:
+            interruptions["stop"] = True
+            raise KeyboardInterrupt
+        return real_is_set()
+
+    def is_alive(thread: Thread) -> bool:
+        if thread.name == "codenib-index-worker" and not interruptions["thread"]:
+            interruptions["thread"] = True
+            raise KeyboardInterrupt
+        return real_is_alive(thread)
+
+    monkeypatch.setattr(service._stop, "is_set", is_set)
+    monkeypatch.setattr(service_module.Thread, "is_alive", is_alive)
+
+    with pytest.raises(KeyboardInterrupt):
+        service.close()
+
+    assert interruptions == {"stop": True, "thread": True}
+    assert worker.exited.is_set()
+    assert runtime.exited.is_set()
+    assert service.state == "closed"
+    assert service.close() == IndexJobBackgroundServiceSummary(
+        worker=_worker_summary(),
+        runtime=_runtime_summary(),
+    )
+
+
 def test_close_settles_both_threads_before_rethrowing_interruption(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/test/web/test_index_job_service.py
+++ b/test/web/test_index_job_service.py
@@ -87,6 +87,41 @@ def test_background_loop_fault_stops_peer_and_is_reported_after_join() -> None:
     assert service.state == "closed"
 
 
+def test_interrupted_outcome_commit_still_stops_peer_and_retains_failure() -> None:
+    failure = RuntimeError("private worker failure")
+
+    class Worker:
+        def run(self, _stop_signal):
+            raise failure
+
+    class InterruptAfterCommitLock:
+        def __init__(self, lock) -> None:
+            self.lock = lock
+            self.interrupted = False
+
+        def run(self, callback):
+            result = self.lock.run(callback)
+            if not self.interrupted:
+                self.interrupted = True
+                raise KeyboardInterrupt
+            return result
+
+    runtime = _Loop(_runtime_summary())
+    service = IndexJobBackgroundService(Worker(), runtime)
+    outcome_lock = InterruptAfterCommitLock(service._outcome_lock)
+    service._outcome_lock = outcome_lock
+    service.start()
+
+    assert runtime.entered.wait(1)
+    assert runtime.exited.wait(1)
+    with pytest.raises(IndexJobBackgroundServiceError) as error:
+        service.close()
+
+    assert outcome_lock.interrupted is True
+    assert error.value.__cause__ is failure
+    assert service.state == "closed"
+
+
 def test_background_loop_cannot_exit_cleanly_before_shutdown() -> None:
     class Worker:
         def run(self, _stop_signal):
@@ -128,28 +163,32 @@ def test_partial_thread_start_failure_stops_and_joins_started_runtime(
         service.close()
 
 
-def test_interrupted_post_start_bookkeeping_still_joins_launched_thread(
+def test_interrupted_pre_ident_start_waits_for_child_entry_before_cleanup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     runtime = _Loop(_runtime_summary())
+    delay = Event()
 
-    class InterruptingThread(Thread):
-        _interrupt_ident = False
-
-        @property
-        def ident(self):
-            if self._interrupt_ident:
-                self._interrupt_ident = False
-                raise KeyboardInterrupt
-            return super().ident
+    class DelayedStartThread(Thread):
+        _delayed = False
 
         def start(self) -> None:
-            super().start()
-            if self.name == "codenib-index-runtime":
-                self._interrupt_ident = True
-                raise KeyboardInterrupt
+            if self.name == "codenib-index-runtime" and not self._delayed:
+                self._delayed = True
 
-    monkeypatch.setattr(service_module, "Thread", InterruptingThread)
+                def launch_after_interruption() -> None:
+                    delay.wait(0.05)
+                    Thread.start(self)
+
+                Thread(
+                    target=launch_after_interruption,
+                    name="test-delayed-index-launch",
+                    daemon=True,
+                ).start()
+                raise KeyboardInterrupt
+            Thread.start(self)
+
+    monkeypatch.setattr(service_module, "Thread", DelayedStartThread)
     service = IndexJobBackgroundService(_Loop(_worker_summary()), runtime)
 
     with pytest.raises(IndexJobBackgroundServiceError, match="could not start"):
@@ -159,6 +198,166 @@ def test_interrupted_post_start_bookkeeping_still_joins_launched_thread(
     assert runtime.exited.is_set()
     with pytest.raises(IndexJobBackgroundServiceError, match="service failed"):
         service.close()
+
+
+def test_interrupted_start_serialization_release_settles_running_loops() -> None:
+    class InterruptAfterRunLock:
+        def __init__(self, lock) -> None:
+            self.lock = lock
+            self.interrupted = False
+
+        def run(self, callback):
+            result = self.lock.run(callback)
+            if not self.interrupted:
+                self.interrupted = True
+                raise KeyboardInterrupt
+            return result
+
+    worker = _Loop(_worker_summary())
+    runtime = _Loop(_runtime_summary())
+    service = IndexJobBackgroundService(worker, runtime)
+    settlement_lock = InterruptAfterRunLock(service._settlement_lock)
+    service._settlement_lock = settlement_lock
+
+    with pytest.raises(IndexJobBackgroundServiceError, match="could not start"):
+        service.start()
+
+    assert settlement_lock.interrupted is True
+    assert service.state == "closed"
+    assert worker.exited.is_set()
+    assert runtime.exited.is_set()
+    with pytest.raises(IndexJobBackgroundServiceError, match="service failed"):
+        service.close()
+
+
+def test_interrupted_running_publication_settles_started_loops() -> None:
+    class InterruptRunningPublicationLock:
+        def __init__(self, lock, service) -> None:
+            self.lock = lock
+            self.service = service
+            self.interrupted = False
+
+        def run(self, callback):
+            result = self.lock.run(callback)
+            if self.service._state == "running" and not self.interrupted:
+                self.interrupted = True
+                raise KeyboardInterrupt
+            return result
+
+    worker = _Loop(_worker_summary())
+    runtime = _Loop(_runtime_summary())
+    service = IndexJobBackgroundService(worker, runtime)
+    lifecycle_lock = InterruptRunningPublicationLock(
+        service._lifecycle_lock,
+        service,
+    )
+    service._lifecycle_lock = lifecycle_lock
+
+    with pytest.raises(IndexJobBackgroundServiceError, match="could not start"):
+        service.start()
+
+    assert lifecycle_lock.interrupted is True
+    assert service.state == "closed"
+    assert worker.exited.is_set()
+    assert runtime.exited.is_set()
+
+
+def test_owned_loop_cannot_close_and_is_joined_by_external_shutdown() -> None:
+    holder = {}
+
+    class Worker:
+        def __init__(self) -> None:
+            self.entered = Event()
+
+        def run(self, _stop_signal):
+            self.entered.set()
+            holder["service"].close()
+            raise AssertionError("owned close unexpectedly returned")
+
+    worker = Worker()
+    runtime = _Loop(_runtime_summary())
+    service = IndexJobBackgroundService(worker, runtime)
+    holder["service"] = service
+    service.start()
+
+    assert worker.entered.wait(1)
+    assert runtime.exited.wait(1)
+    with pytest.raises(IndexJobBackgroundServiceError) as error:
+        service.close()
+
+    assert type(error.value.__cause__) is IndexJobBackgroundServiceError
+    assert "cannot close from an owned loop" in str(error.value.__cause__)
+    assert service.state == "closed"
+
+
+def test_close_releases_lifecycle_lock_while_loops_observe_state() -> None:
+    holder = {}
+    observations = []
+
+    class StateReadingLoop(_Loop):
+        def run(self, stop_signal):
+            self.stop_signal = stop_signal
+            self.entered.set()
+            stop_signal.wait()
+            service = holder["service"]
+            observations.append((service.state, service.healthy))
+            self.exited.set()
+            return self.summary
+
+    worker = StateReadingLoop(_worker_summary())
+    runtime = _Loop(_runtime_summary())
+    service = IndexJobBackgroundService(worker, runtime)
+    holder["service"] = service
+    service.start()
+    assert worker.entered.wait(1)
+    assert runtime.entered.wait(1)
+
+    summary = service.close()
+
+    assert summary == IndexJobBackgroundServiceSummary(
+        worker=_worker_summary(),
+        runtime=_runtime_summary(),
+    )
+    assert observations == [("stopping", True)]
+
+
+def test_interrupted_close_transition_still_stops_and_joins_loops() -> None:
+    class InterruptStoppingPublicationLock:
+        def __init__(self, lock, service) -> None:
+            self.lock = lock
+            self.service = service
+            self.interrupted = False
+
+        def run(self, callback):
+            result = self.lock.run(callback)
+            if self.service._state == "stopping" and not self.interrupted:
+                self.interrupted = True
+                raise KeyboardInterrupt
+            return result
+
+    worker = _Loop(_worker_summary())
+    runtime = _Loop(_runtime_summary())
+    service = IndexJobBackgroundService(worker, runtime)
+    service.start()
+    assert runtime.entered.wait(1)
+    assert worker.entered.wait(1)
+    lifecycle_lock = InterruptStoppingPublicationLock(
+        service._lifecycle_lock,
+        service,
+    )
+    service._lifecycle_lock = lifecycle_lock
+
+    with pytest.raises(KeyboardInterrupt):
+        service.close()
+
+    assert lifecycle_lock.interrupted is True
+    assert worker.exited.is_set()
+    assert runtime.exited.is_set()
+    assert service.state == "closed"
+    assert service.close() == IndexJobBackgroundServiceSummary(
+        worker=_worker_summary(),
+        runtime=_runtime_summary(),
+    )
 
 
 def test_close_retries_interrupted_stop_and_thread_state_checks(
@@ -247,3 +446,24 @@ def test_background_service_closes_cleanly_before_start_and_rejects_restart() ->
     )
     with pytest.raises(RuntimeError, match="only once"):
         service.start()
+
+
+def test_second_start_is_rejected_without_stopping_running_service() -> None:
+    worker = _Loop(_worker_summary())
+    runtime = _Loop(_runtime_summary())
+    service = IndexJobBackgroundService(worker, runtime)
+    service.start()
+    assert runtime.entered.wait(1)
+    assert worker.entered.wait(1)
+
+    with pytest.raises(RuntimeError, match="only once"):
+        service.start()
+
+    assert service.state == "running"
+    assert service.healthy is True
+    assert worker.exited.is_set() is False
+    assert runtime.exited.is_set() is False
+    assert service.close() == IndexJobBackgroundServiceSummary(
+        worker=_worker_summary(),
+        runtime=_runtime_summary(),
+    )

--- a/test/web/test_index_job_service.py
+++ b/test/web/test_index_job_service.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from threading import Event, Thread
+
+import pytest
+
+import codenib.web.index_job_service as service_module
+from codenib.storage import IndexJobSchedulerRunSummary
+from codenib.web.index_job_runtime import IndexJobRuntimeLoopSummary
+from codenib.web.index_job_service import (
+    IndexJobBackgroundService,
+    IndexJobBackgroundServiceError,
+    IndexJobBackgroundServiceSummary,
+)
+
+
+class _Loop:
+    def __init__(self, summary) -> None:
+        self.summary = summary
+        self.entered = Event()
+        self.exited = Event()
+        self.stop_signal = None
+
+    def run(self, stop_signal):
+        self.stop_signal = stop_signal
+        self.entered.set()
+        stop_signal.wait()
+        self.exited.set()
+        return self.summary
+
+
+def _worker_summary() -> IndexJobSchedulerRunSummary:
+    return IndexJobSchedulerRunSummary(0, 0, 0)
+
+
+def _runtime_summary() -> IndexJobRuntimeLoopSummary:
+    return IndexJobRuntimeLoopSummary(0, 0, 0)
+
+
+def test_background_service_stops_and_joins_both_owned_loops() -> None:
+    worker = _Loop(_worker_summary())
+    runtime = _Loop(_runtime_summary())
+    service = IndexJobBackgroundService(worker, runtime)
+
+    service.start()
+    assert runtime.entered.wait(1)
+    assert worker.entered.wait(1)
+    assert service.state == "running"
+    assert service.healthy is True
+    assert worker.stop_signal is runtime.stop_signal
+
+    summary = service.close()
+
+    assert summary == IndexJobBackgroundServiceSummary(
+        worker=_worker_summary(),
+        runtime=_runtime_summary(),
+    )
+    assert service.close() is summary
+    assert service.state == "closed"
+    assert worker.exited.is_set()
+    assert runtime.exited.is_set()
+
+
+def test_background_loop_fault_stops_peer_and_is_reported_after_join() -> None:
+    failure = RuntimeError("private worker failure")
+
+    class Worker:
+        def run(self, _stop_signal):
+            raise failure
+
+    runtime = _Loop(_runtime_summary())
+    service = IndexJobBackgroundService(Worker(), runtime)
+    service.start()
+
+    assert runtime.entered.wait(1)
+    assert runtime.exited.wait(1)
+    assert service.healthy is False
+    with pytest.raises(IndexJobBackgroundServiceError, match="service failed") as error:
+        service.close()
+
+    assert "private" not in str(error.value)
+    assert error.value.__cause__ is failure
+    assert service.state == "closed"
+
+
+def test_partial_thread_start_failure_stops_and_joins_started_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _Loop(_runtime_summary())
+    service = IndexJobBackgroundService(_Loop(_worker_summary()), runtime)
+    real_start = Thread.start
+
+    def start(thread: Thread) -> None:
+        if thread.name == "codenib-index-worker":
+            raise RuntimeError("private start failure")
+        real_start(thread)
+
+    monkeypatch.setattr(service_module.Thread, "start", start)
+
+    with pytest.raises(IndexJobBackgroundServiceError, match="could not start"):
+        service.start()
+
+    assert service.state == "closed"
+    assert runtime.exited.is_set()
+    assert service.healthy is False
+    with pytest.raises(IndexJobBackgroundServiceError, match="service failed"):
+        service.close()
+
+
+def test_close_settles_both_threads_before_rethrowing_interruption(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    worker = _Loop(_worker_summary())
+    runtime = _Loop(_runtime_summary())
+    service = IndexJobBackgroundService(worker, runtime)
+    service.start()
+    assert runtime.entered.wait(1)
+    assert worker.entered.wait(1)
+    real_join = Thread.join
+    interrupted = False
+
+    def join(thread: Thread, *args, **kwargs) -> None:
+        nonlocal interrupted
+        if thread.name == "codenib-index-worker" and not interrupted:
+            interrupted = True
+            raise KeyboardInterrupt
+        real_join(thread, *args, **kwargs)
+
+    monkeypatch.setattr(service_module.Thread, "join", join)
+
+    with pytest.raises(KeyboardInterrupt):
+        service.close()
+
+    assert worker.exited.is_set()
+    assert runtime.exited.is_set()
+    assert service.state == "closed"
+    assert service.close() == IndexJobBackgroundServiceSummary(
+        worker=_worker_summary(),
+        runtime=_runtime_summary(),
+    )
+
+
+def test_background_service_closes_cleanly_before_start_and_rejects_restart() -> None:
+    service = IndexJobBackgroundService(
+        _Loop(_worker_summary()),
+        _Loop(_runtime_summary()),
+    )
+
+    assert service.close() == IndexJobBackgroundServiceSummary(
+        worker=_worker_summary(),
+        runtime=_runtime_summary(),
+    )
+    with pytest.raises(RuntimeError, match="only once"):
+        service.start()

--- a/test/web/test_index_job_service.py
+++ b/test/web/test_index_job_service.py
@@ -87,6 +87,23 @@ def test_background_loop_fault_stops_peer_and_is_reported_after_join() -> None:
     assert service.state == "closed"
 
 
+def test_background_loop_cannot_exit_cleanly_before_shutdown() -> None:
+    class Worker:
+        def run(self, _stop_signal):
+            return _worker_summary()
+
+    runtime = _Loop(_runtime_summary())
+    service = IndexJobBackgroundService(Worker(), runtime)
+    service.start()
+
+    assert runtime.exited.wait(1)
+    with pytest.raises(IndexJobBackgroundServiceError) as error:
+        service.close()
+
+    assert type(error.value.__cause__) is IndexJobBackgroundServiceError
+    assert "exited before shutdown" in str(error.value.__cause__)
+
+
 def test_partial_thread_start_failure_stops_and_joins_started_runtime(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/test/web/test_index_job_service.py
+++ b/test/web/test_index_job_service.py
@@ -163,37 +163,106 @@ def test_partial_thread_start_failure_stops_and_joins_started_runtime(
         service.close()
 
 
-def test_interrupted_pre_ident_start_waits_for_child_entry_before_cleanup(
+def test_interrupted_before_launcher_transfer_cancels_without_waiting_for_child(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     runtime = _Loop(_runtime_summary())
-    delay = Event()
 
-    class DelayedStartThread(Thread):
-        _delayed = False
-
+    class PreLaunchInterruptThread(Thread):
         def start(self) -> None:
-            if self.name == "codenib-index-runtime" and not self._delayed:
-                self._delayed = True
-
-                def launch_after_interruption() -> None:
-                    delay.wait(0.05)
-                    Thread.start(self)
-
-                Thread(
-                    target=launch_after_interruption,
-                    name="test-delayed-index-launch",
-                    daemon=True,
-                ).start()
+            if self.name == "codenib-index-runtime-launcher":
                 raise KeyboardInterrupt
             Thread.start(self)
 
-    monkeypatch.setattr(service_module, "Thread", DelayedStartThread)
+    monkeypatch.setattr(service_module, "Thread", PreLaunchInterruptThread)
     service = IndexJobBackgroundService(_Loop(_worker_summary()), runtime)
 
     with pytest.raises(IndexJobBackgroundServiceError, match="could not start"):
         service.start()
 
+    assert service.state == "closed"
+    assert runtime.entered.is_set() is False
+    with pytest.raises(IndexJobBackgroundServiceError, match="service failed"):
+        service.close()
+
+
+def test_interrupted_unclaimed_launcher_cancels_a_late_transfer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    launcher_exited = Event()
+    runtime = _Loop(_runtime_summary())
+
+    class DelayedLauncherThread(Thread):
+        _delayed = False
+
+        def start(self) -> None:
+            if self.name == "codenib-index-runtime-launcher" and not self._delayed:
+                self._delayed = True
+
+                def launch_later() -> None:
+                    Event().wait(0.05)
+                    Thread.start(self)
+                    self.join()
+                    launcher_exited.set()
+
+                Thread(
+                    target=launch_later,
+                    name="test-delayed-index-launcher",
+                    daemon=True,
+                ).start()
+                raise KeyboardInterrupt
+            Thread.start(self)
+
+    monkeypatch.setattr(service_module, "Thread", DelayedLauncherThread)
+    service = IndexJobBackgroundService(_Loop(_worker_summary()), runtime)
+
+    with pytest.raises(IndexJobBackgroundServiceError, match="could not start"):
+        service.start()
+
+    assert launcher_exited.wait(1)
+    assert service.state == "closed"
+    assert runtime.entered.is_set() is False
+    with pytest.raises(IndexJobBackgroundServiceError, match="service failed"):
+        service.close()
+
+
+def test_interrupted_claimed_launch_waits_for_transfer_and_joins_child(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    actual_start_entered = Event()
+    allow_actual_start = Event()
+    runtime = _Loop(_runtime_summary())
+
+    class ClaimedLaunchThread(Thread):
+        def start(self) -> None:
+            if self.name == "codenib-index-runtime":
+                actual_start_entered.set()
+                allow_actual_start.wait()
+                Thread.start(self)
+                return
+            if self.name == "codenib-index-runtime-launcher":
+                Thread.start(self)
+                assert actual_start_entered.wait(1)
+
+                def release_actual_start() -> None:
+                    Event().wait(0.05)
+                    allow_actual_start.set()
+
+                Thread(
+                    target=release_actual_start,
+                    name="test-release-index-launch",
+                    daemon=True,
+                ).start()
+                raise KeyboardInterrupt
+            Thread.start(self)
+
+    monkeypatch.setattr(service_module, "Thread", ClaimedLaunchThread)
+    service = IndexJobBackgroundService(_Loop(_worker_summary()), runtime)
+
+    with pytest.raises(IndexJobBackgroundServiceError, match="could not start"):
+        service.start()
+
+    assert actual_start_entered.is_set()
     assert service.state == "closed"
     assert runtime.exited.is_set()
     with pytest.raises(IndexJobBackgroundServiceError, match="service failed"):
@@ -360,7 +429,7 @@ def test_interrupted_close_transition_still_stops_and_joins_loops() -> None:
     )
 
 
-def test_close_retries_interrupted_stop_and_thread_state_checks(
+def test_close_replays_settlement_after_interrupted_state_checks(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     worker = _Loop(_worker_summary())
@@ -369,15 +438,26 @@ def test_close_retries_interrupted_stop_and_thread_state_checks(
     service.start()
     assert runtime.entered.wait(1)
     assert worker.entered.wait(1)
-    real_is_set = service._stop.is_set
+    real_set = service._stop.set
+    real_current_thread = service_module.current_thread
     real_is_alive = Thread.is_alive
-    interruptions = {"stop": False, "thread": False}
+    interruptions = {"stop": False, "current": False, "thread": False}
+    current_reads = 0
 
-    def is_set() -> bool:
+    def set_stop() -> None:
         if not interruptions["stop"]:
             interruptions["stop"] = True
+            real_set()
             raise KeyboardInterrupt
-        return real_is_set()
+        real_set()
+
+    def read_current_thread() -> Thread:
+        nonlocal current_reads
+        current_reads += 1
+        if current_reads > 1 and not interruptions["current"]:
+            interruptions["current"] = True
+            raise KeyboardInterrupt
+        return real_current_thread()
 
     def is_alive(thread: Thread) -> bool:
         if thread.name == "codenib-index-worker" and not interruptions["thread"]:
@@ -385,13 +465,14 @@ def test_close_retries_interrupted_stop_and_thread_state_checks(
             raise KeyboardInterrupt
         return real_is_alive(thread)
 
-    monkeypatch.setattr(service._stop, "is_set", is_set)
+    monkeypatch.setattr(service._stop, "set", set_stop)
+    monkeypatch.setattr(service_module, "current_thread", read_current_thread)
     monkeypatch.setattr(service_module.Thread, "is_alive", is_alive)
 
     with pytest.raises(KeyboardInterrupt):
         service.close()
 
-    assert interruptions == {"stop": True, "thread": True}
+    assert interruptions == {"stop": True, "current": True, "thread": True}
     assert worker.exited.is_set()
     assert runtime.exited.is_set()
     assert service.state == "closed"

--- a/test/web/test_index_job_service.py
+++ b/test/web/test_index_job_service.py
@@ -429,6 +429,40 @@ def test_interrupted_close_transition_still_stops_and_joins_loops() -> None:
     )
 
 
+def test_interrupted_close_preflight_still_settles_before_rethrow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    worker = _Loop(_worker_summary())
+    runtime = _Loop(_runtime_summary())
+    service = IndexJobBackgroundService(worker, runtime)
+    service.start()
+    assert runtime.entered.wait(1)
+    assert worker.entered.wait(1)
+    real_current_thread = service_module.current_thread
+    interrupted = False
+
+    def read_current_thread() -> Thread:
+        nonlocal interrupted
+        if not interrupted:
+            interrupted = True
+            raise KeyboardInterrupt
+        return real_current_thread()
+
+    monkeypatch.setattr(service_module, "current_thread", read_current_thread)
+
+    with pytest.raises(KeyboardInterrupt):
+        service.close()
+
+    assert interrupted is True
+    assert worker.exited.is_set()
+    assert runtime.exited.is_set()
+    assert service.state == "closed"
+    assert service.close() == IndexJobBackgroundServiceSummary(
+        worker=_worker_summary(),
+        runtime=_runtime_summary(),
+    )
+
+
 def test_close_replays_settlement_after_interrupted_state_checks(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -527,6 +561,42 @@ def test_background_service_closes_cleanly_before_start_and_rejects_restart() ->
     )
     with pytest.raises(RuntimeError, match="only once"):
         service.start()
+
+
+def test_interrupted_close_before_start_retains_empty_summary() -> None:
+    class InterruptClosedPublicationLock:
+        def __init__(self, lock, service) -> None:
+            self.lock = lock
+            self.service = service
+            self.interrupted = False
+
+        def run(self, callback):
+            result = self.lock.run(callback)
+            if self.service._state == "closed" and not self.interrupted:
+                self.interrupted = True
+                raise KeyboardInterrupt
+            return result
+
+    service = IndexJobBackgroundService(
+        _Loop(_worker_summary()),
+        _Loop(_runtime_summary()),
+    )
+    lifecycle_lock = InterruptClosedPublicationLock(
+        service._lifecycle_lock,
+        service,
+    )
+    service._lifecycle_lock = lifecycle_lock
+
+    with pytest.raises(KeyboardInterrupt):
+        service.close()
+
+    expected = IndexJobBackgroundServiceSummary(
+        worker=_worker_summary(),
+        runtime=_runtime_summary(),
+    )
+    assert lifecycle_lock.interrupted is True
+    assert service.state == "closed"
+    assert service.close() == expected
 
 
 def test_second_start_is_rejected_without_stopping_running_service() -> None:


### PR DESCRIPTION
## Summary
Own the durable Web index worker scheduler and current-result runtime reconciler as one cooperative background service. The runtime starts before the worker, either loop fault stops its peer, and shutdown joins every owned non-daemon thread before shared resources may be released.

#728 is merged, and these commits are restacked onto its rebase-merged `main` result. Local storage composition and FastAPI lifespan installation remain separate follow-up gates.

## Changes
- add exact worker/runtime loop protocols and a bounded terminal service summary
- start the runtime loop before the worker with one shared cooperative stop event
- treat faults, invalid summaries, duplicate outcomes, and premature clean exits as terminal service failures
- gate each non-daemon ownership transfer behind a cancellation-safe daemon launcher
- distinguish never-launched, delayed-unclaimed, claimed, failed, and completed thread starts without relying on `ident`
- replay the complete stop/join transaction after any interruption and publish `closed` only after every transferred thread joins
- replay ownership preflight and settlement acquisition while rejecting owned-loop close before the settlement lock
- serialize startup/close settlement separately from lifecycle reads so joins never hold the lifecycle lock
- durably stop the peer before idempotently committing a terminal outcome
- recover interrupted startup/state publication with a per-call token
- retain an exact empty summary before publishing close-before-start
- make repeated close deterministic while rejecting restart
- document the background ownership boundary and remaining storage/lifespan work

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- latest `main`: planning, activation, runtime, and service files (`45 passed`)
- launch-race regression trio repeated 20 times
- complete unit tier excluding three documented baseline failures (`8855 passed, 35 skipped, 193 deselected`)
- relevant pre-commit hooks

## Checklist
- [x] My code follows the repository style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
