### PR TITLE
feat(web): retain local index topology

### DIFF
--- a/codenib/web/local_index_service.py
+++ b/codenib/web/local_index_service.py
@@ -45,6 +45,7 @@ _CATALOG_SIDECARS = (
     ("-journal", "rollback journal"),
 )
 _MISSING_CATALOG = object()
+_MISSING_TOPOLOGY = object()
 _LOCAL_TOPOLOGY_TOKEN = object()
 _POSIX_PRIVATE_MODE_SEMANTICS = os.name == "posix"
 _WINDOWS_REPARSE_POINT_ATTRIBUTE = getattr(
@@ -267,6 +268,92 @@ class _LinuxPhysicalPath:
     path: PurePosixPath
 
 
+class _LinuxMountIndexNode:
+    """One lexical component in the bounded Linux mount-point trie."""
+
+    __slots__ = ("children", "mappings")
+
+    def __init__(self) -> None:
+        self.children: dict[str, _LinuxMountIndexNode] = {}
+        self.mappings: list[_LinuxMountMapping] = []
+
+
+class _LinuxMountIndex:
+    """Resolve ancestors and enumerate descendants in mount-table input time."""
+
+    __slots__ = ("_root",)
+
+    def __init__(self, mappings: tuple[_LinuxMountMapping, ...]) -> None:
+        if type(mappings) is not tuple or any(
+            type(mapping) is not _LinuxMountMapping for mapping in mappings
+        ):
+            raise TypeError("Linux mount mappings must be an exact tuple")
+        root = _LinuxMountIndexNode()
+        for mapping in mappings:
+            node = root
+            for part in mapping.mount_point.parts:
+                child = node.children.get(part)
+                if child is None:
+                    child = _LinuxMountIndexNode()
+                    node.children[part] = child
+                node = child
+            node.mappings.append(mapping)
+        self._root = root
+
+    def _path_node(self, path: Path) -> _LinuxMountIndexNode | None:
+        node = self._root
+        for part in path.parts:
+            node = node.children.get(part)
+            if node is None:
+                return None
+        return node
+
+    def exact(self, path: Path) -> tuple[_LinuxMountMapping, ...]:
+        node = self._path_node(path)
+        return () if node is None else tuple(node.mappings)
+
+    def descendants(self, path: Path) -> Iterator[_LinuxMountMapping]:
+        node = self._path_node(path)
+        if node is None:
+            return
+        pending = list(node.children.values())
+        while pending:
+            descendant = pending.pop()
+            yield from descendant.mappings
+            pending.extend(descendant.children.values())
+
+    def physical_path(self, path: Path) -> _LinuxPhysicalPath | None:
+        node = self._root
+        selected: list[_LinuxMountMapping] = []
+        for part in path.parts:
+            node = node.children.get(part)
+            if node is None:
+                break
+            if node.mappings:
+                selected = node.mappings
+        if not selected:
+            return None
+        if len(selected) != 1:
+            raise LocalIndexServiceError(
+                "Linux mount table contains an ambiguous stacked mapping"
+            )
+        mapping = selected[0]
+        try:
+            relative = path.relative_to(mapping.mount_point)
+        except ValueError as exc:  # pragma: no cover - trie proves containment
+            raise LocalIndexServiceError("Linux mount mapping changed") from exc
+        internal = PurePosixPath(
+            posixpath.normpath(
+                posixpath.join(mapping.root.as_posix(), relative.as_posix())
+            )
+        )
+        if not internal.is_absolute():  # pragma: no cover - absolute root proves this
+            raise LocalIndexServiceError(
+                "Linux mount mapping produced a relative physical path"
+            )
+        return _LinuxPhysicalPath(mapping.device, internal)
+
+
 def _linux_mount_mappings() -> tuple[_LinuxMountMapping, ...]:
     if not sys.platform.startswith("linux"):
         return ()
@@ -341,36 +428,9 @@ def _linux_mount_mappings() -> tuple[_LinuxMountMapping, ...]:
 
 def _linux_physical_path(
     path: Path,
-    mappings: tuple[_LinuxMountMapping, ...],
+    index: _LinuxMountIndex,
 ) -> _LinuxPhysicalPath | None:
-    candidates = tuple(
-        mapping
-        for mapping in mappings
-        if path == mapping.mount_point or mapping.mount_point in path.parents
-    )
-    if not candidates:
-        return None
-    deepest = max(len(mapping.mount_point.parts) for mapping in candidates)
-    selected = tuple(
-        mapping for mapping in candidates if len(mapping.mount_point.parts) == deepest
-    )
-    if len(selected) != 1:
-        raise LocalIndexServiceError(
-            "Linux mount table contains an ambiguous stacked mapping"
-        )
-    mapping = selected[0]
-    try:
-        relative = path.relative_to(mapping.mount_point)
-    except ValueError as exc:  # pragma: no cover - candidates prove containment
-        raise LocalIndexServiceError("Linux mount mapping changed") from exc
-    internal = PurePosixPath(
-        posixpath.normpath(posixpath.join(mapping.root.as_posix(), relative.as_posix()))
-    )
-    if not internal.is_absolute():  # pragma: no cover - absolute root proves this
-        raise LocalIndexServiceError(
-            "Linux mount mapping produced a relative physical path"
-        )
-    return _LinuxPhysicalPath(mapping.device, internal)
+    return index.physical_path(path)
 
 
 @dataclass(frozen=True, slots=True)
@@ -419,11 +479,9 @@ def _catalog_topology_paths(
 
 
 def _require_disjoint_topology(paths: tuple[_TopologyPath, ...]) -> None:
-    mappings = _linux_mount_mappings()
+    mount_index = _LinuxMountIndex(_linux_mount_mappings())
     for subject in paths:
-        if subject.ancestry_root != subject.path and any(
-            mapping.mount_point == subject.path for mapping in mappings
-        ):
+        if subject.ancestry_root != subject.path and mount_index.exact(subject.path):
             raise LocalIndexServiceError(
                 f"{subject.label} must not be a Linux mount point"
             )
@@ -453,7 +511,7 @@ def _require_disjoint_topology(paths: tuple[_TopologyPath, ...]) -> None:
             ancestry_identities.setdefault(identity, (ancestor, subject.label))
 
     for subject in paths:
-        mapped = _linux_physical_path(subject.path, mappings)
+        mapped = _linux_physical_path(subject.path, mount_index)
         if mapped is not None:
             expected_device = f"{os.major(subject.device)}:{os.minor(subject.device)}"
             if mapped.device != expected_device:
@@ -469,10 +527,8 @@ def _require_disjoint_topology(paths: tuple[_TopologyPath, ...]) -> None:
     for subject in paths:
         if subject.ancestry_root != subject.path:
             continue
-        for mapping in mappings:
-            if subject.path not in mapping.mount_point.parents:
-                continue
-            mapped = _linux_physical_path(mapping.mount_point, mappings)
+        for mapping in mount_index.descendants(subject.path):
+            mapped = _linux_physical_path(mapping.mount_point, mount_index)
             if mapped is None:  # pragma: no cover - the mapping is a candidate
                 raise LocalIndexServiceError("Linux descendant mount mapping changed")
             key = (mapping.mount_point, mapped.device, mapped.path)
@@ -666,6 +722,76 @@ class ExistingLocalIndexCatalogFactory:
             yield catalog
 
 
+class LocalIndexStorageTopologyOwner:
+    """Caller-created owner that receives a topology before acquisition returns."""
+
+    __slots__ = ("_lifecycle_lock", "_topology")
+
+    def __init__(self) -> None:
+        self._lifecycle_lock = _CancellationSafeRLock()
+        self._topology: object = _MISSING_TOPOLOGY
+
+    @property
+    def topology(self) -> "LocalIndexStorageTopology":
+        """Borrow the active topology retained by this owner."""
+
+        def borrow() -> LocalIndexStorageTopology:
+            topology = self._topology
+            if type(topology) is not LocalIndexStorageTopology or topology.closed:
+                raise RuntimeError("local index topology owner is not active")
+            return topology
+
+        return self._lifecycle_lock.run(borrow)
+
+    @property
+    def closed(self) -> bool:
+        def observe() -> bool:
+            topology = self._topology
+            if topology is _MISSING_TOPOLOGY:
+                return True
+            if type(topology) is not LocalIndexStorageTopology:
+                raise RuntimeError("local index topology owner state changed")
+            return topology.closed
+
+        return self._lifecycle_lock.run(observe)
+
+    def _require_empty(self) -> None:
+        if self._topology is not _MISSING_TOPOLOGY:
+            raise RuntimeError("local index topology owner is already used")
+
+    def _install(self, topology: "LocalIndexStorageTopology") -> None:
+        """Publish the topology into caller reachability before public return."""
+
+        def install() -> None:
+            self._require_empty()
+            if type(topology) is not LocalIndexStorageTopology:
+                raise TypeError("local index topology owner requires an exact topology")
+            self._topology = topology
+
+        self._lifecycle_lock.run(install)
+
+    def close(self) -> None:
+        """Close the retained topology and remain retryable after interruption."""
+
+        def close_owned() -> None:
+            topology = self._topology
+            if topology is _MISSING_TOPOLOGY:
+                return
+            if type(topology) is not LocalIndexStorageTopology:
+                raise RuntimeError("local index topology owner state changed")
+            topology.close()
+            if topology.closed:
+                self._topology = _MISSING_TOPOLOGY
+
+        self._lifecycle_lock.run(close_owned)
+
+    def __enter__(self) -> "LocalIndexStorageTopologyOwner":
+        return self
+
+    def __exit__(self, _exc_type: object, _exc: object, _traceback: object) -> None:
+        self.close()
+
+
 class LocalIndexStorageTopology:
     """Retain exact catalog, storage-root, and repository authorities."""
 
@@ -714,11 +840,16 @@ class LocalIndexStorageTopology:
         cls,
         config: LocalIndexStorageConfig,
         repository_roots: Mapping[str, Path],
+        *,
+        owner: LocalIndexStorageTopologyOwner,
     ) -> "LocalIndexStorageTopology":
         """Open every configured authority without creating storage paths."""
 
         if type(config) is not LocalIndexStorageConfig:
             raise TypeError("local index topology requires the exact storage config")
+        if type(owner) is not LocalIndexStorageTopologyOwner:
+            raise TypeError("local index topology requires an exact caller owner")
+        owner._lifecycle_lock.run(owner._require_empty)
         if not isinstance(repository_roots, Mapping) or any(
             type(repo_id) is not str for repo_id in repository_roots
         ):
@@ -853,6 +984,7 @@ class LocalIndexStorageTopology:
                 repositories=repositories,
                 source_owner=source_owner,
             )
+            owner._install(topology)
             topology.verify()
             return topology
 
@@ -980,7 +1112,8 @@ class LocalIndexStorageTopology:
         # Physical ancestry and mount inspection can run arbitrary filesystem
         # syscalls. Sandwich it with a final retained binding check so a rename
         # or replacement cannot be accepted at the public return boundary.
-        self._bound_topology_paths_unlocked()
+        final_topology_paths = self._bound_topology_paths_unlocked()
+        _require_disjoint_topology(final_topology_paths)
 
     def verify(self) -> None:
         """Revalidate every retained path and physical-separation invariant."""
@@ -1024,4 +1157,5 @@ __all__ = [
     "ExistingLocalIndexCatalogFactory",
     "LocalIndexServiceError",
     "LocalIndexStorageTopology",
+    "LocalIndexStorageTopologyOwner",
 ]

--- a/codenib/web/local_index_service.py
+++ b/codenib/web/local_index_service.py
@@ -7,17 +7,38 @@
 from __future__ import annotations
 
 import os
+import posixpath
 import stat
+import sys
+from collections.abc import Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Iterator
 
-from .._atomic_directory import _OrderedAction, _run_context_with_cleanup_actions
+from .._atomic_directory import (
+    _mountinfo_path,
+    _open_publication_authority,
+    _OrderedAction,
+    _PublicationAuthorityOwner,
+    _run_context_with_cleanup_actions,
+    publication_parent_identity,
+)
+from .._owned_file_publication import _CancellationSafeRLock
+from ..artifacts.runtime import SourceBindingCleanupOwner
+from ..source_fingerprint import (
+    RepositorySourceRootAuthority,
+    lexical_repository_path,
+    pin_repository_source_root,
+)
 from ..storage import SQLiteCatalog, StorageError
+from .config import LocalIndexStorageConfig
 
 _MAX_BUSY_TIMEOUT_MS = 86_400_000
+_MAX_MOUNTINFO_ENTRIES = 65_536
+_MAX_MOUNTINFO_LINE_BYTES = 64 * 1024
 _MISSING_CATALOG = object()
+_LOCAL_TOPOLOGY_TOKEN = object()
 
 
 class LocalIndexServiceError(StorageError):
@@ -67,6 +88,290 @@ def _observe_catalog_identity(path: Path) -> tuple[int, int, int]:
             "local index catalog must be one real single-linked file"
         )
     return identity
+
+
+def _observe_real_directory(
+    path: Path,
+    *,
+    label: str,
+    private: bool = False,
+) -> tuple[int, ...]:
+    try:
+        resolved_before = path.resolve(strict=True)
+        metadata = path.lstat()
+        resolved_after = path.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise LocalIndexServiceError(f"{label} cannot be inspected safely") from exc
+    effective_uid = getattr(os, "geteuid", None)
+    wrong_owner = (
+        private and callable(effective_uid) and metadata.st_uid != effective_uid()
+    )
+    if (
+        resolved_before != path
+        or resolved_after != path
+        or not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_dev < 1
+        or metadata.st_ino < 1
+        or wrong_owner
+        or (
+            private
+            and (
+                stat.S_IMODE(metadata.st_mode) & 0o077
+                or stat.S_IMODE(metadata.st_mode) & 0o700 != 0o700
+            )
+        )
+    ):
+        qualifier = "private owner-only " if private else ""
+        raise LocalIndexServiceError(f"{label} must be one real {qualifier}directory")
+    return (
+        int(metadata.st_dev),
+        int(metadata.st_ino),
+        stat.S_IFMT(metadata.st_mode),
+        int(getattr(metadata, "st_file_attributes", 0)),
+    )
+
+
+def _directory_ancestry(
+    path: Path,
+    *,
+    label: str,
+) -> tuple[tuple[Path, tuple[int, int]], ...]:
+    ancestry: list[tuple[Path, tuple[int, int]]] = []
+    current = path
+    while True:
+        identity = _observe_real_directory(current, label=label)
+        ancestry.append((current, (identity[0], identity[1])))
+        if current == current.parent:
+            return tuple(ancestry)
+        current = current.parent
+
+
+@dataclass(frozen=True, slots=True)
+class _LinuxMountMapping:
+    device: str
+    root: PurePosixPath
+    mount_point: Path
+
+
+@dataclass(frozen=True, slots=True)
+class _LinuxPhysicalPath:
+    device: str
+    path: PurePosixPath
+
+
+def _linux_mount_mappings() -> tuple[_LinuxMountMapping, ...]:
+    if not sys.platform.startswith("linux"):
+        return ()
+    mappings: list[_LinuxMountMapping] = []
+    try:
+        with open("/proc/self/mountinfo", "rb") as mountinfo:
+            for index, line in enumerate(mountinfo):
+                if index >= _MAX_MOUNTINFO_ENTRIES:
+                    raise LocalIndexServiceError(
+                        "Linux mount table exceeds its safe entry limit"
+                    )
+                if len(line) > _MAX_MOUNTINFO_LINE_BYTES:
+                    raise LocalIndexServiceError(
+                        "Linux mount table contains an oversized entry"
+                    )
+                fields = line.split()
+                try:
+                    separator = fields.index(b"-")
+                except ValueError as exc:
+                    raise LocalIndexServiceError(
+                        "Linux mount table contains a malformed entry"
+                    ) from exc
+                if separator < 6 or len(fields) < separator + 4:
+                    raise LocalIndexServiceError(
+                        "Linux mount table contains a malformed entry"
+                    )
+                try:
+                    mount_id = int(fields[0])
+                except ValueError as exc:
+                    raise LocalIndexServiceError(
+                        "Linux mount table contains an invalid mount ID"
+                    ) from exc
+                device = os.fsdecode(fields[2])
+                device_parts = device.split(":", 1)
+                if (
+                    mount_id < 1
+                    or len(device_parts) != 2
+                    or any(not part.isdigit() for part in device_parts)
+                ):
+                    raise LocalIndexServiceError(
+                        "Linux mount table contains an invalid identity"
+                    )
+                root = PurePosixPath(
+                    posixpath.normpath(_mountinfo_path(os.fsdecode(fields[3])))
+                )
+                mount_point = Path(
+                    os.path.normpath(_mountinfo_path(os.fsdecode(fields[4])))
+                )
+                if not root.is_absolute():
+                    continue
+                if not mount_point.is_absolute():
+                    raise LocalIndexServiceError(
+                        "Linux mount table contains a relative path"
+                    )
+                mappings.append(
+                    _LinuxMountMapping(
+                        device=device,
+                        root=root,
+                        mount_point=mount_point,
+                    )
+                )
+    except LocalIndexServiceError:
+        raise
+    except (OSError, UnicodeError) as exc:
+        raise LocalIndexServiceError(
+            "Linux mount table cannot be inspected safely"
+        ) from exc
+    if not mappings:
+        raise LocalIndexServiceError("Linux mount table is empty")
+    return tuple(mappings)
+
+
+def _linux_physical_path(
+    path: Path,
+    mappings: tuple[_LinuxMountMapping, ...],
+) -> _LinuxPhysicalPath | None:
+    candidates = tuple(
+        mapping
+        for mapping in mappings
+        if path == mapping.mount_point or mapping.mount_point in path.parents
+    )
+    if not candidates:
+        return None
+    deepest = max(len(mapping.mount_point.parts) for mapping in candidates)
+    selected = tuple(
+        mapping for mapping in candidates if len(mapping.mount_point.parts) == deepest
+    )
+    if len(selected) != 1:
+        raise LocalIndexServiceError(
+            "Linux mount table contains an ambiguous stacked mapping"
+        )
+    mapping = selected[0]
+    try:
+        relative = path.relative_to(mapping.mount_point)
+    except ValueError as exc:  # pragma: no cover - candidates prove containment
+        raise LocalIndexServiceError("Linux mount mapping changed") from exc
+    internal = PurePosixPath(
+        posixpath.normpath(posixpath.join(mapping.root.as_posix(), relative.as_posix()))
+    )
+    if not internal.is_absolute():  # pragma: no cover - absolute root proves this
+        raise LocalIndexServiceError(
+            "Linux mount mapping produced a relative physical path"
+        )
+    return _LinuxPhysicalPath(mapping.device, internal)
+
+
+@dataclass(frozen=True, slots=True)
+class _TopologyPath:
+    label: str
+    path: Path
+    device: int
+    ancestry_root: Path
+
+
+def _require_disjoint_topology(paths: tuple[_TopologyPath, ...]) -> None:
+    mappings = _linux_mount_mappings()
+    physical: list[tuple[_TopologyPath, _LinuxPhysicalPath | None]] = []
+    lexical_stack: list[_TopologyPath] = []
+    ancestry_identities: dict[tuple[int, int], tuple[Path, str]] = {}
+    for subject in sorted(paths, key=lambda item: item.path.parts):
+        while lexical_stack and not (
+            lexical_stack[-1].path == subject.path
+            or lexical_stack[-1].path in subject.path.parents
+        ):
+            lexical_stack.pop()
+        if lexical_stack:
+            raise LocalIndexServiceError(
+                f"{lexical_stack[-1].label} must not overlap {subject.label}"
+            )
+        lexical_stack.append(subject)
+        for ancestor, identity in _directory_ancestry(
+            subject.ancestry_root,
+            label=f"{subject.label} ancestry",
+        ):
+            previous = ancestry_identities.get(identity)
+            if previous is not None and previous[0] != ancestor:
+                raise LocalIndexServiceError(
+                    f"{previous[1]} physically aliases {subject.label}"
+                )
+            ancestry_identities.setdefault(identity, (ancestor, subject.label))
+
+    for subject in paths:
+        mapped = _linux_physical_path(subject.path, mappings)
+        if mapped is not None:
+            expected_device = f"{os.major(subject.device)}:{os.minor(subject.device)}"
+            if mapped.device != expected_device:
+                raise LocalIndexServiceError(
+                    f"{subject.label} mount mapping differs from its inode"
+                )
+        physical.append((subject, mapped))
+
+    physical_stack: list[tuple[_TopologyPath, _LinuxPhysicalPath]] = []
+    concrete = sorted(
+        ((subject, mapped) for subject, mapped in physical if mapped is not None),
+        key=lambda item: (item[1].device, item[1].path.parts),
+    )
+    active_device: str | None = None
+    for subject, mapped in concrete:
+        if mapped.device != active_device:
+            physical_stack.clear()
+            active_device = mapped.device
+        while physical_stack and not (
+            physical_stack[-1][1].path == mapped.path
+            or physical_stack[-1][1].path in mapped.path.parents
+        ):
+            physical_stack.pop()
+        if physical_stack:
+            raise LocalIndexServiceError(
+                f"{physical_stack[-1][0].label} traverses a physical alias of "
+                f"{subject.label}"
+            )
+        physical_stack.append((subject, mapped))
+
+
+@dataclass(frozen=True, slots=True)
+class _RetainedRootBinding:
+    label: str
+    path: Path
+    identity: tuple[int, ...]
+    owner: _PublicationAuthorityOwner = field(repr=False, compare=False)
+
+    def verify(self) -> None:
+        authority = self.owner.authority
+        if authority is None:
+            raise LocalIndexServiceError(f"{self.label} authority is closed")
+        try:
+            authority.verify_path_binding()
+            observed = publication_parent_identity(authority.resource)
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            raise LocalIndexServiceError(f"{self.label} binding changed") from exc
+        if observed != self.identity:
+            raise LocalIndexServiceError(f"{self.label} identity changed")
+
+
+def _open_root_binding(
+    path: Path,
+    *,
+    label: str,
+    owner: _PublicationAuthorityOwner,
+) -> _RetainedRootBinding:
+    authority = _open_publication_authority(
+        path,
+        parent_resource=None,
+        expected_parent_identity=None,
+        authority_owner=owner,
+    )
+    return _RetainedRootBinding(
+        label=label,
+        path=path,
+        identity=publication_parent_identity(authority.resource),
+        owner=owner,
+    )
 
 
 class _CatalogSessionOwner:
@@ -160,7 +465,357 @@ class ExistingLocalIndexCatalogFactory:
             yield catalog
 
 
+class LocalIndexStorageTopology:
+    """Retain exact catalog, storage-root, and repository authorities."""
+
+    __slots__ = (
+        "_catalog_factory",
+        "_cas",
+        "_config",
+        "_lifecycle_lock",
+        "_repositories",
+        "_repository_paths",
+        "_runtime_workspace",
+        "_source_owner",
+        "_worker_workspace",
+    )
+
+    def __init__(
+        self,
+        token: object,
+        *,
+        config: LocalIndexStorageConfig,
+        catalog_factory: ExistingLocalIndexCatalogFactory,
+        cas: _RetainedRootBinding,
+        worker_workspace: _RetainedRootBinding,
+        runtime_workspace: _RetainedRootBinding,
+        repository_paths: tuple[tuple[str, Path], ...],
+        repositories: tuple[
+            tuple[str, RepositorySourceRootAuthority],
+            ...,
+        ],
+        source_owner: SourceBindingCleanupOwner,
+    ) -> None:
+        if token is not _LOCAL_TOPOLOGY_TOKEN:
+            raise TypeError("local index storage topology requires acquisition")
+        self._config = config
+        self._catalog_factory = catalog_factory
+        self._cas = cas
+        self._worker_workspace = worker_workspace
+        self._runtime_workspace = runtime_workspace
+        self._repository_paths = repository_paths
+        self._repositories = repositories
+        self._source_owner = source_owner
+        self._lifecycle_lock = _CancellationSafeRLock()
+
+    @classmethod
+    def acquire(
+        cls,
+        config: LocalIndexStorageConfig,
+        repository_roots: Mapping[str, Path],
+    ) -> "LocalIndexStorageTopology":
+        """Open every configured authority without creating storage paths."""
+
+        if type(config) is not LocalIndexStorageConfig:
+            raise TypeError("local index topology requires the exact storage config")
+        if not isinstance(repository_roots, Mapping) or any(
+            type(repo_id) is not str for repo_id in repository_roots
+        ):
+            raise TypeError("local index repository roots must be a mapping")
+        roots = dict(repository_roots)
+        configured_ids = tuple(binding.repo_id for binding in config.repositories)
+        if set(roots) != set(configured_ids):
+            raise ValueError(
+                "local index repository roots must match configured bindings"
+            )
+        repository_paths: list[tuple[str, Path]] = []
+        repository_identities: list[tuple[int, ...]] = []
+        for repo_id in configured_ids:
+            path = roots[repo_id]
+            if type(path) is not type(Path()):
+                raise TypeError("local index repository roots must be exact Paths")
+            canonical = lexical_repository_path(path)
+            if canonical != path or canonical == canonical.parent:
+                raise ValueError(
+                    "local index repository root must be canonical and non-root"
+                )
+            identity = _observe_real_directory(
+                canonical,
+                label=f"repository {repo_id!r}",
+            )
+            repository_paths.append((repo_id, canonical))
+            repository_identities.append(identity)
+
+        catalog_factory = ExistingLocalIndexCatalogFactory(
+            config.catalog_path,
+            busy_timeout_ms=config.catalog_busy_timeout_ms,
+        )
+        root_specs = (
+            (config.cas_root, "local CAS root", False),
+            (config.worker_workspace_root, "worker workspace root", True),
+            (config.runtime_workspace_root, "runtime workspace root", True),
+        )
+        root_identities = tuple(
+            _observe_real_directory(path, label=label, private=private)
+            for path, label, private in root_specs
+        )
+        catalog_factory.verify()
+        topology_paths = (
+            _TopologyPath(
+                "local index catalog",
+                config.catalog_path,
+                catalog_factory.catalog_identity[0],
+                config.catalog_path.parent,
+            ),
+            *(
+                _TopologyPath(label, path, identity[0], path)
+                for (path, label, _private), identity in zip(
+                    root_specs,
+                    root_identities,
+                    strict=True,
+                )
+            ),
+            *(
+                _TopologyPath(
+                    f"repository {repo_id!r}",
+                    path,
+                    identity[0],
+                    path,
+                )
+                for (repo_id, path), identity in zip(
+                    repository_paths,
+                    repository_identities,
+                    strict=True,
+                )
+            ),
+        )
+        _require_disjoint_topology(topology_paths)
+
+        directory_owners = tuple(_PublicationAuthorityOwner() for _index in range(3))
+        source_owner = SourceBindingCleanupOwner()
+        cleanup_actions = (
+            _OrderedAction(
+                label="local index repository authority cleanup also failed",
+                action=source_owner.close,
+                complete=lambda: source_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=source_owner,
+            ),
+            *(
+                _OrderedAction(
+                    label="local index root authority cleanup also failed",
+                    action=owner.close,
+                    complete=lambda owner=owner: owner.closed,
+                    retry_incomplete="cancellation",
+                    incomplete_owner=owner,
+                )
+                for owner in reversed(directory_owners)
+            ),
+        )
+        with _run_context_with_cleanup_actions(
+            cleanup_actions,
+            cleanup_on_success=False,
+        ):
+            repositories = tuple(
+                (
+                    repo_id,
+                    pin_repository_source_root(
+                        path,
+                        _source_owner=source_owner.retain,
+                    ),
+                )
+                for repo_id, path in repository_paths
+            )
+            cas = _open_root_binding(
+                config.cas_root,
+                label="local CAS root",
+                owner=directory_owners[0],
+            )
+            worker_workspace = _open_root_binding(
+                config.worker_workspace_root,
+                label="worker workspace root",
+                owner=directory_owners[1],
+            )
+            runtime_workspace = _open_root_binding(
+                config.runtime_workspace_root,
+                label="runtime workspace root",
+                owner=directory_owners[2],
+            )
+            topology = cls(
+                _LOCAL_TOPOLOGY_TOKEN,
+                config=config,
+                catalog_factory=catalog_factory,
+                cas=cas,
+                worker_workspace=worker_workspace,
+                runtime_workspace=runtime_workspace,
+                repository_paths=tuple(repository_paths),
+                repositories=repositories,
+                source_owner=source_owner,
+            )
+            topology.verify()
+            return topology
+
+    @property
+    def catalog_factory(self) -> ExistingLocalIndexCatalogFactory:
+        return self._catalog_factory
+
+    @property
+    def worker_workspace_identity(self) -> tuple[int, ...]:
+        return self._worker_workspace.identity
+
+    @property
+    def runtime_workspace_identity(self) -> tuple[int, ...]:
+        return self._runtime_workspace.identity
+
+    @property
+    def closed(self) -> bool:
+        return self._lifecycle_lock.run(self._closed_unlocked)
+
+    def _closed_unlocked(self) -> bool:
+        return self._source_owner.closed and all(
+            binding.owner.closed
+            for binding in (
+                self._cas,
+                self._worker_workspace,
+                self._runtime_workspace,
+            )
+        )
+
+    def repository_authority(
+        self,
+        repo_id: str,
+    ) -> RepositorySourceRootAuthority:
+        """Return one non-owning configured source authority."""
+
+        def read() -> RepositorySourceRootAuthority:
+            if self._closed_unlocked():
+                raise LocalIndexServiceError("local index topology is closed")
+            for candidate_id, authority in self._repositories:
+                if candidate_id == repo_id:
+                    authority.verify()
+                    return authority
+            raise KeyError(repo_id)
+
+        return self._lifecycle_lock.run(read)
+
+    def _verify_unlocked(self) -> None:
+        if self._closed_unlocked():
+            raise LocalIndexServiceError("local index topology is closed")
+        self._catalog_factory.verify()
+        for binding, private in (
+            (self._cas, False),
+            (self._worker_workspace, True),
+            (self._runtime_workspace, True),
+        ):
+            binding.verify()
+            observed = _observe_real_directory(
+                binding.path,
+                label=binding.label,
+                private=private,
+            )
+            if observed != binding.identity:
+                raise LocalIndexServiceError(f"{binding.label} identity changed")
+        for (repo_id, path), (authority_id, authority) in zip(
+            self._repository_paths,
+            self._repositories,
+            strict=True,
+        ):
+            if authority_id != repo_id:
+                raise LocalIndexServiceError(
+                    "local index repository authority ordering changed"
+                )
+            authority.verify()
+            if authority.root != path:
+                raise LocalIndexServiceError(
+                    f"repository {repo_id!r} authority path changed"
+                )
+            observed = _observe_real_directory(
+                path,
+                label=f"repository {repo_id!r}",
+            )
+            if tuple(observed[:2]) != tuple(authority.root_identity[:2]):
+                raise LocalIndexServiceError(f"repository {repo_id!r} identity changed")
+        topology_paths = (
+            _TopologyPath(
+                "local index catalog",
+                self._config.catalog_path,
+                self._catalog_factory.catalog_identity[0],
+                self._config.catalog_path.parent,
+            ),
+            _TopologyPath(
+                self._cas.label,
+                self._cas.path,
+                self._cas.identity[0],
+                self._cas.path,
+            ),
+            _TopologyPath(
+                self._worker_workspace.label,
+                self._worker_workspace.path,
+                self._worker_workspace.identity[0],
+                self._worker_workspace.path,
+            ),
+            _TopologyPath(
+                self._runtime_workspace.label,
+                self._runtime_workspace.path,
+                self._runtime_workspace.identity[0],
+                self._runtime_workspace.path,
+            ),
+            *(
+                _TopologyPath(
+                    f"repository {repo_id!r}",
+                    path,
+                    authority.root_identity[0],
+                    path,
+                )
+                for (repo_id, path), (_authority_id, authority) in zip(
+                    self._repository_paths,
+                    self._repositories,
+                    strict=True,
+                )
+            ),
+        )
+        _require_disjoint_topology(topology_paths)
+
+    def verify(self) -> None:
+        """Revalidate every retained path and physical-separation invariant."""
+
+        self._lifecycle_lock.run(self._verify_unlocked)
+
+    def _close_unlocked(self) -> None:
+        cleanup_actions = (
+            _OrderedAction(
+                label="local index repository authority cleanup also failed",
+                action=self._source_owner.close,
+                complete=lambda: self._source_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=self._source_owner,
+            ),
+            *(
+                _OrderedAction(
+                    label="local index root authority cleanup also failed",
+                    action=binding.owner.close,
+                    complete=lambda binding=binding: binding.owner.closed,
+                    retry_incomplete="cancellation",
+                    incomplete_owner=binding.owner,
+                )
+                for binding in (
+                    self._runtime_workspace,
+                    self._worker_workspace,
+                    self._cas,
+                )
+            ),
+        )
+        with _run_context_with_cleanup_actions(cleanup_actions):
+            pass
+
+    def close(self) -> None:
+        """Release every source and directory authority, with retryable cleanup."""
+
+        self._lifecycle_lock.run(self._close_unlocked)
+
+
 __all__ = [
     "ExistingLocalIndexCatalogFactory",
     "LocalIndexServiceError",
+    "LocalIndexStorageTopology",
 ]

--- a/codenib/web/local_index_service.py
+++ b/codenib/web/local_index_service.py
@@ -46,6 +46,12 @@ _CATALOG_SIDECARS = (
 )
 _MISSING_CATALOG = object()
 _LOCAL_TOPOLOGY_TOKEN = object()
+_POSIX_PRIVATE_MODE_SEMANTICS = os.name == "posix"
+_WINDOWS_REPARSE_POINT_ATTRIBUTE = getattr(
+    stat,
+    "FILE_ATTRIBUTE_REPARSE_POINT",
+    0x400,
+)
 
 
 class LocalIndexServiceError(StorageError):
@@ -90,11 +96,48 @@ def _observe_catalog_identity(path: Path) -> tuple[int, int, int]:
         or identity[0] < 1
         or identity[1] < 1
         or identity[2] != 1
+        or getattr(metadata, "st_file_attributes", 0) & _WINDOWS_REPARSE_POINT_ATTRIBUTE
     ):
         raise LocalIndexServiceError(
             "local index catalog must be one real single-linked file"
         )
     return identity
+
+
+def _observe_optional_catalog_sidecar(
+    path: Path,
+    *,
+    label: str,
+) -> tuple[int, int, int] | None:
+    """Validate one existing WAL/SHM path without requiring its presence."""
+
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise LocalIndexServiceError(
+            f"local index catalog {label} cannot be inspected safely"
+        ) from exc
+    try:
+        return _observe_catalog_identity(path)
+    except LocalIndexServiceError as exc:
+        raise LocalIndexServiceError(
+            f"local index catalog {label} must be one real single-linked file"
+        ) from exc
+
+
+def _require_no_catalog_rollback_journal(path: Path) -> None:
+    journal = Path(f"{path}-journal")
+    try:
+        journal.lstat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise LocalIndexServiceError(
+            "local index catalog rollback journal cannot be inspected safely"
+        ) from exc
+    raise LocalIndexServiceError("local index catalog rollback journal is not allowed")
 
 
 def _observe_real_directory(
@@ -110,8 +153,11 @@ def _observe_real_directory(
     except (OSError, RuntimeError, ValueError) as exc:
         raise LocalIndexServiceError(f"{label} cannot be inspected safely") from exc
     effective_uid = getattr(os, "geteuid", None)
+    enforce_posix_private_mode = private and _POSIX_PRIVATE_MODE_SEMANTICS
     wrong_owner = (
-        private and callable(effective_uid) and metadata.st_uid != effective_uid()
+        enforce_posix_private_mode
+        and callable(effective_uid)
+        and metadata.st_uid != effective_uid()
     )
     if (
         resolved_before != path
@@ -121,7 +167,7 @@ def _observe_real_directory(
         or metadata.st_dev < 1
         or metadata.st_ino < 1
         or wrong_owner
-        or (private and stat.S_IMODE(metadata.st_mode) != 0o700)
+        or (enforce_posix_private_mode and stat.S_IMODE(metadata.st_mode) != 0o700)
     ):
         qualifier = "private owner-only " if private else ""
         raise LocalIndexServiceError(f"{label} must be one real {qualifier}directory")
@@ -344,6 +390,23 @@ def _catalog_topology_paths(
         parent,
         label="local index catalog parent",
     )
+    _require_no_catalog_rollback_journal(path)
+    sidecars: list[_TopologyPath] = []
+    for suffix, label in _CATALOG_SIDECARS:
+        sidecar_path = Path(f"{path}{suffix}")
+        identity = (
+            None
+            if suffix == "-journal"
+            else _observe_optional_catalog_sidecar(sidecar_path, label=label)
+        )
+        sidecars.append(
+            _TopologyPath(
+                f"local index catalog {label}",
+                sidecar_path,
+                parent_identity[0] if identity is None else identity[0],
+                parent,
+            )
+        )
     return (
         _TopologyPath(
             "local index catalog",
@@ -351,15 +414,7 @@ def _catalog_topology_paths(
             catalog_factory.catalog_identity[0],
             parent,
         ),
-        *(
-            _TopologyPath(
-                f"local index catalog {label}",
-                Path(f"{path}{suffix}"),
-                parent_identity[0],
-                parent,
-            )
-            for suffix, label in _CATALOG_SIDECARS
-        ),
+        *sidecars,
     )
 
 
@@ -372,7 +427,7 @@ def _require_disjoint_topology(paths: tuple[_TopologyPath, ...]) -> None:
             raise LocalIndexServiceError(
                 f"{subject.label} must not be a Linux mount point"
             )
-    physical: list[tuple[_TopologyPath, _LinuxPhysicalPath | None]] = []
+    physical: list[tuple[str, _LinuxPhysicalPath | None]] = []
     lexical_stack: list[_TopologyPath] = []
     ancestry_identities: dict[tuple[int, int], tuple[Path, str]] = {}
     for subject in sorted(paths, key=lambda item: item.path.parts):
@@ -405,15 +460,34 @@ def _require_disjoint_topology(paths: tuple[_TopologyPath, ...]) -> None:
                 raise LocalIndexServiceError(
                     f"{subject.label} mount mapping differs from its inode"
                 )
-        physical.append((subject, mapped))
+        physical.append((subject.label, mapped))
 
-    physical_stack: list[tuple[_TopologyPath, _LinuxPhysicalPath]] = []
+    # A protected directory can contain a bind mount whose configured source
+    # lives at another protected root. Mapping only the configured lexical
+    # roots would miss that alias while recursive repository reads traverse it.
+    descendant_mappings: set[tuple[Path, str, PurePosixPath]] = set()
+    for subject in paths:
+        if subject.ancestry_root != subject.path:
+            continue
+        for mapping in mappings:
+            if subject.path not in mapping.mount_point.parents:
+                continue
+            mapped = _linux_physical_path(mapping.mount_point, mappings)
+            if mapped is None:  # pragma: no cover - the mapping is a candidate
+                raise LocalIndexServiceError("Linux descendant mount mapping changed")
+            key = (mapping.mount_point, mapped.device, mapped.path)
+            if key in descendant_mappings:
+                continue
+            descendant_mappings.add(key)
+            physical.append((f"Linux mount below {subject.label}", mapped))
+
+    physical_stack: list[tuple[str, _LinuxPhysicalPath]] = []
     concrete = sorted(
-        ((subject, mapped) for subject, mapped in physical if mapped is not None),
+        ((label, mapped) for label, mapped in physical if mapped is not None),
         key=lambda item: (item[1].device, item[1].path.parts),
     )
     active_device: str | None = None
-    for subject, mapped in concrete:
+    for label, mapped in concrete:
         if mapped.device != active_device:
             physical_stack.clear()
             active_device = mapped.device
@@ -424,10 +498,9 @@ def _require_disjoint_topology(paths: tuple[_TopologyPath, ...]) -> None:
             physical_stack.pop()
         if physical_stack:
             raise LocalIndexServiceError(
-                f"{physical_stack[-1][0].label} traverses a physical alias of "
-                f"{subject.label}"
+                f"{physical_stack[-1][0]} traverses a physical alias of {label}"
             )
-        physical_stack.append((subject, mapped))
+        physical_stack.append((label, mapped))
 
 
 @dataclass(frozen=True, slots=True)
@@ -468,6 +541,38 @@ def _open_root_binding(
         identity=publication_parent_identity(authority.resource),
         owner=owner,
     )
+
+
+def _verify_repository_binding(
+    repo_id: str,
+    path: Path,
+    authority: RepositorySourceRootAuthority,
+) -> tuple[int, ...]:
+    """Normalize retained source failures at the Web storage boundary."""
+
+    try:
+        authority.verify()
+        root = authority.root
+        root_identity = authority.root_identity
+    except (OSError, RuntimeError, TypeError, ValueError) as exc:
+        raise LocalIndexServiceError(f"repository {repo_id!r} binding changed") from exc
+    if root != path:
+        raise LocalIndexServiceError(f"repository {repo_id!r} authority path changed")
+    if (
+        type(root_identity) is not tuple
+        or len(root_identity) < 2
+        or any(type(value) is not int for value in root_identity)
+    ):
+        raise LocalIndexServiceError(
+            f"repository {repo_id!r} authority identity changed"
+        )
+    observed = _observe_real_directory(
+        path,
+        label=f"repository {repo_id!r}",
+    )
+    if tuple(observed[:2]) != tuple(root_identity[:2]):
+        raise LocalIndexServiceError(f"repository {repo_id!r} identity changed")
+    return root_identity
 
 
 class _CatalogSessionOwner:
@@ -786,17 +891,25 @@ class LocalIndexStorageTopology:
         def read() -> RepositorySourceRootAuthority:
             if self._closed_unlocked():
                 raise LocalIndexServiceError("local index topology is closed")
-            for candidate_id, authority in self._repositories:
+            for (path_id, path), (candidate_id, authority) in zip(
+                self._repository_paths,
+                self._repositories,
+                strict=True,
+            ):
+                if path_id != candidate_id:
+                    raise LocalIndexServiceError(
+                        "local index repository authority ordering changed"
+                    )
                 if candidate_id == repo_id:
-                    authority.verify()
+                    _verify_repository_binding(repo_id, path, authority)
                     return authority
             raise KeyError(repo_id)
 
         return self._lifecycle_lock.run(read)
 
-    def _verify_unlocked(self) -> None:
-        if self._closed_unlocked():
-            raise LocalIndexServiceError("local index topology is closed")
+    def _bound_topology_paths_unlocked(self) -> tuple[_TopologyPath, ...]:
+        """Revalidate retained bindings and return detached topology inputs."""
+
         self._catalog_factory.verify()
         for binding, private in (
             (self._cas, False),
@@ -811,6 +924,7 @@ class LocalIndexStorageTopology:
             )
             if observed != binding.identity:
                 raise LocalIndexServiceError(f"{binding.label} identity changed")
+        repository_identities: list[tuple[int, ...]] = []
         for (repo_id, path), (authority_id, authority) in zip(
             self._repository_paths,
             self._repositories,
@@ -820,18 +934,10 @@ class LocalIndexStorageTopology:
                 raise LocalIndexServiceError(
                     "local index repository authority ordering changed"
                 )
-            authority.verify()
-            if authority.root != path:
-                raise LocalIndexServiceError(
-                    f"repository {repo_id!r} authority path changed"
-                )
-            observed = _observe_real_directory(
-                path,
-                label=f"repository {repo_id!r}",
+            repository_identities.append(
+                _verify_repository_binding(repo_id, path, authority)
             )
-            if tuple(observed[:2]) != tuple(authority.root_identity[:2]):
-                raise LocalIndexServiceError(f"repository {repo_id!r} identity changed")
-        topology_paths = (
+        return (
             *_catalog_topology_paths(self._catalog_factory),
             _TopologyPath(
                 self._cas.label,
@@ -855,17 +961,26 @@ class LocalIndexStorageTopology:
                 _TopologyPath(
                     f"repository {repo_id!r}",
                     path,
-                    authority.root_identity[0],
+                    identity[0],
                     path,
                 )
-                for (repo_id, path), (_authority_id, authority) in zip(
+                for (repo_id, path), identity in zip(
                     self._repository_paths,
-                    self._repositories,
+                    repository_identities,
                     strict=True,
                 )
             ),
         )
+
+    def _verify_unlocked(self) -> None:
+        if self._closed_unlocked():
+            raise LocalIndexServiceError("local index topology is closed")
+        topology_paths = self._bound_topology_paths_unlocked()
         _require_disjoint_topology(topology_paths)
+        # Physical ancestry and mount inspection can run arbitrary filesystem
+        # syscalls. Sandwich it with a final retained binding check so a rename
+        # or replacement cannot be accepted at the public return boundary.
+        self._bound_topology_paths_unlocked()
 
     def verify(self) -> None:
         """Revalidate every retained path and physical-separation invariant."""

--- a/codenib/web/local_index_service.py
+++ b/codenib/web/local_index_service.py
@@ -37,6 +37,13 @@ from .config import LocalIndexStorageConfig
 _MAX_BUSY_TIMEOUT_MS = 86_400_000
 _MAX_MOUNTINFO_ENTRIES = 65_536
 _MAX_MOUNTINFO_LINE_BYTES = 64 * 1024
+_MAX_RETAINED_TOPOLOGY_RESOURCES = 16_384
+_TOPOLOGY_TRANSIENT_RESOURCE_RESERVE = 64
+_CATALOG_SIDECARS = (
+    ("-wal", "WAL sidecar"),
+    ("-shm", "SHM sidecar"),
+    ("-journal", "rollback journal"),
+)
 _MISSING_CATALOG = object()
 _LOCAL_TOPOLOGY_TOKEN = object()
 
@@ -124,6 +131,66 @@ def _observe_real_directory(
         stat.S_IFMT(metadata.st_mode),
         int(getattr(metadata, "st_file_attributes", 0)),
     )
+
+
+def _open_descriptor_count() -> int | None:
+    if os.name != "posix":
+        return None
+    candidates = (Path("/proc/self/fd"), Path("/dev/fd"))
+    for candidate in candidates:
+        try:
+            return len(os.listdir(candidate))
+        except OSError:
+            continue
+    return None
+
+
+def _available_topology_resource_budget() -> int:
+    """Bound retained authorities while reserving room for request-time I/O."""
+
+    if os.name != "posix":
+        # Windows has no RLIMIT_NOFILE equivalent. Keep the aggregate HANDLE
+        # chain bounded independently of the configured repository-count cap.
+        return _MAX_RETAINED_TOPOLOGY_RESOURCES
+    try:
+        import resource
+
+        soft_limit, _hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+    except (ImportError, OSError, ValueError):
+        # RLIMIT_NOFILE is expected on supported POSIX hosts. Without it there
+        # is no sound way to admit a long-lived descriptor chain.
+        return 0
+    if soft_limit == resource.RLIM_INFINITY:
+        return _MAX_RETAINED_TOPOLOGY_RESOURCES
+    available = max(0, int(soft_limit))
+    open_descriptors = _open_descriptor_count()
+    if open_descriptors is None:
+        return 0
+    available = max(0, available - open_descriptors)
+    available = max(0, available - _TOPOLOGY_TRANSIENT_RESOURCE_RESERVE)
+    return min(available, _MAX_RETAINED_TOPOLOGY_RESOURCES)
+
+
+def _require_topology_resource_budget(
+    repository_paths: tuple[tuple[str, Path], ...],
+    storage_roots: tuple[Path, ...],
+) -> None:
+    # Both source-root and publication authorities retain the anchor plus one
+    # descriptor/HANDLE per lexical component. Their current implementations do
+    # not share common ancestors between configured roots.
+    required = sum(
+        len(path.parts)
+        for path in (
+            *(path for _repo_id, path in repository_paths),
+            *storage_roots,
+        )
+    )
+    available = _available_topology_resource_budget()
+    if required > available:
+        raise LocalIndexServiceError(
+            "local index storage topology exceeds its retained resource budget "
+            f"({required} required, {available} available)"
+        )
 
 
 def _directory_ancestry(
@@ -266,6 +333,34 @@ class _TopologyPath:
     path: Path
     device: int
     ancestry_root: Path
+
+
+def _catalog_topology_paths(
+    catalog_factory: "ExistingLocalIndexCatalogFactory",
+) -> tuple[_TopologyPath, ...]:
+    path = catalog_factory.catalog_path
+    parent = path.parent
+    parent_identity = _observe_real_directory(
+        parent,
+        label="local index catalog parent",
+    )
+    return (
+        _TopologyPath(
+            "local index catalog",
+            path,
+            catalog_factory.catalog_identity[0],
+            parent,
+        ),
+        *(
+            _TopologyPath(
+                f"local index catalog {label}",
+                Path(f"{path}{suffix}"),
+                parent_identity[0],
+                parent,
+            )
+            for suffix, label in _CATALOG_SIDECARS
+        ),
+    )
 
 
 def _require_disjoint_topology(paths: tuple[_TopologyPath, ...]) -> None:
@@ -560,14 +655,14 @@ class LocalIndexStorageTopology:
             _observe_real_directory(path, label=label, private=private)
             for path, label, private in root_specs
         )
+        repository_path_tuple = tuple(repository_paths)
+        _require_topology_resource_budget(
+            repository_path_tuple,
+            tuple(path for path, _label, _private in root_specs),
+        )
         catalog_factory.verify()
         topology_paths = (
-            _TopologyPath(
-                "local index catalog",
-                config.catalog_path,
-                catalog_factory.catalog_identity[0],
-                config.catalog_path.parent,
-            ),
+            *_catalog_topology_paths(catalog_factory),
             *(
                 _TopologyPath(label, path, identity[0], path)
                 for (path, label, _private), identity in zip(
@@ -649,7 +744,7 @@ class LocalIndexStorageTopology:
                 cas=cas,
                 worker_workspace=worker_workspace,
                 runtime_workspace=runtime_workspace,
-                repository_paths=tuple(repository_paths),
+                repository_paths=repository_path_tuple,
                 repositories=repositories,
                 source_owner=source_owner,
             )
@@ -737,12 +832,7 @@ class LocalIndexStorageTopology:
             if tuple(observed[:2]) != tuple(authority.root_identity[:2]):
                 raise LocalIndexServiceError(f"repository {repo_id!r} identity changed")
         topology_paths = (
-            _TopologyPath(
-                "local index catalog",
-                self._config.catalog_path,
-                self._catalog_factory.catalog_identity[0],
-                self._config.catalog_path.parent,
-            ),
+            *_catalog_topology_paths(self._catalog_factory),
             _TopologyPath(
                 self._cas.label,
                 self._cas.path,

--- a/codenib/web/local_index_service.py
+++ b/codenib/web/local_index_service.py
@@ -73,13 +73,31 @@ def _canonical_catalog_path(value: Path) -> Path:
     return value
 
 
-def _observe_catalog_identity(path: Path) -> tuple[int, int, int]:
-    """Attest one non-aliased, single-linked existing catalog file."""
-
+def _observe_catalog_identity_maybe_missing(
+    path: Path,
+    *,
+    missing_ok: bool,
+) -> tuple[int, int, int] | None:
     try:
         resolved_before = path.resolve(strict=True)
         metadata = path.lstat()
         resolved_after = path.resolve(strict=True)
+    except FileNotFoundError as exc:
+        if missing_ok:
+            # WAL/SHM files are SQLite-owned and may disappear between any two
+            # observations. Accept only a second exact missing observation;
+            # a broken link or immediate replacement remains unsafe.
+            try:
+                path.lstat()
+            except FileNotFoundError:
+                return None
+            except OSError as retry_exc:
+                raise LocalIndexServiceError(
+                    "local index catalog cannot be inspected safely"
+                ) from retry_exc
+        raise LocalIndexServiceError(
+            "local index catalog cannot be inspected safely"
+        ) from exc
     except (OSError, RuntimeError, ValueError) as exc:
         raise LocalIndexServiceError(
             "local index catalog cannot be inspected safely"
@@ -105,6 +123,15 @@ def _observe_catalog_identity(path: Path) -> tuple[int, int, int]:
     return identity
 
 
+def _observe_catalog_identity(path: Path) -> tuple[int, int, int]:
+    """Attest one non-aliased, single-linked existing catalog file."""
+
+    identity = _observe_catalog_identity_maybe_missing(path, missing_ok=False)
+    if identity is None:  # pragma: no cover - missing_ok=False proves this
+        raise LocalIndexServiceError("local index catalog cannot be inspected safely")
+    return identity
+
+
 def _observe_optional_catalog_sidecar(
     path: Path,
     *,
@@ -113,15 +140,7 @@ def _observe_optional_catalog_sidecar(
     """Validate one existing WAL/SHM path without requiring its presence."""
 
     try:
-        path.lstat()
-    except FileNotFoundError:
-        return None
-    except OSError as exc:
-        raise LocalIndexServiceError(
-            f"local index catalog {label} cannot be inspected safely"
-        ) from exc
-    try:
-        return _observe_catalog_identity(path)
+        return _observe_catalog_identity_maybe_missing(path, missing_ok=True)
     except LocalIndexServiceError as exc:
         raise LocalIndexServiceError(
             f"local index catalog {label} must be one real single-linked file"

--- a/codenib/web/local_index_service.py
+++ b/codenib/web/local_index_service.py
@@ -114,13 +114,7 @@ def _observe_real_directory(
         or metadata.st_dev < 1
         or metadata.st_ino < 1
         or wrong_owner
-        or (
-            private
-            and (
-                stat.S_IMODE(metadata.st_mode) & 0o077
-                or stat.S_IMODE(metadata.st_mode) & 0o700 != 0o700
-            )
-        )
+        or (private and stat.S_IMODE(metadata.st_mode) != 0o700)
     ):
         qualifier = "private owner-only " if private else ""
         raise LocalIndexServiceError(f"{label} must be one real {qualifier}directory")
@@ -276,6 +270,13 @@ class _TopologyPath:
 
 def _require_disjoint_topology(paths: tuple[_TopologyPath, ...]) -> None:
     mappings = _linux_mount_mappings()
+    for subject in paths:
+        if subject.ancestry_root != subject.path and any(
+            mapping.mount_point == subject.path for mapping in mappings
+        ):
+            raise LocalIndexServiceError(
+                f"{subject.label} must not be a Linux mount point"
+            )
     physical: list[tuple[_TopologyPath, _LinuxPhysicalPath | None]] = []
     lexical_stack: list[_TopologyPath] = []
     ancestry_identities: dict[tuple[int, int], tuple[Path, str]] = {}

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1679,7 +1679,12 @@ MCP, UI controls, and default routing remain absent.
   runtime workspace roots, namespace/ref bindings, and bounded worker/runtime
   timing. Presence is the explicit opt-in; parsing touches no path and rejects
   relative, overlapping, duplicate, unknown, and incoherent values. Physical
-  topology acquisition, service composition, and lifespan installation remain
+  topology acquisition now binds the existing single-linked catalog inode,
+  opens retained authorities for the CAS and both private workspace roots, and
+  pins every explicitly mapped repository hierarchy. It rejects symbolic
+  traversal plus lexical, inode-ancestry, and Linux mount-mapped physical
+  aliases, revalidates every binding, and retains interrupted cleanup for
+  retry. Actual CAS/worker/runtime composition and lifespan installation remain
   separate gates.
 - An explicitly injected Web reader can now project authorized durable jobs and
   at most 64 events without exposing worker owner IDs, fencing tokens, or raw

--- a/test/web/test_local_index_service.py
+++ b/test/web/test_local_index_service.py
@@ -5,22 +5,55 @@
 from __future__ import annotations
 
 import dis
+import os
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import pytest
 
 import codenib.web.local_index_service as local_index_service
 from codenib.storage import SQLiteCatalog
+from codenib.web.config import LocalIndexStorageConfig, LocalIndexStorageRepository
 from codenib.web.local_index_service import (
     ExistingLocalIndexCatalogFactory,
     LocalIndexServiceError,
+    LocalIndexStorageTopology,
 )
 
 
 def _provision_catalog(path: Path) -> None:
     with SQLiteCatalog(path):
         pass
+
+
+def _topology_config(
+    tmp_path: Path,
+) -> tuple[LocalIndexStorageConfig, dict[str, Path]]:
+    catalog_path = tmp_path / "catalog.sqlite3"
+    cas_root = tmp_path / "cas"
+    worker_root = tmp_path / "worker"
+    runtime_root = tmp_path / "runtime"
+    repository_root = tmp_path / "repository"
+    _provision_catalog(catalog_path)
+    cas_root.mkdir()
+    worker_root.mkdir(mode=0o700)
+    runtime_root.mkdir(mode=0o700)
+    repository_root.mkdir()
+    return (
+        LocalIndexStorageConfig(
+            catalog_path=catalog_path,
+            cas_root=cas_root,
+            worker_workspace_root=worker_root,
+            runtime_workspace_root=runtime_root,
+            repositories=(
+                LocalIndexStorageRepository(
+                    repo_id="repo",
+                    repository_key="org/repo",
+                ),
+            ),
+        ),
+        {"repo": repository_root},
+    )
 
 
 def test_existing_catalog_factory_opens_fresh_exact_sessions(tmp_path: Path) -> None:
@@ -174,4 +207,122 @@ def test_existing_catalog_factory_rejects_invalid_timeout(
         ExistingLocalIndexCatalogFactory(
             catalog_path,
             busy_timeout_ms=timeout,  # type: ignore[arg-type]
+        )
+
+
+def test_local_index_topology_retains_and_revalidates_every_authority(
+    tmp_path: Path,
+) -> None:
+    config, repositories = _topology_config(tmp_path)
+
+    topology = LocalIndexStorageTopology.acquire(config, repositories)
+
+    topology.verify()
+    assert topology.closed is False
+    assert topology.worker_workspace_identity[:2] == (
+        config.worker_workspace_root.stat().st_dev,
+        config.worker_workspace_root.stat().st_ino,
+    )
+    assert topology.runtime_workspace_identity[:2] == (
+        config.runtime_workspace_root.stat().st_dev,
+        config.runtime_workspace_root.stat().st_ino,
+    )
+    assert topology.repository_authority("repo").root == repositories["repo"]
+    with topology.catalog_factory() as catalog:
+        assert catalog.schema_version > 0
+
+    topology.close()
+    topology.close()
+    assert topology.closed is True
+    with pytest.raises(LocalIndexServiceError, match="closed"):
+        topology.verify()
+
+
+def test_local_index_topology_detects_replaced_workspace_root(
+    tmp_path: Path,
+) -> None:
+    config, repositories = _topology_config(tmp_path)
+    topology = LocalIndexStorageTopology.acquire(config, repositories)
+    displaced = tmp_path / "worker-displaced"
+    config.worker_workspace_root.rename(displaced)
+    config.worker_workspace_root.mkdir(mode=0o700)
+
+    try:
+        with pytest.raises(LocalIndexServiceError, match="binding changed"):
+            topology.verify()
+    finally:
+        topology.close()
+
+
+def test_local_index_topology_rejects_symlinked_storage_root(
+    tmp_path: Path,
+) -> None:
+    config, repositories = _topology_config(tmp_path)
+    actual_runtime = tmp_path / "actual-runtime"
+    config.runtime_workspace_root.rename(actual_runtime)
+    config.runtime_workspace_root.symlink_to(actual_runtime, target_is_directory=True)
+
+    with pytest.raises(LocalIndexServiceError, match="real private owner-only"):
+        LocalIndexStorageTopology.acquire(config, repositories)
+
+
+def test_local_index_topology_rejects_repository_storage_overlap(
+    tmp_path: Path,
+) -> None:
+    config, _repositories = _topology_config(tmp_path)
+    repository = config.cas_root / "repository"
+    repository.mkdir()
+
+    with pytest.raises(LocalIndexServiceError, match="must not overlap"):
+        LocalIndexStorageTopology.acquire(config, {"repo": repository})
+
+
+def test_local_index_topology_rejects_mapped_physical_alias(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, repositories = _topology_config(tmp_path)
+    device = config.cas_root.stat().st_dev
+    mount_device = f"{os.major(device)}:{os.minor(device)}"
+    mappings = (
+        local_index_service._LinuxMountMapping(
+            device=mount_device,
+            root=PurePosixPath("/physical/shared/cache"),
+            mount_point=config.cas_root,
+        ),
+        local_index_service._LinuxMountMapping(
+            device=mount_device,
+            root=PurePosixPath("/physical/shared"),
+            mount_point=repositories["repo"],
+        ),
+    )
+    monkeypatch.setattr(
+        local_index_service,
+        "_linux_mount_mappings",
+        lambda: mappings,
+    )
+
+    with pytest.raises(LocalIndexServiceError, match="physical alias"):
+        LocalIndexStorageTopology.acquire(config, repositories)
+
+
+def test_local_index_topology_requires_private_workspace_roots(
+    tmp_path: Path,
+) -> None:
+    config, repositories = _topology_config(tmp_path)
+    config.runtime_workspace_root.chmod(0o755)
+
+    with pytest.raises(LocalIndexServiceError, match="private owner-only"):
+        LocalIndexStorageTopology.acquire(config, repositories)
+
+
+def test_local_index_topology_requires_exact_repository_mapping(
+    tmp_path: Path,
+) -> None:
+    config, repositories = _topology_config(tmp_path)
+
+    with pytest.raises(ValueError, match="match configured bindings"):
+        LocalIndexStorageTopology.acquire(
+            config,
+            {"other": repositories["repo"]},
         )

--- a/test/web/test_local_index_service.py
+++ b/test/web/test_local_index_service.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import dis
 import os
 import sys
+from dataclasses import replace
 from pathlib import Path, PurePosixPath
 
 import pytest
@@ -275,6 +276,86 @@ def test_local_index_topology_rejects_repository_storage_overlap(
 
     with pytest.raises(LocalIndexServiceError, match="must not overlap"):
         LocalIndexStorageTopology.acquire(config, {"repo": repository})
+
+
+@pytest.mark.parametrize(
+    ("suffix", "label"),
+    (
+        ("-wal", "WAL sidecar"),
+        ("-shm", "SHM sidecar"),
+        ("-journal", "rollback journal"),
+    ),
+)
+def test_local_index_topology_reserves_catalog_sidecar_namespace(
+    tmp_path: Path,
+    suffix: str,
+    label: str,
+) -> None:
+    config, repositories = _topology_config(tmp_path)
+    sidecar = Path(f"{config.catalog_path}{suffix}")
+    config.worker_workspace_root.rename(sidecar)
+    config = replace(config, worker_workspace_root=sidecar)
+
+    with pytest.raises(
+        LocalIndexServiceError,
+        match=rf"catalog {label} must not overlap worker workspace root",
+    ):
+        LocalIndexStorageTopology.acquire(config, repositories)
+
+
+def test_local_index_topology_rejects_retained_resource_overcommit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, repositories = _topology_config(tmp_path)
+    required = sum(
+        len(path.parts)
+        for path in (
+            *repositories.values(),
+            config.cas_root,
+            config.worker_workspace_root,
+            config.runtime_workspace_root,
+        )
+    )
+    monkeypatch.setattr(
+        local_index_service,
+        "_available_topology_resource_budget",
+        lambda: required - 1,
+    )
+    monkeypatch.setattr(
+        local_index_service,
+        "pin_repository_source_root",
+        lambda *_args, **_kwargs: pytest.fail(
+            "repository pinning must follow resource admission"
+        ),
+    )
+
+    with pytest.raises(LocalIndexServiceError, match="retained resource budget"):
+        LocalIndexStorageTopology.acquire(config, repositories)
+
+
+def test_local_index_topology_accepts_exact_retained_resource_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, repositories = _topology_config(tmp_path)
+    required = sum(
+        len(path.parts)
+        for path in (
+            *repositories.values(),
+            config.cas_root,
+            config.worker_workspace_root,
+            config.runtime_workspace_root,
+        )
+    )
+    monkeypatch.setattr(
+        local_index_service,
+        "_available_topology_resource_budget",
+        lambda: required,
+    )
+
+    topology = LocalIndexStorageTopology.acquire(config, repositories)
+    topology.close()
 
 
 def test_local_index_topology_rejects_mapped_physical_alias(

--- a/test/web/test_local_index_service.py
+++ b/test/web/test_local_index_service.py
@@ -255,6 +255,64 @@ def test_local_index_topology_detects_replaced_workspace_root(
         topology.close()
 
 
+def test_local_index_topology_normalizes_replaced_repository_authority(
+    tmp_path: Path,
+) -> None:
+    config, repositories = _topology_config(tmp_path)
+    topology = LocalIndexStorageTopology.acquire(config, repositories)
+    repository = repositories["repo"]
+    displaced = tmp_path / "repository-displaced"
+    repository.rename(displaced)
+    repository.mkdir()
+
+    try:
+        with pytest.raises(
+            LocalIndexServiceError,
+            match="repository 'repo' binding changed",
+        ):
+            topology.repository_authority("repo")
+    finally:
+        topology.close()
+
+
+@pytest.mark.parametrize("target", ("catalog", "workspace", "repository"))
+def test_local_index_topology_rechecks_bindings_after_physical_inspection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    target: str,
+) -> None:
+    config, repositories = _topology_config(tmp_path)
+    topology = LocalIndexStorageTopology.acquire(config, repositories)
+    real_require = local_index_service._require_disjoint_topology
+    mutated = False
+
+    def inspect_then_replace(paths) -> None:
+        nonlocal mutated
+        real_require(paths)
+        if target == "catalog":
+            config.catalog_path.rename(tmp_path / "catalog-displaced.sqlite3")
+            _provision_catalog(config.catalog_path)
+        elif target == "workspace":
+            config.worker_workspace_root.rename(tmp_path / "worker-displaced")
+            config.worker_workspace_root.mkdir(mode=0o700)
+        else:
+            repositories["repo"].rename(tmp_path / "repository-displaced")
+            repositories["repo"].mkdir()
+        mutated = True
+
+    monkeypatch.setattr(
+        local_index_service,
+        "_require_disjoint_topology",
+        inspect_then_replace,
+    )
+    try:
+        with pytest.raises(LocalIndexServiceError, match="binding changed"):
+            topology.verify()
+        assert mutated
+    finally:
+        topology.close()
+
+
 def test_local_index_topology_rejects_symlinked_storage_root(
     tmp_path: Path,
 ) -> None:
@@ -279,27 +337,46 @@ def test_local_index_topology_rejects_repository_storage_overlap(
 
 
 @pytest.mark.parametrize(
-    ("suffix", "label"),
+    ("suffix", "error"),
     (
-        ("-wal", "WAL sidecar"),
-        ("-shm", "SHM sidecar"),
-        ("-journal", "rollback journal"),
+        ("-wal", "catalog WAL sidecar must be one real"),
+        ("-shm", "catalog SHM sidecar must be one real"),
+        ("-journal", "rollback journal is not allowed"),
     ),
 )
 def test_local_index_topology_reserves_catalog_sidecar_namespace(
     tmp_path: Path,
     suffix: str,
-    label: str,
+    error: str,
 ) -> None:
     config, repositories = _topology_config(tmp_path)
     sidecar = Path(f"{config.catalog_path}{suffix}")
     config.worker_workspace_root.rename(sidecar)
     config = replace(config, worker_workspace_root=sidecar)
 
-    with pytest.raises(
-        LocalIndexServiceError,
-        match=rf"catalog {label} must not overlap worker workspace root",
-    ):
+    with pytest.raises(LocalIndexServiceError, match=error):
+        LocalIndexStorageTopology.acquire(config, repositories)
+
+
+@pytest.mark.parametrize(
+    ("suffix", "error"),
+    (
+        ("-wal", "catalog WAL sidecar must be one real"),
+        ("-shm", "catalog SHM sidecar must be one real"),
+        ("-journal", "rollback journal is not allowed"),
+    ),
+)
+def test_local_index_topology_rejects_unconfigured_unsafe_catalog_sidecar(
+    tmp_path: Path,
+    suffix: str,
+    error: str,
+) -> None:
+    config, repositories = _topology_config(tmp_path)
+    sidecar = Path(f"{config.catalog_path}{suffix}")
+    assert not sidecar.exists()
+    sidecar.mkdir()
+
+    with pytest.raises(LocalIndexServiceError, match=error):
         LocalIndexStorageTopology.acquire(config, repositories)
 
 
@@ -387,6 +464,40 @@ def test_local_index_topology_rejects_mapped_physical_alias(
         LocalIndexStorageTopology.acquire(config, repositories)
 
 
+def test_local_index_topology_rejects_descendant_mount_alias(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, repositories = _topology_config(tmp_path)
+    device = config.cas_root.stat().st_dev
+    mount_device = f"{os.major(device)}:{os.minor(device)}"
+    mappings = (
+        local_index_service._LinuxMountMapping(
+            device=mount_device,
+            root=PurePosixPath("/physical/cache"),
+            mount_point=config.cas_root,
+        ),
+        local_index_service._LinuxMountMapping(
+            device=mount_device,
+            root=PurePosixPath("/physical/repository"),
+            mount_point=repositories["repo"],
+        ),
+        local_index_service._LinuxMountMapping(
+            device=mount_device,
+            root=PurePosixPath("/physical/cache"),
+            mount_point=repositories["repo"] / "mounted-cache",
+        ),
+    )
+    monkeypatch.setattr(
+        local_index_service,
+        "_linux_mount_mappings",
+        lambda: mappings,
+    )
+
+    with pytest.raises(LocalIndexServiceError, match="physical alias"):
+        LocalIndexStorageTopology.acquire(config, repositories)
+
+
 def test_local_index_topology_rejects_catalog_mount_point(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -420,6 +531,22 @@ def test_local_index_topology_requires_private_workspace_roots(
 
     with pytest.raises(LocalIndexServiceError, match="private owner-only"):
         LocalIndexStorageTopology.acquire(config, repositories)
+
+
+def test_local_index_topology_gates_posix_private_mode_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, repositories = _topology_config(tmp_path)
+    config.runtime_workspace_root.chmod(0o755)
+    monkeypatch.setattr(
+        local_index_service,
+        "_POSIX_PRIVATE_MODE_SEMANTICS",
+        False,
+    )
+
+    topology = LocalIndexStorageTopology.acquire(config, repositories)
+    topology.close()
 
 
 def test_local_index_topology_requires_exact_repository_mapping(

--- a/test/web/test_local_index_service.py
+++ b/test/web/test_local_index_service.py
@@ -19,6 +19,7 @@ from codenib.web.local_index_service import (
     ExistingLocalIndexCatalogFactory,
     LocalIndexServiceError,
     LocalIndexStorageTopology,
+    LocalIndexStorageTopologyOwner,
 )
 
 
@@ -55,6 +56,19 @@ def _topology_config(
         ),
         {"repo": repository_root},
     )
+
+
+def _acquire_topology(
+    config: LocalIndexStorageConfig,
+    repositories: dict[str, Path],
+) -> tuple[LocalIndexStorageTopologyOwner, LocalIndexStorageTopology]:
+    owner = LocalIndexStorageTopologyOwner()
+    topology = LocalIndexStorageTopology.acquire(
+        config,
+        repositories,
+        owner=owner,
+    )
+    return owner, topology
 
 
 def test_existing_catalog_factory_opens_fresh_exact_sessions(tmp_path: Path) -> None:
@@ -216,7 +230,7 @@ def test_local_index_topology_retains_and_revalidates_every_authority(
 ) -> None:
     config, repositories = _topology_config(tmp_path)
 
-    topology = LocalIndexStorageTopology.acquire(config, repositories)
+    owner, topology = _acquire_topology(config, repositories)
 
     topology.verify()
     assert topology.closed is False
@@ -232,18 +246,71 @@ def test_local_index_topology_retains_and_revalidates_every_authority(
     with topology.catalog_factory() as catalog:
         assert catalog.schema_version > 0
 
-    topology.close()
-    topology.close()
+    owner.close()
+    owner.close()
     assert topology.closed is True
     with pytest.raises(LocalIndexServiceError, match="closed"):
         topology.verify()
+
+
+def test_local_index_topology_owner_retains_return_boundary_interruption(
+    tmp_path: Path,
+) -> None:
+    config, repositories = _topology_config(tmp_path)
+    owner = LocalIndexStorageTopologyOwner()
+    interruption = KeyboardInterrupt("topology return interrupted")
+    acquire = LocalIndexStorageTopology.acquire
+    implementation = acquire.__func__
+    instructions = tuple(dis.get_instructions(implementation))
+    return_offsets = {
+        instruction.offset
+        for index, instruction in enumerate(instructions)
+        if instruction.opname == "RETURN_VALUE"
+        and any(
+            candidate.opname == "LOAD_FAST" and candidate.argval == "topology"
+            for candidate in instructions[max(0, index - 15) : index]
+        )
+    }
+    assert len(return_offsets) == 1
+    injected = False
+    previous_trace = sys.gettrace()
+
+    def trace(frame, event: str, _arg: object):
+        nonlocal injected
+        if event == "call" and frame.f_code is implementation.__code__:
+            frame.f_trace_opcodes = True
+            return trace
+        if (
+            not injected
+            and frame.f_code is implementation.__code__
+            and event == "opcode"
+            and frame.f_lasti in return_offsets
+        ):
+            injected = True
+            sys.settrace(None)
+            raise interruption
+        return trace
+
+    sys.settrace(trace)
+    try:
+        with pytest.raises(KeyboardInterrupt) as raised:
+            acquire(config, repositories, owner=owner)
+    finally:
+        sys.settrace(previous_trace)
+
+    assert injected
+    assert raised.value is interruption
+    topology = owner.topology
+    assert not topology.closed
+    owner.close()
+    assert topology.closed
 
 
 def test_local_index_topology_detects_replaced_workspace_root(
     tmp_path: Path,
 ) -> None:
     config, repositories = _topology_config(tmp_path)
-    topology = LocalIndexStorageTopology.acquire(config, repositories)
+    owner, topology = _acquire_topology(config, repositories)
     displaced = tmp_path / "worker-displaced"
     config.worker_workspace_root.rename(displaced)
     config.worker_workspace_root.mkdir(mode=0o700)
@@ -252,14 +319,14 @@ def test_local_index_topology_detects_replaced_workspace_root(
         with pytest.raises(LocalIndexServiceError, match="binding changed"):
             topology.verify()
     finally:
-        topology.close()
+        owner.close()
 
 
 def test_local_index_topology_normalizes_replaced_repository_authority(
     tmp_path: Path,
 ) -> None:
     config, repositories = _topology_config(tmp_path)
-    topology = LocalIndexStorageTopology.acquire(config, repositories)
+    owner, topology = _acquire_topology(config, repositories)
     repository = repositories["repo"]
     displaced = tmp_path / "repository-displaced"
     repository.rename(displaced)
@@ -272,7 +339,7 @@ def test_local_index_topology_normalizes_replaced_repository_authority(
         ):
             topology.repository_authority("repo")
     finally:
-        topology.close()
+        owner.close()
 
 
 @pytest.mark.parametrize("target", ("catalog", "workspace", "repository"))
@@ -282,7 +349,7 @@ def test_local_index_topology_rechecks_bindings_after_physical_inspection(
     target: str,
 ) -> None:
     config, repositories = _topology_config(tmp_path)
-    topology = LocalIndexStorageTopology.acquire(config, repositories)
+    owner, topology = _acquire_topology(config, repositories)
     real_require = local_index_service._require_disjoint_topology
     mutated = False
 
@@ -310,7 +377,47 @@ def test_local_index_topology_rechecks_bindings_after_physical_inspection(
             topology.verify()
         assert mutated
     finally:
-        topology.close()
+        owner.close()
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="injects Linux device-number mount mappings",
+)
+def test_local_index_topology_rechecks_mounts_at_final_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, repositories = _topology_config(tmp_path)
+    owner, topology = _acquire_topology(config, repositories)
+    device = config.cas_root.stat().st_dev
+    mount_device = f"{os.major(device)}:{os.minor(device)}"
+    unsafe = (
+        local_index_service._LinuxMountMapping(
+            device=mount_device,
+            root=PurePosixPath("/physical/shared/cache"),
+            mount_point=config.cas_root,
+        ),
+        local_index_service._LinuxMountMapping(
+            device=mount_device,
+            root=PurePosixPath("/physical/shared"),
+            mount_point=repositories["repo"],
+        ),
+    )
+    observations = iter(((), unsafe))
+    monkeypatch.setattr(
+        local_index_service,
+        "_linux_mount_mappings",
+        lambda: next(observations),
+    )
+
+    try:
+        with pytest.raises(LocalIndexServiceError, match="physical alias"):
+            topology.verify()
+        with pytest.raises(StopIteration):
+            next(observations)
+    finally:
+        owner.close()
 
 
 def test_local_index_topology_rejects_symlinked_storage_root(
@@ -322,7 +429,7 @@ def test_local_index_topology_rejects_symlinked_storage_root(
     config.runtime_workspace_root.symlink_to(actual_runtime, target_is_directory=True)
 
     with pytest.raises(LocalIndexServiceError, match="real private owner-only"):
-        LocalIndexStorageTopology.acquire(config, repositories)
+        _acquire_topology(config, repositories)
 
 
 def test_local_index_topology_rejects_repository_storage_overlap(
@@ -333,7 +440,7 @@ def test_local_index_topology_rejects_repository_storage_overlap(
     repository.mkdir()
 
     with pytest.raises(LocalIndexServiceError, match="must not overlap"):
-        LocalIndexStorageTopology.acquire(config, {"repo": repository})
+        _acquire_topology(config, {"repo": repository})
 
 
 @pytest.mark.parametrize(
@@ -355,7 +462,7 @@ def test_local_index_topology_reserves_catalog_sidecar_namespace(
     config = replace(config, worker_workspace_root=sidecar)
 
     with pytest.raises(LocalIndexServiceError, match=error):
-        LocalIndexStorageTopology.acquire(config, repositories)
+        _acquire_topology(config, repositories)
 
 
 @pytest.mark.parametrize(
@@ -377,7 +484,7 @@ def test_local_index_topology_rejects_unconfigured_unsafe_catalog_sidecar(
     sidecar.mkdir()
 
     with pytest.raises(LocalIndexServiceError, match=error):
-        LocalIndexStorageTopology.acquire(config, repositories)
+        _acquire_topology(config, repositories)
 
 
 def test_local_index_topology_rejects_retained_resource_overcommit(
@@ -408,7 +515,7 @@ def test_local_index_topology_rejects_retained_resource_overcommit(
     )
 
     with pytest.raises(LocalIndexServiceError, match="retained resource budget"):
-        LocalIndexStorageTopology.acquire(config, repositories)
+        _acquire_topology(config, repositories)
 
 
 def test_local_index_topology_accepts_exact_retained_resource_budget(
@@ -431,10 +538,14 @@ def test_local_index_topology_accepts_exact_retained_resource_budget(
         lambda: required,
     )
 
-    topology = LocalIndexStorageTopology.acquire(config, repositories)
-    topology.close()
+    owner, _topology = _acquire_topology(config, repositories)
+    owner.close()
 
 
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="injects Linux device-number mount mappings",
+)
 def test_local_index_topology_rejects_mapped_physical_alias(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -461,9 +572,13 @@ def test_local_index_topology_rejects_mapped_physical_alias(
     )
 
     with pytest.raises(LocalIndexServiceError, match="physical alias"):
-        LocalIndexStorageTopology.acquire(config, repositories)
+        _acquire_topology(config, repositories)
 
 
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="injects Linux device-number mount mappings",
+)
 def test_local_index_topology_rejects_descendant_mount_alias(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -495,9 +610,13 @@ def test_local_index_topology_rejects_descendant_mount_alias(
     )
 
     with pytest.raises(LocalIndexServiceError, match="physical alias"):
-        LocalIndexStorageTopology.acquire(config, repositories)
+        _acquire_topology(config, repositories)
 
 
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="injects Linux device-number mount mappings",
+)
 def test_local_index_topology_rejects_catalog_mount_point(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -518,9 +637,13 @@ def test_local_index_topology_rejects_catalog_mount_point(
     )
 
     with pytest.raises(LocalIndexServiceError, match="catalog.*mount point"):
-        LocalIndexStorageTopology.acquire(config, repositories)
+        _acquire_topology(config, repositories)
 
 
+@pytest.mark.skipif(
+    not local_index_service._POSIX_PRIVATE_MODE_SEMANTICS,
+    reason="requires POSIX owner and mode semantics",
+)
 @pytest.mark.parametrize("mode", (0o755, 0o1700, 0o2700))
 def test_local_index_topology_requires_private_workspace_roots(
     tmp_path: Path,
@@ -530,7 +653,7 @@ def test_local_index_topology_requires_private_workspace_roots(
     config.runtime_workspace_root.chmod(mode)
 
     with pytest.raises(LocalIndexServiceError, match="private owner-only"):
-        LocalIndexStorageTopology.acquire(config, repositories)
+        _acquire_topology(config, repositories)
 
 
 def test_local_index_topology_gates_posix_private_mode_policy(
@@ -545,8 +668,8 @@ def test_local_index_topology_gates_posix_private_mode_policy(
         False,
     )
 
-    topology = LocalIndexStorageTopology.acquire(config, repositories)
-    topology.close()
+    owner, _topology = _acquire_topology(config, repositories)
+    owner.close()
 
 
 def test_local_index_topology_requires_exact_repository_mapping(
@@ -555,7 +678,7 @@ def test_local_index_topology_requires_exact_repository_mapping(
     config, repositories = _topology_config(tmp_path)
 
     with pytest.raises(ValueError, match="match configured bindings"):
-        LocalIndexStorageTopology.acquire(
+        _acquire_topology(
             config,
             {"other": repositories["repo"]},
         )

--- a/test/web/test_local_index_service.py
+++ b/test/web/test_local_index_service.py
@@ -487,6 +487,35 @@ def test_local_index_topology_rejects_unconfigured_unsafe_catalog_sidecar(
         _acquire_topology(config, repositories)
 
 
+def test_optional_catalog_sidecar_accepts_confirmed_disappearance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sidecar = tmp_path / "catalog.sqlite3-wal"
+    sidecar.write_bytes(b"transient WAL")
+    real_lstat = Path.lstat
+    observations = 0
+
+    def disappear(path: Path):
+        nonlocal observations
+        if path == sidecar:
+            observations += 1
+            if observations == 1:
+                sidecar.unlink()
+        return real_lstat(path)
+
+    monkeypatch.setattr(Path, "lstat", disappear)
+
+    assert (
+        local_index_service._observe_optional_catalog_sidecar(
+            sidecar,
+            label="WAL sidecar",
+        )
+        is None
+    )
+    assert observations == 2
+
+
 def test_local_index_topology_rejects_retained_resource_overcommit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/test/web/test_local_index_service.py
+++ b/test/web/test_local_index_service.py
@@ -306,11 +306,36 @@ def test_local_index_topology_rejects_mapped_physical_alias(
         LocalIndexStorageTopology.acquire(config, repositories)
 
 
-def test_local_index_topology_requires_private_workspace_roots(
+def test_local_index_topology_rejects_catalog_mount_point(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     config, repositories = _topology_config(tmp_path)
-    config.runtime_workspace_root.chmod(0o755)
+    device = config.catalog_path.stat().st_dev
+    mappings = (
+        local_index_service._LinuxMountMapping(
+            device=f"{os.major(device)}:{os.minor(device)}",
+            root=PurePosixPath("/physical/catalog.sqlite3"),
+            mount_point=config.catalog_path,
+        ),
+    )
+    monkeypatch.setattr(
+        local_index_service,
+        "_linux_mount_mappings",
+        lambda: mappings,
+    )
+
+    with pytest.raises(LocalIndexServiceError, match="catalog.*mount point"):
+        LocalIndexStorageTopology.acquire(config, repositories)
+
+
+@pytest.mark.parametrize("mode", (0o755, 0o1700, 0o2700))
+def test_local_index_topology_requires_private_workspace_roots(
+    tmp_path: Path,
+    mode: int,
+) -> None:
+    config, repositories = _topology_config(tmp_path)
+    config.runtime_workspace_root.chmod(mode)
 
     with pytest.raises(LocalIndexServiceError, match="private owner-only"):
         LocalIndexStorageTopology.acquire(config, repositories)


### PR DESCRIPTION
## Summary
Retain the complete existing local storage topology before the Web index service can start. A caller-created owner receives the topology before acquisition returns; the topology binds the catalog factory, CAS root, private worker/runtime workspace roots, and every explicitly mapped repository source hierarchy, then revalidates them as one physical-separation invariant.

The former #733 dependency is merged and this branch is restacked directly onto main. Actual LocalCAS, worker/runtime composition, and FastAPI lifespan installation remain focused follow-up gates.

## Changes
- require exact configured repository-root coverage without inferring paths from durable IDs
- reject missing, replaced, symbolic, non-directory, and non-private workspace roots
- require exact 0700 worker/runtime workspace modes, including rejection of special permission bits
- open retained publication authorities for CAS and both workspace roots
- pin every repository hierarchy through retryable source cleanup ownership
- install the completed topology into a caller-created retryable owner before the successful return boundary
- account exact repository/storage-root descriptor or HANDLE chains against current POSIX availability, a transient reserve, and a cross-platform hard cap before pinning
- reserve catalog WAL, SHM, and rollback-journal paths in lexical and physical topology checks
- accept only confirmed disappearance of optional SQLite WAL/SHM sidecars while still rejecting broken links and immediate replacements
- reject lexical overlap, inode-ancestry aliases, Linux mount-mapped physical aliases, and bind-mounted catalog files
- index each bounded Linux mount snapshot once for longest-prefix resolution and disjoint descendant enumeration
- revalidate catalog, root, repository, ownership, mode, and a fresh mount snapshot at the final public boundary
- settle every repository and directory authority through ordered cancellation-safe close
- document the completed physical-topology gate and remaining composition work

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- pytest -q test/web/test_local_index_service.py --tb=short (35 passed)
- pytest -q test/web with the known timing baseline deselected (640 passed, 1 deselected)
- pre-commit run on the changed files
- prior full branch range-diff and Web verification remained clean after the focused review-fix commit

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
