### PR TITLE
feat(web): compose local index runtime

### DIFF
--- a/codenib/compiler/job_resources.py
+++ b/codenib/compiler/job_resources.py
@@ -707,11 +707,13 @@ class _BM25AttemptPoolReaperCleanupOwner:
             )
         self._lease = lease
 
-    def _acquire(self) -> None:
+    def _acquire(self, *, blocking: bool) -> None:
+        if type(blocking) is not bool:
+            raise TypeError("BM25 attempt-pool reaper blocking flag is invalid")
         if self._lease is not None:
             raise RuntimeError("BM25 attempt-pool reaper lease is already acquired")
         lease = self._route._acquire(
-            blocking=True,
+            blocking=blocking,
             check_cancelled=None,
             construction_owner=self._install_lease,
         )
@@ -898,11 +900,14 @@ class LocalBM25AttemptPoolCoordinator:
         self,
         *,
         caller_asserts_quiescence: bool = False,
-    ) -> BM25AttemptPoolReclamation:
-        """Reclaim recognized stale attempts after an exact caller assertion."""
+        blocking: bool = True,
+    ) -> BM25AttemptPoolReclamation | None:
+        """Reclaim recognized attempts, or defer a busy non-blocking route."""
 
         if type(caller_asserts_quiescence) is not bool:
             raise TypeError("BM25 attempt-pool quiescence assertion must be exact bool")
+        if type(blocking) is not bool:
+            raise TypeError("BM25 attempt-pool reaper blocking flag must be exact bool")
         if caller_asserts_quiescence is not True:
             raise StorageValidationError(
                 "BM25 attempt-pool reclamation requires caller-asserted quiescence"
@@ -1000,7 +1005,12 @@ class LocalBM25AttemptPoolCoordinator:
             incomplete_owner=reaper_cleanup,
         )
         with _run_context_with_cleanup_actions((cleanup_action,)):
-            reaper_cleanup._acquire()
+            try:
+                reaper_cleanup._acquire(blocking=blocking)
+            except BlockingIOError:
+                if blocking:
+                    raise
+                return None
             return run_with_topology(
                 "reclaimer lifetime",
                 sweep,

--- a/codenib/web/config.py
+++ b/codenib/web/config.py
@@ -340,15 +340,17 @@ class LocalIndexStorageConfig:
         ):
             raise TypeError("index_storage repository bindings must use exact values")
         by_repo: set[str] = set()
-        by_storage: set[tuple[str, str]] = set()
+        by_repository_id: set[str] = set()
         for repository in self.repositories:
             if repository.namespace_name != namespace.name:
                 raise ValueError("index_storage repository namespace differs")
-            storage_key = (repository.repository_id, repository.ref_name)
-            if repository.repo_id in by_repo or storage_key in by_storage:
+            if (
+                repository.repo_id in by_repo
+                or repository.repository_id in by_repository_id
+            ):
                 raise ValueError("index_storage repository bindings must be unique")
             by_repo.add(repository.repo_id)
-            by_storage.add(storage_key)
+            by_repository_id.add(repository.repository_id)
         _exact_config_integer(
             self.catalog_busy_timeout_ms,
             source="index_storage catalog_busy_timeout_ms",

--- a/codenib/web/local_index_runtime.py
+++ b/codenib/web/local_index_runtime.py
@@ -10,6 +10,7 @@ import os
 import re
 from contextlib import contextmanager
 from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 from threading import get_ident
 from time import monotonic
@@ -774,6 +775,11 @@ class LocalIndexRuntimeService:
                     storage_binding.repository_id,
                     storage_binding.ref_name,
                 )
+                repository_topology_verifier = partial(
+                    _repository_topology_guard,
+                    topology,
+                    storage_binding.repo_id,
+                )
                 worker_target = LocalBM25SourceJobTarget(
                     repository_root=repository_root,
                     workspace_provider=worker_provider,
@@ -792,7 +798,7 @@ class LocalIndexRuntimeService:
                         _repository_head(root)
                     ),
                     workspace_parent_identity=topology.worker_workspace_identity,
-                    topology_verifier=topology.verify,
+                    topology_verifier=repository_topology_verifier,
                     attempt_orphan_sink=attempt_pool.accept,
                 )
                 web_bindings.append(web_binding)

--- a/codenib/web/local_index_runtime.py
+++ b/codenib/web/local_index_runtime.py
@@ -55,7 +55,11 @@ from .index_job_service import IndexJobBackgroundService
 from .index_job_writes import CatalogIndexJobWriter, IndexJobWriter
 from .index_jobs import CatalogIndexJobReader, IndexJobReader, IndexJobRepoBinding
 from .index_status import IndexUpdateCapability
-from .local_index_service import LocalIndexServiceError, LocalIndexStorageTopology
+from .local_index_service import (
+    LocalIndexServiceError,
+    LocalIndexStorageTopology,
+    LocalIndexStorageTopologyOwner,
+)
 from .repo_registry import RepoBundle, RepoRegistry
 from .retained_bm25_activation import (
     LocalRetainedBm25RuntimeTarget,
@@ -151,6 +155,9 @@ class _LocalAttemptPoolLeaseOwner:
                     "local worker workspace is already owned by another process"
                 )
 
+        # Reject topology drift before publishing an unentered generator into
+        # cleanup ownership. Later checks are protected by the retained owner.
+        topology_verifier()
         context = compiler_cache_lock(
             root,
             create=True,
@@ -164,7 +171,6 @@ class _LocalAttemptPoolLeaseOwner:
         self._owner_thread_id = get_ident()
         self._topology_verifier = topology_verifier
         try:
-            topology_verifier()
             context.__enter__()
             self._entered = True
             topology_verifier()
@@ -529,11 +535,11 @@ def _configured_repositories(
         return tuple(selected)
 
 
-def _topology_guard(topology: LocalIndexStorageTopology) -> None:
+def _shared_topology_guard(topology: LocalIndexStorageTopology) -> None:
     try:
-        topology.verify()
+        topology.verify_shared_storage()
     except LocalIndexServiceError as exc:
-        raise StorageIntegrityError("local Web index storage topology changed") from exc
+        raise StorageIntegrityError("local Web index shared storage changed") from exc
 
 
 def _repository_topology_guard(
@@ -588,7 +594,7 @@ class LocalIndexRuntimeService:
         token: object,
         *,
         topology: LocalIndexStorageTopology,
-        topology_owner: _LocalRuntimeResourceOwner,
+        topology_owner: LocalIndexStorageTopologyOwner,
         attempt_pool: _LocalBM25AttemptPoolReaper,
         attempt_pool_lease_owner: _LocalAttemptPoolLeaseOwner,
         object_store_owner: _LocalRuntimeResourceOwner,
@@ -634,7 +640,7 @@ class LocalIndexRuntimeService:
             selected_repo.storage.repo_id: selected_repo.repository_root
             for selected_repo in selected
         }
-        topology_owner = _LocalRuntimeResourceOwner()
+        topology_owner = LocalIndexStorageTopologyOwner()
         attempt_pool_lease_owner = _LocalAttemptPoolLeaseOwner()
         attempt_pool = _LocalBM25AttemptPoolReaper(attempt_pool_lease_owner)
         object_store_owner = _LocalRuntimeResourceOwner()
@@ -730,19 +736,19 @@ class LocalIndexRuntimeService:
             cleanup_actions,
             cleanup_on_success=False,
         ):
-            topology = topology_owner.acquire(
-                lambda: LocalIndexStorageTopology.acquire(
-                    config,
-                    repository_roots,
-                )
+            topology = LocalIndexStorageTopology.acquire(
+                config,
+                repository_roots,
+                owner=topology_owner,
             )
             catalog_factory = topology.catalog_factory
             _verify_catalog_bindings(catalog_factory, selected)
             topology.verify()
+            shared_topology_verifier = partial(_shared_topology_guard, topology)
             attempt_pool_lease_owner.acquire(
                 config.worker_workspace_root,
                 wait_timeout_ms=config.catalog_busy_timeout_ms,
-                topology_verifier=topology.verify,
+                topology_verifier=shared_topology_verifier,
             )
             topology.verify()
             object_store = object_store_owner.acquire(
@@ -756,12 +762,6 @@ class LocalIndexRuntimeService:
             runtime_provider = LocalWorkspaceProvider(config.runtime_workspace_root)
             worker_provider.require_support()
             runtime_provider.require_support()
-            runtime_workspace = _TopologyBoundWorkspaceProvider(
-                runtime_provider,
-                topology.runtime_workspace_identity,
-                topology.verify,
-            )
-
             web_bindings: list[IndexJobRepoBinding] = []
             worker_targets: list[LocalBM25SourceJobTarget] = []
             runtime_targets: list[LocalRetainedBm25RuntimeTarget] = []
@@ -779,6 +779,11 @@ class LocalIndexRuntimeService:
                     _repository_topology_guard,
                     topology,
                     storage_binding.repo_id,
+                )
+                runtime_workspace = _TopologyBoundWorkspaceProvider(
+                    runtime_provider,
+                    topology.runtime_workspace_identity,
+                    repository_topology_verifier,
                 )
                 worker_target = LocalBM25SourceJobTarget(
                     repository_root=repository_root,

--- a/codenib/web/local_index_runtime.py
+++ b/codenib/web/local_index_runtime.py
@@ -486,6 +486,10 @@ def _configured_repositories(
     config: LocalIndexStorageConfig,
     registry: RepoRegistry,
 ) -> tuple[_ConfiguredRepository, ...]:
+    if registry.configured_index_types() != ("bm25",):
+        raise LocalIndexServiceError(
+            "local index runtime currently requires sparse Web mode"
+        )
     with registry.pin_all() as active_bundles:
         by_repo: dict[str, RepoBundle] = {}
         for bundle in active_bundles:
@@ -506,6 +510,11 @@ def _configured_repositories(
                 raise LocalIndexServiceError(
                     "configured local index repository is not loaded"
                 )
+            if bundle.entry.repo != binding.repository_key:
+                raise LocalIndexServiceError(
+                    "configured local index repository identity differs from its "
+                    "loaded Web bundle"
+                )
             repository_root = Path(bundle.entry.repo_dir)
             selected.append(
                 _ConfiguredRepository(
@@ -524,6 +533,30 @@ def _topology_guard(topology: LocalIndexStorageTopology) -> None:
         topology.verify()
     except LocalIndexServiceError as exc:
         raise StorageIntegrityError("local Web index storage topology changed") from exc
+
+
+def _repository_topology_guard(
+    topology: LocalIndexStorageTopology,
+    repo_id: str,
+) -> None:
+    try:
+        topology.verify_repository(repo_id)
+    except (KeyError, LocalIndexServiceError) as exc:
+        raise StorageIntegrityError(
+            "local Web index repository topology changed"
+        ) from exc
+
+
+def _verify_catalog_bindings(
+    catalog_factory,
+    selected: tuple[_ConfiguredRepository, ...],
+) -> None:
+    """Open the existing catalog and require every configured repository ID."""
+
+    with catalog_factory() as catalog:
+        for selected_repo in selected:
+            binding = selected_repo.storage
+            catalog.read_ref_generation(binding.repository_id, binding.ref_name)
 
 
 def _safe_runtime_failure(failure: IndexJobActivationError) -> None:
@@ -702,6 +735,8 @@ class LocalIndexRuntimeService:
                     repository_roots,
                 )
             )
+            catalog_factory = topology.catalog_factory
+            _verify_catalog_bindings(catalog_factory, selected)
             topology.verify()
             attempt_pool_lease_owner.acquire(
                 config.worker_workspace_root,
@@ -785,12 +820,22 @@ class LocalIndexRuntimeService:
             targets = tuple(worker_targets)
             attempt_pool.install(targets[0])
             attempt_pool.reclaim_stale()
-            catalog_factory = topology.catalog_factory
             resources = LocalBM25SourceJobResourceFactory(targets)
+            topology_repo_ids = {
+                selected_repo.storage.repository_id: selected_repo.storage.repo_id
+                for selected_repo in selected
+            }
 
             def accepts_candidate(candidate) -> bool:
-                _topology_guard(topology)
-                return resources.accepts_candidate(candidate)
+                if not resources.accepts_candidate(candidate):
+                    return False
+                repo_id = topology_repo_ids.get(candidate.repository_id)
+                if repo_id is None:  # pragma: no cover - target-map invariant
+                    raise StorageIntegrityError(
+                        "local BM25 candidate has no repository topology"
+                    )
+                _repository_topology_guard(topology, repo_id)
+                return True
 
             worker = IndexJobWorker(
                 catalog_factory=catalog_factory,

--- a/codenib/web/local_index_runtime.py
+++ b/codenib/web/local_index_runtime.py
@@ -12,20 +12,20 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
-from threading import get_ident
-from time import monotonic
 from types import MappingProxyType
 from typing import Callable, Iterator, Mapping
 
 from .._atomic_directory import (
     DirectoryOrphan,
-    QuiescentDirectoryReclaimer,
     _OrderedAction,
     _run_context_with_cleanup_actions,
 )
 from .._local_workspace_provider import LocalWorkspaceProvider
 from .._owned_file_publication import _CancellationSafeRLock
-from ..compiler.cache_lock import compiler_cache_lock
+from ..compiler.bm25_attempt_pool import (
+    LocalBM25AttemptPoolBinding,
+    bootstrap_local_bm25_attempt_pool,
+)
 from ..compiler.checkout_identity import checkout_commit
 from ..compiler.index_builders import BM25IndexBuilder
 from ..compiler.job_resolver import BM25SourceJobResolver
@@ -38,6 +38,7 @@ from ..languages import normalize_chunker_language
 from ..log_utils import get_logger
 from ..repository_source_selection import RepositorySourceSelection
 from ..storage import (
+    IndexJobRecord,
     IndexJobWorker,
     IndexJobWorkerRunResult,
     IndexJobWorkerScheduler,
@@ -72,7 +73,6 @@ _LOCAL_RUNTIME_TOKEN = object()
 _FULL_GIT_COMMIT_RE = re.compile(r"[0-9a-f]{40}\Z")
 _MAX_TARGET_LANGUAGES = 64
 _MAX_PENDING_ATTEMPT_ORPHANS = 4_096
-_MIN_ATTEMPT_POOL_LEASE_WAIT_SECONDS = 0.1
 
 logger = get_logger(__name__)
 
@@ -106,156 +106,90 @@ class _LocalRuntimeResourceOwner:
         self._resource = _MISSING_RESOURCE
 
 
-class _LocalAttemptPoolLeaseOwner:
-    """Retain the cooperative worker/reaper lease across background threads."""
+class _LocalBM25AttemptPoolRegistration:
+    """Retain one target's paired routes, receipts, and retryable cleanup."""
 
     __slots__ = (
-        "_context",
-        "_entered",
-        "_owner_pid",
-        "_owner_thread_id",
-        "_topology_verifier",
+        "binding",
+        "cleanup_owners",
+        "closed",
+        "orphans",
+        "repository_id",
+        "target",
     )
 
-    def __init__(self) -> None:
-        self._context: object = _MISSING_RESOURCE
-        self._entered = False
-        self._owner_pid: int | None = None
-        self._owner_thread_id: int | None = None
-        self._topology_verifier: Callable[[], None] | None = None
-
-    @property
-    def closed(self) -> bool:
-        return self._context is _MISSING_RESOURCE
-
-    def acquire(
+    def __init__(
         self,
-        root: Path,
-        *,
-        wait_timeout_ms: int,
-        topology_verifier: Callable[[], None],
+        repository_id: str,
+        target: LocalBM25SourceJobTarget,
+        binding: LocalBM25AttemptPoolBinding,
     ) -> None:
-        if self._context is not _MISSING_RESOURCE:
-            raise RuntimeError("local attempt-pool lease is already acquired")
-        if type(root) is not type(Path()):
-            raise TypeError("local attempt-pool lease root must be an exact Path")
-        if type(wait_timeout_ms) is not int or wait_timeout_ms < 0:
-            raise TypeError("local attempt-pool lease timeout is invalid")
-        if not callable(topology_verifier):
-            raise TypeError("local attempt-pool topology verifier is invalid")
-
-        deadline = monotonic() + max(
-            _MIN_ATTEMPT_POOL_LEASE_WAIT_SECONDS,
-            wait_timeout_ms / 1_000,
-        )
-
-        def check_wait() -> None:
-            if monotonic() >= deadline:
-                raise LocalIndexServiceError(
-                    "local worker workspace is already owned by another process"
-                )
-
-        # Reject topology drift before publishing an unentered generator into
-        # cleanup ownership. Later checks are protected by the retained owner.
-        topology_verifier()
-        context = compiler_cache_lock(
-            root,
-            create=True,
-            check_cancelled=check_wait,
-        )
-        # Publish the context before entering it. If cancellation lands after
-        # its generator yields but before this method returns, close() can
-        # still drive the retained generator through its finally block.
-        self._context = context
-        self._owner_pid = os.getpid()
-        self._owner_thread_id = get_ident()
-        self._topology_verifier = topology_verifier
-        try:
-            context.__enter__()
-            self._entered = True
-            topology_verifier()
-        except LocalIndexServiceError:
-            raise
-        except (OSError, RuntimeError, ValueError) as exc:
-            raise LocalIndexServiceError(
-                "local worker workspace lease could not be acquired"
-            ) from exc
-
-    def require_held(self) -> None:
-        verifier = self._topology_verifier
-        if self._context is _MISSING_RESOURCE or not self._entered or verifier is None:
-            raise StorageIntegrityError("local attempt-pool lease is not held")
-        if self._owner_pid != os.getpid():
-            raise StorageIntegrityError("local attempt-pool lease crossed a process")
-        verifier()
-
-    def _release(self) -> None:
-        context = self._context
-        if context is _MISSING_RESOURCE:
-            return
-        if self._owner_pid != os.getpid():
-            raise StorageIntegrityError("local attempt-pool lease crossed a process")
-        if self._owner_thread_id != get_ident():
-            raise StorageIntegrityError("local attempt-pool lease crossed a thread")
-        context.__exit__(None, None, None)  # type: ignore[attr-defined]
-        self._context = _MISSING_RESOURCE
-        self._entered = False
-        self._owner_pid = None
-        self._owner_thread_id = None
-        self._topology_verifier = None
-
-    def close(self) -> None:
-        if self._context is _MISSING_RESOURCE:
-            return
-        verifier = self._topology_verifier
-        cleanup_actions = (
-            *(
-                (
-                    (
-                        "local attempt-pool pre-unlock topology validation also "
-                        "failed",
-                        verifier,
-                    ),
-                )
-                if verifier is not None and self._entered
-                else ()
-            ),
-            _OrderedAction(
-                label="local attempt-pool lease release also failed",
-                action=self._release,
-                complete=lambda: self.closed,
-                retry_incomplete="cancellation",
-                incomplete_owner=self,
-            ),
-        )
-        with _run_context_with_cleanup_actions(cleanup_actions):
-            pass
+        self.repository_id = repository_id
+        self.target = target
+        self.binding = binding
+        self.orphans: list[DirectoryOrphan] = []
+        self.cleanup_owners: list[object] = []
+        self.closed = False
 
 
 class _LocalBM25AttemptPoolReaper:
-    """Retain exact attempt receipts and reclaim only while the lease is held."""
+    """Route exact attempt receipts to independently leased repository shards."""
 
-    __slots__ = ("_lease", "_lock", "_orphans", "_state", "_target")
+    __slots__ = ("_by_parent", "_by_repository", "_lock", "_state")
 
-    def __init__(self, lease: _LocalAttemptPoolLeaseOwner) -> None:
-        self._lease = lease
+    def __init__(self) -> None:
+        self._by_parent: dict[
+            tuple[Path, tuple[int, ...]], _LocalBM25AttemptPoolRegistration
+        ] = {}
+        self._by_repository: dict[str, _LocalBM25AttemptPoolRegistration] = {}
         self._lock = _CancellationSafeRLock()
-        self._orphans: list[DirectoryOrphan] = []
         self._state = "open"
-        self._target: LocalBM25SourceJobTarget | None = None
 
     @property
     def closed(self) -> bool:
         return self._lock.run(lambda: self._state == "closed")
 
-    def install(self, target: LocalBM25SourceJobTarget) -> None:
+    def install(
+        self,
+        repository_id: str,
+        target: LocalBM25SourceJobTarget,
+        binding: LocalBM25AttemptPoolBinding,
+    ) -> None:
+        if type(repository_id) is not str or not repository_id:
+            raise TypeError("local attempt-pool repository ID is invalid")
         if type(target) is not LocalBM25SourceJobTarget:
             raise TypeError("local attempt-pool reaper target is invalid")
+        if type(binding) is not LocalBM25AttemptPoolBinding:
+            raise TypeError("local attempt-pool reaper binding is invalid")
+        if target.attempt_pool_writer_route is not binding.writer_route:
+            raise StorageIntegrityError(
+                "local attempt-pool target uses another writer route"
+            )
+        parent = target.attempt_pool_root
+        identity = target.attempt_pool_identity
+        if (
+            type(parent) is not type(Path())
+            or type(identity) is not tuple
+            or len(identity) != 4
+            or any(type(value) is not int for value in identity)
+        ):
+            raise StorageIntegrityError(
+                "local attempt-pool target has no routed parent authority"
+            )
+        key = (parent, identity)
+        registration = _LocalBM25AttemptPoolRegistration(
+            repository_id,
+            target,
+            binding,
+        )
 
         def commit() -> None:
-            if self._state != "open" or self._target is not None:
-                raise RuntimeError("local attempt-pool reaper is already configured")
-            self._target = target
+            if self._state != "open":
+                raise RuntimeError("local attempt-pool reaper is not configurable")
+            if repository_id in self._by_repository or key in self._by_parent:
+                raise RuntimeError("local attempt-pool route is already configured")
+            self._by_repository[repository_id] = registration
+            self._by_parent[key] = registration
 
         self._lock.run(commit)
 
@@ -264,110 +198,216 @@ class _LocalBM25AttemptPoolReaper:
 
         if type(orphan) is not DirectoryOrphan:
             raise TypeError("local attempt-pool orphan receipt is invalid")
-        self._lease.require_held()
+        key = (orphan.path.parent, orphan.parent_identity)
 
         def commit() -> None:
-            target = self._target
-            if self._state != "open" or target is None:
+            registration = self._by_parent.get(key)
+            if self._state != "open" or registration is None or registration.closed:
                 raise StorageIntegrityError("local attempt-pool reaper is unavailable")
-            if (
-                orphan.path.parent != target.attempt_pool_root
-                or orphan.parent_identity != target.attempt_pool_identity
-            ):
-                raise StorageIntegrityError(
-                    "local attempt-pool receipt uses another authority"
-                )
-            if any(candidate == orphan for candidate in self._orphans):
+            if any(candidate == orphan for candidate in registration.orphans):
                 return
-            if len(self._orphans) >= _MAX_PENDING_ATTEMPT_ORPHANS:
+            pending = sum(
+                len(candidate.orphans) for candidate in self._by_repository.values()
+            )
+            if pending >= _MAX_PENDING_ATTEMPT_ORPHANS:
                 raise StorageIntegrityError(
                     "local attempt-pool receipt queue exceeds its bound"
                 )
-            self._orphans.append(orphan)
+            registration.orphans.append(orphan)
 
         self._lock.run(commit)
 
-    def _snapshot(self) -> tuple[LocalBM25SourceJobTarget, tuple[DirectoryOrphan, ...]]:
-        def read():
-            target = self._target
-            if self._state not in {"open", "closing"} or target is None:
+    def _registration(
+        self,
+        repository_id: str,
+    ) -> _LocalBM25AttemptPoolRegistration:
+        if type(repository_id) is not str:
+            raise TypeError("local attempt-pool repository ID must be exact text")
+
+        def read() -> _LocalBM25AttemptPoolRegistration:
+            registration = self._by_repository.get(repository_id)
+            if (
+                self._state not in {"open", "closing"}
+                or registration is None
+                or registration.closed
+            ):
                 raise StorageIntegrityError("local attempt-pool reaper is unavailable")
-            return target, tuple(self._orphans)
+            return registration
 
         return self._lock.run(read)
 
-    def _forget(self, reclaimed: tuple[DirectoryOrphan, ...]) -> None:
+    def _forget(
+        self,
+        registration: _LocalBM25AttemptPoolRegistration,
+        reclaimed: tuple[DirectoryOrphan, ...],
+    ) -> None:
         if not reclaimed:
             return
 
         def commit() -> None:
-            self._orphans[:] = [
+            registration.orphans[:] = [
                 candidate
-                for candidate in self._orphans
+                for candidate in registration.orphans
                 if not any(candidate == receipt for receipt in reclaimed)
             ]
 
         self._lock.run(commit)
 
-    def reclaim_pending(self) -> None:
-        """Reclaim receipts at the scheduler's between-attempt boundary."""
-
-        target, receipts = self._snapshot()
-        if not receipts:
+    def _retain_cleanup_owners(
+        self,
+        registration: _LocalBM25AttemptPoolRegistration,
+        error: BaseException,
+    ) -> None:
+        owners = getattr(error, "publication_cleanup_owners", ())
+        if type(owners) is not tuple:
             return
-        identity = target.attempt_pool_identity
-        if type(identity) is not tuple or len(identity) != 4:
-            raise StorageIntegrityError(
-                "local attempt-pool target has no retained parent identity"
+
+        def commit() -> None:
+            for owner in owners:
+                if not callable(getattr(owner, "close", None)):
+                    continue
+                if any(candidate is owner for candidate in registration.cleanup_owners):
+                    continue
+                registration.cleanup_owners.append(owner)
+
+        self._lock.run(commit)
+
+    def _settle_cleanup_owners(
+        self,
+        registration: _LocalBM25AttemptPoolRegistration,
+    ) -> None:
+        owners = self._lock.run(lambda: tuple(registration.cleanup_owners))
+        if not owners:
+            return
+        actions = tuple(
+            _OrderedAction(
+                label="local attempt-pool retained route cleanup also failed",
+                action=owner.close,  # type: ignore[attr-defined]
+                complete=lambda owner=owner: bool(getattr(owner, "closed", False)),
+                retry_incomplete="cancellation",
+                incomplete_owner=owner,
             )
-        self._lease.require_held()
-        target.verify_topology()
-        with QuiescentDirectoryReclaimer(
-            target.attempt_pool_root,
-            expected_parent_identity=identity,
-        ) as reclaimer:
-            for orphan in receipts:
-                target.verify_topology()
-                reclaimed = reclaimer.reclaim_orphan(orphan)
-                if reclaimed is not True:  # pragma: no cover - exact API invariant
-                    raise StorageIntegrityError(
-                        "local attempt-pool receipt did not reclaim"
-                    )
-                target.verify_topology()
-        self._lease.require_held()
-        self._forget(receipts)
-
-    def reclaim_stale(self) -> None:
-        """Sweep recognized crash leftovers at an explicit quiescent boundary."""
-
-        target, _receipts = self._snapshot()
-        self._lease.require_held()
-        LocalBM25AttemptPoolCoordinator(target).reclaim(
-            caller_asserts_quiescence=True,
+            for owner in owners
+            if not bool(getattr(owner, "closed", False))
         )
-        self._lease.require_held()
+        with _run_context_with_cleanup_actions(actions):
+            pass
 
-    def close(self) -> None:
-        def begin() -> bool:
-            if self._state == "closed":
-                return False
-            if self._target is None:
-                if self._orphans:
-                    raise StorageIntegrityError(
-                        "unconfigured local attempt-pool reaper retained receipts"
-                    )
-                self._state = "closed"
-                return False
-            if self._state == "open":
-                self._state = "closing"
-            return True
+        def forget_closed() -> None:
+            registration.cleanup_owners[:] = [
+                owner
+                for owner in registration.cleanup_owners
+                if not bool(getattr(owner, "closed", False))
+            ]
 
-        if not self._lock.run(begin):
+        self._lock.run(forget_closed)
+
+    def _sweep(self, registration: _LocalBM25AttemptPoolRegistration) -> None:
+        self._settle_cleanup_owners(registration)
+        try:
+            LocalBM25AttemptPoolCoordinator(
+                registration.target,
+                reaper_route=registration.binding.reaper_route,
+            ).reclaim(caller_asserts_quiescence=True)
+        except BaseException as error:  # noqa: B036 - retain exclusive route owner
+            self._retain_cleanup_owners(registration, error)
+            raise
+
+    def _reclaim_pending_one(self, repository_id: str) -> bool:
+        registration = self._registration(repository_id)
+        receipts = self._lock.run(lambda: tuple(registration.orphans))
+        if not receipts:
+            return False
+        # The routed coordinator holds LOCK_EX while it classifies and removes
+        # the complete bounded shard. Keep the exact receipts queued until that
+        # sweep returns, so a failed or interrupted route cleanup remains
+        # retryable without falling back to path authority.
+        self._sweep(registration)
+        self._forget(registration, receipts)
+        return True
+
+    def reclaim_pending(self, repository_id: str) -> None:
+        """Reclaim receipts only through the completed job's repository route."""
+
+        self._reclaim_pending_one(repository_id)
+
+    def _reclaim_stale_one(self, repository_id: str) -> None:
+        self._sweep(self._registration(repository_id))
+
+    def reclaim_stale(self, repository_id: str | None = None) -> None:
+        """Sweep one route, or every configured route, under independent leases."""
+
+        if repository_id is not None:
+            self._reclaim_stale_one(repository_id)
             return
-        self.reclaim_pending()
-        self.reclaim_stale()
+        repository_ids = self._lock.run(lambda: tuple(sorted(self._by_repository)))
+        completed: set[str] = set()
+
+        def reclaim(candidate_id: str) -> None:
+            self._reclaim_stale_one(candidate_id)
+            completed.add(candidate_id)
+
+        actions = tuple(
+            _OrderedAction(
+                label=f"local attempt-pool {candidate_id} sweep also failed",
+                action=lambda candidate_id=candidate_id: reclaim(candidate_id),
+                complete=lambda candidate_id=candidate_id: candidate_id in completed,
+                retry_incomplete="cancellation",
+                incomplete_owner=self,
+            )
+            for candidate_id in repository_ids
+        )
+        with _run_context_with_cleanup_actions(actions):
+            pass
+
+    def _close_repository(self, repository_id: str) -> None:
+        registration = self._registration(repository_id)
+        if not self._reclaim_pending_one(repository_id):
+            self._sweep(registration)
 
         def finish() -> None:
+            registration.closed = True
+
+        self._lock.run(finish)
+
+    def close(self) -> None:
+        def begin() -> tuple[str, ...]:
+            if self._state == "closed":
+                return ()
+            if self._state == "open":
+                self._state = "closing"
+            return tuple(
+                repository_id
+                for repository_id, registration in sorted(self._by_repository.items())
+                if not registration.closed
+            )
+
+        repository_ids = self._lock.run(begin)
+        if not repository_ids:
+            self._lock.run(lambda: setattr(self, "_state", "closed"))
+            return
+        actions = tuple(
+            _OrderedAction(
+                label=f"local attempt-pool {repository_id} cleanup also failed",
+                action=lambda repository_id=repository_id: self._close_repository(
+                    repository_id
+                ),
+                complete=lambda repository_id=repository_id: bool(
+                    self._by_repository[repository_id].closed
+                ),
+                retry_incomplete="cancellation",
+                incomplete_owner=self,
+            )
+            for repository_id in repository_ids
+        )
+        with _run_context_with_cleanup_actions(actions):
+            pass
+
+        def finish() -> None:
+            if not all(
+                registration.closed for registration in self._by_repository.values()
+            ):
+                raise RuntimeError("local attempt-pool cleanup did not settle")
             self._state = "closed"
 
         self._lock.run(finish)
@@ -535,13 +575,6 @@ def _configured_repositories(
         return tuple(selected)
 
 
-def _shared_topology_guard(topology: LocalIndexStorageTopology) -> None:
-    try:
-        topology.verify_shared_storage()
-    except LocalIndexServiceError as exc:
-        raise StorageIntegrityError("local Web index shared storage changed") from exc
-
-
 def _repository_topology_guard(
     topology: LocalIndexStorageTopology,
     repo_id: str,
@@ -578,7 +611,6 @@ class LocalIndexRuntimeService:
 
     __slots__ = (
         "_attempt_pool",
-        "_attempt_pool_lease_owner",
         "_background",
         "_background_owner",
         "_capabilities",
@@ -596,7 +628,6 @@ class LocalIndexRuntimeService:
         topology: LocalIndexStorageTopology,
         topology_owner: LocalIndexStorageTopologyOwner,
         attempt_pool: _LocalBM25AttemptPoolReaper,
-        attempt_pool_lease_owner: _LocalAttemptPoolLeaseOwner,
         object_store_owner: _LocalRuntimeResourceOwner,
         background: IndexJobBackgroundService,
         background_owner: _LocalRuntimeResourceOwner,
@@ -609,7 +640,6 @@ class LocalIndexRuntimeService:
         self._topology = topology
         self._topology_owner = topology_owner
         self._attempt_pool = attempt_pool
-        self._attempt_pool_lease_owner = attempt_pool_lease_owner
         self._object_store_owner = object_store_owner
         self._background = background
         self._background_owner = background_owner
@@ -641,8 +671,7 @@ class LocalIndexRuntimeService:
             for selected_repo in selected
         }
         topology_owner = LocalIndexStorageTopologyOwner()
-        attempt_pool_lease_owner = _LocalAttemptPoolLeaseOwner()
-        attempt_pool = _LocalBM25AttemptPoolReaper(attempt_pool_lease_owner)
+        attempt_pool = _LocalBM25AttemptPoolReaper()
         object_store_owner = _LocalRuntimeResourceOwner()
         background_owner = _LocalRuntimeResourceOwner()
         topology: LocalIndexStorageTopology | None = None
@@ -663,13 +692,6 @@ class LocalIndexRuntimeService:
                 )
             attempt_pool.close()
 
-        def close_attempt_pool_lease() -> None:
-            if not background_closed() or not attempt_pool.closed:
-                raise StorageIntegrityError(
-                    "local index attempt cleanup must settle before lease release"
-                )
-            attempt_pool_lease_owner.close()
-
         def close_object_store() -> None:
             if not background_closed():
                 raise StorageIntegrityError(
@@ -681,7 +703,6 @@ class LocalIndexRuntimeService:
             if (
                 not background_closed()
                 or not attempt_pool.closed
-                or not attempt_pool_lease_owner.closed
                 or not object_store_owner.closed
             ):
                 raise StorageIntegrityError(
@@ -707,13 +728,6 @@ class LocalIndexRuntimeService:
                 complete=lambda: attempt_pool.closed,
                 retry_incomplete="cancellation",
                 incomplete_owner=attempt_pool,
-            ),
-            _OrderedAction(
-                label="local index attempt-pool lease cleanup also failed",
-                action=close_attempt_pool_lease,
-                complete=lambda: attempt_pool_lease_owner.closed,
-                retry_incomplete="cancellation",
-                incomplete_owner=attempt_pool_lease_owner,
             ),
             _OrderedAction(
                 label="local index object store cleanup also failed",
@@ -744,13 +758,6 @@ class LocalIndexRuntimeService:
             catalog_factory = topology.catalog_factory
             _verify_catalog_bindings(catalog_factory, selected)
             topology.verify()
-            shared_topology_verifier = partial(_shared_topology_guard, topology)
-            attempt_pool_lease_owner.acquire(
-                config.worker_workspace_root,
-                wait_timeout_ms=config.catalog_busy_timeout_ms,
-                topology_verifier=shared_topology_verifier,
-            )
-            topology.verify()
             object_store = object_store_owner.acquire(
                 lambda: LocalCAS(
                     config.cas_root,
@@ -780,6 +787,16 @@ class LocalIndexRuntimeService:
                     topology,
                     storage_binding.repo_id,
                 )
+                repository_authority = topology.repository_authority(
+                    storage_binding.repo_id
+                )
+                attempt_pool_binding = bootstrap_local_bm25_attempt_pool(
+                    workspace_root=config.worker_workspace_root,
+                    workspace_identity=topology.worker_workspace_identity,
+                    repository_id=storage_binding.repository_id,
+                    repository_authority=repository_authority,
+                    topology_verifier=repository_topology_verifier,
+                )
                 runtime_workspace = _TopologyBoundWorkspaceProvider(
                     runtime_provider,
                     topology.runtime_workspace_identity,
@@ -796,15 +813,19 @@ class LocalIndexRuntimeService:
                     ),
                     namespace_name=storage_binding.namespace_name,
                     environ=environment,
-                    repository_root_authority=topology.repository_authority(
-                        storage_binding.repo_id
-                    ),
+                    repository_root_authority=repository_authority,
                     display_commit_resolver=lambda root=repository_root: (
                         _repository_head(root)
                     ),
                     workspace_parent_identity=topology.worker_workspace_identity,
                     topology_verifier=repository_topology_verifier,
                     attempt_orphan_sink=attempt_pool.accept,
+                    attempt_pool_writer_route=attempt_pool_binding.writer_route,
+                )
+                attempt_pool.install(
+                    storage_binding.repository_id,
+                    worker_target,
+                    attempt_pool_binding,
                 )
                 web_bindings.append(web_binding)
                 worker_targets.append(worker_target)
@@ -829,7 +850,6 @@ class LocalIndexRuntimeService:
 
             bindings = tuple(web_bindings)
             targets = tuple(worker_targets)
-            attempt_pool.install(targets[0])
             attempt_pool.reclaim_stale()
             resources = LocalBM25SourceJobResourceFactory(targets)
             topology_repo_ids = {
@@ -877,7 +897,18 @@ class LocalIndexRuntimeService:
             )
 
             def on_worker_result(result: IndexJobWorkerRunResult) -> None:
-                attempt_pool.reclaim_pending()
+                if result.job_id is not None:
+                    with catalog_factory() as catalog:
+                        completed_job = catalog.get_job(result.job_id)
+                    if type(completed_job) is not IndexJobRecord:
+                        raise StorageIntegrityError(
+                            "local BM25 worker result has an invalid job record"
+                        )
+                    if completed_job.repository_id not in topology_repo_ids:
+                        raise StorageIntegrityError(
+                            "local BM25 worker result has no repository route"
+                        )
+                    attempt_pool.reclaim_pending(completed_job.repository_id)
                 try:
                     reconciler.on_worker_result(result)
                 except IndexJobActivationError as failure:
@@ -910,7 +941,6 @@ class LocalIndexRuntimeService:
                 topology=topology,
                 topology_owner=topology_owner,
                 attempt_pool=attempt_pool,
-                attempt_pool_lease_owner=attempt_pool_lease_owner,
                 object_store_owner=object_store_owner,
                 background=background,
                 background_owner=background_owner,
@@ -940,7 +970,6 @@ class LocalIndexRuntimeService:
         return (
             self._background.state == "closed"
             and self._attempt_pool.closed
-            and self._attempt_pool_lease_owner.closed
             and self._object_store_owner.closed
             and self._topology.closed
         )
@@ -978,13 +1007,6 @@ class LocalIndexRuntimeService:
                 )
             self._attempt_pool.close()
 
-        def close_attempt_pool_lease() -> None:
-            if not background_closed() or not self._attempt_pool.closed:
-                raise StorageIntegrityError(
-                    "local index attempt cleanup must settle before lease release"
-                )
-            self._attempt_pool_lease_owner.close()
-
         def close_object_store() -> None:
             if not background_closed():
                 raise StorageIntegrityError(
@@ -996,7 +1018,6 @@ class LocalIndexRuntimeService:
             if (
                 not background_closed()
                 or not self._attempt_pool.closed
-                or not self._attempt_pool_lease_owner.closed
                 or not self._object_store_owner.closed
             ):
                 raise StorageIntegrityError(
@@ -1018,13 +1039,6 @@ class LocalIndexRuntimeService:
                 complete=lambda: self._attempt_pool.closed,
                 retry_incomplete="cancellation",
                 incomplete_owner=self._attempt_pool,
-            ),
-            _OrderedAction(
-                label="local index attempt-pool lease cleanup also failed",
-                action=close_attempt_pool_lease,
-                complete=lambda: self._attempt_pool_lease_owner.closed,
-                retry_incomplete="cancellation",
-                incomplete_owner=self._attempt_pool_lease_owner,
             ),
             _OrderedAction(
                 label="local index object store cleanup also failed",

--- a/codenib/web/local_index_runtime.py
+++ b/codenib/web/local_index_runtime.py
@@ -302,16 +302,26 @@ class _LocalBM25AttemptPoolReaper:
 
         self._lock.run(forget_closed)
 
-    def _sweep(self, registration: _LocalBM25AttemptPoolRegistration) -> None:
+    def _sweep(self, registration: _LocalBM25AttemptPoolRegistration) -> bool:
         self._settle_cleanup_owners(registration)
         try:
-            LocalBM25AttemptPoolCoordinator(
+            result = LocalBM25AttemptPoolCoordinator(
                 registration.target,
                 reaper_route=registration.binding.reaper_route,
-            ).reclaim(caller_asserts_quiescence=True)
+            ).reclaim(
+                caller_asserts_quiescence=True,
+                blocking=False,
+            )
         except BaseException as error:  # noqa: B036 - retain exclusive route owner
             self._retain_cleanup_owners(registration, error)
             raise
+        if result is None:
+            logger.debug(
+                "Deferred busy local attempt-pool sweep: repository_id=%s",
+                registration.repository_id,
+            )
+            return False
+        return True
 
     def _reclaim_pending_one(self, repository_id: str) -> bool:
         registration = self._registration(repository_id)
@@ -322,7 +332,8 @@ class _LocalBM25AttemptPoolReaper:
         # the complete bounded shard. Keep the exact receipts queued until that
         # sweep returns, so a failed or interrupted route cleanup remains
         # retryable without falling back to path authority.
-        self._sweep(registration)
+        if not self._sweep(registration):
+            return True
         self._forget(registration, receipts)
         return True
 

--- a/codenib/web/local_index_runtime.py
+++ b/codenib/web/local_index_runtime.py
@@ -1,0 +1,1027 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Production composition for the explicit local Web indexing service."""
+
+from __future__ import annotations
+
+import os
+import re
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from threading import get_ident
+from time import monotonic
+from types import MappingProxyType
+from typing import Callable, Iterator, Mapping
+
+from .._atomic_directory import (
+    DirectoryOrphan,
+    QuiescentDirectoryReclaimer,
+    _OrderedAction,
+    _run_context_with_cleanup_actions,
+)
+from .._local_workspace_provider import LocalWorkspaceProvider
+from .._owned_file_publication import _CancellationSafeRLock
+from ..compiler.cache_lock import compiler_cache_lock
+from ..compiler.checkout_identity import checkout_commit
+from ..compiler.index_builders import BM25IndexBuilder
+from ..compiler.job_resolver import BM25SourceJobResolver
+from ..compiler.job_resources import (
+    LocalBM25AttemptPoolCoordinator,
+    LocalBM25SourceJobResourceFactory,
+    LocalBM25SourceJobTarget,
+)
+from ..languages import normalize_chunker_language
+from ..log_utils import get_logger
+from ..repository_source_selection import RepositorySourceSelection
+from ..storage import (
+    IndexJobWorker,
+    IndexJobWorkerRunResult,
+    IndexJobWorkerScheduler,
+    LocalCAS,
+    StorageIntegrityError,
+)
+from .config import LocalIndexStorageConfig, LocalIndexStorageRepository
+from .index_job_activation import (
+    CatalogIndexJobRuntimeReconciler,
+    IndexJobActivationError,
+)
+from .index_job_planning import LocalBM25SourceJobPlanner
+from .index_job_runtime import IndexJobRuntimeReconciliationLoop
+from .index_job_service import IndexJobBackgroundService
+from .index_job_writes import CatalogIndexJobWriter, IndexJobWriter
+from .index_jobs import CatalogIndexJobReader, IndexJobReader, IndexJobRepoBinding
+from .index_status import IndexUpdateCapability
+from .local_index_service import LocalIndexServiceError, LocalIndexStorageTopology
+from .repo_registry import RepoBundle, RepoRegistry
+from .retained_bm25_activation import (
+    LocalRetainedBm25RuntimeTarget,
+    LocalRetainedBm25SnapshotLoader,
+    RepoRegistryIndexJobRuntimePublisher,
+)
+
+_MISSING_RESOURCE = object()
+_LOCAL_RUNTIME_TOKEN = object()
+_FULL_GIT_COMMIT_RE = re.compile(r"[0-9a-f]{40}\Z")
+_MAX_TARGET_LANGUAGES = 64
+_MAX_PENDING_ATTEMPT_ORPHANS = 4_096
+_MIN_ATTEMPT_POOL_LEASE_WAIT_SECONDS = 0.1
+
+logger = get_logger(__name__)
+
+
+class _LocalRuntimeResourceOwner:
+    """Keep one acquired service resource reachable until cleanup settles."""
+
+    __slots__ = ("_resource",)
+
+    def __init__(self) -> None:
+        self._resource: object = _MISSING_RESOURCE
+
+    @property
+    def closed(self) -> bool:
+        return self._resource is _MISSING_RESOURCE
+
+    def acquire(self, factory):
+        if self._resource is not _MISSING_RESOURCE:
+            raise RuntimeError("local index runtime resource is already acquired")
+        # Keep the owner reachable before construction. A direct attribute store
+        # minimizes the native-return handoff window in the same way as the
+        # retained catalog and CLI resource owners.
+        self._resource = factory()
+        return self._resource
+
+    def close(self) -> None:
+        resource = self._resource
+        if resource is _MISSING_RESOURCE:
+            return
+        resource.close()  # type: ignore[attr-defined]
+        self._resource = _MISSING_RESOURCE
+
+
+class _LocalAttemptPoolLeaseOwner:
+    """Retain the cooperative worker/reaper lease across background threads."""
+
+    __slots__ = (
+        "_context",
+        "_entered",
+        "_owner_pid",
+        "_owner_thread_id",
+        "_topology_verifier",
+    )
+
+    def __init__(self) -> None:
+        self._context: object = _MISSING_RESOURCE
+        self._entered = False
+        self._owner_pid: int | None = None
+        self._owner_thread_id: int | None = None
+        self._topology_verifier: Callable[[], None] | None = None
+
+    @property
+    def closed(self) -> bool:
+        return self._context is _MISSING_RESOURCE
+
+    def acquire(
+        self,
+        root: Path,
+        *,
+        wait_timeout_ms: int,
+        topology_verifier: Callable[[], None],
+    ) -> None:
+        if self._context is not _MISSING_RESOURCE:
+            raise RuntimeError("local attempt-pool lease is already acquired")
+        if type(root) is not type(Path()):
+            raise TypeError("local attempt-pool lease root must be an exact Path")
+        if type(wait_timeout_ms) is not int or wait_timeout_ms < 0:
+            raise TypeError("local attempt-pool lease timeout is invalid")
+        if not callable(topology_verifier):
+            raise TypeError("local attempt-pool topology verifier is invalid")
+
+        deadline = monotonic() + max(
+            _MIN_ATTEMPT_POOL_LEASE_WAIT_SECONDS,
+            wait_timeout_ms / 1_000,
+        )
+
+        def check_wait() -> None:
+            if monotonic() >= deadline:
+                raise LocalIndexServiceError(
+                    "local worker workspace is already owned by another process"
+                )
+
+        context = compiler_cache_lock(
+            root,
+            create=True,
+            check_cancelled=check_wait,
+        )
+        # Publish the context before entering it. If cancellation lands after
+        # its generator yields but before this method returns, close() can
+        # still drive the retained generator through its finally block.
+        self._context = context
+        self._owner_pid = os.getpid()
+        self._owner_thread_id = get_ident()
+        self._topology_verifier = topology_verifier
+        try:
+            topology_verifier()
+            context.__enter__()
+            self._entered = True
+            topology_verifier()
+        except LocalIndexServiceError:
+            raise
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise LocalIndexServiceError(
+                "local worker workspace lease could not be acquired"
+            ) from exc
+
+    def require_held(self) -> None:
+        verifier = self._topology_verifier
+        if self._context is _MISSING_RESOURCE or not self._entered or verifier is None:
+            raise StorageIntegrityError("local attempt-pool lease is not held")
+        if self._owner_pid != os.getpid():
+            raise StorageIntegrityError("local attempt-pool lease crossed a process")
+        verifier()
+
+    def _release(self) -> None:
+        context = self._context
+        if context is _MISSING_RESOURCE:
+            return
+        if self._owner_pid != os.getpid():
+            raise StorageIntegrityError("local attempt-pool lease crossed a process")
+        if self._owner_thread_id != get_ident():
+            raise StorageIntegrityError("local attempt-pool lease crossed a thread")
+        context.__exit__(None, None, None)  # type: ignore[attr-defined]
+        self._context = _MISSING_RESOURCE
+        self._entered = False
+        self._owner_pid = None
+        self._owner_thread_id = None
+        self._topology_verifier = None
+
+    def close(self) -> None:
+        if self._context is _MISSING_RESOURCE:
+            return
+        verifier = self._topology_verifier
+        cleanup_actions = (
+            *(
+                (
+                    (
+                        "local attempt-pool pre-unlock topology validation also "
+                        "failed",
+                        verifier,
+                    ),
+                )
+                if verifier is not None and self._entered
+                else ()
+            ),
+            _OrderedAction(
+                label="local attempt-pool lease release also failed",
+                action=self._release,
+                complete=lambda: self.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=self,
+            ),
+        )
+        with _run_context_with_cleanup_actions(cleanup_actions):
+            pass
+
+
+class _LocalBM25AttemptPoolReaper:
+    """Retain exact attempt receipts and reclaim only while the lease is held."""
+
+    __slots__ = ("_lease", "_lock", "_orphans", "_state", "_target")
+
+    def __init__(self, lease: _LocalAttemptPoolLeaseOwner) -> None:
+        self._lease = lease
+        self._lock = _CancellationSafeRLock()
+        self._orphans: list[DirectoryOrphan] = []
+        self._state = "open"
+        self._target: LocalBM25SourceJobTarget | None = None
+
+    @property
+    def closed(self) -> bool:
+        return self._lock.run(lambda: self._state == "closed")
+
+    def install(self, target: LocalBM25SourceJobTarget) -> None:
+        if type(target) is not LocalBM25SourceJobTarget:
+            raise TypeError("local attempt-pool reaper target is invalid")
+
+        def commit() -> None:
+            if self._state != "open" or self._target is not None:
+                raise RuntimeError("local attempt-pool reaper is already configured")
+            self._target = target
+
+        self._lock.run(commit)
+
+    def accept(self, orphan: DirectoryOrphan) -> None:
+        """Accept an authenticated receipt at least once without reentrancy."""
+
+        if type(orphan) is not DirectoryOrphan:
+            raise TypeError("local attempt-pool orphan receipt is invalid")
+        self._lease.require_held()
+
+        def commit() -> None:
+            target = self._target
+            if self._state != "open" or target is None:
+                raise StorageIntegrityError("local attempt-pool reaper is unavailable")
+            if (
+                orphan.path.parent != target.attempt_pool_root
+                or orphan.parent_identity != target.attempt_pool_identity
+            ):
+                raise StorageIntegrityError(
+                    "local attempt-pool receipt uses another authority"
+                )
+            if any(candidate == orphan for candidate in self._orphans):
+                return
+            if len(self._orphans) >= _MAX_PENDING_ATTEMPT_ORPHANS:
+                raise StorageIntegrityError(
+                    "local attempt-pool receipt queue exceeds its bound"
+                )
+            self._orphans.append(orphan)
+
+        self._lock.run(commit)
+
+    def _snapshot(self) -> tuple[LocalBM25SourceJobTarget, tuple[DirectoryOrphan, ...]]:
+        def read():
+            target = self._target
+            if self._state not in {"open", "closing"} or target is None:
+                raise StorageIntegrityError("local attempt-pool reaper is unavailable")
+            return target, tuple(self._orphans)
+
+        return self._lock.run(read)
+
+    def _forget(self, reclaimed: tuple[DirectoryOrphan, ...]) -> None:
+        if not reclaimed:
+            return
+
+        def commit() -> None:
+            self._orphans[:] = [
+                candidate
+                for candidate in self._orphans
+                if not any(candidate == receipt for receipt in reclaimed)
+            ]
+
+        self._lock.run(commit)
+
+    def reclaim_pending(self) -> None:
+        """Reclaim receipts at the scheduler's between-attempt boundary."""
+
+        target, receipts = self._snapshot()
+        if not receipts:
+            return
+        identity = target.attempt_pool_identity
+        if type(identity) is not tuple or len(identity) != 4:
+            raise StorageIntegrityError(
+                "local attempt-pool target has no retained parent identity"
+            )
+        self._lease.require_held()
+        target.verify_topology()
+        with QuiescentDirectoryReclaimer(
+            target.attempt_pool_root,
+            expected_parent_identity=identity,
+        ) as reclaimer:
+            for orphan in receipts:
+                target.verify_topology()
+                reclaimed = reclaimer.reclaim_orphan(orphan)
+                if reclaimed is not True:  # pragma: no cover - exact API invariant
+                    raise StorageIntegrityError(
+                        "local attempt-pool receipt did not reclaim"
+                    )
+                target.verify_topology()
+        self._lease.require_held()
+        self._forget(receipts)
+
+    def reclaim_stale(self) -> None:
+        """Sweep recognized crash leftovers at an explicit quiescent boundary."""
+
+        target, _receipts = self._snapshot()
+        self._lease.require_held()
+        LocalBM25AttemptPoolCoordinator(target).reclaim(
+            caller_asserts_quiescence=True,
+        )
+        self._lease.require_held()
+
+    def close(self) -> None:
+        def begin() -> bool:
+            if self._state == "closed":
+                return False
+            if self._target is None:
+                if self._orphans:
+                    raise StorageIntegrityError(
+                        "unconfigured local attempt-pool reaper retained receipts"
+                    )
+                self._state = "closed"
+                return False
+            if self._state == "open":
+                self._state = "closing"
+            return True
+
+        if not self._lock.run(begin):
+            return
+        self.reclaim_pending()
+        self.reclaim_stale()
+
+        def finish() -> None:
+            self._state = "closed"
+
+        self._lock.run(finish)
+
+
+class _TopologyBoundWorkspaceProvider:
+    """Bind runtime publications to the retained topology's parent inode."""
+
+    __slots__ = ("_expected_parent_identity", "_provider", "_verify")
+
+    def __init__(
+        self,
+        provider: LocalWorkspaceProvider,
+        expected_parent_identity: tuple[int, ...],
+        verifier: Callable[[], None],
+    ) -> None:
+        if type(provider) is not LocalWorkspaceProvider:
+            raise TypeError("topology workspace provider requires a local provider")
+        if (
+            type(expected_parent_identity) is not tuple
+            or len(expected_parent_identity) < 2
+            or any(type(value) is not int for value in expected_parent_identity)
+        ):
+            raise TypeError("topology workspace parent identity is invalid")
+        if not callable(verifier):
+            raise TypeError("topology workspace verifier is invalid")
+        self._provider = provider
+        self._expected_parent_identity = tuple(expected_parent_identity)
+        self._verify = verifier
+
+    @property
+    def allowed_root(self) -> Path:
+        return self._provider.allowed_root
+
+    def require_support(self) -> None:
+        self._verify()
+        self._provider.require_support()
+        self._verify()
+
+    def run_workspace(
+        self,
+        request,
+        *,
+        receipt_owner,
+        operation,
+        check_cancelled=None,
+        _replacement_source=None,
+    ):
+        cleanup_actions = (
+            (
+                "local runtime topology exit validation also failed",
+                self._verify,
+            ),
+        )
+        with _run_context_with_cleanup_actions(cleanup_actions):
+            self._verify()
+            kwargs = {
+                "receipt_owner": receipt_owner,
+                "operation": operation,
+                "_expected_parent_identity": self._expected_parent_identity,
+            }
+            if check_cancelled is not None:
+                kwargs["check_cancelled"] = check_cancelled
+            if _replacement_source is not None:
+                kwargs["_replacement_source"] = _replacement_source
+            return self._provider.run_workspace(request, **kwargs)
+
+
+def _repository_languages(bundle: RepoBundle) -> list[str]:
+    raw_languages = tuple(getattr(bundle.manifest, "languages", ()) or ())
+    if not raw_languages and bundle.entry.language:
+        raw_languages = (bundle.entry.language,)
+    if not 1 <= len(raw_languages) <= _MAX_TARGET_LANGUAGES:
+        raise LocalIndexServiceError(
+            "local index repository requires bounded chunker languages"
+        )
+    languages: list[str] = []
+    for raw_language in raw_languages:
+        if type(raw_language) is not str:
+            raise LocalIndexServiceError(
+                "local index repository language must be exact text"
+            )
+        language = normalize_chunker_language(raw_language)
+        if language is None:
+            raise LocalIndexServiceError(
+                "local index repository has an unsupported chunker language"
+            )
+        if language not in languages:
+            languages.append(language)
+    if not languages:
+        raise LocalIndexServiceError(
+            "local index repository has no supported chunker language"
+        )
+    return languages
+
+
+def _repository_selection(bundle: RepoBundle) -> RepositorySourceSelection:
+    selection = getattr(bundle.manifest, "source_selection", None)
+    if type(selection) is not RepositorySourceSelection:
+        return RepositorySourceSelection()
+    return RepositorySourceSelection(selection.exclude_subtrees)
+
+
+def _repository_head(repository_root: Path) -> str:
+    commit = (checkout_commit(repository_root) or "").strip().lower()
+    if _FULL_GIT_COMMIT_RE.fullmatch(commit) is None:
+        raise LocalIndexServiceError(
+            "local index repositories require a full resolved Git HEAD"
+        )
+    return commit
+
+
+@dataclass(frozen=True, slots=True)
+class _ConfiguredRepository:
+    storage: LocalIndexStorageRepository
+    repository_root: Path
+    display_commit: str
+    languages: tuple[str, ...]
+    source_selection: RepositorySourceSelection
+
+
+def _configured_repositories(
+    config: LocalIndexStorageConfig,
+    registry: RepoRegistry,
+) -> tuple[_ConfiguredRepository, ...]:
+    with registry.pin_all() as active_bundles:
+        by_repo: dict[str, RepoBundle] = {}
+        for bundle in active_bundles:
+            if type(bundle) is not RepoBundle:
+                raise LocalIndexServiceError(
+                    "repository registry returned an invalid bundle"
+                )
+            repo_id = bundle.entry.instance_id
+            if type(repo_id) is not str or repo_id in by_repo:
+                raise LocalIndexServiceError(
+                    "repository registry contains invalid local bindings"
+                )
+            by_repo[repo_id] = bundle
+        selected: list[_ConfiguredRepository] = []
+        for binding in config.repositories:
+            bundle = by_repo.get(binding.repo_id)
+            if bundle is None:
+                raise LocalIndexServiceError(
+                    "configured local index repository is not loaded"
+                )
+            repository_root = Path(bundle.entry.repo_dir)
+            selected.append(
+                _ConfiguredRepository(
+                    storage=binding,
+                    repository_root=repository_root,
+                    display_commit=_repository_head(repository_root),
+                    languages=tuple(_repository_languages(bundle)),
+                    source_selection=_repository_selection(bundle),
+                )
+            )
+        return tuple(selected)
+
+
+def _topology_guard(topology: LocalIndexStorageTopology) -> None:
+    try:
+        topology.verify()
+    except LocalIndexServiceError as exc:
+        raise StorageIntegrityError("local Web index storage topology changed") from exc
+
+
+def _safe_runtime_failure(failure: IndexJobActivationError) -> None:
+    logger.warning(
+        "Durable index runtime reconciliation will retry: %s",
+        type(failure).__name__,
+    )
+
+
+class LocalIndexRuntimeService:
+    """Own the production local worker and guarded BM25 runtime composition."""
+
+    __slots__ = (
+        "_attempt_pool",
+        "_attempt_pool_lease_owner",
+        "_background",
+        "_background_owner",
+        "_capabilities",
+        "_object_store_owner",
+        "_reader",
+        "_topology",
+        "_topology_owner",
+        "_writer",
+    )
+
+    def __init__(
+        self,
+        token: object,
+        *,
+        topology: LocalIndexStorageTopology,
+        topology_owner: _LocalRuntimeResourceOwner,
+        attempt_pool: _LocalBM25AttemptPoolReaper,
+        attempt_pool_lease_owner: _LocalAttemptPoolLeaseOwner,
+        object_store_owner: _LocalRuntimeResourceOwner,
+        background: IndexJobBackgroundService,
+        background_owner: _LocalRuntimeResourceOwner,
+        reader: CatalogIndexJobReader,
+        writer: CatalogIndexJobWriter,
+        capabilities: Mapping[str, Mapping[str, IndexUpdateCapability]],
+    ) -> None:
+        if token is not _LOCAL_RUNTIME_TOKEN:
+            raise TypeError("local index runtime service requires acquisition")
+        self._topology = topology
+        self._topology_owner = topology_owner
+        self._attempt_pool = attempt_pool
+        self._attempt_pool_lease_owner = attempt_pool_lease_owner
+        self._object_store_owner = object_store_owner
+        self._background = background
+        self._background_owner = background_owner
+        self._reader = reader
+        self._writer = writer
+        self._capabilities = MappingProxyType(
+            {
+                repo_id: MappingProxyType(dict(repo_capabilities))
+                for repo_id, repo_capabilities in capabilities.items()
+            }
+        )
+
+    @classmethod
+    def acquire(
+        cls,
+        config: LocalIndexStorageConfig,
+        registry: RepoRegistry,
+    ) -> "LocalIndexRuntimeService":
+        """Compose existing storage and loaded repositories without starting."""
+
+        if type(config) is not LocalIndexStorageConfig:
+            raise TypeError("local index runtime requires the exact storage config")
+        if type(registry) is not RepoRegistry:
+            raise TypeError("local index runtime requires an exact RepoRegistry")
+
+        selected = _configured_repositories(config, registry)
+        repository_roots = {
+            selected_repo.storage.repo_id: selected_repo.repository_root
+            for selected_repo in selected
+        }
+        topology_owner = _LocalRuntimeResourceOwner()
+        attempt_pool_lease_owner = _LocalAttemptPoolLeaseOwner()
+        attempt_pool = _LocalBM25AttemptPoolReaper(attempt_pool_lease_owner)
+        object_store_owner = _LocalRuntimeResourceOwner()
+        background_owner = _LocalRuntimeResourceOwner()
+        topology: LocalIndexStorageTopology | None = None
+        object_store: LocalCAS | None = None
+        background: IndexJobBackgroundService | None = None
+
+        def background_closed() -> bool:
+            return (
+                background_owner.closed
+                if background is None
+                else background.state == "closed"
+            )
+
+        def close_attempt_pool() -> None:
+            if not background_closed():
+                raise StorageIntegrityError(
+                    "local index background must settle before attempt cleanup"
+                )
+            attempt_pool.close()
+
+        def close_attempt_pool_lease() -> None:
+            if not background_closed() or not attempt_pool.closed:
+                raise StorageIntegrityError(
+                    "local index attempt cleanup must settle before lease release"
+                )
+            attempt_pool_lease_owner.close()
+
+        def close_object_store() -> None:
+            if not background_closed():
+                raise StorageIntegrityError(
+                    "local index background must settle before CAS release"
+                )
+            object_store_owner.close()
+
+        def close_topology() -> None:
+            if (
+                not background_closed()
+                or not attempt_pool.closed
+                or not attempt_pool_lease_owner.closed
+                or not object_store_owner.closed
+            ):
+                raise StorageIntegrityError(
+                    "local index resources must settle before topology release"
+                )
+            topology_owner.close()
+
+        cleanup_actions = (
+            _OrderedAction(
+                label="local index background cleanup also failed",
+                action=background_owner.close,
+                complete=lambda: (
+                    background_owner.closed
+                    if background is None
+                    else background.state == "closed"
+                ),
+                retry_incomplete="cancellation",
+                incomplete_owner=background_owner,
+            ),
+            _OrderedAction(
+                label="local index attempt-pool cleanup also failed",
+                action=close_attempt_pool,
+                complete=lambda: attempt_pool.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=attempt_pool,
+            ),
+            _OrderedAction(
+                label="local index attempt-pool lease cleanup also failed",
+                action=close_attempt_pool_lease,
+                complete=lambda: attempt_pool_lease_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=attempt_pool_lease_owner,
+            ),
+            _OrderedAction(
+                label="local index object store cleanup also failed",
+                action=close_object_store,
+                complete=lambda: object_store_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=object_store_owner,
+            ),
+            _OrderedAction(
+                label="local index topology cleanup also failed",
+                action=close_topology,
+                complete=lambda: (
+                    topology_owner.closed if topology is None else topology.closed
+                ),
+                retry_incomplete="cancellation",
+                incomplete_owner=topology_owner,
+            ),
+        )
+        with _run_context_with_cleanup_actions(
+            cleanup_actions,
+            cleanup_on_success=False,
+        ):
+            topology = topology_owner.acquire(
+                lambda: LocalIndexStorageTopology.acquire(
+                    config,
+                    repository_roots,
+                )
+            )
+            topology.verify()
+            attempt_pool_lease_owner.acquire(
+                config.worker_workspace_root,
+                wait_timeout_ms=config.catalog_busy_timeout_ms,
+                topology_verifier=topology.verify,
+            )
+            topology.verify()
+            object_store = object_store_owner.acquire(
+                lambda: LocalCAS(
+                    config.cas_root,
+                    require_preprovisioned=True,
+                )
+            )
+            topology.verify()
+            worker_provider = LocalWorkspaceProvider(config.worker_workspace_root)
+            runtime_provider = LocalWorkspaceProvider(config.runtime_workspace_root)
+            worker_provider.require_support()
+            runtime_provider.require_support()
+            runtime_workspace = _TopologyBoundWorkspaceProvider(
+                runtime_provider,
+                topology.runtime_workspace_identity,
+                topology.verify,
+            )
+
+            web_bindings: list[IndexJobRepoBinding] = []
+            worker_targets: list[LocalBM25SourceJobTarget] = []
+            runtime_targets: list[LocalRetainedBm25RuntimeTarget] = []
+            capabilities: dict[str, Mapping[str, IndexUpdateCapability]] = {}
+            environment = dict(os.environ)
+            for selected_repo in selected:
+                storage_binding = selected_repo.storage
+                repository_root = selected_repo.repository_root
+                web_binding = IndexJobRepoBinding(
+                    storage_binding.repo_id,
+                    storage_binding.repository_id,
+                    storage_binding.ref_name,
+                )
+                worker_target = LocalBM25SourceJobTarget(
+                    repository_root=repository_root,
+                    workspace_provider=worker_provider,
+                    repository_key=storage_binding.repository_key,
+                    display_commit=selected_repo.display_commit,
+                    builder=BM25IndexBuilder(
+                        languages=list(selected_repo.languages),
+                        source_selection=selected_repo.source_selection,
+                    ),
+                    namespace_name=storage_binding.namespace_name,
+                    environ=environment,
+                    repository_root_authority=topology.repository_authority(
+                        storage_binding.repo_id
+                    ),
+                    display_commit_resolver=lambda root=repository_root: (
+                        _repository_head(root)
+                    ),
+                    workspace_parent_identity=topology.worker_workspace_identity,
+                    topology_verifier=topology.verify,
+                    attempt_orphan_sink=attempt_pool.accept,
+                )
+                web_bindings.append(web_binding)
+                worker_targets.append(worker_target)
+                runtime_targets.append(
+                    LocalRetainedBm25RuntimeTarget(
+                        binding=web_binding,
+                        repository_key=storage_binding.repository_key,
+                        repository_root=repository_root,
+                        workspace_root=config.runtime_workspace_root,
+                        workspace_provider=runtime_workspace,
+                        namespace_name=storage_binding.namespace_name,
+                        environ=environment,
+                    )
+                )
+                capabilities[storage_binding.repo_id] = {
+                    "bm25": IndexUpdateCapability(
+                        mode="rebuild",
+                        enabled=True,
+                        reason="",
+                    )
+                }
+
+            bindings = tuple(web_bindings)
+            targets = tuple(worker_targets)
+            attempt_pool.install(targets[0])
+            attempt_pool.reclaim_stale()
+            catalog_factory = topology.catalog_factory
+            resources = LocalBM25SourceJobResourceFactory(targets)
+
+            def accepts_candidate(candidate) -> bool:
+                _topology_guard(topology)
+                return resources.accepts_candidate(candidate)
+
+            worker = IndexJobWorker(
+                catalog_factory=catalog_factory,
+                object_store=object_store,
+                resolver=BM25SourceJobResolver(
+                    resource_factory=resources,
+                    object_store=object_store,
+                ),
+                lease_duration_ms=config.worker.lease_duration_ms,
+                heartbeat_interval_ms=config.worker.heartbeat_interval_ms,
+                scan_limit=config.worker.scan_limit,
+                candidate_filter=accepts_candidate,
+            )
+            loader = LocalRetainedBm25SnapshotLoader(
+                catalog_factory,
+                object_store,
+                tuple(runtime_targets),
+            )
+            publisher = RepoRegistryIndexJobRuntimePublisher(
+                registry,
+                catalog_factory,
+                loader,
+            )
+            reconciler = CatalogIndexJobRuntimeReconciler(
+                catalog_factory,
+                bindings,
+                publisher,
+            )
+
+            def on_worker_result(result: IndexJobWorkerRunResult) -> None:
+                attempt_pool.reclaim_pending()
+                try:
+                    reconciler.on_worker_result(result)
+                except IndexJobActivationError as failure:
+                    _safe_runtime_failure(failure)
+
+            scheduler = IndexJobWorkerScheduler(
+                worker=worker,
+                initial_idle_delay_ms=config.worker.initial_idle_delay_ms,
+                max_idle_delay_ms=config.worker.max_idle_delay_ms,
+                on_result=on_worker_result,
+            )
+            runtime = IndexJobRuntimeReconciliationLoop(
+                reconciler,
+                poll_interval_ms=config.runtime.poll_interval_ms,
+                on_failure=_safe_runtime_failure,
+            )
+            background = background_owner.acquire(
+                lambda: IndexJobBackgroundService(scheduler, runtime)
+            )
+            planner = LocalBM25SourceJobPlanner(
+                catalog_factory,
+                targets,
+                max_attempts=config.worker.max_attempts,
+            )
+            reader = CatalogIndexJobReader(catalog_factory, bindings)
+            writer = CatalogIndexJobWriter(catalog_factory, bindings, planner)
+            topology.verify()
+            return cls(
+                _LOCAL_RUNTIME_TOKEN,
+                topology=topology,
+                topology_owner=topology_owner,
+                attempt_pool=attempt_pool,
+                attempt_pool_lease_owner=attempt_pool_lease_owner,
+                object_store_owner=object_store_owner,
+                background=background,
+                background_owner=background_owner,
+                reader=reader,
+                writer=writer,
+                capabilities=capabilities,
+            )
+
+    @property
+    def reader(self) -> IndexJobReader:
+        return self._reader
+
+    @property
+    def writer(self) -> IndexJobWriter:
+        return self._writer
+
+    @property
+    def state(self) -> str:
+        return self._background.state
+
+    @property
+    def healthy(self) -> bool:
+        return self._background.healthy
+
+    @property
+    def closed(self) -> bool:
+        return (
+            self._background.state == "closed"
+            and self._attempt_pool.closed
+            and self._attempt_pool_lease_owner.closed
+            and self._object_store_owner.closed
+            and self._topology.closed
+        )
+
+    def capabilities(self, repo_id: str) -> dict[str, IndexUpdateCapability]:
+        """Return one detached repository-scoped writer capability snapshot."""
+
+        if type(repo_id) is not str:
+            raise TypeError("local index capability repository ID must be exact text")
+        capabilities = self._capabilities.get(repo_id)
+        if capabilities is None:
+            raise KeyError(repo_id)
+        return dict(capabilities)
+
+    def start(self) -> None:
+        """Start both loops or settle the whole local service before failing."""
+
+        cleanup_actions = self._cleanup_actions()
+        with _run_context_with_cleanup_actions(
+            cleanup_actions,
+            cleanup_on_success=False,
+        ):
+            self._topology.verify()
+            self._background.start()
+            self._topology.verify()
+
+    def _cleanup_actions(self) -> tuple[_OrderedAction, ...]:
+        def background_closed() -> bool:
+            return self._background.state == "closed"
+
+        def close_attempt_pool() -> None:
+            if not background_closed():
+                raise StorageIntegrityError(
+                    "local index background must settle before attempt cleanup"
+                )
+            self._attempt_pool.close()
+
+        def close_attempt_pool_lease() -> None:
+            if not background_closed() or not self._attempt_pool.closed:
+                raise StorageIntegrityError(
+                    "local index attempt cleanup must settle before lease release"
+                )
+            self._attempt_pool_lease_owner.close()
+
+        def close_object_store() -> None:
+            if not background_closed():
+                raise StorageIntegrityError(
+                    "local index background must settle before CAS release"
+                )
+            self._object_store_owner.close()
+
+        def close_topology() -> None:
+            if (
+                not background_closed()
+                or not self._attempt_pool.closed
+                or not self._attempt_pool_lease_owner.closed
+                or not self._object_store_owner.closed
+            ):
+                raise StorageIntegrityError(
+                    "local index resources must settle before topology release"
+                )
+            self._topology_owner.close()
+
+        return (
+            _OrderedAction(
+                label="local index background cleanup also failed",
+                action=self._background_owner.close,
+                complete=lambda: self._background.state == "closed",
+                retry_incomplete="cancellation",
+                incomplete_owner=self._background_owner,
+            ),
+            _OrderedAction(
+                label="local index attempt-pool cleanup also failed",
+                action=close_attempt_pool,
+                complete=lambda: self._attempt_pool.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=self._attempt_pool,
+            ),
+            _OrderedAction(
+                label="local index attempt-pool lease cleanup also failed",
+                action=close_attempt_pool_lease,
+                complete=lambda: self._attempt_pool_lease_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=self._attempt_pool_lease_owner,
+            ),
+            _OrderedAction(
+                label="local index object store cleanup also failed",
+                action=close_object_store,
+                complete=lambda: self._object_store_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=self._object_store_owner,
+            ),
+            _OrderedAction(
+                label="local index topology cleanup also failed",
+                action=close_topology,
+                complete=lambda: self._topology.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=self._topology_owner,
+            ),
+        )
+
+    def close(self) -> None:
+        """Join loops before releasing the object store and path authorities."""
+
+        with _run_context_with_cleanup_actions(self._cleanup_actions()):
+            pass
+
+
+@contextmanager
+def open_local_index_runtime_service(
+    config: LocalIndexStorageConfig,
+    registry: RepoRegistry,
+) -> Iterator[LocalIndexRuntimeService]:
+    """Acquire, start, and always settle one production local service."""
+
+    service_owner = _LocalRuntimeResourceOwner()
+    service: LocalIndexRuntimeService | None = None
+    cleanup_actions = (
+        _OrderedAction(
+            label="local index runtime service cleanup also failed",
+            action=service_owner.close,
+            complete=lambda: (
+                service_owner.closed if service is None else service.closed
+            ),
+            retry_incomplete="cancellation",
+            incomplete_owner=service_owner,
+        ),
+    )
+    with _run_context_with_cleanup_actions(cleanup_actions):
+        service = service_owner.acquire(
+            lambda: LocalIndexRuntimeService.acquire(config, registry)
+        )
+        service.start()
+        yield service
+
+
+__all__ = [
+    "LocalIndexRuntimeService",
+    "open_local_index_runtime_service",
+]

--- a/codenib/web/local_index_service.py
+++ b/codenib/web/local_index_service.py
@@ -1064,9 +1064,15 @@ class LocalIndexStorageTopology:
     def _bound_topology_paths_unlocked(
         self,
         repository_id: str | None = None,
+        *,
+        include_repositories: bool = True,
     ) -> tuple[_TopologyPath, ...]:
         """Revalidate shared roots plus the selected repository bindings."""
 
+        if type(include_repositories) is not bool:
+            raise TypeError("local index repository verification policy is invalid")
+        if not include_repositories and repository_id is not None:
+            raise ValueError("shared-only topology cannot select a repository")
         self._catalog_factory.verify()
         for binding, private in (
             (self._cas, False),
@@ -1081,7 +1087,9 @@ class LocalIndexStorageTopology:
             )
             if observed != binding.identity:
                 raise LocalIndexServiceError(f"{binding.label} identity changed")
-        if repository_id is None:
+        if not include_repositories:
+            repository_indexes = ()
+        elif repository_id is None:
             repository_indexes = range(len(self._repository_paths))
         else:
             selected_index = self._repository_indexes.get(repository_id)
@@ -1130,15 +1138,26 @@ class LocalIndexStorageTopology:
             ),
         )
 
-    def _verify_unlocked(self, repository_id: str | None = None) -> None:
+    def _verify_unlocked(
+        self,
+        repository_id: str | None = None,
+        *,
+        include_repositories: bool = True,
+    ) -> None:
         if self._closed_unlocked():
             raise LocalIndexServiceError("local index topology is closed")
-        topology_paths = self._bound_topology_paths_unlocked(repository_id)
+        topology_paths = self._bound_topology_paths_unlocked(
+            repository_id,
+            include_repositories=include_repositories,
+        )
         _require_disjoint_topology(topology_paths)
         # Physical ancestry and mount inspection can run arbitrary filesystem
         # syscalls. Sandwich it with a final retained binding check so a rename
         # or replacement cannot be accepted at the public return boundary.
-        final_topology_paths = self._bound_topology_paths_unlocked(repository_id)
+        final_topology_paths = self._bound_topology_paths_unlocked(
+            repository_id,
+            include_repositories=include_repositories,
+        )
         _require_disjoint_topology(final_topology_paths)
 
     def verify(self) -> None:
@@ -1152,6 +1171,13 @@ class LocalIndexStorageTopology:
         if type(repo_id) is not str:
             raise TypeError("local index repository ID must be exact text")
         self._lifecycle_lock.run(lambda: self._verify_unlocked(repo_id))
+
+    def verify_shared_storage(self) -> None:
+        """Revalidate catalog, CAS, and workspace roots without repositories."""
+
+        self._lifecycle_lock.run(
+            lambda: self._verify_unlocked(include_repositories=False)
+        )
 
     def _close_unlocked(self) -> None:
         cleanup_actions = (

--- a/codenib/web/local_index_service.py
+++ b/codenib/web/local_index_service.py
@@ -14,6 +14,7 @@ from collections.abc import Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
+from types import MappingProxyType
 from typing import Iterator
 
 from .._atomic_directory import (
@@ -820,6 +821,7 @@ class LocalIndexStorageTopology:
         "_config",
         "_lifecycle_lock",
         "_repositories",
+        "_repository_indexes",
         "_repository_paths",
         "_runtime_workspace",
         "_source_owner",
@@ -851,6 +853,9 @@ class LocalIndexStorageTopology:
         self._runtime_workspace = runtime_workspace
         self._repository_paths = repository_paths
         self._repositories = repositories
+        self._repository_indexes = MappingProxyType(
+            {repo_id: index for index, (repo_id, _path) in enumerate(repository_paths)}
+        )
         self._source_owner = source_owner
         self._lifecycle_lock = _CancellationSafeRLock()
 
@@ -1042,24 +1047,25 @@ class LocalIndexStorageTopology:
         def read() -> RepositorySourceRootAuthority:
             if self._closed_unlocked():
                 raise LocalIndexServiceError("local index topology is closed")
-            for (path_id, path), (candidate_id, authority) in zip(
-                self._repository_paths,
-                self._repositories,
-                strict=True,
-            ):
-                if path_id != candidate_id:
-                    raise LocalIndexServiceError(
-                        "local index repository authority ordering changed"
-                    )
-                if candidate_id == repo_id:
-                    _verify_repository_binding(repo_id, path, authority)
-                    return authority
-            raise KeyError(repo_id)
+            index = self._repository_indexes.get(repo_id)
+            if index is None:
+                raise KeyError(repo_id)
+            path_id, path = self._repository_paths[index]
+            authority_id, authority = self._repositories[index]
+            if path_id != repo_id or authority_id != repo_id:
+                raise LocalIndexServiceError(
+                    "local index repository authority ordering changed"
+                )
+            _verify_repository_binding(repo_id, path, authority)
+            return authority
 
         return self._lifecycle_lock.run(read)
 
-    def _bound_topology_paths_unlocked(self) -> tuple[_TopologyPath, ...]:
-        """Revalidate retained bindings and return detached topology inputs."""
+    def _bound_topology_paths_unlocked(
+        self,
+        repository_id: str | None = None,
+    ) -> tuple[_TopologyPath, ...]:
+        """Revalidate shared roots plus the selected repository bindings."""
 
         self._catalog_factory.verify()
         for binding, private in (
@@ -1075,18 +1081,23 @@ class LocalIndexStorageTopology:
             )
             if observed != binding.identity:
                 raise LocalIndexServiceError(f"{binding.label} identity changed")
-        repository_identities: list[tuple[int, ...]] = []
-        for (repo_id, path), (authority_id, authority) in zip(
-            self._repository_paths,
-            self._repositories,
-            strict=True,
-        ):
+        if repository_id is None:
+            repository_indexes = range(len(self._repository_paths))
+        else:
+            selected_index = self._repository_indexes.get(repository_id)
+            if selected_index is None:
+                raise KeyError(repository_id)
+            repository_indexes = (selected_index,)
+        verified_repositories: list[tuple[str, Path, tuple[int, ...]]] = []
+        for index in repository_indexes:
+            repo_id, path = self._repository_paths[index]
+            authority_id, authority = self._repositories[index]
             if authority_id != repo_id:
                 raise LocalIndexServiceError(
                     "local index repository authority ordering changed"
                 )
-            repository_identities.append(
-                _verify_repository_binding(repo_id, path, authority)
+            verified_repositories.append(
+                (repo_id, path, _verify_repository_binding(repo_id, path, authority))
             )
         return (
             *_catalog_topology_paths(self._catalog_factory),
@@ -1115,29 +1126,32 @@ class LocalIndexStorageTopology:
                     identity[0],
                     path,
                 )
-                for (repo_id, path), identity in zip(
-                    self._repository_paths,
-                    repository_identities,
-                    strict=True,
-                )
+                for repo_id, path, identity in verified_repositories
             ),
         )
 
-    def _verify_unlocked(self) -> None:
+    def _verify_unlocked(self, repository_id: str | None = None) -> None:
         if self._closed_unlocked():
             raise LocalIndexServiceError("local index topology is closed")
-        topology_paths = self._bound_topology_paths_unlocked()
+        topology_paths = self._bound_topology_paths_unlocked(repository_id)
         _require_disjoint_topology(topology_paths)
         # Physical ancestry and mount inspection can run arbitrary filesystem
         # syscalls. Sandwich it with a final retained binding check so a rename
         # or replacement cannot be accepted at the public return boundary.
-        final_topology_paths = self._bound_topology_paths_unlocked()
+        final_topology_paths = self._bound_topology_paths_unlocked(repository_id)
         _require_disjoint_topology(final_topology_paths)
 
     def verify(self) -> None:
         """Revalidate every retained path and physical-separation invariant."""
 
         self._lifecycle_lock.run(self._verify_unlocked)
+
+    def verify_repository(self, repo_id: str) -> None:
+        """Revalidate shared storage plus one selected repository authority."""
+
+        if type(repo_id) is not str:
+            raise TypeError("local index repository ID must be exact text")
+        self._lifecycle_lock.run(lambda: self._verify_unlocked(repo_id))
 
     def _close_unlocked(self) -> None:
         cleanup_actions = (

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -3170,6 +3170,11 @@ class RepoRegistry:
         if cleanup_failure is not None:
             raise cleanup_failure
 
+    def configured_index_types(self) -> Tuple[str, ...]:
+        """Return the configured retrieval-mode contract used by this registry."""
+
+        return tuple(self._config.index_types())
+
     @contextmanager
     def pin_all(self) -> Iterator[Tuple[RepoBundle, ...]]:
         """Pin one coherent snapshot of every currently published bundle."""

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1534,10 +1534,10 @@ default-off two-pass CLI sweep are implemented. The production routed source
 path writes only into its leased shard; the compatibility workspace-root path
 and its cleanup remain unleased and manual. The local Web composition explicitly
 bootstraps each configured repository shard, routes its authenticated attempt
-receipts to the matching bounded reaper, reclaims exact receipts after worker
-results, and sweeps only those configured shards before start and after joined
-shutdown. Automatic shard discovery and default/background reaping remain
-pending.
+receipts to the matching bounded reaper, settles them after worker results under
+that route's exclusive lease, and sweeps only those configured shards before
+start and after joined shutdown. Automatic shard discovery and default server
+installation remain pending.
 Vector and graph source builders, generic builder routing, and remaining
 runtime wiring remain.
 
@@ -1650,11 +1650,11 @@ MCP, UI controls, and default routing remain absent.
   configured target, directs every at-least-once receipt to its exact shard,
   cleans it after worker results, and performs shard-policy sweeps only before
   worker start or after both background loops join. Automatic shard discovery
-  and installed default/background reaping remain pending, and legacy cleanup
-  continues to require explicit operator quiescence. Then add vector and graph
-  source adapters, install the composed service in the production server
-  lifespan, and wire MCP, UI, and default routes. Older self-publishing ingress
-  APIs remain compatibility paths and are never nested inside the worker.
+  and default server installation remain pending, and legacy cleanup continues
+  to require explicit operator quiescence. Then add vector and graph source
+  adapters, install the composed service in the production server lifespan, and
+  wire MCP, UI, and default routes. Older self-publishing ingress APIs remain
+  compatibility paths and are never nested inside the worker.
 - Complete the #266 job and update APIs with accurate incremental versus rebuild
   behavior; the first read-only status slice is described below.
 - `RepoRegistry.load_all()` now reconciles each complete registry snapshot,
@@ -1671,9 +1671,8 @@ MCP, UI controls, and default routing remain absent.
   cancellation-class cleanup failures never demoted behind ordinary errors.
   Bundle-derived Wiki, edge-label, and commit-window helpers are generation
   keyed and stale entries are pruned after replacement, removal, and shutdown.
-  The remaining #266 work is to own the existing reconciliation loop in the
-  production server lifespan, invoke its existing callback only after an
-  attested update job succeeds, and expose its status/results to the UI.
+  The remaining #266 work is to own the composed service in the production
+  server lifespan and expose its status/results to the UI.
 - The first #266 read slice exposes one pinned, detached status snapshot for
   exactly BM25, vector, and symbol-graph surfaces. It reports manifest/current
   commit drift and retained incremental metrics without exposing mutable bundle

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1463,12 +1463,10 @@ returning the prepared result, and binds every attempt/view/context provision
 to the retained startup workspace identity while rechecking the complete
 storage topology. The planner captures that same topology-guarded retained
 source and registers only its content-addressed planning identities through a
-least-authority catalog surface. The guarded result reconciler, retained
-publisher, and polling loop remain dependency-injected; no default Web lifespan
-installation, acquired local-storage service composition, or default route
-selects either production binding yet. Typed local-storage configuration parsing
-is implemented, but it remains a side-effect-free opt-in until those runtime
-ownership gates are installed.
+least-authority catalog surface. An explicit local production composition now
+assembles those targets with the strict preprovisioned CAS, scheduler, retained
+publisher, polling reconciler, reader, and writer. No default Web lifespan or
+default route selects that composition yet.
 
 The production CLI binding exposes both trusted local adapters through
 `codenib jobs run-once` and `codenib jobs run`, with an explicit mutually
@@ -1534,8 +1532,12 @@ classification, phase-A per-repository shard bootstrap and paired
 writer/reaper routes, exact-group retained-owner retry routing, and the
 default-off two-pass CLI sweep are implemented. The production routed source
 path writes only into its leased shard; the compatibility workspace-root path
-and its cleanup remain unleased and manual. Automatic multi-target shard
-discovery/routing and default/background reaping remain pending.
+and its cleanup remain unleased and manual. The local Web composition explicitly
+bootstraps each configured repository shard, routes its authenticated attempt
+receipts to the matching bounded reaper, reclaims exact receipts after worker
+results, and sweeps only those configured shards before start and after joined
+shutdown. Automatic shard discovery and default/background reaping remain
+pending.
 Vector and graph source builders, generic builder routing, and remaining
 runtime wiring remain.
 
@@ -1575,10 +1577,12 @@ and invalidates bundle-bound Wiki, edge-label, and commit-window caches by
 generation identity.
 The first #266 status, durable-read, explicitly injected one-view write,
 retained-source BM25 planning, guarded reconciliation, retained publication,
-and polling slices are present. The success callback exists but is not installed
-by the default server. Typed local-storage configuration parsing and explicit
-physical topology acquisition are present; service composition, Web lifespan
-ownership, MCP, UI controls, and default routing remain absent.
+and polling slices are present. Typed local-storage configuration parsing and
+explicit physical topology acquisition are implemented. An explicit local
+composition now invokes the success callback from the worker, owns both
+background loops, exposes the durable reader/writer and BM25 capability, and
+settles them before CAS and topology release. Default Web lifespan ownership,
+MCP, UI controls, and default routing remain absent.
 
 - The backend-neutral worker now owns advisory scan/claim, per-attempt task
   authority, independent heartbeat sessions, cancellation precedence, bounded
@@ -1642,13 +1646,15 @@ ownership, MCP, UI controls, and default routing remain absent.
   least-authority catalog surface that can register only content-addressed
   source/profile identities and read one ref generation. The generic
   descriptor reclaimer remains policy-free and carries no publication
-  authority. Automatic multi-target shard discovery/routing and installed
-  default/background reaping remain pending, and legacy cleanup continues to
-  require explicit operator quiescence. Then add vector and graph source
-  adapters, install the existing reconciler and polling loop in the production
-  server lifespan, invoke its callback from attested worker success, and wire
-  MCP, UI, and default routes. Older self-publishing ingress APIs remain
-  compatibility paths and are never nested inside the worker.
+  authority. The Web composition bootstraps the same paired routes for each
+  configured target, directs every at-least-once receipt to its exact shard,
+  cleans it after worker results, and performs shard-policy sweeps only before
+  worker start or after both background loops join. Automatic shard discovery
+  and installed default/background reaping remain pending, and legacy cleanup
+  continues to require explicit operator quiescence. Then add vector and graph
+  source adapters, install the composed service in the production server
+  lifespan, and wire MCP, UI, and default routes. Older self-publishing ingress
+  APIs remain compatibility paths and are never nested inside the worker.
 - Complete the #266 job and update APIs with accurate incremental versus rebuild
   behavior; the first read-only status slice is described below.
 - `RepoRegistry.load_all()` now reconciles each complete registry snapshot,
@@ -1741,8 +1747,11 @@ ownership, MCP, UI controls, and default routing remain absent.
   pins every explicitly mapped repository hierarchy. It rejects symbolic
   traversal plus lexical, inode-ancestry, and Linux mount-mapped physical
   aliases, revalidates every binding, and retains interrupted cleanup for
-  retry. Actual CAS/worker/runtime composition and lifespan installation remain
-  separate gates.
+  retry. The explicit composition now opens the strict preprovisioned CAS,
+  freezes loaded repository inputs, builds matching BM25 worker/runtime targets,
+  owns the fair scheduler and guarded reconciliation loop, and releases them in
+  background/reaper/lease/CAS/topology order. Lifespan installation remains a
+  separate gate.
 - An explicitly injected Web reader can now project authorized durable jobs and
   at most 64 events without exposing worker owner IDs, fencing tokens, or raw
   executor errors or event keys. Each event is rebound to the exact job, a

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1749,7 +1749,7 @@ MCP, UI controls, and default routing remain absent.
   retry. The explicit composition now opens the strict preprovisioned CAS,
   freezes loaded repository inputs, builds matching BM25 worker/runtime targets,
   owns the fair scheduler and guarded reconciliation loop, and releases them in
-  background/reaper/lease/CAS/topology order. Lifespan installation remains a
+  background/reaper/CAS/topology order. Lifespan installation remains a
   separate gate.
 - An explicitly injected Web reader can now project authorized durable jobs and
   at most 64 events without exposing worker owner IDs, fencing tokens, or raw

--- a/test/compiler/test_bm25_attempt_pool.py
+++ b/test/compiler/test_bm25_attempt_pool.py
@@ -215,6 +215,11 @@ def test_bm25_attempt_pool_coordinator_requires_exact_quiescence_and_topology(
         coordinator.reclaim()
     with pytest.raises(TypeError, match="exact bool"):
         coordinator.reclaim(caller_asserts_quiescence=1)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="blocking flag"):
+        coordinator.reclaim(
+            caller_asserts_quiescence=True,
+            blocking=1,  # type: ignore[arg-type]
+        )
 
     no_topology_target = LocalBM25SourceJobTarget(
         repository_root=target.repository_root,

--- a/test/compiler/test_bm25_attempt_pool_binding.py
+++ b/test/compiler/test_bm25_attempt_pool_binding.py
@@ -723,6 +723,48 @@ def test_leased_attempt_pool_reclaims_shard_only_under_exclusive_route(
             is None
         )
 
+        installed: list[PrivateDirectoryLeaseOwner] = []
+        writer_lease = binding.writer_route._acquire(
+            check_cancelled=lambda: None,
+            construction_owner=installed.append,
+        )
+        deferred: list[BM25AttemptPoolReclamation | None] = []
+        failures: list[BaseException] = []
+
+        def try_nonblocking_reclaim() -> None:
+            try:
+                deferred.append(
+                    LocalBM25AttemptPoolCoordinator(
+                        target,
+                        reaper_route=binding.reaper_route,
+                    ).reclaim(
+                        caller_asserts_quiescence=True,
+                        blocking=False,
+                    )
+                )
+            except BaseException as error:  # noqa: B036 - exact failure asserted
+                failures.append(error)
+
+        contender = threading.Thread(target=try_nonblocking_reclaim)
+        contender.start()
+        contender.join(timeout=10)
+        try:
+            assert not contender.is_alive()
+            assert failures == []
+            assert deferred == [None]
+        finally:
+            writer_lease.close()
+
+        assert installed == [writer_lease]
+        assert writer_lease.closed
+        assert (
+            _probe_raw_lease(
+                binding.reaper_route._state.directory_lease_route,
+                DirectoryLeaseMode.EXCLUSIVE,
+            )
+            is None
+        )
+
         legacy = LocalBM25AttemptPoolCoordinator(
             target,
             _legacy_workspace=True,
@@ -881,7 +923,7 @@ def test_incomplete_reclaimer_close_retains_exclusive_lease(
         cleanup = job_resources_module._BM25AttemptPoolReaperCleanupOwner(
             binding.reaper_route
         )
-        cleanup._acquire()
+        cleanup._acquire(blocking=True)
         reclaimer = cleanup._open_reclaimer()
         real_close = job_resources_module.QuiescentDirectoryReclaimer.close
         monkeypatch.setattr(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -590,8 +590,6 @@ def test_jobs_run_once_parser_exposes_bounded_worker_inputs() -> None:
     with pytest.raises(SystemExit) as invalid:
         cli.build_parser().parse_args([*base, "--scan-limit", "0"])
     assert invalid.value.code == 2
-
-
 def test_jobs_worker_parser_requires_one_explicit_input_mode() -> None:
     topology = [
         "--catalog",

--- a/test/web/test_config.py
+++ b/test/web/test_config.py
@@ -236,6 +236,22 @@ def test_local_index_storage_config_rejects_duplicate_storage_bindings(
         load_config(str(config_path))
 
 
+def test_local_index_storage_config_rejects_duplicate_durable_repository(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        _local_index_storage_yaml(
+            "    alias:\n"
+            "      repository_key: org/demo\n"
+            "      ref_name: release\n"
+        )
+    )
+
+    with pytest.raises(ValueError, match="bindings must be unique"):
+        load_config(str(config_path))
+
+
 def test_config_rejects_duplicate_yaml_keys_within_one_profile(
     tmp_path: Path,
 ) -> None:

--- a/test/web/test_local_index_runtime.py
+++ b/test/web/test_local_index_runtime.py
@@ -1,0 +1,364 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+import codenib.web.local_index_runtime as local_runtime_module
+from codenib.compiler.cache_lock import COMPILER_CACHE_LOCK_FILENAME
+from codenib.compiler.manifest import RepoManifest
+from codenib.repository_source_selection import RepositorySourceSelection
+from codenib.storage import LocalCAS, SQLiteCatalog
+from codenib.web.config import (
+    LocalIndexRuntimeConfig,
+    LocalIndexStorageConfig,
+    LocalIndexStorageRepository,
+    LocalIndexWorkerConfig,
+    QAConfig,
+    RepoEntry,
+)
+from codenib.web.local_index_runtime import (
+    LocalIndexRuntimeService,
+    open_local_index_runtime_service,
+)
+from codenib.web.local_index_service import LocalIndexServiceError
+from codenib.web.repo_registry import RepoBundle, RepoRegistry
+
+
+def _git(*arguments: str, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "CodeNib Tests",
+            "GIT_AUTHOR_EMAIL": "tests@codenib.invalid",
+            "GIT_COMMITTER_NAME": "CodeNib Tests",
+            "GIT_COMMITTER_EMAIL": "tests@codenib.invalid",
+        },
+    )
+    return result.stdout.strip()
+
+
+def _repository(root: Path) -> tuple[Path, str]:
+    repository = root / "repository"
+    repository.mkdir()
+    _git("init", "--quiet", cwd=repository)
+    (repository / "sample.py").write_text(
+        "def sample():\n    return 1\n",
+        encoding="utf-8",
+    )
+    _git("add", "sample.py", cwd=repository)
+    _git("commit", "--quiet", "-m", "initial", cwd=repository)
+    return repository, _git("rev-parse", "HEAD", cwd=repository)
+
+
+def _runtime_fixture(
+    tmp_path: Path,
+) -> tuple[LocalIndexStorageConfig, RepoRegistry]:
+    repository, commit = _repository(tmp_path)
+    catalog_path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(catalog_path) as catalog:
+        repository_id = catalog.create_repository("org/repo")
+    cas_root = tmp_path / "cas"
+    LocalCAS.provision(cas_root).close()
+    worker_root = tmp_path / "worker"
+    runtime_root = tmp_path / "runtime"
+    worker_root.mkdir(mode=0o700)
+    runtime_root.mkdir(mode=0o700)
+
+    storage_binding = LocalIndexStorageRepository(
+        repo_id="demo",
+        repository_key="org/repo",
+    )
+    assert storage_binding.repository_id == repository_id
+    storage = LocalIndexStorageConfig(
+        catalog_path=catalog_path,
+        cas_root=cas_root,
+        worker_workspace_root=worker_root,
+        runtime_workspace_root=runtime_root,
+        repositories=(storage_binding,),
+        worker=LocalIndexWorkerConfig(
+            lease_duration_ms=3_000,
+            heartbeat_interval_ms=500,
+            scan_limit=4,
+            initial_idle_delay_ms=10,
+            max_idle_delay_ms=20,
+            max_attempts=2,
+        ),
+        runtime=LocalIndexRuntimeConfig(poll_interval_ms=10),
+    )
+    registry = RepoRegistry(QAConfig(mode="sparse"))
+    registry._bundles["demo"] = RepoBundle(
+        entry=RepoEntry(
+            instance_id="demo",
+            repo="org/repo",
+            base_commit=commit,
+            language="python",
+            repo_dir=str(repository),
+            manifest_path=str(tmp_path / "repo_manifest.json"),
+        ),
+        manifest=RepoManifest(
+            repo_path=str(repository),
+            commit=commit,
+            last_indexed_commit=commit,
+            source_selection=RepositorySourceSelection(("generated",)),
+            languages=["python"],
+        ),
+    )
+    return storage, registry
+
+
+def test_local_index_runtime_composes_and_settles_production_loops(
+    tmp_path: Path,
+) -> None:
+    storage, registry = _runtime_fixture(tmp_path)
+    service = None
+    try:
+        with open_local_index_runtime_service(storage, registry) as opened:
+            service = opened
+            assert service.state == "running"
+            assert service.healthy is True
+            assert service.reader.active("demo") is None
+            capabilities = service.capabilities("demo")
+            assert capabilities["bm25"].mode == "rebuild"
+            assert capabilities["bm25"].enabled is True
+            assert "vector" not in capabilities
+            with pytest.raises(KeyError):
+                service.capabilities("other")
+    finally:
+        registry.close()
+
+    assert service is not None
+    assert service.state == "closed"
+    assert service.closed is True
+
+
+def test_local_index_runtime_preserves_context_failure_after_cleanup(
+    tmp_path: Path,
+) -> None:
+    storage, registry = _runtime_fixture(tmp_path)
+    failure = RuntimeError("requesting shutdown")
+    service = None
+    try:
+        with pytest.raises(RuntimeError) as raised:
+            with open_local_index_runtime_service(storage, registry) as opened:
+                service = opened
+                raise failure
+        assert raised.value is failure
+    finally:
+        registry.close()
+
+    assert service is not None
+    assert service.closed is True
+
+
+def test_local_index_runtime_rejects_a_second_attempt_pool_owner(
+    tmp_path: Path,
+) -> None:
+    storage, registry = _runtime_fixture(tmp_path)
+    try:
+        with open_local_index_runtime_service(storage, registry) as service:
+            with pytest.raises(LocalIndexServiceError, match="workspace lease"):
+                LocalIndexRuntimeService.acquire(storage, registry)
+            assert service.healthy is True
+        with open_local_index_runtime_service(storage, registry) as restarted:
+            assert restarted.healthy is True
+    finally:
+        registry.close()
+
+
+def test_attempt_pool_lease_owner_retains_interrupted_enter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    active = False
+    events: list[str] = []
+
+    class InterruptedContext:
+        def __enter__(self):
+            nonlocal active
+            active = True
+            events.append("enter")
+            raise KeyboardInterrupt("interrupt after lease acquisition")
+
+        def __exit__(self, *_args):
+            nonlocal active
+            active = False
+            events.append("exit")
+            return False
+
+    def lease_factory(root: Path, *, create: bool, check_cancelled):
+        assert root == tmp_path
+        assert create is True
+        assert callable(check_cancelled)
+        return InterruptedContext()
+
+    monkeypatch.setattr(
+        local_runtime_module,
+        "compiler_cache_lock",
+        lease_factory,
+    )
+    owner = local_runtime_module._LocalAttemptPoolLeaseOwner()
+
+    with pytest.raises(KeyboardInterrupt, match="after lease acquisition"):
+        owner.acquire(
+            tmp_path,
+            wait_timeout_ms=0,
+            topology_verifier=lambda: events.append("verify"),
+        )
+
+    assert active is True
+    assert owner.closed is False
+    owner.close()
+    assert active is False
+    assert owner.closed is True
+    assert events == ["verify", "enter", "exit"]
+
+
+def test_local_index_runtime_reclaims_stale_attempts_before_start(
+    tmp_path: Path,
+) -> None:
+    storage, registry = _runtime_fixture(tmp_path)
+    stale = storage.worker_workspace_root / (
+        f".codenib-source-job-{'a' * 32}.normalize-{'b' * 24}"
+    )
+    stale.mkdir()
+    (stale / "payload").write_text("stale", encoding="utf-8")
+    try:
+        with open_local_index_runtime_service(storage, registry):
+            assert not stale.exists()
+    finally:
+        registry.close()
+
+
+def test_local_index_runtime_retains_lease_when_reaper_cleanup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage, registry = _runtime_fixture(tmp_path)
+    service = LocalIndexRuntimeService.acquire(storage, registry)
+    service.start()
+    reaper_type = type(service._attempt_pool)
+    real_close = reaper_type.close
+    attempts = 0
+
+    def fail_once(reaper) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("reaper cleanup failed")
+        real_close(reaper)
+
+    monkeypatch.setattr(reaper_type, "close", fail_once)
+    try:
+        with pytest.raises(RuntimeError, match="reaper cleanup failed"):
+            service.close()
+
+        assert service.state == "closed"
+        assert service._attempt_pool.closed is False
+        assert service._attempt_pool_lease_owner.closed is False
+        assert service._object_store_owner.closed is True
+        assert service._topology.closed is False
+
+        service.close()
+        assert service.closed is True
+    finally:
+        if not service.closed:
+            service.close()
+        registry.close()
+
+
+def test_local_index_runtime_retains_resources_when_background_join_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage, registry = _runtime_fixture(tmp_path)
+    service = LocalIndexRuntimeService.acquire(storage, registry)
+    service.start()
+    owner_type = type(service._background_owner)
+    real_close = owner_type.close
+    attempts = 0
+
+    def fail_background_once(owner) -> None:
+        nonlocal attempts
+        if owner is service._background_owner:
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("background join failed")
+        real_close(owner)
+
+    monkeypatch.setattr(owner_type, "close", fail_background_once)
+    try:
+        with pytest.raises(RuntimeError, match="background join failed"):
+            service.close()
+
+        assert service.state == "running"
+        assert service._attempt_pool.closed is False
+        assert service._attempt_pool_lease_owner.closed is False
+        assert service._object_store_owner.closed is False
+        assert service._topology.closed is False
+
+        service.close()
+        assert service.closed is True
+    finally:
+        if not service.closed:
+            service.close()
+        registry.close()
+
+
+def test_local_index_runtime_executes_submitted_bm25_job(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    storage, registry = _runtime_fixture(tmp_path)
+    try:
+        with open_local_index_runtime_service(storage, registry) as service:
+            created = service.writer.create(
+                "demo",
+                indexes=("bm25",),
+                mode="full",
+                force=False,
+                idempotency_key="integration-job",
+            )
+            deadline = time.monotonic() + 15
+            observed = created
+            while observed.status in {"queued", "running"}:
+                if time.monotonic() >= deadline:
+                    pytest.fail("background BM25 job did not settle")
+                time.sleep(0.02)
+                observed = service.reader.get(created.job_id)
+
+            assert observed.status == "succeeded"
+            assert observed.indexes[0].index_type == "bm25"
+            assert observed.result_snapshot_id is not None
+            assert observed.finished_at_ms is not None
+            assert any(
+                event.kind == "view_result"
+                and event.index_type == "bm25"
+                and event.outcome == "succeeded"
+                for event in observed.events
+            )
+            while tuple(storage.worker_workspace_root.glob(".*codenib-source-job-*")):
+                if time.monotonic() >= deadline:
+                    pytest.fail("background BM25 attempt receipt was not reclaimed")
+                time.sleep(0.02)
+            assert service.healthy is True
+    finally:
+        registry.close()
+
+    workspace_entries = tuple(storage.worker_workspace_root.iterdir())
+    assert [entry.name for entry in workspace_entries] == [COMPILER_CACHE_LOCK_FILENAME]
+    assert not any(
+        "attempt-root orphan" in record.getMessage() for record in caplog.records
+    )

--- a/test/web/test_local_index_runtime.py
+++ b/test/web/test_local_index_runtime.py
@@ -489,6 +489,41 @@ def test_local_index_runtime_reclaims_stale_attempts_before_start(
         registry.close()
 
 
+def test_local_index_runtime_defers_busy_attempt_sweeps(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage, registry = _runtime_fixture(tmp_path)
+    calls: list[bool] = []
+
+    def defer_busy(
+        _coordinator,
+        *,
+        caller_asserts_quiescence=False,
+        blocking=True,
+    ):
+        assert caller_asserts_quiescence is True
+        calls.append(blocking)
+        return None
+
+    monkeypatch.setattr(
+        local_runtime_module.LocalBM25AttemptPoolCoordinator,
+        "reclaim",
+        defer_busy,
+    )
+    service = LocalIndexRuntimeService.acquire(storage, registry)
+    try:
+        service.start()
+        assert service.healthy is True
+        service.close()
+        assert service.closed is True
+        assert calls == [False, False]
+    finally:
+        if not service.closed:
+            service.close()
+        registry.close()
+
+
 def test_local_index_runtime_retains_routed_reaper_cleanup_owner(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -509,7 +544,12 @@ def test_local_index_runtime_retains_routed_reaper_cleanup_owner(
     failure = RuntimeError("routed reaper cleanup failed")
     failure.publication_cleanup_owners = (cleanup_owner,)  # type: ignore[attr-defined]
 
-    def fail_once(coordinator, *, caller_asserts_quiescence=False):
+    def fail_once(
+        coordinator,
+        *,
+        caller_asserts_quiescence=False,
+        blocking=True,
+    ):
         nonlocal attempts
         attempts += 1
         if attempts == 1:
@@ -517,6 +557,7 @@ def test_local_index_runtime_retains_routed_reaper_cleanup_owner(
         return real_reclaim(
             coordinator,
             caller_asserts_quiescence=caller_asserts_quiescence,
+            blocking=blocking,
         )
 
     monkeypatch.setattr(

--- a/test/web/test_local_index_runtime.py
+++ b/test/web/test_local_index_runtime.py
@@ -13,7 +13,6 @@ from pathlib import Path
 import pytest
 
 import codenib.web.local_index_runtime as local_runtime_module
-from codenib.compiler.cache_lock import COMPILER_CACHE_LOCK_FILENAME
 from codenib.compiler.manifest import RepoManifest
 from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.storage import (
@@ -277,7 +276,7 @@ def test_local_index_runtime_rejects_hybrid_registry_before_acquisition(
         registry.close()
 
 
-def test_local_index_runtime_attests_catalog_before_workspace_lease(
+def test_local_index_runtime_attests_catalog_before_attempt_pool_bootstrap(
     tmp_path: Path,
 ) -> None:
     storage, registry = _runtime_fixture(tmp_path)
@@ -287,14 +286,12 @@ def test_local_index_runtime_attests_catalog_before_workspace_lease(
     try:
         with pytest.raises(StorageNotFound, match="not found"):
             LocalIndexRuntimeService.acquire(storage, registry)
-        assert not (
-            storage.worker_workspace_root / COMPILER_CACHE_LOCK_FILENAME
-        ).exists()
+        assert tuple(storage.worker_workspace_root.iterdir()) == ()
     finally:
         registry.close()
 
 
-def test_local_index_runtime_rejects_invalid_catalog_before_workspace_lease(
+def test_local_index_runtime_rejects_invalid_catalog_before_attempt_pool_bootstrap(
     tmp_path: Path,
 ) -> None:
     storage, registry = _runtime_fixture(tmp_path)
@@ -303,9 +300,7 @@ def test_local_index_runtime_rejects_invalid_catalog_before_workspace_lease(
     try:
         with pytest.raises(CatalogError, match="existing SQLite catalog"):
             LocalIndexRuntimeService.acquire(storage, registry)
-        assert not (
-            storage.worker_workspace_root / COMPILER_CACHE_LOCK_FILENAME
-        ).exists()
+        assert tuple(storage.worker_workspace_root.iterdir()) == ()
     finally:
         registry.close()
 
@@ -366,7 +361,7 @@ def test_local_index_runtime_filters_before_scoped_topology_verification(
         registry.close()
 
 
-def test_local_index_runtime_scopes_shared_lease_and_runtime_providers(
+def test_local_index_runtime_scopes_attempt_routes_and_runtime_providers(
     tmp_path: Path,
 ) -> None:
     storage, registry = _runtime_fixture(tmp_path)
@@ -376,12 +371,19 @@ def test_local_index_runtime_scopes_shared_lease_and_runtime_providers(
         registry,
     )
     service = LocalIndexRuntimeService.acquire(storage, registry)
+    service.start()
+    repository_ids = {
+        binding.repo_id: binding.repository_id for binding in storage.repositories
+    }
+    registrations = service._attempt_pool._by_repository
+    assert set(registrations) == set(repository_ids.values())
+    assert (
+        registrations[repository_ids["demo"]].target.attempt_pool_root
+        != registrations[repository_ids["other"]].target.attempt_pool_root
+    )
     displaced = tmp_path / "demo-displaced"
     repositories["demo"].rename(displaced)
     try:
-        # Attempt-pool ownership depends only on catalog/CAS/workspace roots.
-        service._attempt_pool_lease_owner.require_held()
-
         loader = service._background._runtime._reconciler._publisher._loader
         targets = {
             target.binding.repo_id: target for target in loader._by_storage.values()
@@ -397,6 +399,31 @@ def test_local_index_runtime_scopes_shared_lease_and_runtime_providers(
             match="repository topology changed",
         ):
             targets["demo"].workspace_provider.require_support()
+
+        created = service.writer.create(
+            "other",
+            indexes=("bm25",),
+            mode="full",
+            force=False,
+            idempotency_key="healthy-route-after-foreign-drift",
+        )
+        deadline = time.monotonic() + 15
+        observed = created
+        while observed.status in {"queued", "running"}:
+            if time.monotonic() >= deadline:
+                pytest.fail("healthy repository job did not settle after foreign drift")
+            time.sleep(0.02)
+            observed = service.reader.get(created.job_id)
+        assert observed.status == "succeeded"
+
+        healthy_registration = registrations[repository_ids["other"]]
+        while tuple(
+            healthy_registration.target.attempt_pool_root.glob(".*codenib-source-job-*")
+        ):
+            if time.monotonic() >= deadline:
+                pytest.fail("healthy repository receipt was not routed to its shard")
+            time.sleep(0.02)
+        service._attempt_pool.reclaim_stale(repository_ids["other"])
     finally:
         displaced.rename(repositories["demo"])
         service.close()
@@ -422,107 +449,37 @@ def test_local_index_runtime_preserves_context_failure_after_cleanup(
     assert service.closed is True
 
 
-def test_local_index_runtime_rejects_a_second_attempt_pool_owner(
+def test_local_index_runtime_allows_cooperating_workers_on_the_same_shard(
     tmp_path: Path,
 ) -> None:
     storage, registry = _runtime_fixture(tmp_path)
     try:
-        with open_local_index_runtime_service(storage, registry) as service:
-            with pytest.raises(LocalIndexServiceError, match="workspace lease"):
-                LocalIndexRuntimeService.acquire(storage, registry)
-            assert service.healthy is True
+        with open_local_index_runtime_service(storage, registry) as first:
+            with open_local_index_runtime_service(storage, registry) as second:
+                assert first.healthy is True
+                assert second.healthy is True
+                first_target = next(
+                    iter(first._attempt_pool._by_repository.values())
+                ).target
+                second_target = next(
+                    iter(second._attempt_pool._by_repository.values())
+                ).target
+                assert first_target.attempt_pool_root == second_target.attempt_pool_root
         with open_local_index_runtime_service(storage, registry) as restarted:
             assert restarted.healthy is True
     finally:
         registry.close()
 
 
-def test_attempt_pool_lease_owner_retains_interrupted_enter(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    active = False
-    events: list[str] = []
-
-    class InterruptedContext:
-        def __enter__(self):
-            nonlocal active
-            active = True
-            events.append("enter")
-            raise KeyboardInterrupt("interrupt after lease acquisition")
-
-        def __exit__(self, *_args):
-            nonlocal active
-            active = False
-            events.append("exit")
-            return False
-
-    def lease_factory(root: Path, *, create: bool, check_cancelled):
-        assert root == tmp_path
-        assert create is True
-        assert callable(check_cancelled)
-        return InterruptedContext()
-
-    monkeypatch.setattr(
-        local_runtime_module,
-        "compiler_cache_lock",
-        lease_factory,
-    )
-    owner = local_runtime_module._LocalAttemptPoolLeaseOwner()
-
-    with pytest.raises(KeyboardInterrupt, match="after lease acquisition"):
-        owner.acquire(
-            tmp_path,
-            wait_timeout_ms=0,
-            topology_verifier=lambda: events.append("verify"),
-        )
-
-    assert active is True
-    assert owner.closed is False
-    owner.close()
-    assert active is False
-    assert owner.closed is True
-    assert events == ["verify", "enter", "exit"]
-
-
-def test_attempt_pool_lease_owner_verifies_before_publishing_context(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    events: list[str] = []
-
-    monkeypatch.setattr(
-        local_runtime_module,
-        "compiler_cache_lock",
-        lambda *_args, **_kwargs: pytest.fail(
-            "lock context must follow the initial topology check"
-        ),
-    )
-    owner = local_runtime_module._LocalAttemptPoolLeaseOwner()
-
-    def reject_topology() -> None:
-        events.append("verify")
-        raise LocalIndexServiceError("workspace binding changed")
-
-    with pytest.raises(LocalIndexServiceError, match="binding changed"):
-        owner.acquire(
-            tmp_path,
-            wait_timeout_ms=0,
-            topology_verifier=reject_topology,
-        )
-
-    assert events == ["verify"]
-    assert owner.closed
-    owner.close()
-
-
 def test_local_index_runtime_reclaims_stale_attempts_before_start(
     tmp_path: Path,
 ) -> None:
     storage, registry = _runtime_fixture(tmp_path)
-    stale = storage.worker_workspace_root / (
-        f".codenib-source-job-{'a' * 32}.normalize-{'b' * 24}"
+    shard = storage.worker_workspace_root / (
+        ".codenib-bm25-attempt-pool-v1-" + storage.repositories[0].repository_id
     )
+    shard.mkdir(mode=0o700)
+    stale = shard / (f".codenib-source-job-{'a' * 32}.normalize-{'b' * 24}")
     stale.mkdir()
     (stale / "payload").write_text("stale", encoding="utf-8")
     try:
@@ -532,36 +489,56 @@ def test_local_index_runtime_reclaims_stale_attempts_before_start(
         registry.close()
 
 
-def test_local_index_runtime_retains_lease_when_reaper_cleanup_fails(
+def test_local_index_runtime_retains_routed_reaper_cleanup_owner(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     storage, registry = _runtime_fixture(tmp_path)
     service = LocalIndexRuntimeService.acquire(storage, registry)
     service.start()
-    reaper_type = type(service._attempt_pool)
-    real_close = reaper_type.close
+    real_reclaim = local_runtime_module.LocalBM25AttemptPoolCoordinator.reclaim
     attempts = 0
 
-    def fail_once(reaper) -> None:
+    class RetryOwner:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    cleanup_owner = RetryOwner()
+    failure = RuntimeError("routed reaper cleanup failed")
+    failure.publication_cleanup_owners = (cleanup_owner,)  # type: ignore[attr-defined]
+
+    def fail_once(coordinator, *, caller_asserts_quiescence=False):
         nonlocal attempts
         attempts += 1
         if attempts == 1:
-            raise RuntimeError("reaper cleanup failed")
-        real_close(reaper)
+            raise failure
+        return real_reclaim(
+            coordinator,
+            caller_asserts_quiescence=caller_asserts_quiescence,
+        )
 
-    monkeypatch.setattr(reaper_type, "close", fail_once)
+    monkeypatch.setattr(
+        local_runtime_module.LocalBM25AttemptPoolCoordinator,
+        "reclaim",
+        fail_once,
+    )
     try:
-        with pytest.raises(RuntimeError, match="reaper cleanup failed"):
+        with pytest.raises(RuntimeError, match="routed reaper cleanup failed"):
             service.close()
 
         assert service.state == "closed"
         assert service._attempt_pool.closed is False
-        assert service._attempt_pool_lease_owner.closed is False
         assert service._object_store_owner.closed is True
         assert service._topology.closed is False
+        registration = next(iter(service._attempt_pool._by_repository.values()))
+        assert registration.cleanup_owners == [cleanup_owner]
+        assert cleanup_owner.closed is False
 
         service.close()
+        assert cleanup_owner.closed is True
+        assert registration.cleanup_owners == []
         assert service.closed is True
     finally:
         if not service.closed:
@@ -595,7 +572,6 @@ def test_local_index_runtime_retains_resources_when_background_join_fails(
 
         assert service.state == "running"
         assert service._attempt_pool.closed is False
-        assert service._attempt_pool_lease_owner.closed is False
         assert service._object_store_owner.closed is False
         assert service._topology.closed is False
 
@@ -612,8 +588,12 @@ def test_local_index_runtime_executes_submitted_bm25_job(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     storage, registry = _runtime_fixture(tmp_path)
+    attempt_pool_root: Path | None = None
     try:
         with open_local_index_runtime_service(storage, registry) as service:
+            attempt_pool_root = next(
+                iter(service._attempt_pool._by_repository.values())
+            ).target.attempt_pool_root
             created = service.writer.create(
                 "demo",
                 indexes=("bm25",),
@@ -639,7 +619,7 @@ def test_local_index_runtime_executes_submitted_bm25_job(
                 and event.outcome == "succeeded"
                 for event in observed.events
             )
-            while tuple(storage.worker_workspace_root.glob(".*codenib-source-job-*")):
+            while tuple(attempt_pool_root.glob(".*codenib-source-job-*")):
                 if time.monotonic() >= deadline:
                     pytest.fail("background BM25 attempt receipt was not reclaimed")
                 time.sleep(0.02)
@@ -647,8 +627,10 @@ def test_local_index_runtime_executes_submitted_bm25_job(
     finally:
         registry.close()
 
+    assert attempt_pool_root is not None
     workspace_entries = tuple(storage.worker_workspace_root.iterdir())
-    assert [entry.name for entry in workspace_entries] == [COMPILER_CACHE_LOCK_FILENAME]
+    assert workspace_entries == (attempt_pool_root,)
+    assert tuple(attempt_pool_root.iterdir()) == ()
     assert not any(
         "attempt-root orphan" in record.getMessage() for record in caplog.records
     )

--- a/test/web/test_local_index_runtime.py
+++ b/test/web/test_local_index_runtime.py
@@ -24,6 +24,7 @@ from codenib.storage import (
     IndexJobStatus,
     LocalCAS,
     SQLiteCatalog,
+    StorageIntegrityError,
     StorageNotFound,
 )
 from codenib.web.config import (
@@ -135,6 +136,46 @@ def _runtime_fixture(
         ),
     )
     return storage, registry
+
+
+def _add_second_runtime_repository(
+    tmp_path: Path,
+    storage: LocalIndexStorageConfig,
+    registry: RepoRegistry,
+) -> tuple[LocalIndexStorageConfig, dict[str, Path]]:
+    parent = tmp_path / "other-root"
+    parent.mkdir()
+    repository, commit = _repository(parent)
+    with SQLiteCatalog(storage.catalog_path, create=False) as catalog:
+        repository_id = catalog.create_repository("org/other")
+    binding = LocalIndexStorageRepository(
+        repo_id="other",
+        repository_key="org/other",
+    )
+    assert binding.repository_id == repository_id
+    registry._bundles["other"] = RepoBundle(
+        entry=RepoEntry(
+            instance_id="other",
+            repo="org/other",
+            base_commit=commit,
+            language="python",
+            repo_dir=str(repository),
+            manifest_path=str(parent / "repo_manifest.json"),
+        ),
+        manifest=RepoManifest(
+            repo_path=str(repository),
+            commit=commit,
+            last_indexed_commit=commit,
+            languages=["python"],
+        ),
+    )
+    return (
+        replace(storage, repositories=(*storage.repositories, binding)),
+        {
+            "demo": Path(registry._bundles["demo"].entry.repo_dir),
+            "other": repository,
+        },
+    )
 
 
 def _candidate(repository_id: str, *, idempotency_key: str) -> IndexJobRecord:
@@ -325,6 +366,43 @@ def test_local_index_runtime_filters_before_scoped_topology_verification(
         registry.close()
 
 
+def test_local_index_runtime_scopes_shared_lease_and_runtime_providers(
+    tmp_path: Path,
+) -> None:
+    storage, registry = _runtime_fixture(tmp_path)
+    storage, repositories = _add_second_runtime_repository(
+        tmp_path,
+        storage,
+        registry,
+    )
+    service = LocalIndexRuntimeService.acquire(storage, registry)
+    displaced = tmp_path / "demo-displaced"
+    repositories["demo"].rename(displaced)
+    try:
+        # Attempt-pool ownership depends only on catalog/CAS/workspace roots.
+        service._attempt_pool_lease_owner.require_held()
+
+        loader = service._background._runtime._reconciler._publisher._loader
+        targets = {
+            target.binding.repo_id: target for target in loader._by_storage.values()
+        }
+        assert set(targets) == {"demo", "other"}
+        assert (
+            targets["demo"].workspace_provider
+            is not targets["other"].workspace_provider
+        )
+        targets["other"].workspace_provider.require_support()
+        with pytest.raises(
+            StorageIntegrityError,
+            match="repository topology changed",
+        ):
+            targets["demo"].workspace_provider.require_support()
+    finally:
+        displaced.rename(repositories["demo"])
+        service.close()
+        registry.close()
+
+
 def test_local_index_runtime_preserves_context_failure_after_cleanup(
     tmp_path: Path,
 ) -> None:
@@ -405,6 +483,37 @@ def test_attempt_pool_lease_owner_retains_interrupted_enter(
     assert active is False
     assert owner.closed is True
     assert events == ["verify", "enter", "exit"]
+
+
+def test_attempt_pool_lease_owner_verifies_before_publishing_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    monkeypatch.setattr(
+        local_runtime_module,
+        "compiler_cache_lock",
+        lambda *_args, **_kwargs: pytest.fail(
+            "lock context must follow the initial topology check"
+        ),
+    )
+    owner = local_runtime_module._LocalAttemptPoolLeaseOwner()
+
+    def reject_topology() -> None:
+        events.append("verify")
+        raise LocalIndexServiceError("workspace binding changed")
+
+    with pytest.raises(LocalIndexServiceError, match="binding changed"):
+        owner.acquire(
+            tmp_path,
+            wait_timeout_ms=0,
+            topology_verifier=reject_topology,
+        )
+
+    assert events == ["verify"]
+    assert owner.closed
+    owner.close()
 
 
 def test_local_index_runtime_reclaims_stale_attempts_before_start(

--- a/test/web/test_local_index_runtime.py
+++ b/test/web/test_local_index_runtime.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import os
 import subprocess
 import time
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -15,7 +16,16 @@ import codenib.web.local_index_runtime as local_runtime_module
 from codenib.compiler.cache_lock import COMPILER_CACHE_LOCK_FILENAME
 from codenib.compiler.manifest import RepoManifest
 from codenib.repository_source_selection import RepositorySourceSelection
-from codenib.storage import LocalCAS, SQLiteCatalog
+from codenib.storage import (
+    INDEX_JOB_REQUEST_CONTRACT,
+    CatalogError,
+    IndexJobRecord,
+    IndexJobRequest,
+    IndexJobStatus,
+    LocalCAS,
+    SQLiteCatalog,
+    StorageNotFound,
+)
 from codenib.web.config import (
     LocalIndexRuntimeConfig,
     LocalIndexStorageConfig,
@@ -28,7 +38,10 @@ from codenib.web.local_index_runtime import (
     LocalIndexRuntimeService,
     open_local_index_runtime_service,
 )
-from codenib.web.local_index_service import LocalIndexServiceError
+from codenib.web.local_index_service import (
+    LocalIndexServiceError,
+    LocalIndexStorageTopology,
+)
 from codenib.web.repo_registry import RepoBundle, RepoRegistry
 
 
@@ -65,6 +78,8 @@ def _repository(root: Path) -> tuple[Path, str]:
 
 def _runtime_fixture(
     tmp_path: Path,
+    *,
+    registry_mode: str = "sparse",
 ) -> tuple[LocalIndexStorageConfig, RepoRegistry]:
     repository, commit = _repository(tmp_path)
     catalog_path = tmp_path / "catalog.sqlite3"
@@ -98,7 +113,10 @@ def _runtime_fixture(
         ),
         runtime=LocalIndexRuntimeConfig(poll_interval_ms=10),
     )
-    registry = RepoRegistry(QAConfig(mode="sparse"))
+    registry = RepoRegistry(
+        QAConfig(mode=registry_mode),
+        allow_missing_native_index_authorization=registry_mode == "hybrid",
+    )
     registry._bundles["demo"] = RepoBundle(
         entry=RepoEntry(
             instance_id="demo",
@@ -117,6 +135,45 @@ def _runtime_fixture(
         ),
     )
     return storage, registry
+
+
+def _candidate(repository_id: str, *, idempotency_key: str) -> IndexJobRecord:
+    request = IndexJobRequest.create(
+        repository_id,
+        "src_" + "a" * 64,
+        idempotency_key,
+        {
+            "contract": INDEX_JOB_REQUEST_CONTRACT,
+            "views": {
+                "bm25": {
+                    "profile_id": "profile_" + "b" * 64,
+                    "requested_mode": "full",
+                    "required": True,
+                }
+            },
+        },
+    )
+    return IndexJobRecord(
+        job_id=request.job_id,
+        repository_id=request.repository_id,
+        source_revision_id=request.source_revision_id,
+        ref_name=request.ref_name,
+        idempotency_key=request.idempotency_key,
+        expected_ref_generation=request.expected_ref_generation,
+        max_attempts=request.max_attempts,
+        request_json=request.request_json,
+        request_digest=request.request_digest,
+        status=IndexJobStatus.QUEUED,
+        cancel_requested=False,
+        attempt_count=0,
+        result_snapshot_id=None,
+        error_code=None,
+        error_message=None,
+        created_at_ms=1,
+        updated_at_ms=1,
+        started_at_ms=None,
+        finished_at_ms=None,
+    )
 
 
 def test_local_index_runtime_composes_and_settles_production_loops(
@@ -142,6 +199,121 @@ def test_local_index_runtime_composes_and_settles_production_loops(
     assert service is not None
     assert service.state == "closed"
     assert service.closed is True
+
+
+def test_local_index_runtime_rejects_loaded_repository_identity_mismatch(
+    tmp_path: Path,
+) -> None:
+    storage, registry = _runtime_fixture(tmp_path)
+    bundle = registry._bundles["demo"]
+    registry._bundles["demo"] = RepoBundle(
+        entry=replace(bundle.entry, repo="other/repo"),
+        manifest=bundle.manifest,
+    )
+    try:
+        with pytest.raises(LocalIndexServiceError, match="identity differs"):
+            LocalIndexRuntimeService.acquire(storage, registry)
+    finally:
+        registry.close()
+
+
+def test_local_index_runtime_rejects_hybrid_registry_before_acquisition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage, registry = _runtime_fixture(tmp_path, registry_mode="hybrid")
+    monkeypatch.setattr(
+        LocalIndexStorageTopology,
+        "acquire",
+        lambda *_args, **_kwargs: pytest.fail(
+            "hybrid mode must be rejected before topology acquisition"
+        ),
+    )
+    try:
+        with pytest.raises(LocalIndexServiceError, match="sparse Web mode"):
+            LocalIndexRuntimeService.acquire(storage, registry)
+    finally:
+        registry.close()
+
+
+def test_local_index_runtime_attests_catalog_before_workspace_lease(
+    tmp_path: Path,
+) -> None:
+    storage, registry = _runtime_fixture(tmp_path)
+    storage.catalog_path.unlink()
+    with SQLiteCatalog(storage.catalog_path):
+        pass
+    try:
+        with pytest.raises(StorageNotFound, match="not found"):
+            LocalIndexRuntimeService.acquire(storage, registry)
+        assert not (
+            storage.worker_workspace_root / COMPILER_CACHE_LOCK_FILENAME
+        ).exists()
+    finally:
+        registry.close()
+
+
+def test_local_index_runtime_rejects_invalid_catalog_before_workspace_lease(
+    tmp_path: Path,
+) -> None:
+    storage, registry = _runtime_fixture(tmp_path)
+    storage.catalog_path.unlink()
+    storage.catalog_path.write_bytes(b"not a SQLite catalog")
+    try:
+        with pytest.raises(CatalogError, match="existing SQLite catalog"):
+            LocalIndexRuntimeService.acquire(storage, registry)
+        assert not (
+            storage.worker_workspace_root / COMPILER_CACHE_LOCK_FILENAME
+        ).exists()
+    finally:
+        registry.close()
+
+
+def test_local_index_runtime_filters_before_scoped_topology_verification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage, registry = _runtime_fixture(tmp_path)
+    service = LocalIndexRuntimeService.acquire(storage, registry)
+    expected_repository_id = storage.repositories[0].repository_id
+    calls: list[tuple[str, str | None]] = []
+    monkeypatch.setattr(
+        local_runtime_module.LocalBM25SourceJobResourceFactory,
+        "accepts_candidate",
+        lambda _resources, candidate: (
+            candidate.repository_id == expected_repository_id
+        ),
+    )
+    monkeypatch.setattr(
+        LocalIndexStorageTopology,
+        "verify",
+        lambda _topology: calls.append(("global", None)),
+    )
+    monkeypatch.setattr(
+        LocalIndexStorageTopology,
+        "verify_repository",
+        lambda _topology, repo_id: calls.append(("repository", repo_id)),
+    )
+    candidate_filter = service._background._worker._worker._candidate_filter
+    assert candidate_filter is not None
+    try:
+        assert (
+            candidate_filter(
+                _candidate("repo_unconfigured", idempotency_key="unconfigured")
+            )
+            is False
+        )
+        assert calls == []
+        assert (
+            candidate_filter(
+                _candidate(expected_repository_id, idempotency_key="configured")
+            )
+            is True
+        )
+        assert calls == [("repository", "demo")]
+    finally:
+        service.close()
+        registry.close()
 
 
 def test_local_index_runtime_preserves_context_failure_after_cleanup(

--- a/test/web/test_local_index_runtime.py
+++ b/test/web/test_local_index_runtime.py
@@ -311,6 +311,15 @@ def test_local_index_runtime_filters_before_scoped_topology_verification(
             is True
         )
         assert calls == [("repository", "demo")]
+        target = service._background._worker._worker._resolver.resource_factory.targets[
+            0
+        ]
+        assert target.topology_verifier is not None
+        target.topology_verifier()
+        assert calls == [
+            ("repository", "demo"),
+            ("repository", "demo"),
+        ]
     finally:
         service.close()
         registry.close()


### PR DESCRIPTION
## Summary
Compose the explicit production local Web indexing service from the durable storage and topology boundaries now on `main`. The service opens the strict preprovisioned CAS, assembles BM25 planning/execution and retained activation, owns both background loops, and releases every acquired resource in dependency order.

The branch is based directly on `main` and integrates #738 by giving every configured repository its own permanent BM25 attempt shard with paired writer/reaper routes. FastAPI lifespan installation, default routing, vector/graph adapters, and UI controls remain separate gates.

## Changes
- bootstrap one authenticated BM25 attempt-pool shard and paired route binding per configured repository
- hold `LOCK_SH` only for active source attempts and attempt `LOCK_EX` on the matching route for bounded Web reclamation
- defer a busy exclusive sweep without blocking Web acquisition or shutdown, retaining receipts for a later job or restart
- route authenticated attempt receipts by exact parent path and identity instead of selecting the first configured target
- reclaim only the repository route for the completed job and sweep available configured shards before start and after joined shutdown
- retain retryable routed cleanup owners so interrupted or failed exclusive cleanup can settle on a later close
- isolate repository topology verification so drift in one repository does not block healthy repository work or receipt cleanup
- allow cooperating Web workers to share the same routed shard while catalog job leases serialize execution
- freeze loaded repository identities, languages, source selection, topology authorities, and environment snapshots
- reject mismatched loaded repository identities and non-sparse Web registries before topology acquisition
- receive the topology through its caller-created owner before any public handoff
- open and attest the existing catalog plus every configured durable repository before attempt-pool bootstrap
- compose BM25 source targets, resource resolver, worker, fair scheduler, Web planner, reader, and writer
- filter detached candidates before an O(1) repository-scoped topology validation
- bind each runtime workspace provider to its own repository-scoped topology guard
- compose strict retained snapshot loading, guarded RepoRegistry publication, startup reconciliation, and polling retry
- own worker and reconciler background loops before attempt cleanup, CAS, and topology release
- expose detached repository-scoped BM25 rebuild capabilities without enabling a default route
- document the completed composition boundary and remaining lifespan/vector/UI work

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- compiler attempt-pool, binding, source-job, and Web runtime regression set (160 passed)
- Web planning, activation, loops, writes, reads, runtime, and topology services (126 passed)
- real shared-lease contention verifies non-blocking deferral and no leaked exclusive lease
- pre-commit on every changed file
- range-diff across the latest `main` advancement; prior code commits are equivalent and only the expected roadmap reconciliation changed

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published