### PR TITLE
feat(web): bind existing catalog sessions

### DIFF
--- a/codenib/web/local_index_service.py
+++ b/codenib/web/local_index_service.py
@@ -14,13 +14,13 @@ from pathlib import Path
 from typing import Iterator
 
 from .._atomic_directory import _OrderedAction, _run_context_with_cleanup_actions
-from ..storage import SQLiteCatalog
+from ..storage import SQLiteCatalog, StorageError
 
 _MAX_BUSY_TIMEOUT_MS = 86_400_000
 _MISSING_CATALOG = object()
 
 
-class LocalIndexServiceError(RuntimeError):
+class LocalIndexServiceError(StorageError):
     """The explicitly configured local index service is unavailable."""
 
 
@@ -84,9 +84,11 @@ class _CatalogSessionOwner:
     def acquire(self, factory) -> SQLiteCatalog:
         if self._catalog is not _MISSING_CATALOG:
             raise RuntimeError("local index catalog session is already open")
-        catalog = factory()
-        self._catalog = catalog
-        return catalog
+        # The cleanup owner is reachable before the factory runs. A direct
+        # attribute store leaves only the native-return-to-STORE_ATTR edge that
+        # Python cannot protect without a constructor-owned handoff protocol.
+        self._catalog = factory()
+        return self._catalog  # type: ignore[return-value]
 
     def close(self) -> None:
         catalog = self._catalog

--- a/codenib/web/local_index_service.py
+++ b/codenib/web/local_index_service.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Existing-only local storage ownership for the Web index service."""
+
+from __future__ import annotations
+
+import os
+import stat
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterator
+
+from .._atomic_directory import _OrderedAction, _run_context_with_cleanup_actions
+from ..storage import SQLiteCatalog
+
+_MAX_BUSY_TIMEOUT_MS = 86_400_000
+_MISSING_CATALOG = object()
+
+
+class LocalIndexServiceError(RuntimeError):
+    """The explicitly configured local index service is unavailable."""
+
+
+def _canonical_catalog_path(value: Path) -> Path:
+    if type(value) is not type(Path()):
+        raise TypeError("local index catalog path must be an exact Path")
+    if (
+        not value.is_absolute()
+        or value == value.parent
+        or Path(os.path.abspath(os.fspath(value))) != value
+    ):
+        raise ValueError(
+            "local index catalog path must be canonical, absolute, and non-root"
+        )
+    return value
+
+
+def _observe_catalog_identity(path: Path) -> tuple[int, int, int]:
+    """Attest one non-aliased, single-linked existing catalog file."""
+
+    try:
+        resolved_before = path.resolve(strict=True)
+        metadata = path.lstat()
+        resolved_after = path.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise LocalIndexServiceError(
+            "local index catalog cannot be inspected safely"
+        ) from exc
+    identity = (
+        int(metadata.st_dev),
+        int(metadata.st_ino),
+        int(metadata.st_nlink),
+    )
+    if (
+        resolved_before != path
+        or resolved_after != path
+        or not stat.S_ISREG(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or identity[0] < 1
+        or identity[1] < 1
+        or identity[2] != 1
+    ):
+        raise LocalIndexServiceError(
+            "local index catalog must be one real single-linked file"
+        )
+    return identity
+
+
+class _CatalogSessionOwner:
+    """Retain an opened catalog until cancellation-safe cleanup completes."""
+
+    __slots__ = ("_catalog",)
+
+    def __init__(self) -> None:
+        self._catalog: object = _MISSING_CATALOG
+
+    @property
+    def closed(self) -> bool:
+        return self._catalog is _MISSING_CATALOG
+
+    def acquire(self, factory) -> SQLiteCatalog:
+        if self._catalog is not _MISSING_CATALOG:
+            raise RuntimeError("local index catalog session is already open")
+        catalog = factory()
+        self._catalog = catalog
+        return catalog
+
+    def close(self) -> None:
+        catalog = self._catalog
+        if catalog is _MISSING_CATALOG:
+            return
+        catalog.close()  # type: ignore[attr-defined]
+        self._catalog = _MISSING_CATALOG
+
+
+@dataclass(frozen=True, slots=True)
+class ExistingLocalIndexCatalogFactory:
+    """Open short existing-only sessions bound to one catalog inode."""
+
+    catalog_path: Path
+    busy_timeout_ms: int = 5_000
+    _catalog_identity: tuple[int, int, int] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if type(self) is not ExistingLocalIndexCatalogFactory:
+            raise TypeError("local index catalog factory must use the exact type")
+        path = _canonical_catalog_path(self.catalog_path)
+        timeout = self.busy_timeout_ms
+        if type(timeout) is not int or not 0 <= timeout <= _MAX_BUSY_TIMEOUT_MS:
+            raise ValueError("local index catalog busy timeout is invalid")
+        object.__setattr__(self, "catalog_path", path)
+        object.__setattr__(self, "_catalog_identity", _observe_catalog_identity(path))
+
+    @property
+    def catalog_identity(self) -> tuple[int, int, int]:
+        """Return the immutable existing-file identity for topology checks."""
+
+        return self._catalog_identity
+
+    def verify(self) -> None:
+        """Fail if the configured catalog path no longer names its inode."""
+
+        if _observe_catalog_identity(self.catalog_path) != self._catalog_identity:
+            raise LocalIndexServiceError("local index catalog binding changed")
+
+    @contextmanager
+    def __call__(self) -> Iterator[SQLiteCatalog]:
+        """Open one thread-confined catalog and revalidate its exit binding."""
+
+        owner = _CatalogSessionOwner()
+        cleanup_actions = (
+            (
+                "local index catalog exit binding validation also failed",
+                self.verify,
+            ),
+            _OrderedAction(
+                label="local index catalog session cleanup also failed",
+                action=owner.close,
+                complete=lambda: owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=owner,
+            ),
+        )
+        with _run_context_with_cleanup_actions(cleanup_actions):
+            self.verify()
+            catalog = owner.acquire(
+                lambda: SQLiteCatalog(
+                    self.catalog_path,
+                    create=False,
+                    expected_file_identity=self._catalog_identity,
+                    busy_timeout_ms=self.busy_timeout_ms,
+                )
+            )
+            self.verify()
+            yield catalog
+
+
+__all__ = [
+    "ExistingLocalIndexCatalogFactory",
+    "LocalIndexServiceError",
+]

--- a/test/web/test_index_jobs.py
+++ b/test/web/test_index_jobs.py
@@ -31,6 +31,7 @@ from codenib.web.index_jobs import (
     IndexJobRepoBinding,
     overlay_active_job,
 )
+from codenib.web.local_index_service import LocalIndexServiceError
 from codenib.web.schemas import (
     IndexJobStatusResponse,
     IndexJobSurface,
@@ -432,6 +433,36 @@ def test_index_job_endpoint_is_unavailable_without_reader(monkeypatch) -> None:
         asyncio.run(web_app.index_job_status("job_" + "f" * 64, 0, 64))
 
     assert raised.value.status_code == 503
+
+
+def test_index_job_endpoint_sanitizes_local_catalog_factory_failure(
+    monkeypatch,
+) -> None:
+    job = _job()
+    private_failure = LocalIndexServiceError("private catalog topology detail")
+
+    def unavailable_factory():
+        raise private_failure
+
+    reader = CatalogIndexJobReader(
+        unavailable_factory,
+        (IndexJobRepoBinding("demo", _STORAGE_REPO),),
+    )
+
+    async def inline(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(web_app.app.state, "index_job_reader", reader, raising=False)
+    monkeypatch.setattr(web_app.asyncio, "to_thread", inline)
+
+    with pytest.raises(HTTPException) as raised:
+        asyncio.run(web_app.index_job_status(job.job_id, 0, 64))
+
+    assert raised.value.status_code == 503
+    assert raised.value.detail == "Durable index job status is unavailable"
+    assert isinstance(raised.value.__cause__, IndexJobReadError)
+    assert raised.value.__cause__.__cause__ is private_failure
+    assert "topology" not in raised.value.detail
 
 
 def test_repo_status_releases_bundle_pin_before_active_job_read(monkeypatch) -> None:

--- a/test/web/test_local_index_service.py
+++ b/test/web/test_local_index_service.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codenib.storage import SQLiteCatalog
+from codenib.web.local_index_service import (
+    ExistingLocalIndexCatalogFactory,
+    LocalIndexServiceError,
+)
+
+
+def _provision_catalog(path: Path) -> None:
+    with SQLiteCatalog(path):
+        pass
+
+
+def test_existing_catalog_factory_opens_fresh_exact_sessions(tmp_path: Path) -> None:
+    catalog_path = tmp_path / "catalog.sqlite3"
+    _provision_catalog(catalog_path)
+    factory = ExistingLocalIndexCatalogFactory(catalog_path, busy_timeout_ms=250)
+
+    with factory() as first:
+        assert first.schema_version > 0
+    with factory() as second:
+        assert second.schema_version > 0
+        assert second is not first
+
+    assert factory.catalog_identity == (
+        catalog_path.stat().st_dev,
+        catalog_path.stat().st_ino,
+        1,
+    )
+
+
+def test_existing_catalog_factory_rejects_symbolic_path_components(
+    tmp_path: Path,
+) -> None:
+    catalog_path = tmp_path / "catalog.sqlite3"
+    alias = tmp_path / "alias.sqlite3"
+    _provision_catalog(catalog_path)
+    alias.symlink_to(catalog_path)
+
+    with pytest.raises(LocalIndexServiceError, match="single-linked file"):
+        ExistingLocalIndexCatalogFactory(alias)
+
+
+def test_existing_catalog_factory_rejects_replaced_catalog(tmp_path: Path) -> None:
+    catalog_path = tmp_path / "catalog.sqlite3"
+    displaced = tmp_path / "displaced.sqlite3"
+    _provision_catalog(catalog_path)
+    factory = ExistingLocalIndexCatalogFactory(catalog_path)
+    catalog_path.rename(displaced)
+    _provision_catalog(catalog_path)
+
+    with pytest.raises(LocalIndexServiceError, match="binding changed"):
+        with factory():
+            pass
+
+
+def test_existing_catalog_factory_revalidates_after_session_body(
+    tmp_path: Path,
+) -> None:
+    catalog_path = tmp_path / "catalog.sqlite3"
+    displaced = tmp_path / "displaced.sqlite3"
+    _provision_catalog(catalog_path)
+    factory = ExistingLocalIndexCatalogFactory(catalog_path)
+
+    with pytest.raises(LocalIndexServiceError, match="cannot be inspected safely"):
+        with factory() as catalog:
+            assert catalog.schema_version > 0
+            catalog_path.rename(displaced)
+
+    with SQLiteCatalog(displaced, create=False) as reopened:
+        assert reopened.schema_version > 0
+
+
+@pytest.mark.parametrize("timeout", (True, -1, 86_400_001))
+def test_existing_catalog_factory_rejects_invalid_timeout(
+    tmp_path: Path,
+    timeout: object,
+) -> None:
+    catalog_path = tmp_path / "catalog.sqlite3"
+    _provision_catalog(catalog_path)
+
+    with pytest.raises(ValueError, match="busy timeout"):
+        ExistingLocalIndexCatalogFactory(
+            catalog_path,
+            busy_timeout_ms=timeout,  # type: ignore[arg-type]
+        )

--- a/test/web/test_local_index_service.py
+++ b/test/web/test_local_index_service.py
@@ -4,10 +4,13 @@
 
 from __future__ import annotations
 
+import dis
+import sys
 from pathlib import Path
 
 import pytest
 
+import codenib.web.local_index_service as local_index_service
 from codenib.storage import SQLiteCatalog
 from codenib.web.local_index_service import (
     ExistingLocalIndexCatalogFactory,
@@ -36,6 +39,85 @@ def test_existing_catalog_factory_opens_fresh_exact_sessions(tmp_path: Path) -> 
         catalog_path.stat().st_ino,
         1,
     )
+
+
+def test_existing_catalog_factory_closes_session_after_store_interruption(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog_path = tmp_path / "catalog.sqlite3"
+    _provision_catalog(catalog_path)
+    factory = ExistingLocalIndexCatalogFactory(catalog_path)
+    interruption = KeyboardInterrupt("catalog session stored")
+
+    class Session:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    session = Session()
+    monkeypatch.setattr(
+        local_index_service,
+        "SQLiteCatalog",
+        lambda *_args, **_kwargs: session,
+    )
+
+    acquire = local_index_service._CatalogSessionOwner.acquire
+    instructions = tuple(dis.get_instructions(acquire))
+    store_indexes = {
+        index
+        for index, instruction in enumerate(instructions[:-1])
+        if instruction.opname == "STORE_ATTR" and instruction.argval == "_catalog"
+    }
+    assert len(store_indexes) == 1
+    store_index = next(iter(store_indexes))
+    opcode_offsets_after_store = {instructions[store_index + 1].offset}
+    store_offset = instructions[store_index].offset
+    line_offsets_after_store = {
+        instruction.offset
+        for instruction in instructions
+        if instruction.starts_line is not None and instruction.offset > store_offset
+    }
+    injected = False
+    previous_trace = sys.gettrace()
+
+    def trace(frame, event: str, _arg: object):
+        nonlocal injected
+        if event == "call" and frame.f_code is acquire.__code__:
+            frame.f_trace_opcodes = True
+            frame.f_trace_lines = True
+            return trace
+        if (
+            not injected
+            and frame.f_code is acquire.__code__
+            and (
+                event == "opcode"
+                and frame.f_lasti in opcode_offsets_after_store
+                or event == "line"
+                and frame.f_lasti in line_offsets_after_store
+            )
+            and frame.f_locals["self"].closed is False
+        ):
+            injected = True
+            sys.settrace(None)
+            raise interruption
+        return trace
+
+    def open_session() -> None:
+        with factory():
+            pytest.fail("interruption must precede the context body")
+
+    sys.settrace(trace)
+    try:
+        with pytest.raises(KeyboardInterrupt) as raised:
+            open_session()
+    finally:
+        sys.settrace(previous_trace)
+
+    assert injected
+    assert raised.value is interruption
+    assert session.closed
 
 
 def test_existing_catalog_factory_rejects_symbolic_path_components(


### PR DESCRIPTION
## Summary
Add the existing-only SQLite catalog session boundary needed by the explicitly configured Web index service. Every reader, writer, worker, heartbeat, and reconciler call can open a fresh thread-confined session bound to the exact pre-existing single-linked catalog inode.

The dependency chain through #732 is merged, and this branch is restacked directly on current `main`. Directory/source topology ownership and full service composition remain follow-up gates.

## Changes
- capture one canonical, non-symlinked, single-linked existing catalog identity
- open each session with `create=False` and `expected_file_identity`
- preserve the configured bounded SQLite busy timeout
- revalidate the path binding before open, after open, and when the session exits
- transfer opened sessions directly into retryable cleanup ownership
- classify catalog replacement and binding drift as storage failures
- reject replaced catalogs, symbolic path components, and invalid timeouts

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/web/test_local_index_service.py test/web/test_index_jobs.py --tb=short` (`20 passed`)
- `pre-commit run --from-ref origin/main --to-ref HEAD`

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published