### PR TITLE
fix(storage): publish loadable job snapshots

### DIFF
--- a/codenib/compiler/cache_import.py
+++ b/codenib/compiler/cache_import.py
@@ -112,7 +112,8 @@ from .manifest_import import (
     _expected_generation,
     _expected_namespace_id,
     _positive_limit,
-    _prepare_job_view_artifacts_inside_authority,
+    _prepare_job_snapshot_artifacts_inside_authority,
+    _PreparedJobSnapshotArtifacts,
     _require_static_methods,
     _snapshot_environment,
     _snapshot_forbidden_paths,
@@ -126,6 +127,11 @@ from .manifest_storage import (
     _preflight_json_bytes,
     _strict_json_loads,
     plan_repo_manifest_import_bytes,
+)
+from .retained_manifest_contract import (
+    REPO_MANIFEST_PROJECTION_SCHEMA,
+    REPO_MANIFEST_PROJECTION_VIEW,
+    repo_manifest_projection_profile,
 )
 from .snapshot_store import normalize_repo
 
@@ -460,6 +466,7 @@ class CompilerCacheJobPreparationResult:
     recapture: CompilerCacheViewRecaptureResult
     context_artifact: ContextArtifactResult
     artifact: IndexJobViewArtifact
+    supporting_artifacts: tuple[IndexJobViewArtifact, ...]
 
     def __post_init__(self) -> None:
         if type(self) is not CompilerCacheJobPreparationResult:
@@ -480,6 +487,15 @@ class CompilerCacheJobPreparationResult:
             raise TypeError("compiler cache prepared context artifact is invalid")
         if type(self.artifact) is not IndexJobViewArtifact:
             raise TypeError("compiler cache prepared view artifact is invalid")
+        if (
+            type(self.supporting_artifacts) is not tuple
+            or len(self.supporting_artifacts) != 1
+            or any(
+                type(artifact) is not IndexJobViewArtifact
+                for artifact in self.supporting_artifacts
+            )
+        ):
+            raise TypeError("compiler cache prepared supporting artifacts are invalid")
         try:
             job = _detach_index_job_record(self.job)
             view = _detach_index_job_views((self.view,))[0]
@@ -516,6 +532,11 @@ class CompilerCacheJobPreparationResult:
             or self.artifact.view_type != view.view_type
             or self.artifact.profile_id != view.profile_id
             or self.artifact.schema_version != VIEW_BUNDLE_SCHEMA
+            or self.supporting_artifacts[0].view_type != REPO_MANIFEST_PROJECTION_VIEW
+            or self.supporting_artifacts[0].profile_id
+            != repo_manifest_projection_profile().profile_id
+            or self.supporting_artifacts[0].schema_version
+            != REPO_MANIFEST_PROJECTION_SCHEMA
         ):
             raise StorageIntegrityError(
                 "compiler cache job preparation identities are inconsistent"
@@ -523,6 +544,11 @@ class CompilerCacheJobPreparationResult:
         object.__setattr__(self, "job", job)
         object.__setattr__(self, "view", view)
         object.__setattr__(self, "manifest", manifest)
+        object.__setattr__(
+            self,
+            "supporting_artifacts",
+            tuple(self.supporting_artifacts),
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -2193,8 +2219,8 @@ def _ingest_prepared_compiler_cache_job(
     context_output_owner: PublishedWorkspaceReceiptOwner,
     object_store: RetainedImportObjectStore,
     check_cancelled: Callable[[], None] | None = None,
-) -> IndexJobViewArtifact:
-    """Ingest one prepared cache view without granting catalog authority."""
+) -> _PreparedJobSnapshotArtifacts:
+    """Ingest one loadable cache snapshot without catalog authority."""
 
     if type(preparation) is not _PreparedCompilerCacheImport:
         raise TypeError("compiler cache job preparation is invalid")
@@ -2210,7 +2236,7 @@ def _ingest_prepared_compiler_cache_job(
     if check_cancelled is not None:
         check_cancelled()
     artifacts = context_output_owner.consume(
-        lambda receipt, publication: _prepare_job_view_artifacts_inside_authority(
+        lambda receipt, publication: _prepare_job_snapshot_artifacts_inside_authority(
             receipt,
             publication,
             plan=preparation.import_plan,
@@ -2225,15 +2251,20 @@ def _ingest_prepared_compiler_cache_job(
             max_bundle_files=operation.inputs.max_bundle_files,
             max_bundle_bytes=operation.inputs.max_bundle_bytes,
             max_bundle_metadata_bytes=operation.inputs.max_bundle_metadata_bytes,
+            max_projection_bytes=operation.inputs.max_projection_bytes,
             check_cancelled=check_cancelled,
         ),
         check_cancelled=check_cancelled,
     )
-    if type(artifacts) is not tuple or len(artifacts) != 1:
+    if (
+        type(artifacts) is not _PreparedJobSnapshotArtifacts
+        or len(artifacts.artifacts) != 1
+        or len(artifacts.supporting_artifacts) != 1
+    ):
         raise StorageIntegrityError(
             f"compiler cache {view_type} ingestion returned invalid job artifacts"
         )
-    artifact = artifacts[0]
+    artifact = artifacts.artifacts[0]
     if (
         type(artifact) is not IndexJobViewArtifact
         or artifact.view_type != binding.view.view_type
@@ -2255,7 +2286,7 @@ def _ingest_prepared_compiler_cache_job(
         )
     if check_cancelled is not None:
         check_cancelled()
-    return artifact
+    return artifacts
 
 
 def import_compiler_cache(
@@ -2652,7 +2683,7 @@ def prepare_compiler_cache_job_view_from_generation(
     )
     if check_cancelled is not None:
         check_cancelled()
-    artifact = _ingest_prepared_compiler_cache_job(
+    snapshot_artifacts = _ingest_prepared_compiler_cache_job(
         preparation,
         operation,
         binding,
@@ -2669,7 +2700,8 @@ def prepare_compiler_cache_job_view_from_generation(
         import_plan=preparation.import_plan,
         recapture=preparation.recaptures[0],
         context_artifact=preparation.context_artifact,
-        artifact=artifact,
+        artifact=snapshot_artifacts.artifacts[0],
+        supporting_artifacts=snapshot_artifacts.supporting_artifacts,
     )
     if check_cancelled is not None:
         check_cancelled()
@@ -2757,7 +2789,7 @@ def prepare_compiler_cache_job_view(
         )
     if check_cancelled is not None:
         check_cancelled()
-    artifact = _ingest_prepared_compiler_cache_job(
+    snapshot_artifacts = _ingest_prepared_compiler_cache_job(
         preparation,
         operation,
         binding,
@@ -2778,7 +2810,8 @@ def prepare_compiler_cache_job_view(
         import_plan=preparation.import_plan,
         recapture=preparation.recaptures[0],
         context_artifact=preparation.context_artifact,
-        artifact=artifact,
+        artifact=snapshot_artifacts.artifacts[0],
+        supporting_artifacts=snapshot_artifacts.supporting_artifacts,
     )
     if check_cancelled is not None:
         check_cancelled()
@@ -2858,6 +2891,7 @@ class CompilerCacheJobExecutor:
                 ),
             ),
             retryable=False,
+            supporting_artifacts=prepared.supporting_artifacts,
         )
 
 
@@ -2955,7 +2989,7 @@ def _publish_compiler_cache_job(
             "compiler cache job or repository source changed before CAS ingestion"
         )
 
-    artifact = _ingest_prepared_compiler_cache_job(
+    snapshot_artifacts = _ingest_prepared_compiler_cache_job(
         preparation,
         operation,
         binding,
@@ -2991,7 +3025,10 @@ def _publish_compiler_cache_job(
         object_store=object_store,
         owner_id=normalized_owner_id,
         fencing_token=token,
-        outputs=(artifact,),
+        outputs=(
+            *snapshot_artifacts.artifacts,
+            *snapshot_artifacts.supporting_artifacts,
+        ),
     )
     return preparation, completed
 

--- a/codenib/compiler/cache_import.py
+++ b/codenib/compiler/cache_import.py
@@ -2233,6 +2233,7 @@ def _ingest_prepared_compiler_cache_job(
     context_output_owner: PublishedWorkspaceReceiptOwner,
     object_store: RetainedImportObjectStore,
     check_cancelled: Callable[[], None] | None = None,
+    replay_job: IndexJobRecord | None = None,
 ) -> _PreparedJobSnapshotArtifacts:
     """Ingest one loadable cache snapshot without catalog authority."""
 
@@ -2242,6 +2243,12 @@ def _ingest_prepared_compiler_cache_job(
         raise TypeError("compiler cache job operation is invalid")
     if type(binding) is not _CompilerCacheJobBinding:
         raise TypeError("compiler cache job binding is invalid")
+    if replay_job is not None and (
+        type(replay_job) is not IndexJobRecord
+        or replay_job.status is not IndexJobStatus.SUCCEEDED
+        or replay_job.result_snapshot_id is None
+    ):
+        raise TypeError("compiler cache replay job is invalid")
     _require_compiler_cache_job_profile(
         binding,
         preparation.import_plan,
@@ -2249,6 +2256,19 @@ def _ingest_prepared_compiler_cache_job(
     )
     if check_cancelled is not None:
         check_cancelled()
+    projection_decider: Callable[[tuple[IndexJobViewArtifact, ...]], bool] | None = None
+    if replay_job is not None:
+
+        def require_projection(
+            artifacts: tuple[IndexJobViewArtifact, ...],
+        ) -> bool:
+            return replay_job.result_snapshot_id != _index_job_artifact_snapshot_id(
+                replay_job,
+                artifacts,
+            )
+
+        projection_decider = require_projection
+
     artifacts = context_output_owner.consume(
         lambda receipt, publication: _prepare_job_snapshot_artifacts_inside_authority(
             receipt,
@@ -2266,6 +2286,7 @@ def _ingest_prepared_compiler_cache_job(
             max_bundle_bytes=operation.inputs.max_bundle_bytes,
             max_bundle_metadata_bytes=operation.inputs.max_bundle_metadata_bytes,
             max_projection_bytes=operation.inputs.max_projection_bytes,
+            projection_required=projection_decider,
             check_cancelled=check_cancelled,
         ),
         check_cancelled=check_cancelled,
@@ -2273,8 +2294,21 @@ def _ingest_prepared_compiler_cache_job(
     if (
         type(artifacts) is not _PreparedJobSnapshotArtifacts
         or len(artifacts.artifacts) != 1
-        or len(artifacts.supporting_artifacts) != 1
+        or len(artifacts.supporting_artifacts) > 1
     ):
+        raise StorageIntegrityError(
+            f"compiler cache {view_type} ingestion returned invalid job artifacts"
+        )
+    expected_supporting_artifacts = 1
+    if replay_job is not None:
+        requested_snapshot_id = _index_job_artifact_snapshot_id(
+            replay_job,
+            artifacts.artifacts,
+        )
+        expected_supporting_artifacts = int(
+            replay_job.result_snapshot_id != requested_snapshot_id
+        )
+    if len(artifacts.supporting_artifacts) != expected_supporting_artifacts:
         raise StorageIntegrityError(
             f"compiler cache {view_type} ingestion returned invalid job artifacts"
         )
@@ -3011,6 +3045,9 @@ def _publish_compiler_cache_job(
             "compiler cache job or repository source changed before CAS ingestion"
         )
 
+    # A schema-v7 success has no support projection. Decide from the requested
+    # artifacts before any projection measurement or write, while retaining a
+    # single ingestion pass for current loadable snapshots.
     snapshot_artifacts = _ingest_prepared_compiler_cache_job(
         preparation,
         operation,
@@ -3019,6 +3056,9 @@ def _publish_compiler_cache_job(
         repository_source=repository_source,
         context_output_owner=context_output_owner,
         object_store=object_store,
+        replay_job=(
+            current.job if current.job.status is IndexJobStatus.SUCCEEDED else None
+        ),
     )
     current = _read_compiler_cache_job_binding(
         normalized_job_id,

--- a/codenib/compiler/cache_import.py
+++ b/codenib/compiler/cache_import.py
@@ -90,7 +90,11 @@ from ..storage.protocols import (
     RetainedImportCatalog,
     RetainedImportObjectStore,
 )
-from ..storage.publication import IndexJobViewArtifact, publish_job_artifacts
+from ..storage.publication import (
+    IndexJobViewArtifact,
+    _index_job_artifact_snapshot_id,
+    publish_job_artifacts,
+)
 from ..storage.view_bundle import (
     DEFAULT_MAX_BUNDLE_BYTES,
     DEFAULT_MAX_BUNDLE_FILES,
@@ -1167,6 +1171,7 @@ def _preflight_cache_job_operation(
     max_bundle_files: int,
     max_bundle_bytes: int,
     max_bundle_metadata_bytes: int,
+    max_projection_bytes: int,
     forbidden_paths: Iterable[Path],
     environ: Mapping[str, str] | None,
 ) -> tuple[_ImportOperation, _CompilerCacheJobBinding, str, str, int]:
@@ -1204,6 +1209,10 @@ def _preflight_cache_job_operation(
     bundle_metadata_bytes = _positive_limit(
         max_bundle_metadata_bytes,
         "bundle metadata byte limit",
+    )
+    projection_bytes = _positive_limit(
+        max_projection_bytes,
+        "projection byte limit",
     )
     environment = _snapshot_environment(environ)
     forbidden = _snapshot_forbidden_paths(forbidden_paths)
@@ -1243,7 +1252,7 @@ def _preflight_cache_job_operation(
         max_bundle_files=bundle_files,
         max_bundle_bytes=bundle_bytes,
         max_bundle_metadata_bytes=bundle_metadata_bytes,
-        max_projection_bytes=DEFAULT_MAX_PROJECTION_BYTES,
+        max_projection_bytes=projection_bytes,
         forbidden_paths=forbidden,
         environment=environment,
     )
@@ -1298,6 +1307,7 @@ def _preflight_cache_job_preparation_operation(
     max_bundle_files: int,
     max_bundle_bytes: int,
     max_bundle_metadata_bytes: int,
+    max_projection_bytes: int,
     forbidden_paths: Iterable[Path],
     environ: Mapping[str, str] | None,
     check_cancelled: Callable[[], None] | None = None,
@@ -1355,6 +1365,10 @@ def _preflight_cache_job_preparation_operation(
         max_bundle_metadata_bytes,
         "bundle metadata byte limit",
     )
+    projection_bytes = _positive_limit(
+        max_projection_bytes,
+        "projection byte limit",
+    )
     environment = _snapshot_environment(environ)
     forbidden = _snapshot_forbidden_paths(forbidden_paths)
     if not isinstance(object_store, RetainedImportObjectStore):
@@ -1388,7 +1402,7 @@ def _preflight_cache_job_preparation_operation(
         max_bundle_files=bundle_files,
         max_bundle_bytes=bundle_bytes,
         max_bundle_metadata_bytes=bundle_metadata_bytes,
-        max_projection_bytes=DEFAULT_MAX_PROJECTION_BYTES,
+        max_projection_bytes=projection_bytes,
         forbidden_paths=forbidden,
         environment=environment,
     )
@@ -2618,6 +2632,7 @@ def prepare_compiler_cache_job_view_from_generation(
     max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
     max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
     max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
     forbidden_paths: Iterable[Path] = (),
     environ: Mapping[str, str] | None = None,
 ) -> CompilerCacheJobPreparationResult:
@@ -2656,6 +2671,7 @@ def prepare_compiler_cache_job_view_from_generation(
         max_bundle_files=max_bundle_files,
         max_bundle_bytes=max_bundle_bytes,
         max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        max_projection_bytes=max_projection_bytes,
         forbidden_paths=forbidden_paths,
         environ=environ,
         check_cancelled=check_cancelled,
@@ -2730,6 +2746,7 @@ def prepare_compiler_cache_job_view(
     max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
     max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
     max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
     forbidden_paths: Iterable[Path] = (),
     environ: Mapping[str, str] | None = None,
 ) -> CompilerCacheJobPreparationResult:
@@ -2767,6 +2784,7 @@ def prepare_compiler_cache_job_view(
         max_bundle_files=max_bundle_files,
         max_bundle_bytes=max_bundle_bytes,
         max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        max_projection_bytes=max_projection_bytes,
         forbidden_paths=forbidden_paths,
         environ=environ,
         check_cancelled=check_cancelled,
@@ -2845,6 +2863,7 @@ class CompilerCacheJobExecutor:
     max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES
     max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES
     max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES
+    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES
     forbidden_paths: Iterable[Path] = ()
     environ: Mapping[str, str] | None = None
 
@@ -2877,6 +2896,7 @@ class CompilerCacheJobExecutor:
             max_bundle_files=self.max_bundle_files,
             max_bundle_bytes=self.max_bundle_bytes,
             max_bundle_metadata_bytes=self.max_bundle_metadata_bytes,
+            max_projection_bytes=self.max_projection_bytes,
             forbidden_paths=self.forbidden_paths,
             environ=self.environ,
         )
@@ -2918,6 +2938,7 @@ def _publish_compiler_cache_job(
     max_bundle_files: int,
     max_bundle_bytes: int,
     max_bundle_metadata_bytes: int,
+    max_projection_bytes: int,
     forbidden_paths: Iterable[Path],
     environ: Mapping[str, str] | None,
 ) -> tuple[_PreparedCompilerCacheImport, IndexJobRecord]:
@@ -2951,6 +2972,7 @@ def _publish_compiler_cache_job(
         max_bundle_files=max_bundle_files,
         max_bundle_bytes=max_bundle_bytes,
         max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        max_projection_bytes=max_projection_bytes,
         forbidden_paths=forbidden_paths,
         environ=environ,
     )
@@ -3019,16 +3041,33 @@ def _publish_compiler_cache_job(
         raise StorageIntegrityError(
             "compiler cache job or repository source changed before publication"
         )
+    publication_artifacts = (
+        *snapshot_artifacts.artifacts,
+        *snapshot_artifacts.supporting_artifacts,
+    )
+    if current.job.status is IndexJobStatus.SUCCEEDED:
+        historical_snapshot_id = current.job.result_snapshot_id
+        requested_snapshot_id = _index_job_artifact_snapshot_id(
+            current.job,
+            snapshot_artifacts.artifacts,
+        )
+        complete_snapshot_id = _index_job_artifact_snapshot_id(
+            current.job,
+            publication_artifacts,
+        )
+        if historical_snapshot_id == requested_snapshot_id:
+            publication_artifacts = snapshot_artifacts.artifacts
+        elif historical_snapshot_id != complete_snapshot_id:
+            raise StorageIntegrityError(
+                "successful compiler cache job has an unknown publication snapshot"
+            )
     completed = publish_job_artifacts(
         normalized_job_id,
         catalog=catalog,
         object_store=object_store,
         owner_id=normalized_owner_id,
         fencing_token=token,
-        outputs=(
-            *snapshot_artifacts.artifacts,
-            *snapshot_artifacts.supporting_artifacts,
-        ),
+        outputs=publication_artifacts,
     )
     return preparation, completed
 
@@ -3055,6 +3094,7 @@ def publish_compiler_cache_bm25_job(
     max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
     max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
     max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
     forbidden_paths: Iterable[Path] = (),
     environ: Mapping[str, str] | None = None,
 ) -> CompilerCacheJobPublicationResult:
@@ -3091,6 +3131,7 @@ def publish_compiler_cache_bm25_job(
         max_bundle_files=max_bundle_files,
         max_bundle_bytes=max_bundle_bytes,
         max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        max_projection_bytes=max_projection_bytes,
         forbidden_paths=forbidden_paths,
         environ=environ,
     )
@@ -3133,6 +3174,7 @@ def publish_compiler_cache_vector_job(
     max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
     max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
     max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
     forbidden_paths: Iterable[Path] = (),
     environ: Mapping[str, str] | None = None,
 ) -> CompilerCacheVectorJobPublicationResult:
@@ -3167,6 +3209,7 @@ def publish_compiler_cache_vector_job(
         max_bundle_files=max_bundle_files,
         max_bundle_bytes=max_bundle_bytes,
         max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        max_projection_bytes=max_projection_bytes,
         forbidden_paths=forbidden_paths,
         environ=environ,
     )

--- a/codenib/compiler/manifest_export.py
+++ b/codenib/compiler/manifest_export.py
@@ -78,6 +78,7 @@ from .manifest_storage import (
 from .retained_manifest_contract import (
     REPO_MANIFEST_PROJECTION_MEDIA_TYPE,
     REPO_MANIFEST_PROJECTION_SCHEMA,
+    REPO_MANIFEST_PROJECTION_SNAPSHOT_REACHABILITY,
     REPO_MANIFEST_PROJECTION_VIEW,
     repo_manifest_generation_metadata,
     repo_manifest_projection_profile,
@@ -1649,6 +1650,14 @@ def _read_and_validate_projection(
     plan_identity = projection["plan"]["manifest"]
     metadata = json.loads(projection_view.generation.metadata_json)
     metadata.pop(VIEW_GENERATION_MEMBERS_METADATA_KEY, None)
+    reachability = metadata.get("reachability")
+    if reachability not in {
+        None,
+        REPO_MANIFEST_PROJECTION_SNAPSHOT_REACHABILITY,
+    }:
+        raise StorageIntegrityError(
+            "snapshot repository manifest projection reachability is invalid"
+        )
     expected_metadata = {
         "contract": REPO_MANIFEST_PROJECTION_SCHEMA,
         "manifest_version": validated.plan.manifest.version,
@@ -1656,9 +1665,18 @@ def _read_and_validate_projection(
         "plan_digest": validated.plan.plan_digest,
         "projected_views": list(validated.plan.selection.selected_views),
     }
+    if reachability is not None:
+        expected_metadata["reachability"] = reachability
     dependency_records: dict[str, ObjectRecord] = {}
     for _view_type, view in validated.view_items:
-        for record in (view.catalog_view.primary, *view.catalog_view.members):
+        # Snapshot-scoped projections rely on the selected sibling generations,
+        # whose primary/member closures were validated above.
+        records = (
+            ()
+            if reachability == REPO_MANIFEST_PROJECTION_SNAPSHOT_REACHABILITY
+            else (view.catalog_view.primary, *view.catalog_view.members)
+        )
+        for record in records:
             existing = dependency_records.get(record.digest)
             if existing is None:
                 dependency_records[record.digest] = record

--- a/codenib/compiler/manifest_import.py
+++ b/codenib/compiler/manifest_import.py
@@ -239,6 +239,14 @@ class _PreparedImport:
         return _unique_stored_objects(values)
 
 
+@dataclass(frozen=True, slots=True)
+class _PreparedJobSnapshotArtifacts:
+    """Requested job outputs plus reserved snapshot-support generations."""
+
+    artifacts: tuple[IndexJobViewArtifact, ...]
+    supporting_artifacts: tuple[IndexJobViewArtifact, ...]
+
+
 def _validate_result_items(result: RepoManifestImportResult) -> None:
     if type(result.views) is not tuple or not result.views:
         raise StorageValidationError("published views must be a nonempty tuple")
@@ -1231,43 +1239,50 @@ def _prepare_job_view_artifacts_inside_authority(
         max_bundle_metadata_bytes=max_bundle_metadata_bytes,
         check_cancelled=check_cancelled,
     )
-    artifacts: list[IndexJobViewArtifact] = []
-    for view in prepared.views:
-        if check_cancelled is not None:
-            check_cancelled()
-        members = _unique_stored_objects(member[3] for member in view.members)
-        artifact = IndexJobViewArtifact.create(
-            view.intent.view_type,
-            view.intent.profile_id,
-            view.bundle.receipt,
-            schema_version=VIEW_BUNDLE_SCHEMA,
-            media_type=view.bundle.record.media_type,
-            metadata=_intent_generation_metadata(view.intent),
-            member_artifacts=tuple(
-                IndexJobObjectArtifact(member.receipt, member.record.media_type)
-                for member in members
-            ),
-        )
-        output = artifact._output()
-        if (
-            output.view_type != view.generation.view_type
-            or output.profile_id != view.generation.profile_id
-            or output.object_record != view.bundle.record
-            or output.schema_version != view.generation.schema_version
-            or canonical_json(output.generation_metadata)
-            != view.generation.metadata_json
-            or output.member_object_records
-            != tuple(member.record for member in members)
-        ):
-            raise StorageIntegrityError(
-                "retained job artifact differs from its prepared view generation"
-            )
-        artifacts.append(artifact)
+    artifacts = tuple(
+        _prepared_view_job_artifact(view, check_cancelled=check_cancelled)
+        for view in prepared.views
+    )
     if check_cancelled is None:
         repository_source.verify_snapshot()
     else:
         repository_source.verify_snapshot(check_cancelled=check_cancelled)
-    return tuple(artifacts)
+    return artifacts
+
+
+def _prepared_view_job_artifact(
+    view: _PreparedView,
+    *,
+    check_cancelled: Callable[[], None] | None,
+) -> IndexJobViewArtifact:
+    if check_cancelled is not None:
+        check_cancelled()
+    members = _unique_stored_objects(member[3] for member in view.members)
+    artifact = IndexJobViewArtifact.create(
+        view.intent.view_type,
+        view.intent.profile_id,
+        view.bundle.receipt,
+        schema_version=VIEW_BUNDLE_SCHEMA,
+        media_type=view.bundle.record.media_type,
+        metadata=_intent_generation_metadata(view.intent),
+        member_artifacts=tuple(
+            IndexJobObjectArtifact(member.receipt, member.record.media_type)
+            for member in members
+        ),
+    )
+    output = artifact._output()
+    if (
+        output.view_type != view.generation.view_type
+        or output.profile_id != view.generation.profile_id
+        or output.object_record != view.bundle.record
+        or output.schema_version != view.generation.schema_version
+        or canonical_json(output.generation_metadata) != view.generation.metadata_json
+        or output.member_object_records != tuple(member.record for member in members)
+    ):
+        raise StorageIntegrityError(
+            "retained job artifact differs from its prepared view generation"
+        )
+    return artifact
 
 
 def _prepare_import_inside_authority(
@@ -1287,6 +1302,7 @@ def _prepare_import_inside_authority(
     max_bundle_bytes: int,
     max_bundle_metadata_bytes: int,
     max_projection_bytes: int,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> _PreparedImport:
     prepared = _prepare_manifest_views_inside_authority(
         receipt,
@@ -1303,7 +1319,11 @@ def _prepare_import_inside_authority(
         max_bundle_files=max_bundle_files,
         max_bundle_bytes=max_bundle_bytes,
         max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        check_cancelled=check_cancelled,
     )
+
+    if check_cancelled is not None:
+        check_cancelled()
 
     projection_profile = _projection_profile()
     projection_value = _projection_value(
@@ -1317,13 +1337,22 @@ def _prepare_import_inside_authority(
         projection_value,
         max_bytes=max_projection_bytes,
     )
-    raw_projection = object_store.put_chunks(  # type: ignore[attr-defined]
-        _iter_canonical_json_chunks(
-            projection_value,
-            max_bytes=max_projection_bytes,
-        ),
+    projection_chunks: Iterable[bytes] = _iter_canonical_json_chunks(
+        projection_value,
+        max_bytes=max_projection_bytes,
+    )
+    if check_cancelled is not None:
+        projection_chunks = _interruptible_expected_chunks(
+            projection_chunks,
+            projection_size,
+            check_cancelled,
+        )
+    raw_projection = _put_exact_chunks(
+        object_store,
+        projection_chunks,
         projection_digest,
         projection_size,
+        check_cancelled=check_cancelled,
     )
     projection_object = _exact_blob_object(
         raw_projection,
@@ -1356,13 +1385,113 @@ def _prepare_import_inside_authority(
         metadata=projection_metadata,
         member_object_digests=dependencies,
     )
-    repository_source.verify_snapshot()
+    if check_cancelled is None:
+        repository_source.verify_snapshot()
+    else:
+        repository_source.verify_snapshot(check_cancelled=check_cancelled)
     return _PreparedImport(
         artifact_plan_digest=prepared.artifact_plan_digest,
         views=prepared.views,
         projection=projection_object,
         projection_profile=projection_profile,
         projection_generation=projection_generation,
+    )
+
+
+def _prepare_job_snapshot_artifacts_inside_authority(
+    receipt: PublishedWorkspaceReceipt,
+    publication: PublicationDirectoryReader,
+    *,
+    plan: RepoManifestImportPlan,
+    repository_source: RepositorySourceBinding,
+    repository_key: str,
+    source_identity: SourceRevision,
+    object_store: RetainedImportObjectStore,
+    environment: Mapping[str, str],
+    forbidden_paths: tuple[Path, ...],
+    max_context_files: int,
+    max_context_bytes: int,
+    max_bundle_files: int,
+    max_bundle_bytes: int,
+    max_bundle_metadata_bytes: int,
+    max_projection_bytes: int,
+    check_cancelled: Callable[[], None] | None = None,
+) -> _PreparedJobSnapshotArtifacts:
+    """Ingest a loadable job snapshot without granting catalog authority."""
+
+    prepared = _prepare_import_inside_authority(
+        receipt,
+        publication,
+        plan=plan,
+        repository_source=repository_source,
+        repository_key=repository_key,
+        source_identity=source_identity,
+        object_store=object_store,
+        environment=environment,
+        forbidden_paths=forbidden_paths,
+        max_context_files=max_context_files,
+        max_context_bytes=max_context_bytes,
+        max_bundle_files=max_bundle_files,
+        max_bundle_bytes=max_bundle_bytes,
+        max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        max_projection_bytes=max_projection_bytes,
+        check_cancelled=check_cancelled,
+    )
+    _verify_exact_receipt(
+        object_store,
+        prepared.projection,
+        check_cancelled=check_cancelled,
+    )
+    artifacts = tuple(
+        _prepared_view_job_artifact(view, check_cancelled=check_cancelled)
+        for view in prepared.views
+    )
+    stored_by_digest = {
+        stored.record.digest: stored for stored in prepared.stored_objects
+    }
+    try:
+        projection_members = tuple(
+            stored_by_digest[digest]
+            for digest in prepared.projection_generation.member_object_digests
+        )
+    except KeyError as exc:  # pragma: no cover - local preparation invariant
+        raise StorageIntegrityError(
+            "manifest projection references an unavailable retained object"
+        ) from exc
+    projection_metadata = json.loads(prepared.projection_generation.metadata_json)
+    projection_metadata.pop(VIEW_GENERATION_MEMBERS_METADATA_KEY, None)
+    projection_artifact = IndexJobViewArtifact.create(
+        REPO_MANIFEST_PROJECTION_VIEW,
+        prepared.projection_profile.profile_id,
+        prepared.projection.receipt,
+        schema_version=REPO_MANIFEST_PROJECTION_SCHEMA,
+        media_type=REPO_MANIFEST_PROJECTION_MEDIA_TYPE,
+        metadata=projection_metadata,
+        member_artifacts=tuple(
+            IndexJobObjectArtifact(member.receipt, member.record.media_type)
+            for member in projection_members
+        ),
+    )
+    projection_output = projection_artifact._output()
+    if (
+        projection_output.view_type != prepared.projection_generation.view_type
+        or projection_output.profile_id != prepared.projection_generation.profile_id
+        or projection_output.object_record != prepared.projection.record
+        or projection_output.schema_version
+        != prepared.projection_generation.schema_version
+        or canonical_json(projection_output.generation_metadata)
+        != prepared.projection_generation.metadata_json
+        or projection_output.member_object_records
+        != tuple(member.record for member in projection_members)
+    ):
+        raise StorageIntegrityError(
+            "retained job projection differs from its prepared generation"
+        )
+    if check_cancelled is not None:
+        check_cancelled()
+    return _PreparedJobSnapshotArtifacts(
+        artifacts=artifacts,
+        supporting_artifacts=(projection_artifact,),
     )
 
 

--- a/codenib/compiler/manifest_import.py
+++ b/codenib/compiler/manifest_import.py
@@ -764,12 +764,19 @@ def _measure_canonical_json(
     value: Mapping[str, Any],
     *,
     max_bytes: int,
+    check_cancelled: Callable[[], None] | None = None,
 ) -> tuple[str, int]:
     digest = hashlib.sha256()
     size = 0
-    for chunk in _iter_canonical_json_chunks(value, max_bytes=max_bytes):
-        digest.update(chunk)
-        size += len(chunk)
+    try:
+        for chunk in _interruptible_chunks(
+            _iter_canonical_json_chunks(value, max_bytes=max_bytes),
+            check_cancelled,
+        ):
+            digest.update(chunk)
+            size += len(chunk)
+    except _ManifestChunkStop as signal:
+        _raise_exact_chunk_stop(signal)
     return digest.hexdigest(), size
 
 
@@ -1330,6 +1337,40 @@ def _prepare_import_inside_authority(
         max_bundle_metadata_bytes=max_bundle_metadata_bytes,
         check_cancelled=check_cancelled,
     )
+    return _prepare_projection_inside_authority(
+        prepared,
+        plan=plan,
+        repository_source=repository_source,
+        source_identity=source_identity,
+        object_store=object_store,
+        max_projection_bytes=max_projection_bytes,
+        projection_reachability=projection_reachability,
+        check_cancelled=check_cancelled,
+    )
+
+
+def _prepare_projection_inside_authority(
+    prepared: _PreparedManifestViews,
+    *,
+    plan: RepoManifestImportPlan,
+    repository_source: RepositorySourceBinding,
+    source_identity: SourceRevision,
+    object_store: RetainedImportObjectStore,
+    max_projection_bytes: int,
+    projection_reachability: str | None,
+    check_cancelled: Callable[[], None] | None = None,
+) -> _PreparedImport:
+    """Add one projection to already ingested, authority-scoped views."""
+
+    if type(prepared) is not _PreparedManifestViews:
+        raise TypeError("prepared manifest views are invalid")
+    if projection_reachability not in {
+        None,
+        REPO_MANIFEST_PROJECTION_SNAPSHOT_REACHABILITY,
+    }:
+        raise StorageValidationError(
+            "repository manifest projection reachability is invalid"
+        )
 
     if check_cancelled is not None:
         check_cancelled()
@@ -1345,6 +1386,7 @@ def _prepare_import_inside_authority(
     projection_digest, projection_size = _measure_canonical_json(
         projection_value,
         max_bytes=max_projection_bytes,
+        check_cancelled=check_cancelled,
     )
     projection_chunks: Iterable[bytes] = _iter_canonical_json_chunks(
         projection_value,
@@ -1437,11 +1479,14 @@ def _prepare_job_snapshot_artifacts_inside_authority(
     max_bundle_bytes: int,
     max_bundle_metadata_bytes: int,
     max_projection_bytes: int,
+    projection_required: (
+        Callable[[tuple[IndexJobViewArtifact, ...]], bool] | None
+    ) = None,
     check_cancelled: Callable[[], None] | None = None,
 ) -> _PreparedJobSnapshotArtifacts:
     """Ingest a loadable job snapshot without granting catalog authority."""
 
-    prepared = _prepare_import_inside_authority(
+    prepared_views = _prepare_manifest_views_inside_authority(
         receipt,
         publication,
         plan=plan,
@@ -1456,6 +1501,33 @@ def _prepare_job_snapshot_artifacts_inside_authority(
         max_bundle_files=max_bundle_files,
         max_bundle_bytes=max_bundle_bytes,
         max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        check_cancelled=check_cancelled,
+    )
+    artifacts = tuple(
+        _prepared_view_job_artifact(view, check_cancelled=check_cancelled)
+        for view in prepared_views.views
+    )
+    include_projection = True
+    if projection_required is not None:
+        include_projection = projection_required(artifacts)
+        if type(include_projection) is not bool:
+            raise TypeError("job projection decision must be an exact boolean")
+    if not include_projection:
+        if check_cancelled is None:
+            repository_source.verify_snapshot()
+        else:
+            repository_source.verify_snapshot(check_cancelled=check_cancelled)
+        return _PreparedJobSnapshotArtifacts(
+            artifacts=artifacts,
+            supporting_artifacts=(),
+        )
+
+    prepared = _prepare_projection_inside_authority(
+        prepared_views,
+        plan=plan,
+        repository_source=repository_source,
+        source_identity=source_identity,
+        object_store=object_store,
         max_projection_bytes=max_projection_bytes,
         projection_reachability=REPO_MANIFEST_PROJECTION_SNAPSHOT_REACHABILITY,
         check_cancelled=check_cancelled,
@@ -1464,10 +1536,6 @@ def _prepare_job_snapshot_artifacts_inside_authority(
         object_store,
         prepared.projection,
         check_cancelled=check_cancelled,
-    )
-    artifacts = tuple(
-        _prepared_view_job_artifact(view, check_cancelled=check_cancelled)
-        for view in prepared.views
     )
     stored_by_digest = {
         stored.record.digest: stored for stored in prepared.stored_objects

--- a/codenib/compiler/manifest_import.py
+++ b/codenib/compiler/manifest_import.py
@@ -95,6 +95,7 @@ from .retained_manifest_contract import (
     REPO_MANIFEST_PROJECTION_MEDIA_TYPE,
     REPO_MANIFEST_PROJECTION_PROFILE_NAME,
     REPO_MANIFEST_PROJECTION_SCHEMA,
+    REPO_MANIFEST_PROJECTION_SNAPSHOT_REACHABILITY,
     REPO_MANIFEST_PROJECTION_VIEW,
 )
 from .retained_manifest_contract import (
@@ -1302,8 +1303,16 @@ def _prepare_import_inside_authority(
     max_bundle_bytes: int,
     max_bundle_metadata_bytes: int,
     max_projection_bytes: int,
+    projection_reachability: str | None = None,
     check_cancelled: Callable[[], None] | None = None,
 ) -> _PreparedImport:
+    if projection_reachability not in {
+        None,
+        REPO_MANIFEST_PROJECTION_SNAPSHOT_REACHABILITY,
+    }:
+        raise StorageValidationError(
+            "repository manifest projection reachability is invalid"
+        )
     prepared = _prepare_manifest_views_inside_authority(
         receipt,
         publication,
@@ -1361,14 +1370,25 @@ def _prepare_import_inside_authority(
         media_type=REPO_MANIFEST_PROJECTION_MEDIA_TYPE,
         label="repository manifest projection ingestion",
     )
-    dependencies = tuple(
-        sorted(
-            {
-                dependency.record.digest
-                for view in prepared.views
-                for dependency in (view.bundle, *(member[3] for member in view.members))
-            }
+    # A job publishes every selected generation in the same snapshot, so the
+    # sibling views already retain their complete primary/member closure. Keep
+    # standalone imports self-contained, but do not duplicate those edges in
+    # the job-only projection generation.
+    dependencies = (
+        tuple(
+            sorted(
+                {
+                    dependency.record.digest
+                    for view in prepared.views
+                    for dependency in (
+                        view.bundle,
+                        *(member[3] for member in view.members),
+                    )
+                }
+            )
         )
+        if projection_reachability is None
+        else ()
     )
     projection_metadata = {
         "contract": REPO_MANIFEST_PROJECTION_SCHEMA,
@@ -1377,6 +1397,8 @@ def _prepare_import_inside_authority(
         "plan_digest": plan.plan_digest,
         "projected_views": [view.intent.view_type for view in prepared.views],
     }
+    if projection_reachability is not None:
+        projection_metadata["reachability"] = projection_reachability
     projection_generation = ViewGeneration.create(
         source_identity,
         projection_profile,
@@ -1435,6 +1457,7 @@ def _prepare_job_snapshot_artifacts_inside_authority(
         max_bundle_bytes=max_bundle_bytes,
         max_bundle_metadata_bytes=max_bundle_metadata_bytes,
         max_projection_bytes=max_projection_bytes,
+        projection_reachability=REPO_MANIFEST_PROJECTION_SNAPSHOT_REACHABILITY,
         check_cancelled=check_cancelled,
     )
     _verify_exact_receipt(

--- a/codenib/compiler/manifest_materialization.py
+++ b/codenib/compiler/manifest_materialization.py
@@ -115,6 +115,7 @@ from .manifest_storage import (
 from .retained_manifest_contract import (
     REPO_MANIFEST_PROJECTION_MEDIA_TYPE,
     REPO_MANIFEST_PROJECTION_SCHEMA,
+    REPO_MANIFEST_PROJECTION_SNAPSHOT_REACHABILITY,
     repo_manifest_generation_metadata,
     repo_manifest_projection_profile,
 )
@@ -1132,35 +1133,54 @@ def _authenticate_projection(
         "plan_digest": plan.plan_digest,
         "projected_views": list(selected),
     }
-    projection_generation = _retained_generation(
-        source,
-        receipt=projection_receipt,
-        media_type=REPO_MANIFEST_PROJECTION_MEDIA_TYPE,
-        profile=repo_manifest_projection_profile(),
-        schema_version=REPO_MANIFEST_PROJECTION_SCHEMA,
-        metadata=projection_metadata,
-        member_digests=tuple(sorted(dependency_digests)),
-    )
-    try:
-        snapshot = PublishedSnapshot(
-            repository_id=receipt.repository_id,
-            source_revision_id=receipt.source_revision_id,
-            views=tuple(
-                SnapshotView(generation)
-                for generation in (*view_generations, projection_generation)
-            ),
-        )
-    except StorageValidationError as exc:
-        raise StorageIntegrityError(
-            "retained projection snapshot identity is invalid"
-        ) from exc
-    if (
-        projection_generation.view_generation_id != receipt.projection_generation_id
-        or snapshot.snapshot_id != receipt.snapshot_id
+    # The data-only export carries both content IDs but not the catalog's
+    # reachability metadata.  Reconstruct the two contract-sanctioned forms and
+    # require those IDs to authenticate exactly one of them.
+    candidates: list[tuple[ViewGeneration, str]] = []
+    for candidate_metadata, candidate_dependencies in (
+        (projection_metadata, tuple(sorted(dependency_digests))),
+        (
+            {
+                **projection_metadata,
+                "reachability": REPO_MANIFEST_PROJECTION_SNAPSHOT_REACHABILITY,
+            },
+            (),
+        ),
     ):
+        candidate = _retained_generation(
+            source,
+            receipt=projection_receipt,
+            media_type=REPO_MANIFEST_PROJECTION_MEDIA_TYPE,
+            profile=repo_manifest_projection_profile(),
+            schema_version=REPO_MANIFEST_PROJECTION_SCHEMA,
+            metadata=candidate_metadata,
+            member_digests=candidate_dependencies,
+        )
+        try:
+            snapshot = PublishedSnapshot(
+                repository_id=receipt.repository_id,
+                source_revision_id=receipt.source_revision_id,
+                views=tuple(
+                    SnapshotView(generation)
+                    for generation in (*view_generations, candidate)
+                ),
+            )
+        except StorageValidationError as exc:
+            raise StorageIntegrityError(
+                "retained projection snapshot identity is invalid"
+            ) from exc
+        candidates.append((candidate, snapshot.snapshot_id))
+    matches = tuple(
+        candidate
+        for candidate, snapshot_id in candidates
+        if candidate.view_generation_id == receipt.projection_generation_id
+        and snapshot_id == receipt.snapshot_id
+    )
+    if len(matches) != 1:
         raise StorageIntegrityError(
             "retained projection generation or snapshot identity conflicts"
         )
+    projection_generation = matches[0]
     return _AuthenticatedProjection(
         plan=plan,
         source=source,

--- a/codenib/compiler/manifest_materialization.py
+++ b/codenib/compiler/manifest_materialization.py
@@ -1133,20 +1133,11 @@ def _authenticate_projection(
         "plan_digest": plan.plan_digest,
         "projected_views": list(selected),
     }
-    # The data-only export carries both content IDs but not the catalog's
-    # reachability metadata.  Reconstruct the two contract-sanctioned forms and
-    # require those IDs to authenticate exactly one of them.
-    candidates: list[tuple[ViewGeneration, str]] = []
-    for candidate_metadata, candidate_dependencies in (
-        (projection_metadata, tuple(sorted(dependency_digests))),
-        (
-            {
-                **projection_metadata,
-                "reachability": REPO_MANIFEST_PROJECTION_SNAPSHOT_REACHABILITY,
-            },
-            (),
-        ),
-    ):
+
+    def projection_candidate(
+        candidate_metadata: Mapping[str, Any],
+        candidate_dependencies: tuple[str, ...],
+    ) -> tuple[ViewGeneration, str]:
         candidate = _retained_generation(
             source,
             receipt=projection_receipt,
@@ -1169,18 +1160,31 @@ def _authenticate_projection(
             raise StorageIntegrityError(
                 "retained projection snapshot identity is invalid"
             ) from exc
-        candidates.append((candidate, snapshot.snapshot_id))
-    matches = tuple(
-        candidate
-        for candidate, snapshot_id in candidates
-        if candidate.view_generation_id == receipt.projection_generation_id
-        and snapshot_id == receipt.snapshot_id
+        return candidate, snapshot.snapshot_id
+
+    # The generation ID selects the contract-sanctioned reachability mode before
+    # its closure is reconstructed. A valid sibling-reachable projection may
+    # contain the full member capacity even though the corresponding legacy
+    # dependency closure would add one bundle primary beyond that capacity.
+    projection_generation, snapshot_id = projection_candidate(
+        {
+            **projection_metadata,
+            "reachability": REPO_MANIFEST_PROJECTION_SNAPSHOT_REACHABILITY,
+        },
+        (),
     )
-    if len(matches) != 1:
+    if projection_generation.view_generation_id != receipt.projection_generation_id:
+        projection_generation, snapshot_id = projection_candidate(
+            projection_metadata,
+            tuple(sorted(dependency_digests)),
+        )
+    if (
+        projection_generation.view_generation_id != receipt.projection_generation_id
+        or snapshot_id != receipt.snapshot_id
+    ):
         raise StorageIntegrityError(
             "retained projection generation or snapshot identity conflicts"
         )
-    projection_generation = matches[0]
     return _AuthenticatedProjection(
         plan=plan,
         source=source,

--- a/codenib/compiler/retained_manifest_contract.py
+++ b/codenib/compiler/retained_manifest_contract.py
@@ -8,29 +8,20 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..storage.models import ViewProfile
+from ..storage.models import (
+    REPO_MANIFEST_PROJECTION_PROFILE_NAME,
+    REPO_MANIFEST_PROJECTION_SCHEMA,
+    REPO_MANIFEST_PROJECTION_VIEW,
+    repo_manifest_projection_profile,
+)
 from .manifest import MANIFEST_VERSION
 from .manifest_storage import ViewImportIntent
 
 REPO_MANIFEST_IMPORT_GENERATION_CONTRACT = "codenib.repo-manifest-import-generation.v2"
-REPO_MANIFEST_PROJECTION_VIEW = "codenib.internal.repo-manifest"
-REPO_MANIFEST_PROJECTION_SCHEMA = "codenib.internal.repo-manifest.v2"
 REPO_MANIFEST_PROJECTION_MEDIA_TYPE = (
     "application/vnd.codenib.repo-manifest-projection.v2+json"
 )
-REPO_MANIFEST_PROJECTION_PROFILE_NAME = "canonical"
-
-
-def repo_manifest_projection_profile() -> ViewProfile:
-    return ViewProfile.create(
-        REPO_MANIFEST_PROJECTION_VIEW,
-        {
-            "contract": REPO_MANIFEST_PROJECTION_SCHEMA,
-            "builder_schema": REPO_MANIFEST_PROJECTION_SCHEMA,
-            "artifact_schema": REPO_MANIFEST_PROJECTION_SCHEMA,
-        },
-        name=REPO_MANIFEST_PROJECTION_PROFILE_NAME,
-    )
+REPO_MANIFEST_PROJECTION_SNAPSHOT_REACHABILITY = "snapshot-views.v1"
 
 
 def repo_manifest_generation_metadata(intent: ViewImportIntent) -> dict[str, Any]:
@@ -50,6 +41,7 @@ __all__ = [
     "REPO_MANIFEST_PROJECTION_MEDIA_TYPE",
     "REPO_MANIFEST_PROJECTION_PROFILE_NAME",
     "REPO_MANIFEST_PROJECTION_SCHEMA",
+    "REPO_MANIFEST_PROJECTION_SNAPSHOT_REACHABILITY",
     "REPO_MANIFEST_PROJECTION_VIEW",
     "repo_manifest_generation_metadata",
     "repo_manifest_projection_profile",

--- a/codenib/compiler/source_job.py
+++ b/codenib/compiler/source_job.py
@@ -1088,6 +1088,7 @@ class BM25SourceJobExecutor:
                 ),
             ),
             retryable=False,
+            supporting_artifacts=prepared.supporting_artifacts,
         )
 
 

--- a/codenib/compiler/source_job.py
+++ b/codenib/compiler/source_job.py
@@ -90,6 +90,7 @@ from .manifest import MANIFEST_FILENAME, MANIFEST_VERSION, IndexEntry, RepoManif
 from .manifest_import import (
     DEFAULT_MAX_CONTEXT_BYTES,
     DEFAULT_MAX_CONTEXT_FILES,
+    DEFAULT_MAX_PROJECTION_BYTES,
     _snapshot_environment,
     _snapshot_forbidden_paths,
 )
@@ -856,6 +857,7 @@ class BM25SourceJobExecutor:
     max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES
     max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES
     max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES
+    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES
     forbidden_paths: Iterable[Path] = ()
     environ: Mapping[str, str] | None = field(
         default=None,
@@ -977,6 +979,7 @@ class BM25SourceJobExecutor:
             max_bundle_files=self.max_bundle_files,
             max_bundle_bytes=self.max_bundle_bytes,
             max_bundle_metadata_bytes=self.max_bundle_metadata_bytes,
+            max_projection_bytes=self.max_projection_bytes,
             forbidden_paths=self.forbidden_paths,
             environ=self.environ,
             check_cancelled=check_cancelled,
@@ -1067,6 +1070,7 @@ class BM25SourceJobExecutor:
             max_bundle_files=self.max_bundle_files,
             max_bundle_bytes=self.max_bundle_bytes,
             max_bundle_metadata_bytes=self.max_bundle_metadata_bytes,
+            max_projection_bytes=self.max_projection_bytes,
             forbidden_paths=self.forbidden_paths,
             environ=self.environ,
         )

--- a/codenib/storage/job_worker.py
+++ b/codenib/storage/job_worker.py
@@ -43,6 +43,7 @@ from .models import (
     StorageValidationError,
     assert_no_secret_fields,
     canonical_json,
+    is_index_job_supporting_view,
     snapshot_index_job_event_payload,
 )
 from .protocols import (
@@ -61,6 +62,7 @@ _MAX_JOB_ID_CHARS = 80
 _MAX_JOB_ERROR_CODE_CHARS = 128
 _MAX_JOB_ERROR_MESSAGE_CHARS = 4_096
 _MAX_JOB_ATTEMPTS = 1_000
+_MAX_JOB_PUBLICATION_VIEWS = 128
 _MAX_LEASE_DURATION_MS = 2_147_483_647
 _MAX_SCAN_LIMIT = 256
 _CATALOG_INT64_MAX = 2**63 - 1
@@ -608,6 +610,7 @@ class IndexJobExecutionResult:
     retryable: bool = False
     error_code: str | None = None
     error_message: str | None = None
+    supporting_artifacts: tuple[IndexJobViewArtifact, ...] = ()
 
     def __post_init__(self) -> None:
         if type(self) is not IndexJobExecutionResult:
@@ -646,10 +649,51 @@ class IndexJobExecutionResult:
             raise StorageValidationError(
                 "worker execution result views belong to different jobs"
             )
+        if type(self.supporting_artifacts) is not tuple:
+            raise StorageValidationError(
+                "worker supporting artifacts must be an exact tuple"
+            )
+        if any(
+            type(artifact) is not IndexJobViewArtifact
+            for artifact in self.supporting_artifacts
+        ):
+            raise StorageValidationError(
+                "worker supporting artifacts must use exact artifact models"
+            )
+        supporting_artifacts = tuple(
+            IndexJobViewArtifact(
+                view_type=artifact.view_type,
+                profile_id=artifact.profile_id,
+                object_artifact=artifact.object_artifact,
+                schema_version=artifact.schema_version,
+                metadata_json=artifact.metadata_json,
+                member_artifacts=artifact.member_artifacts,
+            )
+            for artifact in self.supporting_artifacts
+        )
+        supporting_order = tuple(
+            artifact.view_type for artifact in supporting_artifacts
+        )
+        if supporting_order != tuple(sorted(supporting_order)) or len(
+            supporting_order
+        ) != len(set(supporting_order)):
+            raise StorageValidationError(
+                "worker supporting artifacts are not canonical"
+            )
+        if any(
+            not is_index_job_supporting_view(artifact.view_type)
+            for artifact in supporting_artifacts
+        ):
+            raise StorageValidationError(
+                "worker supporting artifacts must use the reserved view namespace"
+            )
         artifacts = tuple(view.artifact for view in views if view.artifact is not None)
-        if artifacts:
+        publication_artifacts = artifacts + supporting_artifacts
+        if len(publication_artifacts) > _MAX_JOB_PUBLICATION_VIEWS:
+            raise StorageValidationError("worker publication cannot exceed 128 views")
+        if publication_artifacts:
             try:
-                _preflight_job_artifacts(artifacts)
+                _preflight_job_artifacts(publication_artifacts)
             except StorageValidationError:
                 raise
             except (StorageIntegrityError, TypeError) as exc:
@@ -681,9 +725,14 @@ class IndexJobExecutionResult:
         object.__setattr__(self, "views", views)
         object.__setattr__(self, "error_code", code)
         object.__setattr__(self, "error_message", message)
+        object.__setattr__(self, "supporting_artifacts", supporting_artifacts)
         if self.publishable and self.retryable:
             raise StorageValidationError(
                 "publishable worker execution result cannot be retryable"
+            )
+        if supporting_artifacts and not self.publishable:
+            raise StorageValidationError(
+                "worker supporting artifacts require a publishable result"
             )
 
     @property
@@ -702,6 +751,12 @@ class IndexJobExecutionResult:
     @property
     def artifacts(self) -> tuple[IndexJobViewArtifact, ...]:
         return tuple(view.artifact for view in self.views if view.artifact is not None)
+
+    @property
+    def publication_artifacts(self) -> tuple[IndexJobViewArtifact, ...]:
+        """Return requested results plus reserved snapshot-support generations."""
+
+        return self.artifacts + self.supporting_artifacts
 
 
 @runtime_checkable
@@ -1905,6 +1960,9 @@ class IndexJobWorker:
                                     retryable=returned.retryable,
                                     error_code=returned.error_code,
                                     error_message=returned.error_message,
+                                    supporting_artifacts=(
+                                        returned.supporting_artifacts
+                                    ),
                                 )
                             except Exception:
                                 failure_code = "worker_executor_incomplete"
@@ -2734,7 +2792,7 @@ class IndexJobWorker:
         before_catalog_publish: Callable[[], None] | None = None,
     ) -> IndexJobWorkerRunResult:
         _artifacts, expected_outputs, _receipts = _preflight_job_artifacts(
-            result.artifacts
+            result.publication_artifacts
         )
         pre_catalog_failure: BaseException | None = None
 
@@ -2764,7 +2822,7 @@ class IndexJobWorker:
                 object_store=self._object_store,
                 owner_id=authority.owner_id,
                 fencing_token=authority.fencing_token,
-                outputs=result.artifacts,
+                outputs=result.publication_artifacts,
                 _retention_cleanup_as_integrity=True,
                 _before_catalog_publish=(
                     run_before_catalog_publish

--- a/codenib/storage/models.py
+++ b/codenib/storage/models.py
@@ -27,6 +27,9 @@ DEFAULT_NAMESPACE_NAME = "default"
 INDEX_JOB_REQUEST_CONTRACT = "codenib.index-job-request.v1"
 INDEX_JOB_PUBLICATION_CONTRACT = "codenib.index-job-publication.v1"
 INDEX_JOB_SUPPORTING_VIEW_PREFIX = "codenib.internal."
+REPO_MANIFEST_PROJECTION_VIEW = "codenib.internal.repo-manifest"
+REPO_MANIFEST_PROJECTION_SCHEMA = "codenib.internal.repo-manifest.v2"
+REPO_MANIFEST_PROJECTION_PROFILE_NAME = "canonical"
 INDEX_JOB_EVENT_PAYLOAD_MAX_DEPTH = 16
 INDEX_JOB_EVENT_PAYLOAD_MAX_NODES = 1_024
 INDEX_JOB_EVENT_PAYLOAD_MAX_TEXT_CHARS = 16 * 1_024
@@ -722,6 +725,20 @@ class ViewProfile:
         )
 
 
+def repo_manifest_projection_profile() -> ViewProfile:
+    """Return the canonical profile required by retained manifest snapshots."""
+
+    return ViewProfile.create(
+        REPO_MANIFEST_PROJECTION_VIEW,
+        {
+            "contract": REPO_MANIFEST_PROJECTION_SCHEMA,
+            "builder_schema": REPO_MANIFEST_PROJECTION_SCHEMA,
+            "artifact_schema": REPO_MANIFEST_PROJECTION_SCHEMA,
+        },
+        name=REPO_MANIFEST_PROJECTION_PROFILE_NAME,
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class ObjectRecord:
     """Catalog metadata for one immutable object-store payload."""
@@ -1227,11 +1244,6 @@ class IndexJobRequest:
                 requested_mode=view_request.get("requested_mode"),
                 required=view_request.get("required"),
             )
-            if is_index_job_supporting_view(normalized_view.view_type):
-                raise StorageValidationError(
-                    "index job requests cannot include reserved supporting views: "
-                    f"{view_type}"
-                )
             if (
                 normalized_view.view_type != view_type
                 or normalized_view.profile_id != view_request["profile_id"]
@@ -1261,7 +1273,7 @@ class IndexJobRequest:
         expected_ref_generation: int = 0,
         max_attempts: int = 3,
     ) -> IndexJobRequest:
-        return cls(
+        created = cls(
             repository_id=repository_id,
             source_revision_id=source_revision_id,
             ref_name=ref_name,
@@ -1270,6 +1282,20 @@ class IndexJobRequest:
             max_attempts=max_attempts,
             request_json=canonical_json(request),
         )
+        # Schema-v7 catalogs could persist requests under this prefix. The
+        # low-level constructor remains able to rehydrate those durable rows;
+        # admission for every new request stays closed at this factory.
+        reserved = tuple(
+            view.view_type
+            for view in created.view_requests
+            if is_index_job_supporting_view(view.view_type)
+        )
+        if reserved:
+            raise StorageValidationError(
+                "index job requests cannot include reserved supporting views: "
+                + ", ".join(reserved)
+            )
+        return created
 
     @property
     def request(self) -> dict[str, Any]:
@@ -1939,6 +1965,9 @@ __all__ = [
     "INDEX_JOB_REQUEST_CONTRACT",
     "INDEX_JOB_PUBLICATION_CONTRACT",
     "INDEX_JOB_SUPPORTING_VIEW_PREFIX",
+    "REPO_MANIFEST_PROJECTION_PROFILE_NAME",
+    "REPO_MANIFEST_PROJECTION_SCHEMA",
+    "REPO_MANIFEST_PROJECTION_VIEW",
     "INDEX_JOB_EVENT_PAYLOAD_MAX_DEPTH",
     "INDEX_JOB_EVENT_PAYLOAD_MAX_KEY_CHARS",
     "INDEX_JOB_EVENT_PAYLOAD_MAX_NODES",
@@ -1986,6 +2015,7 @@ __all__ = [
     "is_index_job_supporting_view",
     "normalize_digest",
     "normalize_view_generation_metadata",
+    "repo_manifest_projection_profile",
     "snapshot_index_job_event_payload",
     "view_generation_member_digests",
 ]

--- a/codenib/storage/models.py
+++ b/codenib/storage/models.py
@@ -26,6 +26,7 @@ DEFAULT_NAMESPACE_ID = "ns_default"
 DEFAULT_NAMESPACE_NAME = "default"
 INDEX_JOB_REQUEST_CONTRACT = "codenib.index-job-request.v1"
 INDEX_JOB_PUBLICATION_CONTRACT = "codenib.index-job-publication.v1"
+INDEX_JOB_SUPPORTING_VIEW_PREFIX = "codenib.internal."
 INDEX_JOB_EVENT_PAYLOAD_MAX_DEPTH = 16
 INDEX_JOB_EVENT_PAYLOAD_MAX_NODES = 1_024
 INDEX_JOB_EVENT_PAYLOAD_MAX_TEXT_CHARS = 16 * 1_024
@@ -36,6 +37,14 @@ VIEW_GENERATION_MEMBERS_METADATA_KEY = "_codenib_member_object_digests"
 # generation metadata and once as its identity-closed object envelope. Keep
 # this producer bound comfortably below the 250k-node response capability.
 MAX_VIEW_GENERATION_MEMBERS = 32_768
+
+
+def is_index_job_supporting_view(view_type: object) -> bool:
+    """Return whether a view belongs to the reserved job-support namespace."""
+
+    return type(view_type) is str and view_type.startswith(
+        INDEX_JOB_SUPPORTING_VIEW_PREFIX
+    )
 
 
 class StorageError(RuntimeError):
@@ -1218,6 +1227,11 @@ class IndexJobRequest:
                 requested_mode=view_request.get("requested_mode"),
                 required=view_request.get("required"),
             )
+            if is_index_job_supporting_view(normalized_view.view_type):
+                raise StorageValidationError(
+                    "index job requests cannot include reserved supporting views: "
+                    f"{view_type}"
+                )
             if (
                 normalized_view.view_type != view_type
                 or normalized_view.profile_id != view_request["profile_id"]
@@ -1924,6 +1938,7 @@ __all__ = [
     "DEFAULT_NAMESPACE_NAME",
     "INDEX_JOB_REQUEST_CONTRACT",
     "INDEX_JOB_PUBLICATION_CONTRACT",
+    "INDEX_JOB_SUPPORTING_VIEW_PREFIX",
     "INDEX_JOB_EVENT_PAYLOAD_MAX_DEPTH",
     "INDEX_JOB_EVENT_PAYLOAD_MAX_KEY_CHARS",
     "INDEX_JOB_EVENT_PAYLOAD_MAX_NODES",
@@ -1968,6 +1983,7 @@ __all__ = [
     "canonical_utc_timestamp",
     "canonical_json",
     "content_id",
+    "is_index_job_supporting_view",
     "normalize_digest",
     "normalize_view_generation_metadata",
     "snapshot_index_job_event_payload",

--- a/codenib/storage/publication.py
+++ b/codenib/storage/publication.py
@@ -237,6 +237,47 @@ def _preflight_job_artifacts(
     return artifacts, frozen_outputs, retained_receipts
 
 
+def _index_job_output_snapshot_id(
+    job: IndexJobRecord,
+    outputs: Sequence[IndexJobViewOutput],
+) -> str:
+    return content_id(
+        "snapshot",
+        {
+            "repository_id": job.repository_id,
+            "source_revision_id": job.source_revision_id,
+            "views": [
+                [
+                    output.view_type,
+                    content_id(
+                        "view",
+                        {
+                            "repository_id": job.repository_id,
+                            "source_revision_id": job.source_revision_id,
+                            "profile_id": output.profile_id,
+                            "view_type": output.view_type,
+                            "object_digest": output.object_record.digest,
+                            "schema_version": output.schema_version,
+                            "metadata": output.generation_metadata,
+                        },
+                    ),
+                ]
+                for output in outputs
+            ],
+        },
+    )
+
+
+def _index_job_artifact_snapshot_id(
+    job: IndexJobRecord,
+    artifacts: Sequence[IndexJobViewArtifact],
+) -> str:
+    """Return the exact snapshot identity implied by detached artifacts."""
+
+    _artifacts, outputs, _receipts = _preflight_job_artifacts(artifacts)
+    return _index_job_output_snapshot_id(job, outputs)
+
+
 def publish_job_artifacts(
     job_id: str,
     *,
@@ -497,7 +538,6 @@ def _attest_completed_publication(
     ):
         raise StorageIntegrityError("catalog omitted a required output view")
 
-    snapshot_members: list[list[str]] = []
     for output in outputs:
         request = request_views.get(output.view_type)
         if request is not None and (
@@ -505,27 +545,7 @@ def _attest_completed_publication(
             or request.get("profile_id") != output.profile_id
         ):
             raise StorageIntegrityError("catalog accepted an output profile mismatch")
-        generation_id = content_id(
-            "view",
-            {
-                "repository_id": completed.repository_id,
-                "source_revision_id": completed.source_revision_id,
-                "profile_id": output.profile_id,
-                "view_type": output.view_type,
-                "object_digest": output.object_record.digest,
-                "schema_version": output.schema_version,
-                "metadata": output.generation_metadata,
-            },
-        )
-        snapshot_members.append([output.view_type, generation_id])
-    expected_snapshot_id = content_id(
-        "snapshot",
-        {
-            "repository_id": completed.repository_id,
-            "source_revision_id": completed.source_revision_id,
-            "views": snapshot_members,
-        },
-    )
+    expected_snapshot_id = _index_job_output_snapshot_id(completed, outputs)
     if completed.result_snapshot_id != expected_snapshot_id:
         raise StorageIntegrityError("catalog returned a different publication snapshot")
 

--- a/codenib/storage/publication.py
+++ b/codenib/storage/publication.py
@@ -23,6 +23,7 @@ from .models import (
     StorageValidationError,
     canonical_json,
     content_id,
+    is_index_job_supporting_view,
 )
 from .protocols import (
     RETAINED_IMPORT_RESPONSE_MAX_TEXT_CHARS,
@@ -31,7 +32,7 @@ from .protocols import (
     snapshot_retained_import_response,
 )
 
-_MAX_JOB_OUTPUTS = 64
+_MAX_JOB_OUTPUTS = 128
 _CATALOG_INT64_MAX = 9_223_372_036_854_775_807
 
 
@@ -484,7 +485,10 @@ def _attest_completed_publication(
     if not isinstance(request_views, dict):
         raise StorageIntegrityError("catalog returned an invalid job request closure")
     offered = {output.view_type: output for output in outputs}
-    if any(view_type not in request_views for view_type in offered):
+    if any(
+        view_type not in request_views and not is_index_job_supporting_view(view_type)
+        for view_type in offered
+    ):
         raise StorageIntegrityError("catalog accepted an unrequested output view")
     if any(
         request.get("required") is True and view_type not in offered
@@ -496,7 +500,7 @@ def _attest_completed_publication(
     snapshot_members: list[list[str]] = []
     for output in outputs:
         request = request_views.get(output.view_type)
-        if (
+        if request is not None and (
             not isinstance(request, dict)
             or request.get("profile_id") != output.profile_id
         ):

--- a/codenib/storage/sqlite_catalog.py
+++ b/codenib/storage/sqlite_catalog.py
@@ -38,6 +38,7 @@ from .models import (
     DEFAULT_NAMESPACE_NAME,
     INDEX_JOB_EVENT_PAYLOAD_MAX_TEXT_CHARS,
     INDEX_JOB_PUBLICATION_CONTRACT,
+    INDEX_JOB_SUPPORTING_VIEW_PREFIX,
     MAX_INDEX_JOB_EVENTS_PER_ATTEMPT,
     MAX_VIEW_GENERATION_MEMBERS,
     VIEW_GENERATION_MEMBERS_METADATA_KEY,
@@ -71,6 +72,7 @@ from .models import (
     canonical_json,
     canonical_utc_timestamp,
     content_id,
+    is_index_job_supporting_view,
     normalize_digest,
     normalize_view_generation_metadata,
     snapshot_index_job_event_payload,
@@ -82,7 +84,7 @@ from .protocols import (
     snapshot_retained_import_response,
 )
 
-LATEST_SCHEMA_VERSION = 7
+LATEST_SCHEMA_VERSION = 8
 
 CatalogError = StorageError
 CatalogConflictError = PublishConflict
@@ -190,7 +192,7 @@ UNION ALL
 SELECT completed_at_ms FROM index_job_publications
 """
 _SQLITE_INT64_MAX = 9_223_372_036_854_775_807
-_MAX_JOB_PUBLICATION_OUTPUTS = 64
+_MAX_JOB_PUBLICATION_OUTPUTS = 128
 _MAX_RUNNABLE_JOB_SCAN_LIMIT = 256
 _MAX_JOB_EVENT_PAGE_LIMIT = 256
 _SQLITE_LEGACY_AUTOCOMMIT = getattr(
@@ -3601,6 +3603,44 @@ _SCHEMA_V7 = (
     """,
 )
 
+
+def _supporting_view_publication_trigger_sql() -> str:
+    """Derive the v8 trigger while preserving every historical schema."""
+
+    historical = _V6_INDEX_JOB_PUBLICATIONS_VALIDATE_INSERT
+    old_bound = "json_array_length(NEW.closure_json, '$.outputs') BETWEEN 1 AND 64"
+    old_request_gate = """                OR requested.job_id IS NULL
+                OR requested.profile_id != json_extract(
+                    output.value, '$.profile_id'
+                )"""
+    new_request_gate = f"""                OR (
+                    requested.job_id IS NULL
+                    AND substr(
+                        json_extract(output.value, '$.view_type'),
+                        1,
+                        length({INDEX_JOB_SUPPORTING_VIEW_PREFIX!r})
+                    ) != {INDEX_JOB_SUPPORTING_VIEW_PREFIX!r}
+                )
+                OR (
+                    requested.job_id IS NOT NULL
+                    AND requested.profile_id != json_extract(
+                        output.value, '$.profile_id'
+                    )
+                )"""
+    if historical.count(old_bound) != 1 or historical.count(old_request_gate) != 1:
+        raise AssertionError("historical job publication trigger shape changed")
+    return historical.replace(old_bound, old_bound.replace("64", "128"), 1).replace(
+        old_request_gate,
+        new_request_gate,
+        1,
+    )
+
+
+_SCHEMA_V8 = (
+    "DROP TRIGGER index_job_publications_validate_insert",
+    _supporting_view_publication_trigger_sql(),
+)
+
 _MIGRATIONS: dict[int, tuple[str, ...]] = {
     1: _SCHEMA_V1,
     2: _SCHEMA_V2,
@@ -3609,6 +3649,7 @@ _MIGRATIONS: dict[int, tuple[str, ...]] = {
     5: _SCHEMA_V5,
     6: _SCHEMA_V6,
     7: _SCHEMA_V7,
+    8: _SCHEMA_V8,
 }
 
 _CatalogSchemaObject = tuple[str, str, str, str | None]
@@ -5356,7 +5397,11 @@ class SQLiteCatalog:
     ) -> tuple[dict[str, Any], ...]:
         requested = {view.view_type: view for view in requested_views}
         offered = {output.view_type: output for output in outputs}
-        extras = sorted(set(offered) - set(requested))
+        extras = sorted(
+            view_type
+            for view_type in set(offered) - set(requested)
+            if not is_index_job_supporting_view(view_type)
+        )
         missing = sorted(
             view_type
             for view_type, view in requested.items()

--- a/codenib/storage/sqlite_catalog.py
+++ b/codenib/storage/sqlite_catalog.py
@@ -75,6 +75,7 @@ from .models import (
     is_index_job_supporting_view,
     normalize_digest,
     normalize_view_generation_metadata,
+    repo_manifest_projection_profile,
     snapshot_index_job_event_payload,
     view_generation_member_digests,
 )
@@ -4563,6 +4564,51 @@ class SQLiteCatalog:
         if owner.primary_error is not None:
             raise owner.primary_error
 
+    def _ensure_repo_manifest_projection_profile(self) -> None:
+        """Backfill the support profile required by upgraded queued jobs."""
+
+        profile = repo_manifest_projection_profile()
+        digest = profile.profile_id.removeprefix("profile_")
+        expected = (
+            profile.profile_id,
+            profile.view_type,
+            profile.name,
+            profile.config_json,
+            digest,
+        )
+        rows = self._connection.execute(
+            """
+            SELECT profile_id, view_type, name, config_json, profile_digest
+            FROM view_profiles
+            WHERE profile_id = ? OR profile_digest = ?
+            ORDER BY profile_id
+            """,
+            (profile.profile_id, digest),
+        ).fetchall()
+        if not rows:
+            self._connection.execute(
+                """
+                INSERT INTO view_profiles(
+                    profile_id, view_type, name, config_json,
+                    profile_digest, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (*expected, _now()),
+            )
+            rows = self._connection.execute(
+                """
+                SELECT profile_id, view_type, name, config_json, profile_digest
+                FROM view_profiles
+                WHERE profile_id = ? OR profile_digest = ?
+                ORDER BY profile_id
+                """,
+                (profile.profile_id, digest),
+            ).fetchall()
+        if len(rows) != 1 or tuple(rows[0]) != expected:
+            raise CatalogError(
+                "repository manifest projection profile identity conflicts"
+            )
+
     @_coordinated_catalog_method
     def _migrate(self) -> None:
         with self._transaction():
@@ -4615,6 +4661,8 @@ class SQLiteCatalog:
                     (version, _now()),
                 )
                 self._connection.execute(f"PRAGMA user_version = {version:d}")
+            if self.schema_version >= 8:
+                self._ensure_repo_manifest_projection_profile()
             if self.schema_version >= 5:
                 self._validate_publication_aggregates()
             if self.schema_version >= 6:

--- a/codenib/web/index_job_planning.py
+++ b/codenib/web/index_job_planning.py
@@ -12,6 +12,7 @@ from typing import Callable, Mapping
 
 from ..artifacts.runtime import SourceBindingCleanupOwner, _attach_source_cleanup_owner
 from ..compiler.job_resources import LocalBM25SourceJobTarget
+from ..compiler.retained_manifest_contract import repo_manifest_projection_profile
 from ..storage import IndexJobPlanningCatalog, SourceRevision
 from .index_job_writes import (
     IndexJobCreatePlan,
@@ -109,6 +110,7 @@ class LocalBM25SourceJobPlanner:
                 commit_sha=None,
             )
             profile = target.profile
+            supporting_profile = repo_manifest_projection_profile()
             with self._catalog_factory() as value:
                 catalog = self._require_catalog(value)
                 source_revision_id = catalog.create_source_revision(
@@ -122,6 +124,11 @@ class LocalBM25SourceJobPlanner:
                     profile.config,
                     name=profile.name,
                 )
+                supporting_profile_id = catalog.create_view_profile(
+                    supporting_profile.view_type,
+                    supporting_profile.config,
+                    name=supporting_profile.name,
+                )
                 expected_ref_generation = catalog.read_ref_generation(
                     target.repository_id,
                     binding.ref_name,
@@ -133,6 +140,10 @@ class LocalBM25SourceJobPlanner:
             if profile_id != profile.profile_id:
                 raise IndexJobWriteError(
                     "catalog registered a different BM25 view profile"
+                )
+            if supporting_profile_id != supporting_profile.profile_id:
+                raise IndexJobWriteError(
+                    "catalog registered a different snapshot-support profile"
                 )
             result = IndexJobCreatePlan(
                 source_revision_id=source_revision_id,

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1206,10 +1206,15 @@ reject values outside signed SQLite int64 before SQL execution.
 
 The receipt-retaining coordinator freezes exact artifact receipts and keeps
 them retained across the complete catalog transaction and returned-result
-attestation. Required views must be present, optional views may be omitted, and
-extra, duplicate, or profile-mismatched outputs fail closed. Publication is
-bounded to 64 output views and 32,768 aggregate compound members, with the full
-closure also subject to the retained response node/text budget. Per-view
+attestation. Required requested views must be present, optional requested views
+may be omitted, and duplicate, profile-mismatched, or unrequested public outputs
+fail closed. Job requests cannot name the reserved `codenib.internal.*`
+namespace; executors may add only that reserved snapshot-support closure.
+Publication is bounded to 128 combined requested/supporting views and 32,768
+aggregate compound members, with the full closure also subject to the retained
+response node/text budget. SQLite schema 8 migrates the declarative publication
+trigger to the same rule while preserving exact v1-v7 schema authentication and
+reopen validation. Per-view
 semantic compatibility remains the responsibility of the outstanding adapters;
 an explicit profile label alone does not establish byte-level semantics.
 
@@ -1231,11 +1236,14 @@ whole-context evidence publication, then releases before the retained context
 is converted to one canonical view-bundle receipt plus every independently
 reachable member receipt. `publish_job_artifacts` remains the sole catalog
 mutation: it retains that complete receipt set through the atomic job/snapshot/
-ref transaction and returned-result attestation. The job path publishes only
-the BM25 generation, not the direct M1 importer's internal manifest projection.
-The caller still owns repository/source/profile registration, job creation,
-lease acquisition, and all receipt owners; the adapter adds no worker, CLI,
-runtime, vector, graph, or default-route wiring. Exact retry remains historical:
+ref transaction and returned-result attestation. The caller-visible result is
+still exactly the requested BM25 generation, while the same atomic snapshot now
+also carries the reserved internal manifest projection and its complete member
+closure required by strict retained loading. The caller still owns
+repository/source/profile registration, including the deterministic projection
+profile, job creation, lease acquisition, and all receipt owners; the production
+Web planner registers both profiles through its least-authority session. Exact
+retry remains historical:
 a committed BM25 job returns its original snapshot without moving a ref that a
 later valid publication has already advanced.
 
@@ -1559,8 +1567,10 @@ runtime wiring remain.
 
 ### M3: Jobs and runtime hot switching
 
-Status: in progress. Schema-v6 durable execution control is implemented for the
-local SQLite catalog. The backend-neutral prepare-only whole-job worker is
+Status: in progress. Schema-v6 durable execution control, schema-7 fair
+insertion sequencing, and the schema-8 supporting-view publication contract are
+implemented for the local SQLite catalog. The backend-neutral prepare-only
+whole-job worker is
 implemented and verified with file-backed SQLite integration coverage. An
 explicit one-view compiler-cache executor now supplies parser-inert BM25 or
 schema-8 vector artifacts without catalog authority, and the first
@@ -1644,7 +1654,8 @@ MCP, UI controls, and default routing remain absent.
   unleased legacy-root pass. The planner captures the same frozen local target
   as the worker, revalidates source after planning, and uses a separate
   least-authority catalog surface that can register only content-addressed
-  source/profile identities and read one ref generation. The generic
+  source/profile identities and read one ref generation; it also registers the
+  reserved manifest-projection support profile. The generic
   descriptor reclaimer remains policy-free and carries no publication
   authority. The Web composition bootstraps the same paired routes for each
   configured target, directs every at-least-once receipt to its exact shard,

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -80,6 +80,7 @@ from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.compiler.manifest_import import RepoManifestImportResult
 from codenib.compiler.manifest_materialization import (
     materialize_retained_repo_manifest_ref,
+    materialize_retained_repo_manifest_snapshot,
 )
 from codenib.compiler.manifest_storage import (
     VECTOR_PROFILE_AXES,
@@ -3292,6 +3293,7 @@ def test_compiler_cache_bm25_job_publishes_only_exact_bundle_and_replays(
     tmp_path: Path,
 ) -> None:
     fixture = _cache_fixture(tmp_path)
+    materialized_owner = PublishedWorkspaceReceiptOwner()
     retry_bm25_owner = PublishedWorkspaceReceiptOwner()
     retry_context_owner = PublishedWorkspaceReceiptOwner()
     plan = _expected_bm25_job_plan(fixture)
@@ -3369,6 +3371,25 @@ def test_compiler_cache_bm25_job_publishes_only_exact_bundle_and_replays(
                 receipt = cas.verify(persisted["digest"])
                 assert receipt.byte_size == persisted["byte_size"]
                 assert receipt.storage_key == persisted["storage_key"]
+            materialized = materialize_retained_repo_manifest_snapshot(
+                _REPOSITORY_KEY,
+                result.job.result_snapshot_id,
+                fixture.workspace / "materialized-job-context",
+                catalog=catalog,
+                object_store=cas,
+                workspace_provider=fixture.provider,
+                output_receipt_owner=materialized_owner,
+                environ={},
+            )
+            assert materialized.export_receipt.snapshot_id == (
+                result.job.result_snapshot_id
+            )
+            assert materialized.artifact.views == ("bm25",)
+            assert materialized_owner.active
+            assert cas.retained_receipt_sets == [
+                expected_receipts,
+                expected_receipts,
+            ]
             first_ref = catalog.resolve_ref(repository_id)
             _seed_bm25_snapshot(
                 catalog,
@@ -3405,6 +3426,7 @@ def test_compiler_cache_bm25_job_publishes_only_exact_bundle_and_replays(
             assert cas.retained_receipt_sets == [
                 expected_receipts,
                 expected_receipts,
+                expected_receipts,
             ]
             assert catalog.job_publication_calls == 2
             assert fixture.bm25_owner.active
@@ -3414,6 +3436,7 @@ def test_compiler_cache_bm25_job_publishes_only_exact_bundle_and_replays(
     finally:
         retry_context_owner.close()
         retry_bm25_owner.close()
+        materialized_owner.close()
         fixture.close()
 
 

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -25,6 +25,7 @@ import codenib.artifacts.strict_vector as strict_vector_module
 import codenib.compiler as compiler_module
 import codenib.compiler.cache_import as cache_import_module
 import codenib.compiler.job_resources as job_resources_module
+import codenib.compiler.manifest_materialization as manifest_materialization_module
 import codenib.index.embedding.vector_store as vector_store_module
 import codenib.source_fingerprint as source_fingerprint_module
 import codenib.storage.view_bundle as view_bundle_module
@@ -88,6 +89,7 @@ from codenib.compiler.manifest_storage import (
     plan_repo_manifest_import_bytes,
 )
 from codenib.compiler.retained_manifest_contract import (
+    REPO_MANIFEST_PROJECTION_MEDIA_TYPE,
     REPO_MANIFEST_PROJECTION_SNAPSHOT_REACHABILITY,
     REPO_MANIFEST_PROJECTION_VIEW,
     repo_manifest_projection_profile,
@@ -3291,6 +3293,7 @@ def _seed_bm25_snapshot(
 
 def test_compiler_cache_bm25_job_publishes_only_exact_bundle_and_replays(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fixture = _cache_fixture(tmp_path)
     materialized_owner = PublishedWorkspaceReceiptOwner()
@@ -3371,6 +3374,24 @@ def test_compiler_cache_bm25_job_publishes_only_exact_bundle_and_replays(
                 receipt = cas.verify(persisted["digest"])
                 assert receipt.byte_size == persisted["byte_size"]
                 assert receipt.storage_key == persisted["storage_key"]
+            projection_dependency_sets = []
+            retained_generation = manifest_materialization_module._retained_generation
+
+            def reject_legacy_projection(*args, **kwargs):
+                if kwargs["media_type"] == REPO_MANIFEST_PROJECTION_MEDIA_TYPE:
+                    dependencies = kwargs["member_digests"]
+                    projection_dependency_sets.append(dependencies)
+                    if dependencies:
+                        raise AssertionError(
+                            "snapshot-scoped loading reconstructed legacy closure"
+                        )
+                return retained_generation(*args, **kwargs)
+
+            monkeypatch.setattr(
+                manifest_materialization_module,
+                "_retained_generation",
+                reject_legacy_projection,
+            )
             materialized = materialize_retained_repo_manifest_snapshot(
                 _REPOSITORY_KEY,
                 result.job.result_snapshot_id,
@@ -3386,6 +3407,7 @@ def test_compiler_cache_bm25_job_publishes_only_exact_bundle_and_replays(
             )
             assert materialized.artifact.views == ("bm25",)
             assert materialized_owner.active
+            assert projection_dependency_sets == [()]
             assert cas.retained_receipt_sets == [
                 expected_receipts,
                 expected_receipts,

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -86,7 +86,10 @@ from codenib.compiler.manifest_storage import (
     RepoManifestImportPlan,
     plan_repo_manifest_import_bytes,
 )
-from codenib.compiler.retained_manifest_contract import REPO_MANIFEST_PROJECTION_VIEW
+from codenib.compiler.retained_manifest_contract import (
+    REPO_MANIFEST_PROJECTION_VIEW,
+    repo_manifest_projection_profile,
+)
 from codenib.index.embedding.vector_store import CodeVectorStore
 from codenib.mcp.context import ServerContext
 from codenib.repository_source_selection import RepositorySourceSelection
@@ -1107,6 +1110,15 @@ def _register_bm25_job_subject(
         name=intent.profile.name,
     )
     assert profile_id == intent.profile_id
+    supporting_profile = repo_manifest_projection_profile()
+    assert (
+        catalog.create_view_profile(
+            supporting_profile.view_type,
+            supporting_profile.config,
+            name=supporting_profile.name,
+        )
+        == supporting_profile.profile_id
+    )
     return repository_id, source_revision_id, profile_id
 
 
@@ -1241,9 +1253,12 @@ def test_prepare_compiler_cache_job_view_leaves_catalog_running(
             assert result.artifact.profile_id == profile_id
             assert result.artifact.schema_version == VIEW_BUNDLE_SCHEMA
             assert len(result.artifact.member_artifacts) == 2
+            assert tuple(
+                artifact.view_type for artifact in result.supporting_artifacts
+            ) == (REPO_MANIFEST_PROJECTION_VIEW,)
             assert catalog.get_job(queued.job_id) == running
             assert catalog.get_job(queued.job_id).status is IndexJobStatus.RUNNING
-            assert len(cas.put_chunk_receipts) == 3
+            assert len(cas.put_chunk_receipts) == 4
             assert cas.retained_receipt_sets == []
             assert fixture.provider.run_count == 2
     finally:
@@ -1563,7 +1578,7 @@ def test_prepare_compiler_cache_job_attests_artifact_before_final_stop(
     def forged_artifact(*args, **kwargs):
         nonlocal forged_returned
         forged_returned = True
-        return (object(),)
+        return object()
 
     def stop_before_final_source_scan(binding, *args, **kwargs):
         nonlocal final_scan_attempted
@@ -1578,7 +1593,7 @@ def test_prepare_compiler_cache_job_attests_artifact_before_final_stop(
 
     monkeypatch.setattr(
         cache_import_module,
-        "_prepare_job_view_artifacts_inside_authority",
+        "_prepare_job_snapshot_artifacts_inside_authority",
         forged_artifact,
     )
     monkeypatch.setattr(
@@ -1610,7 +1625,7 @@ def test_prepare_compiler_cache_job_attests_artifact_before_final_stop(
 
             with pytest.raises(
                 StorageIntegrityError,
-                match="ingestion returned a different requested view",
+                match="ingestion returned invalid job artifacts",
             ):
                 _prepare_bm25_job(
                     fixture,
@@ -2218,14 +2233,17 @@ def test_compiler_cache_executor_delegates_only_final_publish_to_worker(
             assert fixture.bm25_owner.closed
             assert fixture.context_owner.closed
             assert publication_calls == [queued.job_id]
-            assert len(cas.put_chunk_receipts) == 3
+            assert len(cas.put_chunk_receipts) == 4
             assert len(cas.retained_receipt_sets) == 1
             with SQLiteCatalog(catalog_path, create=False) as catalog:
                 completed = catalog.get_job(queued.job_id)
                 assert completed.status is IndexJobStatus.SUCCEEDED
                 assert completed.result_snapshot_id is not None
                 summary = catalog.get_manifest_summary(completed.result_snapshot_id)
-                assert tuple(summary["views"]) == ("bm25",)
+                assert tuple(summary["views"]) == (
+                    "bm25",
+                    REPO_MANIFEST_PROJECTION_VIEW,
+                )
                 assert summary["views"]["bm25"]["profile"]["profile_id"] == (profile_id)
     finally:
         fixture.close()
@@ -2466,7 +2484,7 @@ def test_local_compiler_cache_job_factory_runs_and_isolates_attempt_workspaces(
             assert outcome.disposition is IndexJobWorkerDisposition.SUCCEEDED
             assert outcome.job_id == queued.job_id
             assert publication_calls == [queued.job_id]
-            assert len(cas.put_chunk_receipts) == 3
+            assert len(cas.put_chunk_receipts) == 4
             assert len(cas.retained_receipt_sets) == 1
             assert not tuple(fixture.workspace.glob(".codenib-cache-job-*"))
             orphans = tuple(fixture.workspace.glob(".*.discarded-*"))
@@ -3244,16 +3262,18 @@ def test_compiler_cache_bm25_job_publishes_only_exact_bundle_and_replays(
             assert result.recapture.canonical_manifest_bytes == (
                 cache_import_module._pretty_manifest_bytes(result.import_plan.manifest)
             )
-            assert len(cas.put_chunk_receipts) == 3
-            assert len({receipt.digest for receipt in cas.put_chunk_receipts}) == 3
+            assert len(cas.put_chunk_receipts) == 4
+            assert len({receipt.digest for receipt in cas.put_chunk_receipts}) == 4
             expected_receipts = tuple(
                 sorted(cas.put_chunk_receipts, key=lambda receipt: receipt.digest)
             )
             assert cas.retained_receipt_sets == [expected_receipts]
             assert catalog.job_publication_calls == 1
             summary = catalog.get_manifest_summary(result.job.result_snapshot_id)
-            assert tuple(summary["views"]) == ("bm25",)
-            assert REPO_MANIFEST_PROJECTION_VIEW not in summary["views"]
+            assert tuple(summary["views"]) == (
+                "bm25",
+                REPO_MANIFEST_PROJECTION_VIEW,
+            )
             bm25 = summary["views"]["bm25"]
             assert bm25["profile"]["profile_id"] == profile_id
             assert bm25["schema_version"] == VIEW_BUNDLE_SCHEMA
@@ -3297,8 +3317,8 @@ def test_compiler_cache_bm25_job_publishes_only_exact_bundle_and_replays(
             assert retry.import_plan.plan_digest == result.import_plan.plan_digest
             assert retry.job.result_snapshot_id == first_ref["snapshot_id"]
             assert catalog.resolve_ref(repository_id) == advanced_ref
-            assert tuple(cas.put_chunk_receipts[:3]) == tuple(
-                cas.put_chunk_receipts[3:]
+            assert tuple(cas.put_chunk_receipts[:4]) == tuple(
+                cas.put_chunk_receipts[4:]
             )
             assert cas.retained_receipt_sets == [
                 expected_receipts,
@@ -3602,7 +3622,7 @@ def test_compiler_cache_bm25_job_rejects_post_ingest_drift_or_substitution(
                     cas=cas,
                 )
 
-            expected_put_count = 1 if case == "receipt_substitution" else 3
+            expected_put_count = 1 if case == "receipt_substitution" else 4
             assert len(cas.put_chunk_receipts) == expected_put_count
             assert catalog.resolve_ref(repository_id) == preserved_ref
             assert cas.read_bytes(preserved_digest) == (
@@ -4960,6 +4980,15 @@ def _register_vector_job_subject(
         name=intent.profile.name,
     )
     assert profile_id == intent.profile_id
+    supporting_profile = repo_manifest_projection_profile()
+    assert (
+        catalog.create_view_profile(
+            supporting_profile.view_type,
+            supporting_profile.config,
+            name=supporting_profile.name,
+        )
+        == supporting_profile.profile_id
+    )
     return repository_id, source_revision_id, profile_id
 
 
@@ -5120,7 +5149,7 @@ def test_prepare_compiler_cache_vector_job_uses_only_portable_schema8(
             assert result.import_plan.views[0].profile.config["builder_schema"] == 8
             assert result.artifact.schema_version == VIEW_BUNDLE_SCHEMA
             assert len(result.artifact.member_artifacts) == 4
-            assert len(cas.put_chunk_receipts) == 5
+            assert len(cas.put_chunk_receipts) == 6
             assert cas.retained_receipt_sets == []
             assert catalog.get_job(queued.job_id) == running
             assert fixture.provider.run_count == 2
@@ -5515,16 +5544,18 @@ def test_compiler_cache_vector_job_publishes_schema8_closure_and_replays(
                 or "incremental_state" in record.path
                 for record in result.recapture.output_records
             )
-            assert len(cas.put_chunk_receipts) == len(expected_paths) + 1
-            assert len({receipt.digest for receipt in cas.put_chunk_receipts}) == 5
+            assert len(cas.put_chunk_receipts) == len(expected_paths) + 2
+            assert len({receipt.digest for receipt in cas.put_chunk_receipts}) == 6
             expected_receipts = tuple(
                 sorted(cas.put_chunk_receipts, key=lambda receipt: receipt.digest)
             )
             assert cas.retained_receipt_sets == [expected_receipts]
             assert catalog.job_publication_calls == 1
             summary = catalog.get_manifest_summary(result.job.result_snapshot_id)
-            assert tuple(summary["views"]) == ("vector",)
-            assert REPO_MANIFEST_PROJECTION_VIEW not in summary["views"]
+            assert tuple(summary["views"]) == (
+                REPO_MANIFEST_PROJECTION_VIEW,
+                "vector",
+            )
             vector = summary["views"]["vector"]
             assert vector["profile"]["profile_id"] == profile_id
             assert vector["schema_version"] == VIEW_BUNDLE_SCHEMA
@@ -5565,8 +5596,8 @@ def test_compiler_cache_vector_job_publishes_schema8_closure_and_replays(
             assert retry.import_plan.plan_digest == result.import_plan.plan_digest
             assert retry.job.result_snapshot_id == first_ref["snapshot_id"]
             assert catalog.resolve_ref(repository_id) == advanced_ref
-            assert tuple(cas.put_chunk_receipts[:5]) == tuple(
-                cas.put_chunk_receipts[5:]
+            assert tuple(cas.put_chunk_receipts[:6]) == tuple(
+                cas.put_chunk_receipts[6:]
             )
             assert cas.retained_receipt_sets == [
                 expected_receipts,
@@ -5997,7 +6028,7 @@ def test_compiler_cache_vector_job_rejects_post_ingest_drift_or_substitution(
                     cas=cas,
                 )
 
-            expected_put_count = 1 if case == "receipt_substitution" else 5
+            expected_put_count = 1 if case == "receipt_substitution" else 6
             assert len(cas.put_chunk_receipts) == expected_put_count
             assert catalog.resolve_ref(repository_id) == preserved_ref
             assert cas.read_bytes(preserved_digest) == (

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -1182,7 +1182,13 @@ def _publish_bm25_job(
     context_owner: PublishedWorkspaceReceiptOwner | None = None,
     bm25_destination: Path | None = None,
     context_destination: Path | None = None,
+    max_projection_bytes: int | None = None,
 ) -> CompilerCacheJobPublicationResult:
+    limits = (
+        {}
+        if max_projection_bytes is None
+        else {"max_projection_bytes": max_projection_bytes}
+    )
     return publish_compiler_cache_bm25_job(
         fixture.cache,
         job_id=job_id,
@@ -1198,6 +1204,7 @@ def _publish_bm25_job(
         catalog=catalog,
         object_store=cas,
         environ={},
+        **limits,
     )
 
 
@@ -3482,6 +3489,7 @@ def test_compiler_cache_bm25_job_replays_legacy_requested_only_snapshot(
                 context_owner=retry_context_owner,
                 bm25_destination=fixture.workspace / "legacy-retry-bm25",
                 context_destination=fixture.workspace / "legacy-retry-context",
+                max_projection_bytes=1,
             )
 
             assert replay.job == legacy

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -87,6 +87,7 @@ from codenib.compiler.manifest_storage import (
     plan_repo_manifest_import_bytes,
 )
 from codenib.compiler.retained_manifest_contract import (
+    REPO_MANIFEST_PROJECTION_SNAPSHOT_REACHABILITY,
     REPO_MANIFEST_PROJECTION_VIEW,
     repo_manifest_projection_profile,
 )
@@ -119,6 +120,7 @@ from codenib.storage import (
     SQLiteCatalog,
     StorageIntegrityError,
     StorageValidationError,
+    publish_job_artifacts,
 )
 
 _Result = TypeVar("_Result")
@@ -1049,6 +1051,18 @@ def test_compiler_cache_import_is_a_lazy_public_export() -> None:
         "native_index_authorization",
     } & set(preparation_signature.parameters)
     assert "stop_token" in preparation_signature.parameters
+    assert (
+        preparation_signature.parameters["max_projection_bytes"].default
+        == cache_import_module.DEFAULT_MAX_PROJECTION_BYTES
+    )
+    assert all(
+        inspect.signature(adapter).parameters["max_projection_bytes"].default
+        == cache_import_module.DEFAULT_MAX_PROJECTION_BYTES
+        for adapter in (
+            publish_compiler_cache_bm25_job,
+            publish_compiler_cache_vector_job,
+        )
+    )
     executor_signature = inspect.signature(CompilerCacheJobExecutor)
     assert not {
         "catalog",
@@ -1057,6 +1071,10 @@ def test_compiler_cache_import_is_a_lazy_public_export() -> None:
         "ref_name",
         "expected_generation",
     } & set(executor_signature.parameters)
+    assert (
+        executor_signature.parameters["max_projection_bytes"].default
+        == cache_import_module.DEFAULT_MAX_PROJECTION_BYTES
+    )
     compile_signature = inspect.signature(compile_and_import_repo)
     assert list(compile_signature.parameters)[:4] == [
         "compiler",
@@ -1190,7 +1208,13 @@ def _prepare_bm25_job(
     views,
     cas: LocalCAS,
     stop_token: _TestStopToken | None = None,
+    max_projection_bytes: int | None = None,
 ) -> CompilerCacheJobPreparationResult:
+    limits = (
+        {}
+        if max_projection_bytes is None
+        else {"max_projection_bytes": max_projection_bytes}
+    )
     return prepare_compiler_cache_job_view(
         fixture.cache,
         view_type="bm25",
@@ -1206,6 +1230,7 @@ def _prepare_bm25_job(
         object_store=cas,
         stop_token=stop_token,
         environ={},
+        **limits,
     )
 
 
@@ -1261,6 +1286,51 @@ def test_prepare_compiler_cache_job_view_leaves_catalog_running(
             assert len(cas.put_chunk_receipts) == 4
             assert cas.retained_receipt_sets == []
             assert fixture.provider.run_count == 2
+    finally:
+        fixture.close()
+
+
+def test_prepare_compiler_cache_job_view_honors_projection_limit(
+    tmp_path: Path,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    plan = _expected_bm25_job_plan(fixture)
+    try:
+        with (
+            _JobTrackingCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            repository_id, source_revision_id, profile_id = _register_bm25_job_subject(
+                catalog,
+                fixture,
+                plan,
+            )
+            queued = _create_bm25_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+            )
+            catalog.acquire_job_lease(
+                queued.job_id,
+                owner_id="projection-limit-worker",
+                lease_duration_ms=60_000,
+            )
+            running = catalog.get_job(queued.job_id)
+
+            with pytest.raises(
+                StorageValidationError,
+                match="repository manifest projection exceeds 1 bytes",
+            ):
+                _prepare_bm25_job(
+                    fixture,
+                    job=running,
+                    views=catalog.get_job_views(queued.job_id),
+                    cas=cas,
+                    max_projection_bytes=1,
+                )
+
+            assert catalog.get_job(queued.job_id) == running
     finally:
         fixture.close()
 
@@ -3275,6 +3345,11 @@ def test_compiler_cache_bm25_job_publishes_only_exact_bundle_and_replays(
                 REPO_MANIFEST_PROJECTION_VIEW,
             )
             bm25 = summary["views"]["bm25"]
+            projection = summary["views"][REPO_MANIFEST_PROJECTION_VIEW]
+            assert projection["metadata"]["reachability"] == (
+                REPO_MANIFEST_PROJECTION_SNAPSHOT_REACHABILITY
+            )
+            assert projection["member_objects"] == []
             assert bm25["profile"]["profile_id"] == profile_id
             assert bm25["schema_version"] == VIEW_BUNDLE_SCHEMA
             assert bm25["object"]["media_type"] == VIEW_BUNDLE_MEDIA_TYPE
@@ -3329,6 +3404,96 @@ def test_compiler_cache_bm25_job_publishes_only_exact_bundle_and_replays(
             assert fixture.context_owner.active
             assert retry_bm25_owner.active
             assert retry_context_owner.active
+    finally:
+        retry_context_owner.close()
+        retry_bm25_owner.close()
+        fixture.close()
+
+
+def test_compiler_cache_bm25_job_replays_legacy_requested_only_snapshot(
+    tmp_path: Path,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    retry_bm25_owner = PublishedWorkspaceReceiptOwner()
+    retry_context_owner = PublishedWorkspaceReceiptOwner()
+    plan = _expected_bm25_job_plan(fixture)
+    try:
+        with (
+            _JobTrackingCAS(tmp_path / "cas") as cas,
+            _RetentionAwareJobCatalog(
+                tmp_path / "catalog.sqlite",
+                cas,
+            ) as catalog,
+        ):
+            repository_id, source_revision_id, profile_id = _register_bm25_job_subject(
+                catalog,
+                fixture,
+                plan,
+            )
+            queued = _create_bm25_job(
+                catalog,
+                repository_id=repository_id,
+                source_revision_id=source_revision_id,
+                profile_id=profile_id,
+            )
+            lease = catalog.acquire_job_lease(
+                queued.job_id,
+                owner_id="legacy-worker",
+                lease_duration_ms=60_000,
+            )
+            running = catalog.get_job(queued.job_id)
+            prepared = _prepare_bm25_job(
+                fixture,
+                job=running,
+                views=catalog.get_job_views(queued.job_id),
+                cas=cas,
+            )
+            legacy = publish_job_artifacts(
+                queued.job_id,
+                catalog=catalog,
+                object_store=cas,
+                owner_id=lease.owner_id,
+                fencing_token=lease.fencing_token,
+                outputs=(prepared.artifact,),
+            )
+            legacy_summary = catalog.get_manifest_summary(legacy.result_snapshot_id)
+            assert tuple(legacy_summary["views"]) == ("bm25",)
+            requested_receipts = tuple(
+                sorted(
+                    (
+                        prepared.artifact.object_artifact.receipt,
+                        *(
+                            member.receipt
+                            for member in prepared.artifact.member_artifacts
+                        ),
+                    ),
+                    key=lambda receipt: receipt.digest,
+                )
+            )
+
+            replay = _publish_bm25_job(
+                fixture,
+                job_id=queued.job_id,
+                owner_id=lease.owner_id,
+                fencing_token=lease.fencing_token,
+                catalog=catalog,
+                cas=cas,
+                bm25_owner=retry_bm25_owner,
+                context_owner=retry_context_owner,
+                bm25_destination=fixture.workspace / "legacy-retry-bm25",
+                context_destination=fixture.workspace / "legacy-retry-context",
+            )
+
+            assert replay.job == legacy
+            assert replay.job.result_snapshot_id == legacy.result_snapshot_id
+            assert tuple(
+                catalog.get_manifest_summary(replay.job.result_snapshot_id)["views"]
+            ) == ("bm25",)
+            assert cas.retained_receipt_sets == [
+                requested_receipts,
+                requested_receipts,
+            ]
+            assert catalog.job_publication_calls == 2
     finally:
         retry_context_owner.close()
         retry_bm25_owner.close()

--- a/test/compiler/test_manifest_import.py
+++ b/test/compiler/test_manifest_import.py
@@ -948,6 +948,27 @@ def test_expected_chunks_infinite_empty_tail_stops_cooperatively() -> None:
     assert cancellation_calls == 3
 
 
+def test_projection_measurement_polls_cancellation_between_chunks() -> None:
+    stop = SystemExit("projection measurement cancelled")
+    cancellation_calls = 0
+
+    def check_cancelled() -> None:
+        nonlocal cancellation_calls
+        cancellation_calls += 1
+        if cancellation_calls == 3:
+            raise stop
+
+    with pytest.raises(SystemExit) as caught:
+        manifest_import_module._measure_canonical_json(
+            {"items": [{"value": value} for value in range(1_000)]},
+            max_bytes=1024 * 1024,
+            check_cancelled=check_cancelled,
+        )
+
+    assert caught.value is stop
+    assert cancellation_calls == 3
+
+
 def _prepare_vector_job_artifacts(
     fixture: _ContextFixture,
     object_store: LocalCAS,

--- a/test/compiler/test_source_job.py
+++ b/test/compiler/test_source_job.py
@@ -359,7 +359,13 @@ def _executor(
     context_destination: Path | None = None,
     forbidden_paths=(),
     environ=None,
+    max_projection_bytes: int | None = None,
 ) -> BM25SourceJobExecutor:
+    limits = (
+        {}
+        if max_projection_bytes is None
+        else {"max_projection_bytes": max_projection_bytes}
+    )
     return BM25SourceJobExecutor(
         attempt_generation=attempt_generation,
         display_commit=_COMMIT,
@@ -388,6 +394,7 @@ def _executor(
         object_store=cas,
         forbidden_paths=forbidden_paths,
         environ=environ,
+        **limits,
     )
 
 
@@ -477,6 +484,7 @@ def test_bm25_source_executor_prepares_exact_artifact_without_lexical_reads(
                 context_owner=context_owner,
                 forbidden_paths=(path for path in (forbidden,)),
                 environ=environment,
+                max_projection_bytes=32 * 1024 * 1024,
             )
             assert executor.forbidden_paths == (forbidden,)
             assert executor.environ == environment
@@ -504,6 +512,7 @@ def test_bm25_source_executor_prepares_exact_artifact_without_lexical_reads(
                 assert kwargs["expected_manifest"].to_dict() == manifest.to_dict()
                 assert kwargs["forbidden_paths"] == (forbidden,)
                 assert kwargs["environ"]["CODENIB_SOURCE_JOB_TEST"] == "before"
+                assert kwargs["max_projection_bytes"] == 32 * 1024 * 1024
                 return real_prepare(cache_generation, **kwargs)
 
             with monkeypatch.context() as guard:
@@ -1365,6 +1374,10 @@ def test_bm25_source_executor_api_has_no_publication_authority() -> None:
         "expected_generation",
         "generation_id",
     } & set(parameters)
+    assert (
+        parameters["max_projection_bytes"].default
+        == source_job_module.DEFAULT_MAX_PROJECTION_BYTES
+    )
 
 
 def test_bm25_source_executor_repr_does_not_expose_environment(

--- a/test/compiler/test_source_job.py
+++ b/test/compiler/test_source_job.py
@@ -54,6 +54,7 @@ from codenib.compiler.job_resources import (
 )
 from codenib.compiler.manifest import RepoManifest
 from codenib.compiler.manifest_storage import BM25_PROFILE_AXES
+from codenib.compiler.retained_manifest_contract import repo_manifest_projection_profile
 from codenib.compiler.source_job import BM25SourceJobExecutor, bm25_source_job_profile
 from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.source_fingerprint import (
@@ -81,6 +82,18 @@ from codenib.storage.models import NamespaceIdentity, RepositoryIdentity
 
 _COMMIT = "a" * 40
 _REPOSITORY_KEY = "owner/repo"
+
+
+def _register_projection_profile(catalog: SQLiteCatalog) -> None:
+    profile = repo_manifest_projection_profile()
+    assert (
+        catalog.create_view_profile(
+            profile.view_type,
+            profile.config,
+            name=profile.name,
+        )
+        == profile.profile_id
+    )
 
 
 class _StopToken:
@@ -289,6 +302,7 @@ def _execution_context(
         profile.config,
         name=profile.name,
     )
+    _register_projection_profile(catalog)
     views: dict[str, dict[str, object]] = {
         "bm25": {
             "profile_id": profile_id,
@@ -1634,6 +1648,7 @@ def test_local_bm25_source_job_factory_runs_worker_and_cleans_attempt(
                 profile.config,
                 name=profile.name,
             )
+            _register_projection_profile(catalog)
             assert profile_id == target.profile_id
             queued = catalog.create_job(
                 repository_id,
@@ -1950,6 +1965,7 @@ def test_jobs_run_once_source_bm25_executes_matching_catalog_job(
                 profile.config,
                 name=profile.name,
             )
+            _register_projection_profile(catalog)
             assert profile_id == profile.profile_id
             queued = catalog.create_job(
                 repository_id,
@@ -2066,6 +2082,7 @@ def test_local_bm25_source_worker_preserves_current_ref_after_source_changes(
                 )
                 == profile.profile_id
             )
+            _register_projection_profile(catalog)
             first = catalog.create_job(
                 repository_id,
                 source_revision_id,

--- a/test/storage/test_job_execution_models.py
+++ b/test/storage/test_job_execution_models.py
@@ -17,6 +17,7 @@ from codenib.storage.models import (
     INDEX_JOB_EVENT_PAYLOAD_MAX_KEY_CHARS,
     INDEX_JOB_EVENT_PAYLOAD_MAX_NODES,
     INDEX_JOB_EVENT_PAYLOAD_MAX_TEXT_CHARS,
+    INDEX_JOB_SUPPORTING_VIEW_PREFIX,
     MAX_INDEX_JOB_EVENTS_PER_ATTEMPT,
     IndexJobAttemptCompletionRecord,
     IndexJobAttemptHeartbeat,
@@ -87,6 +88,26 @@ def test_execution_contract_bounds_are_explicit() -> None:
     assert INDEX_JOB_EVENT_PAYLOAD_MAX_TEXT_CHARS == 16 * 1_024
     assert INDEX_JOB_EVENT_PAYLOAD_MAX_KEY_CHARS == 128
     assert MAX_INDEX_JOB_EVENTS_PER_ATTEMPT == 256
+
+
+def test_job_request_reserves_internal_supporting_views() -> None:
+    with pytest.raises(StorageValidationError, match="reserved supporting views"):
+        IndexJobRequest.create(
+            "repo_" + "a" * 64,
+            "src_" + "b" * 64,
+            "reserved-view",
+            {
+                "contract": "codenib.index-job-request.v1",
+                "views": {
+                    INDEX_JOB_SUPPORTING_VIEW_PREFIX
+                    + "test-support": {
+                        "profile_id": "profile_" + "c" * 64,
+                        "requested_mode": "full",
+                        "required": True,
+                    }
+                },
+            },
+        )
 
 
 def test_attempt_completion_and_heartbeat_close_exact_authority() -> None:

--- a/test/storage/test_job_worker.py
+++ b/test/storage/test_job_worker.py
@@ -31,6 +31,7 @@ from codenib.storage.job_worker import (
 from codenib.storage.models import (
     INDEX_JOB_EVENT_PAYLOAD_MAX_TEXT_CHARS,
     INDEX_JOB_REQUEST_CONTRACT,
+    INDEX_JOB_SUPPORTING_VIEW_PREFIX,
     MAX_INDEX_JOB_EVENTS_PER_ATTEMPT,
     IndexJobAttemptCompletionRecord,
     IndexJobAttemptHeartbeat,
@@ -2930,6 +2931,31 @@ def test_result_models_reject_invalid_combinations_and_nonexact_values() -> None
     )
     assert valid.publishable
     assert valid.artifacts == (bm25_success.artifact,)
+    supporting_view = INDEX_JOB_SUPPORTING_VIEW_PREFIX + "test-support"
+    supporting = IndexJobViewArtifact.create(
+        supporting_view,
+        _profile_id(supporting_view),
+        _receipt(b"supporting worker artifact"),
+        schema_version="test.support.v1",
+    )
+    supported = IndexJobExecutionResult(
+        (bm25_success, vector_skipped),
+        supporting_artifacts=(supporting,),
+    )
+    assert supported.artifacts == (bm25_success.artifact,)
+    assert supported.publication_artifacts == (bm25_success.artifact, supporting)
+    with pytest.raises(StorageValidationError, match="reserved view namespace"):
+        IndexJobExecutionResult(
+            (bm25_success, vector_skipped),
+            supporting_artifacts=(
+                IndexJobViewArtifact.create(
+                    "public-extra",
+                    _profile_id("public-extra"),
+                    _receipt(b"public extra"),
+                    schema_version="test.public.v1",
+                ),
+            ),
+        )
 
     shared_receipt = _receipt(b"shared-result-object")
     conflicting_bm25 = IndexJobViewExecutionResult.create(

--- a/test/storage/test_sqlite_job_publication.py
+++ b/test/storage/test_sqlite_job_publication.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import pytest
 
+from codenib.storage import models as storage_models_module
 from codenib.storage import sqlite_catalog as sqlite_catalog_module
 from codenib.storage.models import (
     INDEX_JOB_PUBLICATION_CONTRACT,
@@ -35,6 +36,7 @@ from codenib.storage.models import (
     StorageIntegrityError,
     StorageValidationError,
     canonical_json,
+    repo_manifest_projection_profile,
 )
 from codenib.storage.sqlite_catalog import (
     LATEST_SCHEMA_VERSION,
@@ -913,13 +915,23 @@ def test_v8_migration_accepts_reserved_support_and_still_closes_replay(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     path = tmp_path / "catalog.sqlite3"
-    supporting_view = INDEX_JOB_SUPPORTING_VIEW_PREFIX + "test-support"
+    supporting_profile = repo_manifest_projection_profile()
     monkeypatch.setattr(sqlite_catalog_module, "LATEST_SCHEMA_VERSION", 7)
     with SQLiteCatalog(path) as catalog:
-        fixture = _create_running_job(catalog)
-        supporting_profile = catalog.create_view_profile(
-            supporting_view,
-            {"contract": "test-support.v1"},
+        repository_id, source_revision_id = _repository(catalog)
+        profiles = _profiles(catalog, ("bm25",))
+        queued = catalog.create_job(
+            repository_id,
+            source_revision_id,
+            "queued-before-support-profile",
+            _request(profiles),
+        )
+        assert (
+            catalog._connection.execute(
+                "SELECT 1 FROM view_profiles WHERE profile_id = ?",
+                (supporting_profile.profile_id,),
+            ).fetchone()
+            is None
         )
 
     monkeypatch.setattr(
@@ -928,22 +940,110 @@ def test_v8_migration_accepts_reserved_support_and_still_closes_replay(
         LATEST_SCHEMA_VERSION,
     )
     outputs = (
-        _output("bm25", fixture.profiles["bm25"], 100),
-        _output(supporting_view, supporting_profile, 102),
+        _output("bm25", profiles["bm25"], 100),
+        _output(
+            supporting_profile.view_type,
+            supporting_profile.profile_id,
+            102,
+        ),
     )
     with SQLiteCatalog(path, create=False) as catalog:
         assert catalog.schema_version == LATEST_SCHEMA_VERSION
+        assert (
+            catalog.create_view_profile(
+                supporting_profile.view_type,
+                supporting_profile.config,
+                name=supporting_profile.name,
+            )
+            == supporting_profile.profile_id
+        )
+        lease = catalog.acquire_job_lease(
+            queued.job_id,
+            owner_id="upgraded-worker",
+            lease_duration_ms=60_000,
+        )
         completed = catalog.publish_job_outputs(
-            fixture.job.job_id,
-            owner_id=fixture.owner_id,
-            fencing_token=fixture.fencing_token,
+            queued.job_id,
+            owner_id=lease.owner_id,
+            fencing_token=lease.fencing_token,
             outputs=outputs,
         )
         summary = catalog.get_manifest_summary(completed.result_snapshot_id)
-        assert tuple(summary["views"]) == ("bm25", supporting_view)
+        assert tuple(summary["views"]) == (
+            "bm25",
+            supporting_profile.view_type,
+        )
 
     with SQLiteCatalog(path, create=False) as catalog:
-        assert catalog.get_job(fixture.job.job_id) == completed
+        replay = catalog.publish_job_outputs(
+            queued.job_id,
+            owner_id=lease.owner_id,
+            fencing_token=lease.fencing_token,
+            outputs=outputs,
+        )
+        assert replay == completed
+
+
+def test_v8_migration_grandfathers_legacy_internal_view_requests(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "legacy-internal-request.sqlite3"
+    internal_view = INDEX_JOB_SUPPORTING_VIEW_PREFIX + "legacy-request"
+    monkeypatch.setattr(sqlite_catalog_module, "LATEST_SCHEMA_VERSION", 7)
+    with monkeypatch.context() as legacy_models:
+        legacy_models.setattr(
+            storage_models_module,
+            "is_index_job_supporting_view",
+            lambda _view_type: False,
+        )
+        with SQLiteCatalog(path) as catalog:
+            repository_id, source_revision_id = _repository(catalog)
+            profile_id = catalog.create_view_profile(internal_view, {"legacy": True})
+            queued = catalog.create_job(
+                repository_id,
+                source_revision_id,
+                "legacy-internal-request",
+                _request(
+                    {internal_view: profile_id}, required=frozenset({internal_view})
+                ),
+            )
+
+    monkeypatch.setattr(
+        sqlite_catalog_module,
+        "LATEST_SCHEMA_VERSION",
+        LATEST_SCHEMA_VERSION,
+    )
+    with SQLiteCatalog(path, create=False) as catalog:
+        assert catalog.get_job(queued.job_id) == queued
+        assert tuple(
+            view.view_type for view in catalog.get_job_views(queued.job_id)
+        ) == (internal_view,)
+        with pytest.raises(StorageValidationError, match="reserved supporting views"):
+            catalog.create_job(
+                repository_id,
+                source_revision_id,
+                "new-internal-request",
+                _request(
+                    {internal_view: profile_id},
+                    required=frozenset({internal_view}),
+                ),
+            )
+        lease = catalog.acquire_job_lease(
+            queued.job_id,
+            owner_id="legacy-internal-worker",
+            lease_duration_ms=60_000,
+        )
+        completed = catalog.publish_job_outputs(
+            queued.job_id,
+            owner_id=lease.owner_id,
+            fencing_token=lease.fencing_token,
+            outputs=(_output(internal_view, profile_id, 100),),
+        )
+        assert completed.status is IndexJobStatus.SUCCEEDED
+        assert tuple(
+            catalog.get_manifest_summary(completed.result_snapshot_id)["views"]
+        ) == (internal_view,)
 
 
 @pytest.mark.parametrize(
@@ -2545,6 +2645,15 @@ def test_sqlite_publication_accepts_exactly_the_public_compound_member_cap(
     with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
         repository_id, source_revision_id = _repository(catalog)
         profiles = _profiles(catalog, ("semantic_facts",))
+        supporting_profile = repo_manifest_projection_profile()
+        assert (
+            catalog.create_view_profile(
+                supporting_profile.view_type,
+                supporting_profile.config,
+                name=supporting_profile.name,
+            )
+            == supporting_profile.profile_id
+        )
         fixture = _create_running_job(
             catalog,
             repository_id=repository_id,
@@ -2562,17 +2671,26 @@ def test_sqlite_publication_accepts_exactly_the_public_compound_member_cap(
             MAX_VIEW_GENERATION_MEMBERS + 100,
             members=members,
         )
+        supporting = _output(
+            supporting_profile.view_type,
+            supporting_profile.profile_id,
+            MAX_VIEW_GENERATION_MEMBERS + 101,
+        )
 
         completed = catalog.publish_job_outputs(
             fixture.job.job_id,
             owner_id=fixture.owner_id,
             fencing_token=fixture.fencing_token,
-            outputs=(output,),
+            outputs=(output, supporting),
         )
 
         assert completed.status is IndexJobStatus.SUCCEEDED
         manifest = catalog.get_manifest_summary(completed.result_snapshot_id)
         persisted = manifest["views"]["semantic_facts"]["member_objects"]
+        supporting_persisted = manifest["views"][supporting_profile.view_type][
+            "member_objects"
+        ]
         assert len(persisted) == MAX_VIEW_GENERATION_MEMBERS
+        assert supporting_persisted == []
         assert persisted[0]["digest"] == members[0].digest
         assert persisted[-1]["digest"] == members[-1].digest

--- a/test/storage/test_sqlite_job_publication.py
+++ b/test/storage/test_sqlite_job_publication.py
@@ -25,6 +25,7 @@ from codenib.storage import sqlite_catalog as sqlite_catalog_module
 from codenib.storage.models import (
     INDEX_JOB_PUBLICATION_CONTRACT,
     INDEX_JOB_REQUEST_CONTRACT,
+    INDEX_JOB_SUPPORTING_VIEW_PREFIX,
     MAX_VIEW_GENERATION_MEMBERS,
     IndexJobCurrentResult,
     IndexJobRecord,
@@ -905,6 +906,44 @@ def test_optional_requested_views_may_be_omitted_or_published_as_a_subset(
 
         manifest = catalog.get_manifest_summary(completed.result_snapshot_id)
         assert tuple(manifest["views"]) == ("bm25", "semantic_facts")
+
+
+def test_v8_migration_accepts_reserved_support_and_still_closes_replay(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "catalog.sqlite3"
+    supporting_view = INDEX_JOB_SUPPORTING_VIEW_PREFIX + "test-support"
+    monkeypatch.setattr(sqlite_catalog_module, "LATEST_SCHEMA_VERSION", 7)
+    with SQLiteCatalog(path) as catalog:
+        fixture = _create_running_job(catalog)
+        supporting_profile = catalog.create_view_profile(
+            supporting_view,
+            {"contract": "test-support.v1"},
+        )
+
+    monkeypatch.setattr(
+        sqlite_catalog_module,
+        "LATEST_SCHEMA_VERSION",
+        LATEST_SCHEMA_VERSION,
+    )
+    outputs = (
+        _output("bm25", fixture.profiles["bm25"], 100),
+        _output(supporting_view, supporting_profile, 102),
+    )
+    with SQLiteCatalog(path, create=False) as catalog:
+        assert catalog.schema_version == LATEST_SCHEMA_VERSION
+        completed = catalog.publish_job_outputs(
+            fixture.job.job_id,
+            owner_id=fixture.owner_id,
+            fencing_token=fixture.fencing_token,
+            outputs=outputs,
+        )
+        summary = catalog.get_manifest_summary(completed.result_snapshot_id)
+        assert tuple(summary["views"]) == ("bm25", supporting_view)
+
+    with SQLiteCatalog(path, create=False) as catalog:
+        assert catalog.get_job(fixture.job.job_id) == completed
 
 
 @pytest.mark.parametrize(

--- a/test/web/test_index_job_planning.py
+++ b/test/web/test_index_job_planning.py
@@ -14,7 +14,7 @@ from codenib.compiler.index_builders import BM25IndexBuilder
 from codenib.compiler.job_resources import LocalBM25SourceJobTarget
 from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.source_fingerprint import RepositoryChangedError
-from codenib.storage import SourceRevision, SQLiteCatalog
+from codenib.storage import SourceRevision, SQLiteCatalog, ViewProfile
 from codenib.web.index_job_planning import LocalBM25SourceJobPlanner
 from codenib.web.index_job_writes import (
     CatalogIndexJobWriter,
@@ -161,7 +161,7 @@ def test_local_bm25_source_planner_revalidates_source_after_catalog_calls(
             return revision.source_revision_id
 
         def create_view_profile(self, view_type, config=None, *, name="default"):
-            return target.profile.profile_id
+            return ViewProfile.create(view_type, config or {}, name=name).profile_id
 
         def read_ref_generation(self, repository_id, ref_name="main"):
             return 0


### PR DESCRIPTION
## Summary

Make successful retained-source index jobs publish snapshots that the strict runtime loader can actually materialize. Each requested BM25 generation is atomically accompanied by the reserved repository-manifest projection and its complete retained member closure; historical requested-only successes remain replayable without preparing the newer projection.

#735 is merged. This branch is now based directly on `main`; its six commits are patch-equivalent to the previously reviewed stack.

## Changes

- reserve `codenib.internal.*` for executor-produced snapshot-support views and reject it from job requests
- keep caller-visible requested artifacts separate from exact supporting artifacts in the worker result model
- validate, retain, and publish the combined closure while preserving the 64 requested-view limit and the complete 32768-member capacity
- prepare the manifest projection plus full member closure under the same source, cancellation, receipt, and topology checks as requested views
- poll cooperative cancellation during both projection measurement and projection ingestion passes
- publish the support closure from cache and retained-source BM25 executors without granting catalog authority
- identify historical requested-only successful snapshots from the requested artifact closure before projection measurement or CAS writes
- preserve deterministic one-pass replay for current loadable snapshots
- authenticate and materialize both legacy dependency-closed projections and snapshot-scoped sibling-reachable projections by requiring exact generation and snapshot IDs
- select snapshot-scoped reachability from its generation ID before constructing a potentially oversized legacy dependency candidate
- register and backfill the deterministic projection profile through least-authority catalog paths
- add SQLite schema 8 with an authenticated v7-to-v8 trigger migration that permits only reserved extras and preserves current clock/fencing checks
- grandfather authenticated v7 requested-only completed jobs while retaining strict rejection of ordinary unrequested public outputs
- thread `max_projection_bytes` through prepare-only executors and adapters
- document the loadable snapshot contract and remaining runtime/UI gates

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- focused compiler, source-job, execution-model, worker, SQLite publication, and Web planning set (552 passed)
- regression proves snapshot-scoped materialization never constructs a nonempty legacy dependency closure
- exact six-commit range-diff after #735 merged; all six commits are patch-equivalent
- pre-commit on every changed file

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
