### PR TITLE
fix(web): scope index update capabilities

### DIFF
--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -263,6 +263,30 @@ def _index_job_writer() -> IndexJobWriter:
     return writer
 
 
+def _index_update_capabilities(repo_id: str):
+    """Resolve writer capabilities for one Web repository binding."""
+
+    resolver = getattr(app.state, "index_update_capabilities_resolver", None)
+    if resolver is None:
+        return getattr(app.state, "index_update_capabilities", None)
+    if not callable(resolver):
+        raise HTTPException(
+            status_code=503,
+            detail="Index update capabilities are unavailable",
+        )
+    try:
+        return resolver(repo_id)
+    except Exception as exc:
+        logger.warning(
+            "Index update capability resolution unavailable: %s",
+            type(exc).__name__,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Index update capabilities are unavailable",
+        ) from exc
+
+
 def _bundle(repo_id: str):
     bundle = _registry().get(repo_id)
     if bundle is None:
@@ -652,11 +676,7 @@ async def index_status(repo_id: str) -> RepoIndexStatus:
 
     with _pinned_bundle(repo_id) as bundle:
         kwargs = {
-            "update_capabilities": getattr(
-                app.state,
-                "index_update_capabilities",
-                None,
-            )
+            "update_capabilities": _index_update_capabilities(repo_id),
         }
         head_resolver = getattr(app.state, "index_head_resolver", None)
         if callable(head_resolver):

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -60,7 +60,7 @@ from .index_jobs import (
     IndexJobReadError,
     overlay_active_job,
 )
-from .index_status import build_repo_index_status
+from .index_status import build_repo_index_status, validate_index_update_capabilities
 from .native_authority import authorize_local_manifest_vector
 from .ports import argparse_tcp_port
 from .repo_registry import RepoRegistry
@@ -267,15 +267,18 @@ def _index_update_capabilities(repo_id: str):
     """Resolve writer capabilities for one Web repository binding."""
 
     resolver = getattr(app.state, "index_update_capabilities_resolver", None)
-    if resolver is None:
-        return getattr(app.state, "index_update_capabilities", None)
-    if not callable(resolver):
+    if resolver is not None and not callable(resolver):
         raise HTTPException(
             status_code=503,
             detail="Index update capabilities are unavailable",
         )
     try:
-        return resolver(repo_id)
+        candidate = (
+            getattr(app.state, "index_update_capabilities", None)
+            if resolver is None
+            else resolver(repo_id)
+        )
+        return validate_index_update_capabilities(candidate)
     except Exception as exc:
         logger.warning(
             "Index update capability resolution unavailable: %s",

--- a/codenib/web/index_status.py
+++ b/codenib/web/index_status.py
@@ -44,9 +44,11 @@ class IndexUpdateCapability:
 _UNAVAILABLE = IndexUpdateCapability()
 
 
-def _capability_snapshot(
+def validate_index_update_capabilities(
     capabilities: Mapping[str, IndexUpdateCapability] | None,
 ) -> dict[str, IndexUpdateCapability]:
+    """Return a detached, complete capability snapshot or reject bad input."""
+
     result = {index_type: _UNAVAILABLE for index_type in PRIMARY_INDEX_TYPES}
     if capabilities is None:
         return result
@@ -193,7 +195,7 @@ def build_repo_index_status(
         getattr(entry, "repo_dir", None),
         current_head_resolver,
     )
-    capabilities = _capability_snapshot(update_capabilities)
+    capabilities = validate_index_update_capabilities(update_capabilities)
     indexes = [
         _surface_status(
             manifest,
@@ -224,4 +226,5 @@ __all__ = [
     "IndexUpdateCapability",
     "PRIMARY_INDEX_TYPES",
     "build_repo_index_status",
+    "validate_index_update_capabilities",
 ]

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1616,7 +1616,10 @@ MCP, UI controls, and default routing remain absent.
   commit drift and retained incremental metrics without exposing mutable bundle
   state. Update capability is explicit and defaults to `unavailable` until an
   owning Web job service is configured, so the read API never implies that the
-  current server can write or incrementally patch an index.
+  current server can write or incrementally patch an index. The route now also
+  accepts a per-repository capability resolver; an explicitly configured
+  storage subset therefore cannot advertise its BM25 writer on an unbound Web
+  repository through a process-global capability map.
 - The durable job catalog now has an additive, read-only active-job query for
   Web status consumers. It prefers the fenced running attempt and otherwise
   returns the oldest queued job for the exact repository/ref, while terminal

--- a/test/web/test_index_status.py
+++ b/test/web/test_index_status.py
@@ -229,6 +229,56 @@ def test_index_status_endpoint_pins_generation_through_projection(monkeypatch) -
     assert events == ["pin-enter", "thread", "head", "pin-exit"]
 
 
+def test_index_status_endpoint_resolves_update_capabilities_per_repository(
+    monkeypatch,
+) -> None:
+    bundle = _bundle({"bm25": _entry("bm25")})
+    observed: list[str] = []
+
+    class Registry:
+        @contextmanager
+        def pin(self, repo_id: str):
+            assert repo_id == "repo"
+            yield bundle
+
+    def resolve(repo_id: str):
+        observed.append(repo_id)
+        return None
+
+    async def inline(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    globally_enabled = {
+        "bm25": IndexUpdateCapability(mode="rebuild", enabled=True, reason="")
+    }
+    monkeypatch.setattr(web_app.app.state, "registry", Registry(), raising=False)
+    monkeypatch.setattr(
+        web_app.app.state,
+        "index_update_capabilities",
+        globally_enabled,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        web_app.app.state,
+        "index_update_capabilities_resolver",
+        resolve,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        web_app.app.state,
+        "index_head_resolver",
+        lambda _path: _INDEXED,
+        raising=False,
+    )
+    monkeypatch.setattr(web_app, "_run_pinned_thread", inline)
+
+    status = asyncio.run(web_app.index_status("repo"))
+
+    assert observed == ["repo"]
+    assert status.indexes[0].updates_enabled is False
+    assert status.indexes[0].update_mode == "unavailable"
+
+
 def test_index_status_endpoint_retains_pin_until_cancelled_projection_settles(
     monkeypatch,
 ) -> None:

--- a/test/web/test_index_status.py
+++ b/test/web/test_index_status.py
@@ -279,6 +279,42 @@ def test_index_status_endpoint_resolves_update_capabilities_per_repository(
     assert status.indexes[0].update_mode == "unavailable"
 
 
+@pytest.mark.parametrize(
+    "invalid_capabilities",
+    [
+        [],
+        {"zoekt": IndexUpdateCapability()},
+        {"bm25": object()},
+    ],
+    ids=["not-a-mapping", "unknown-index", "invalid-capability"],
+)
+def test_index_status_endpoint_sanitizes_invalid_resolver_capabilities(
+    monkeypatch,
+    invalid_capabilities,
+) -> None:
+    bundle = _bundle({"bm25": _entry("bm25")})
+
+    class Registry:
+        @contextmanager
+        def pin(self, repo_id: str):
+            assert repo_id == "repo"
+            yield bundle
+
+    monkeypatch.setattr(web_app.app.state, "registry", Registry(), raising=False)
+    monkeypatch.setattr(
+        web_app.app.state,
+        "index_update_capabilities_resolver",
+        lambda _repo_id: invalid_capabilities,
+        raising=False,
+    )
+
+    with pytest.raises(web_app.HTTPException) as raised:
+        asyncio.run(web_app.index_status("repo"))
+
+    assert raised.value.status_code == 503
+    assert raised.value.detail == "Index update capabilities are unavailable"
+
+
 def test_index_status_endpoint_retains_pin_until_cancelled_projection_settles(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary
Scope Web index-update capabilities to the requested repository so a server configured for only a storage subset cannot advertise its writer on unbound repositories.

Dependencies #731, #730, and #728 are merged, and this branch is restacked directly onto current `main`. Production storage topology acquisition, service composition, and lifespan installation remain follow-up gates.

## Changes
- add a per-repository index-update capability resolver injection point
- prefer the scoped resolver over the legacy process-global capability map
- validate resolver results inside the sanitized 503 boundary
- preserve the global fallback for existing offline and route-test injection contracts
- cover unbound repositories and malformed resolver outputs
- record the repository-scoped capability boundary in the storage roadmap

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/web/test_index_status.py test/web/test_index_jobs.py test/web/test_config.py test/web/test_build_qa_index_config.py test/test_lazy_imports.py --tb=short` (`63 passed`)
- relevant pre-commit hooks

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published