### PR TITLE
feat(web): add explicit local index config

### DIFF
--- a/codenib/web/config.py
+++ b/codenib/web/config.py
@@ -45,6 +45,7 @@ _LOCAL_INDEX_MAX_REPOSITORIES = 4_096
 _LOCAL_INDEX_MAX_DELAY_MS = 86_400_000
 _LOCAL_INDEX_MAX_LEASE_MS = 2_147_483_647
 _LOCAL_INDEX_MAX_SCAN_LIMIT = 256
+_YAML_MERGE_TAG = "tag:yaml.org,2002:merge"
 # Keep the read-only default config lightweight; storage models are imported
 # only after this explicit opt-in is present.
 _DEFAULT_LOCAL_INDEX_NAMESPACE = "default"
@@ -81,7 +82,12 @@ def _exact_config_integer(
 def _absolute_config_path(value: Any, *, source: str) -> Path:
     text = _exact_config_text(value, source=source, max_length=32_768)
     path = Path(text)
-    if not path.is_absolute() or path == path.parent or str(path) != text:
+    if (
+        not path.is_absolute()
+        or path == path.parent
+        or str(path) != text
+        or (os.name == "posix" and path.anchor != os.path.sep)
+    ):
         raise ValueError(f"{source} must be a canonical absolute non-root path")
     return path
 
@@ -105,6 +111,40 @@ def _reject_unknown_config_keys(
     unknown = set(value) - allowed
     if unknown:
         raise ValueError(f"{source} contains unsupported key {sorted(unknown)[0]!r}")
+
+
+class _UniqueKeySafeLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects explicit duplicates per profile file."""
+
+
+def _construct_unique_mapping(
+    loader: _UniqueKeySafeLoader,
+    node: yaml.MappingNode,
+    deep: bool = False,
+) -> Dict[Any, Any]:
+    seen: set[Any] = set()
+    for key_node, _value_node in node.value:
+        # Preserve SafeLoader's standard YAML merge-key behavior. Explicit
+        # keys remain unique in this document, while profile layering is still
+        # handled later by _merge_config_data.
+        if key_node.tag == _YAML_MERGE_TAG:
+            continue
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in seen
+        except TypeError:
+            # SafeLoader will report an invalid unhashable mapping key below.
+            continue
+        if duplicate:
+            raise ValueError("demo config contains a duplicate YAML mapping key")
+        seen.add(key)
+    return yaml.SafeLoader.construct_mapping(loader, node, deep=deep)
+
+
+_UniqueKeySafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -275,6 +315,7 @@ class LocalIndexStorageConfig:
                 not path.is_absolute()
                 or path == path.parent
                 or Path(os.path.abspath(os.fspath(path))) != path
+                or (os.name == "posix" and path.anchor != os.path.sep)
             ):
                 raise ValueError(
                     f"index_storage {name} must be a canonical absolute non-root path"
@@ -533,7 +574,7 @@ def _load_config_data(path: Path, *, chain: tuple[Path, ...] = ()) -> Dict[str, 
         return {}
 
     with resolved.open(encoding="utf-8") as handle:
-        loaded = yaml.safe_load(handle) or {}
+        loaded = yaml.load(handle, Loader=_UniqueKeySafeLoader) or {}
     if not isinstance(loaded, dict):
         raise ValueError(f"demo config must contain a YAML mapping: {resolved}")
 

--- a/codenib/web/config.py
+++ b/codenib/web/config.py
@@ -118,6 +118,7 @@ class LocalIndexStorageRepository:
     _repository_id: str = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
+        from ..compiler.snapshot_store import normalize_repo
         from ..storage.models import NamespaceIdentity, RepositoryIdentity
 
         if type(self) is not LocalIndexStorageRepository:
@@ -133,6 +134,12 @@ class LocalIndexStorageRepository:
             max_length=32_768,
         )
         if _LOCAL_INDEX_REPOSITORY_RE.fullmatch(repository_key) is None:
+            raise ValueError("index_storage repository key is not canonical")
+        try:
+            normalized_repository_key = normalize_repo(repository_key)
+        except ValueError as exc:
+            raise ValueError("index_storage repository key is not canonical") from exc
+        if normalized_repository_key != repository_key:
             raise ValueError("index_storage repository key is not canonical")
         namespace_name = _exact_config_text(
             self.namespace_name,

--- a/codenib/web/config.py
+++ b/codenib/web/config.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -36,6 +37,419 @@ REGISTRY_FILENAME = "qa_registry.json"
 CONFIG_EXTENDS_KEY = "extends"
 _TRUE_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
 _FALSE_ENV_VALUES = frozenset({"", "0", "false", "no", "off"})
+_LOCAL_INDEX_REPOSITORY_RE = re.compile(
+    r"[a-z0-9_.-]+(?:/[a-z0-9_.-]+)*\Z",
+    re.ASCII,
+)
+_LOCAL_INDEX_MAX_REPOSITORIES = 4_096
+_LOCAL_INDEX_MAX_DELAY_MS = 86_400_000
+_LOCAL_INDEX_MAX_LEASE_MS = 2_147_483_647
+_LOCAL_INDEX_MAX_SCAN_LIMIT = 256
+# Keep the read-only default config lightweight; storage models are imported
+# only after this explicit opt-in is present.
+_DEFAULT_LOCAL_INDEX_NAMESPACE = "default"
+
+
+def _exact_config_text(value: Any, *, source: str, max_length: int) -> str:
+    if type(value) is not str:
+        raise TypeError(f"{source} must be exact text")
+    normalized = value.strip()
+    if (
+        not normalized
+        or normalized != value
+        or len(normalized) > max_length
+        or "\x00" in normalized
+    ):
+        raise ValueError(f"{source} is invalid")
+    return normalized
+
+
+def _exact_config_integer(
+    value: Any,
+    *,
+    source: str,
+    minimum: int = 1,
+    maximum: int,
+) -> int:
+    if type(value) is not int or not minimum <= value <= maximum:
+        raise ValueError(
+            f"{source} must be an exact integer between {minimum} and {maximum}"
+        )
+    return value
+
+
+def _absolute_config_path(value: Any, *, source: str) -> Path:
+    text = _exact_config_text(value, source=source, max_length=32_768)
+    path = Path(text)
+    if not path.is_absolute() or path == path.parent or str(path) != text:
+        raise ValueError(f"{source} must be a canonical absolute non-root path")
+    return path
+
+
+def _config_paths_overlap(first: Path, second: Path) -> bool:
+    return first == second or first in second.parents or second in first.parents
+
+
+def _config_mapping(value: Any, *, source: str) -> Dict[str, Any]:
+    if type(value) is not dict or any(type(key) is not str for key in value):
+        raise TypeError(f"{source} must be a mapping with exact text keys")
+    return value
+
+
+def _reject_unknown_config_keys(
+    value: Dict[str, Any],
+    *,
+    source: str,
+    allowed: frozenset[str],
+) -> None:
+    unknown = set(value) - allowed
+    if unknown:
+        raise ValueError(f"{source} contains unsupported key {sorted(unknown)[0]!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class LocalIndexStorageRepository:
+    """One explicit Web repository to durable storage ref binding."""
+
+    repo_id: str
+    repository_key: str
+    namespace_name: str = _DEFAULT_LOCAL_INDEX_NAMESPACE
+    ref_name: str = "main"
+    _repository_id: str = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        from ..storage.models import NamespaceIdentity, RepositoryIdentity
+
+        if type(self) is not LocalIndexStorageRepository:
+            raise TypeError("local index repository binding must use the exact type")
+        repo_id = _exact_config_text(
+            self.repo_id,
+            source="index_storage repository ID",
+            max_length=512,
+        )
+        repository_key = _exact_config_text(
+            self.repository_key,
+            source="index_storage repository key",
+            max_length=32_768,
+        )
+        if _LOCAL_INDEX_REPOSITORY_RE.fullmatch(repository_key) is None:
+            raise ValueError("index_storage repository key is not canonical")
+        namespace_name = _exact_config_text(
+            self.namespace_name,
+            source="index_storage namespace",
+            max_length=32_768,
+        )
+        namespace = NamespaceIdentity(namespace_name)
+        if namespace.name != namespace_name:
+            raise ValueError("index_storage namespace is not canonical")
+        ref_name = _exact_config_text(
+            self.ref_name,
+            source="index_storage ref name",
+            max_length=512,
+        )
+        repository = RepositoryIdentity(
+            namespace_id=namespace.namespace_id,
+            repository_key=repository_key,
+        )
+        if repository.repository_key != repository_key:
+            raise ValueError("index_storage repository key is not canonical")
+        object.__setattr__(self, "repo_id", repo_id)
+        object.__setattr__(self, "repository_key", repository_key)
+        object.__setattr__(self, "namespace_name", namespace.name)
+        object.__setattr__(self, "ref_name", ref_name)
+        object.__setattr__(self, "_repository_id", repository.repository_id)
+
+    @property
+    def repository_id(self) -> str:
+        return self._repository_id
+
+
+@dataclass(frozen=True, slots=True)
+class LocalIndexWorkerConfig:
+    """Bounded worker and scheduler settings for the local Web service."""
+
+    lease_duration_ms: int = 30_000
+    heartbeat_interval_ms: int = 5_000
+    scan_limit: int = 64
+    initial_idle_delay_ms: int = 250
+    max_idle_delay_ms: int = 5_000
+    max_attempts: int = 3
+
+    def __post_init__(self) -> None:
+        if type(self) is not LocalIndexWorkerConfig:
+            raise TypeError("local index worker config must use the exact type")
+        lease = _exact_config_integer(
+            self.lease_duration_ms,
+            source="index_storage worker lease_duration_ms",
+            maximum=_LOCAL_INDEX_MAX_LEASE_MS,
+        )
+        heartbeat = _exact_config_integer(
+            self.heartbeat_interval_ms,
+            source="index_storage worker heartbeat_interval_ms",
+            maximum=_LOCAL_INDEX_MAX_LEASE_MS,
+        )
+        if heartbeat * 3 >= lease:
+            raise ValueError(
+                "index_storage worker heartbeat interval must be less than one third "
+                "of its lease"
+            )
+        _exact_config_integer(
+            self.scan_limit,
+            source="index_storage worker scan_limit",
+            maximum=_LOCAL_INDEX_MAX_SCAN_LIMIT,
+        )
+        initial = _exact_config_integer(
+            self.initial_idle_delay_ms,
+            source="index_storage worker initial_idle_delay_ms",
+            maximum=_LOCAL_INDEX_MAX_DELAY_MS,
+        )
+        maximum = _exact_config_integer(
+            self.max_idle_delay_ms,
+            source="index_storage worker max_idle_delay_ms",
+            maximum=_LOCAL_INDEX_MAX_DELAY_MS,
+        )
+        if maximum < initial:
+            raise ValueError(
+                "index_storage worker maximum idle delay cannot be below its initial "
+                "delay"
+            )
+        _exact_config_integer(
+            self.max_attempts,
+            source="index_storage worker max_attempts",
+            maximum=1_000,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class LocalIndexRuntimeConfig:
+    """Bounded current-result polling settings for the local Web service."""
+
+    poll_interval_ms: int = 1_000
+
+    def __post_init__(self) -> None:
+        if type(self) is not LocalIndexRuntimeConfig:
+            raise TypeError("local index runtime config must use the exact type")
+        _exact_config_integer(
+            self.poll_interval_ms,
+            source="index_storage runtime poll_interval_ms",
+            maximum=_LOCAL_INDEX_MAX_DELAY_MS,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class LocalIndexStorageConfig:
+    """Explicit existing local durable storage selection for the Web service."""
+
+    catalog_path: Path
+    cas_root: Path
+    worker_workspace_root: Path
+    runtime_workspace_root: Path
+    repositories: tuple[LocalIndexStorageRepository, ...]
+    namespace_name: str = _DEFAULT_LOCAL_INDEX_NAMESPACE
+    catalog_busy_timeout_ms: int = 5_000
+    worker: LocalIndexWorkerConfig = field(default_factory=LocalIndexWorkerConfig)
+    runtime: LocalIndexRuntimeConfig = field(default_factory=LocalIndexRuntimeConfig)
+
+    def __post_init__(self) -> None:
+        from ..storage.models import NamespaceIdentity
+
+        if type(self) is not LocalIndexStorageConfig:
+            raise TypeError("local index storage config must use the exact type")
+        path_values = (
+            (self.catalog_path, "catalog_path"),
+            (self.cas_root, "cas_root"),
+            (self.worker_workspace_root, "worker_workspace_root"),
+            (self.runtime_workspace_root, "runtime_workspace_root"),
+        )
+        for path, name in path_values:
+            if type(path) is not type(Path()):
+                raise TypeError(f"index_storage {name} must be an exact Path")
+            if (
+                not path.is_absolute()
+                or path == path.parent
+                or Path(os.path.abspath(os.fspath(path))) != path
+            ):
+                raise ValueError(
+                    f"index_storage {name} must be a canonical absolute non-root path"
+                )
+        for index, (first, first_name) in enumerate(path_values):
+            for second, second_name in path_values[index + 1 :]:
+                if _config_paths_overlap(first, second):
+                    raise ValueError(
+                        f"index_storage {first_name} must not overlap {second_name}"
+                    )
+        namespace = NamespaceIdentity(self.namespace_name)
+        if namespace.name != self.namespace_name:
+            raise ValueError("index_storage namespace is not canonical")
+        if (
+            type(self.repositories) is not tuple
+            or not 1 <= len(self.repositories) <= _LOCAL_INDEX_MAX_REPOSITORIES
+        ):
+            raise ValueError("index_storage requires 1 to 4096 repository bindings")
+        if any(
+            type(repository) is not LocalIndexStorageRepository
+            for repository in self.repositories
+        ):
+            raise TypeError("index_storage repository bindings must use exact values")
+        by_repo: set[str] = set()
+        by_storage: set[tuple[str, str]] = set()
+        for repository in self.repositories:
+            if repository.namespace_name != namespace.name:
+                raise ValueError("index_storage repository namespace differs")
+            storage_key = (repository.repository_id, repository.ref_name)
+            if repository.repo_id in by_repo or storage_key in by_storage:
+                raise ValueError("index_storage repository bindings must be unique")
+            by_repo.add(repository.repo_id)
+            by_storage.add(storage_key)
+        _exact_config_integer(
+            self.catalog_busy_timeout_ms,
+            source="index_storage catalog_busy_timeout_ms",
+            minimum=0,
+            maximum=_LOCAL_INDEX_MAX_DELAY_MS,
+        )
+        if type(self.worker) is not LocalIndexWorkerConfig:
+            raise TypeError("index_storage worker config must use the exact type")
+        if type(self.runtime) is not LocalIndexRuntimeConfig:
+            raise TypeError("index_storage runtime config must use the exact type")
+
+
+def _parse_local_index_worker(value: Any) -> LocalIndexWorkerConfig:
+    data = _config_mapping(value, source="index_storage.worker")
+    _reject_unknown_config_keys(
+        data,
+        source="index_storage.worker",
+        allowed=frozenset(
+            {
+                "lease_duration_ms",
+                "heartbeat_interval_ms",
+                "scan_limit",
+                "initial_idle_delay_ms",
+                "max_idle_delay_ms",
+                "max_attempts",
+            }
+        ),
+    )
+    defaults = LocalIndexWorkerConfig()
+    return LocalIndexWorkerConfig(
+        lease_duration_ms=data.get("lease_duration_ms", defaults.lease_duration_ms),
+        heartbeat_interval_ms=data.get(
+            "heartbeat_interval_ms",
+            defaults.heartbeat_interval_ms,
+        ),
+        scan_limit=data.get("scan_limit", defaults.scan_limit),
+        initial_idle_delay_ms=data.get(
+            "initial_idle_delay_ms",
+            defaults.initial_idle_delay_ms,
+        ),
+        max_idle_delay_ms=data.get(
+            "max_idle_delay_ms",
+            defaults.max_idle_delay_ms,
+        ),
+        max_attempts=data.get("max_attempts", defaults.max_attempts),
+    )
+
+
+def _parse_local_index_runtime(value: Any) -> LocalIndexRuntimeConfig:
+    data = _config_mapping(value, source="index_storage.runtime")
+    _reject_unknown_config_keys(
+        data,
+        source="index_storage.runtime",
+        allowed=frozenset({"poll_interval_ms"}),
+    )
+    defaults = LocalIndexRuntimeConfig()
+    return LocalIndexRuntimeConfig(
+        poll_interval_ms=data.get("poll_interval_ms", defaults.poll_interval_ms),
+    )
+
+
+def _parse_local_index_storage(value: Any) -> LocalIndexStorageConfig | None:
+    if value is None:
+        return None
+    data = _config_mapping(value, source="index_storage")
+    _reject_unknown_config_keys(
+        data,
+        source="index_storage",
+        allowed=frozenset(
+            {
+                "catalog_path",
+                "cas_root",
+                "worker_workspace_root",
+                "runtime_workspace_root",
+                "namespace",
+                "catalog_busy_timeout_ms",
+                "repositories",
+                "worker",
+                "runtime",
+            }
+        ),
+    )
+    required = (
+        "catalog_path",
+        "cas_root",
+        "worker_workspace_root",
+        "runtime_workspace_root",
+        "repositories",
+    )
+    missing = [name for name in required if name not in data]
+    if missing:
+        raise ValueError(f"index_storage requires {missing[0]}")
+    namespace = _exact_config_text(
+        data.get("namespace", _DEFAULT_LOCAL_INDEX_NAMESPACE),
+        source="index_storage namespace",
+        max_length=32_768,
+    )
+    raw_repositories = _config_mapping(
+        data["repositories"],
+        source="index_storage.repositories",
+    )
+    if not 1 <= len(raw_repositories) <= _LOCAL_INDEX_MAX_REPOSITORIES:
+        raise ValueError("index_storage requires 1 to 4096 repository bindings")
+    repositories = []
+    for repo_id in sorted(raw_repositories):
+        repository_data = _config_mapping(
+            raw_repositories[repo_id],
+            source=f"index_storage.repositories[{repo_id!r}]",
+        )
+        _reject_unknown_config_keys(
+            repository_data,
+            source=f"index_storage.repositories[{repo_id!r}]",
+            allowed=frozenset({"repository_key", "ref_name"}),
+        )
+        if "repository_key" not in repository_data:
+            raise ValueError(
+                f"index_storage repository {repo_id!r} requires repository_key"
+            )
+        repositories.append(
+            LocalIndexStorageRepository(
+                repo_id=repo_id,
+                repository_key=repository_data["repository_key"],
+                namespace_name=namespace,
+                ref_name=repository_data.get("ref_name", "main"),
+            )
+        )
+    return LocalIndexStorageConfig(
+        catalog_path=_absolute_config_path(
+            data["catalog_path"],
+            source="index_storage catalog_path",
+        ),
+        cas_root=_absolute_config_path(
+            data["cas_root"],
+            source="index_storage cas_root",
+        ),
+        worker_workspace_root=_absolute_config_path(
+            data["worker_workspace_root"],
+            source="index_storage worker_workspace_root",
+        ),
+        runtime_workspace_root=_absolute_config_path(
+            data["runtime_workspace_root"],
+            source="index_storage runtime_workspace_root",
+        ),
+        repositories=tuple(repositories),
+        namespace_name=namespace,
+        catalog_busy_timeout_ms=data.get("catalog_busy_timeout_ms", 5_000),
+        worker=_parse_local_index_worker(data.get("worker", {})),
+        runtime=_parse_local_index_runtime(data.get("runtime", {})),
+    )
 
 
 def _validated_bool(value: Any, *, source: str) -> bool:
@@ -236,8 +650,16 @@ class QAConfig:
         default_factory=lambda: ["python", "javascript", "typescript", "go", "rust"]
     )
     per_language: int = 1
+    # Optional existing-only local durable storage. Presence is the opt-in;
+    # default demo servers retain their read-only registry behavior. Keep this
+    # additive field last so existing positional QAConfig callers remain stable.
+    index_storage: Optional[LocalIndexStorageConfig] = None
 
     def __post_init__(self) -> None:
+        if self.index_storage is not None and (
+            type(self.index_storage) is not LocalIndexStorageConfig
+        ):
+            raise TypeError("index_storage must use the exact local config type")
         self.wiki_visual_facts_enabled = _validated_bool(
             self.wiki_visual_facts_enabled,
             source="wiki_visual_facts_enabled",
@@ -393,6 +815,7 @@ def load_config(path: Optional[str] = None) -> QAConfig:
         embedding_base_url=data.get("embedding_base_url"),
         embedding_api_key=data.get("embedding_api_key"),
         data_dir=data.get("data_dir", defaults.data_dir),
+        index_storage=_parse_local_index_storage(data.get("index_storage")),
         prebuilt_dir=data.get("prebuilt_dir", defaults.prebuilt_dir),
         max_turns=data.get("max_turns", defaults.max_turns),
         max_tokens=data.get("max_tokens", defaults.max_tokens),

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1670,9 +1670,14 @@ MCP, UI controls, and default routing remain absent.
   worker thread, uses one cooperative stop signal, stops the peer after either
   loop faults, and joins both non-daemon threads before shared storage or registry
   resources may be released. Partial thread start and interrupted shutdown still
-  settle every thread before reporting a sanitized lifecycle failure.
-  Explicit local storage composition, configuration, and server lifespan
-  installation remain separate gates.
+  settle every thread before reporting a sanitized lifecycle failure. Web
+  configuration now has an optional typed local-storage
+  selection for one existing catalog, preprovisioned CAS, disjoint worker and
+  runtime workspace roots, namespace/ref bindings, and bounded worker/runtime
+  timing. Presence is the explicit opt-in; parsing touches no path and rejects
+  relative, overlapping, duplicate, unknown, and incoherent values. Physical
+  topology acquisition, service composition, and lifespan installation remain
+  separate gates.
 - An explicitly injected Web reader can now project authorized durable jobs and
   at most 64 events without exposing worker owner IDs, fencing tokens, or raw
   executor errors or event keys. Each event is rebound to the exact job, a

--- a/test/web/test_config.py
+++ b/test/web/test_config.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -22,6 +24,201 @@ def test_minimal_config_uses_concrete_dataclass_defaults(tmp_path: Path) -> None
     assert config.embedding_dimension == 384
     assert config.max_turns == 8
     assert config.wiki_agent is False
+    assert config.index_storage is None
+
+
+def test_default_config_does_not_import_durable_storage() -> None:
+    root = Path(__file__).resolve().parents[2]
+    script = """
+import sys
+
+from codenib.web.config import QAConfig
+
+config = QAConfig()
+if config.index_storage is not None:
+    raise SystemExit("durable storage unexpectedly enabled")
+if "codenib.storage" in sys.modules:
+    raise SystemExit("durable storage imported without explicit configuration")
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_local_index_storage_config_is_explicit_bounded_and_deterministic(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+index_storage:
+  catalog_path: /srv/codenib/catalog.sqlite3
+  cas_root: /srv/codenib/cas
+  worker_workspace_root: /srv/codenib/worker
+  runtime_workspace_root: /srv/codenib/runtime
+  namespace: demo-team
+  catalog_busy_timeout_ms: 750
+  repositories:
+    zeta:
+      repository_key: org/zeta
+    alpha:
+      repository_key: org/alpha
+      ref_name: release
+  worker:
+    lease_duration_ms: 60000
+    heartbeat_interval_ms: 10000
+    scan_limit: 32
+    initial_idle_delay_ms: 100
+    max_idle_delay_ms: 2000
+    max_attempts: 5
+  runtime:
+    poll_interval_ms: 250
+""".lstrip()
+    )
+
+    storage = load_config(str(config_path)).index_storage
+
+    assert storage is not None
+    assert storage.catalog_path == Path("/srv/codenib/catalog.sqlite3")
+    assert storage.cas_root == Path("/srv/codenib/cas")
+    assert storage.worker_workspace_root == Path("/srv/codenib/worker")
+    assert storage.runtime_workspace_root == Path("/srv/codenib/runtime")
+    assert storage.namespace_name == "demo-team"
+    assert storage.catalog_busy_timeout_ms == 750
+    assert [binding.repo_id for binding in storage.repositories] == [
+        "alpha",
+        "zeta",
+    ]
+    assert storage.repositories[0].repository_key == "org/alpha"
+    assert storage.repositories[0].ref_name == "release"
+    assert storage.repositories[0].repository_id.startswith("repo_")
+    assert storage.worker.lease_duration_ms == 60_000
+    assert storage.worker.heartbeat_interval_ms == 10_000
+    assert storage.worker.scan_limit == 32
+    assert storage.worker.initial_idle_delay_ms == 100
+    assert storage.worker.max_idle_delay_ms == 2_000
+    assert storage.worker.max_attempts == 5
+    assert storage.runtime.poll_interval_ms == 250
+
+
+def test_local_index_storage_config_layers_nested_repo_and_runtime_values(
+    tmp_path: Path,
+) -> None:
+    base = tmp_path / "base.yaml"
+    base.write_text(
+        """
+index_storage:
+  catalog_path: /srv/codenib/catalog.sqlite3
+  cas_root: /srv/codenib/cas
+  worker_workspace_root: /srv/codenib/worker
+  runtime_workspace_root: /srv/codenib/runtime
+  repositories:
+    demo:
+      repository_key: org/demo
+      ref_name: main
+  runtime:
+    poll_interval_ms: 1000
+""".lstrip()
+    )
+    profile = tmp_path / "profile.yaml"
+    profile.write_text(
+        """
+extends: base.yaml
+index_storage:
+  repositories:
+    demo:
+      ref_name: release
+  runtime:
+    poll_interval_ms: 2000
+""".lstrip()
+    )
+
+    storage = load_config(str(profile)).index_storage
+
+    assert storage is not None
+    assert storage.repositories[0].ref_name == "release"
+    assert storage.runtime.poll_interval_ms == 2_000
+
+
+def _local_index_storage_yaml(overrides: str = "") -> str:
+    return (
+        """
+index_storage:
+  catalog_path: /srv/codenib/catalog.sqlite3
+  cas_root: /srv/codenib/cas
+  worker_workspace_root: /srv/codenib/worker
+  runtime_workspace_root: /srv/codenib/runtime
+  repositories:
+    demo:
+      repository_key: org/demo
+""".lstrip()
+        + overrides
+    )
+
+
+@pytest.mark.parametrize(
+    ("contents", "message"),
+    (
+        (
+            _local_index_storage_yaml().replace(
+                "/srv/codenib/catalog.sqlite3",
+                "relative/catalog.sqlite3",
+            ),
+            "canonical absolute",
+        ),
+        (
+            _local_index_storage_yaml().replace(
+                "/srv/codenib/runtime",
+                "/srv/codenib/worker/runtime",
+            ),
+            "must not overlap",
+        ),
+        (
+            _local_index_storage_yaml("  unsupported: true\n"),
+            "unsupported key",
+        ),
+        (
+            _local_index_storage_yaml(
+                "  worker:\n"
+                "    lease_duration_ms: 30000\n"
+                "    heartbeat_interval_ms: 10000\n"
+            ),
+            "less than one third",
+        ),
+        (
+            _local_index_storage_yaml("  worker:\n    scan_limit: true\n"),
+            "exact integer",
+        ),
+    ),
+)
+def test_local_index_storage_config_rejects_unsafe_or_incoherent_values(
+    tmp_path: Path,
+    contents: str,
+    message: str,
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(contents)
+
+    with pytest.raises((TypeError, ValueError), match=message):
+        load_config(str(config_path))
+
+
+def test_local_index_storage_config_rejects_duplicate_storage_bindings(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        _local_index_storage_yaml("    alias:\n" "      repository_key: org/demo\n")
+    )
+
+    with pytest.raises(ValueError, match="bindings must be unique"):
+        load_config(str(config_path))
 
 
 def test_wiki_media_config_enables_local_renderer_without_endpoint(

--- a/test/web/test_config.py
+++ b/test/web/test_config.py
@@ -180,6 +180,14 @@ index_storage:
             "must not overlap",
         ),
         (
+            _local_index_storage_yaml().replace("org/demo", "org/demo.git"),
+            "repository key is not canonical",
+        ),
+        (
+            _local_index_storage_yaml().replace("org/demo", "org/../demo"),
+            "repository key is not canonical",
+        ),
+        (
             _local_index_storage_yaml("  unsupported: true\n"),
             "unsupported key",
         ),

--- a/test/web/test_config.py
+++ b/test/web/test_config.py
@@ -180,6 +180,13 @@ index_storage:
             "must not overlap",
         ),
         (
+            _local_index_storage_yaml().replace(
+                "/srv/codenib/cas",
+                "//srv/codenib/cas",
+            ),
+            "canonical absolute",
+        ),
+        (
             _local_index_storage_yaml().replace("org/demo", "org/demo.git"),
             "repository key is not canonical",
         ),
@@ -226,6 +233,20 @@ def test_local_index_storage_config_rejects_duplicate_storage_bindings(
     )
 
     with pytest.raises(ValueError, match="bindings must be unique"):
+        load_config(str(config_path))
+
+
+def test_config_rejects_duplicate_yaml_keys_within_one_profile(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        _local_index_storage_yaml(
+            "    demo:\n" "      repository_key: org/replacement\n"
+        )
+    )
+
+    with pytest.raises(ValueError, match="duplicate YAML mapping key"):
         load_config(str(config_path))
 
 


### PR DESCRIPTION
## Summary
Add an explicit, typed, existing-only local storage selection for the Web index service. The default remains `None` and does not import durable-storage modules; only a present `index_storage` block opts into parsing the catalog, preprovisioned CAS, worker/runtime workspace roots, repository/ref bindings, and bounded loop settings.

Dependencies #730 and #728 are merged, and this branch is restacked onto current `main`. Physical topology acquisition, service composition, and FastAPI lifespan installation remain follow-up gates.

## Changes
- add immutable local repository, worker, runtime, and storage configuration values
- derive deterministic namespace/repository identities only after explicit opt-in and require repository keys to match the shared canonical normalization
- require canonical absolute non-root paths and reject every lexical overlap
- reject unknown keys, duplicate Web/storage bindings, malformed slugs/refs, booleans as integers, and incoherent lease/backoff bounds
- preserve nested profile layering and deterministic repository ordering
- keep `QAConfig` positional compatibility by adding the optional field last
- verify the default configuration remains storage-import inert
- document the explicit configuration boundary and remaining physical/service work

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- latest `main`: config, build-config, lazy-import, and complete RepoRegistry files (`255 passed`)
- relevant pre-commit hooks

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
