### PR TITLE
feat(web): own local index runtime lifespan

### DIFF
--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -61,11 +61,16 @@ from .index_jobs import (
     IndexJobReadError,
     overlay_active_job,
 )
-from .index_status import build_repo_index_status, validate_index_update_capabilities
+from .index_status import (
+    IndexUpdateCapability,
+    build_repo_index_status,
+    validate_index_update_capabilities,
+)
 from .local_index_runtime import (
     LocalIndexRuntimeService,
     open_local_index_runtime_service,
 )
+from .local_index_service import LocalIndexServiceError
 from .native_authority import authorize_local_manifest_vector
 from .ports import argparse_tcp_port
 from .repo_registry import RepoRegistry
@@ -97,6 +102,53 @@ _MISSING_APP_STATE = object()
 class _LocalRuntimeLifespanState:
     service: LocalIndexRuntimeService | None = None
     startup_cleanup_pending: bool = False
+
+
+class _LiveLocalIndexJobWriter:
+    """Stop admitting durable writes as soon as the owned loops fault."""
+
+    __slots__ = ("_service", "_writer")
+
+    def __init__(
+        self, service: LocalIndexRuntimeService, writer: IndexJobWriter
+    ) -> None:
+        if not isinstance(writer, IndexJobWriter):
+            raise TypeError("local runtime writer does not implement its contract")
+        self._service = service
+        self._writer = writer
+
+    def create(
+        self,
+        repo_id: str,
+        *,
+        indexes: tuple[str, ...],
+        mode: str,
+        force: bool,
+        idempotency_key: str,
+    ) -> IndexJobStatusResponse:
+        if self._service.state != "running" or self._service.healthy is not True:
+            raise IndexJobWriteError("local index runtime is unhealthy")
+        return self._writer.create(
+            repo_id,
+            indexes=indexes,
+            mode=mode,
+            force=force,
+            idempotency_key=idempotency_key,
+        )
+
+
+def _live_local_index_capabilities(
+    service: LocalIndexRuntimeService,
+    repo_id: str,
+) -> Mapping[str, IndexUpdateCapability] | None:
+    """Return unavailable for an unhealthy runtime or an unbound repository."""
+
+    if service.state != "running" or service.healthy is not True:
+        return None
+    try:
+        return service.capabilities(repo_id)
+    except KeyError:
+        return None
 
 
 def _has_pending_publication_cleanup(failure: BaseException) -> bool:
@@ -179,15 +231,21 @@ def _configured_local_index_runtime(app, config, registry, lifecycle):
     if storage is None:
         yield None
         return
+    if getattr(config, "mode", "sparse") != "sparse":
+        raise LocalIndexServiceError(
+            "local index runtime currently requires sparse Web mode"
+        )
 
     try:
         with open_local_index_runtime_service(storage, registry) as service:
             lifecycle.service = service
+            writer = _LiveLocalIndexJobWriter(service, service.writer)
+            capabilities = partial(_live_local_index_capabilities, service)
             bindings = {
                 "index_runtime_service": service,
                 "index_job_reader": service.reader,
-                "index_job_writer": service.writer,
-                "index_update_capabilities_resolver": service.capabilities,
+                "index_job_writer": writer,
+                "index_update_capabilities_resolver": capabilities,
             }
             previous = {
                 name: getattr(app.state, name, _MISSING_APP_STATE) for name in bindings

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -23,6 +23,7 @@ import hashlib
 import os
 from collections.abc import Mapping
 from contextlib import asynccontextmanager, contextmanager
+from dataclasses import dataclass
 from functools import partial
 from pathlib import Path, PurePosixPath
 from time import perf_counter
@@ -61,6 +62,10 @@ from .index_jobs import (
     overlay_active_job,
 )
 from .index_status import build_repo_index_status, validate_index_update_capabilities
+from .local_index_runtime import (
+    LocalIndexRuntimeService,
+    open_local_index_runtime_service,
+)
 from .native_authority import authorize_local_manifest_vector
 from .ports import argparse_tcp_port
 from .repo_registry import RepoRegistry
@@ -84,6 +89,29 @@ _WIKI_MEDIA_TYPES = {
 }
 
 logger = get_logger(__name__)
+
+_MISSING_APP_STATE = object()
+
+
+@dataclass(slots=True)
+class _LocalRuntimeLifespanState:
+    service: LocalIndexRuntimeService | None = None
+    startup_cleanup_pending: bool = False
+
+
+def _has_pending_publication_cleanup(failure: BaseException) -> bool:
+    """Fail closed when startup retained an unfinished cleanup owner."""
+
+    try:
+        owners = BaseException.__getattribute__(
+            failure,
+            "publication_cleanup_owners",
+        )
+    except AttributeError:
+        return False
+    except BaseException:  # noqa: B036 - malformed metadata retains the registry
+        return True
+    return type(owners) is not tuple or bool(owners)
 
 
 def _manifest_source_selection(bundle) -> RepositorySourceSelection:
@@ -140,6 +168,54 @@ def _wiki_narrator(config):
     )
 
 
+@contextmanager
+def _configured_local_index_runtime(app, config, registry, lifecycle):
+    """Expose one configured runtime only for its live service lifetime."""
+
+    if type(lifecycle) is not _LocalRuntimeLifespanState:
+        raise TypeError("local runtime lifespan state must use the exact model")
+
+    storage = getattr(config, "index_storage", None)
+    if storage is None:
+        yield None
+        return
+
+    try:
+        with open_local_index_runtime_service(storage, registry) as service:
+            lifecycle.service = service
+            bindings = {
+                "index_runtime_service": service,
+                "index_job_reader": service.reader,
+                "index_job_writer": service.writer,
+                "index_update_capabilities_resolver": service.capabilities,
+            }
+            previous = {
+                name: getattr(app.state, name, _MISSING_APP_STATE) for name in bindings
+            }
+            try:
+                for name, value in bindings.items():
+                    setattr(app.state, name, value)
+                yield service
+            finally:
+                # Stop exposing this generation before its synchronous close joins
+                # the worker and reconciler. Preserve any state a test harness or
+                # embedding application deliberately replaced while it was live.
+                for name, value in bindings.items():
+                    if getattr(app.state, name, _MISSING_APP_STATE) is not value:
+                        continue
+                    prior = previous[name]
+                    if prior is _MISSING_APP_STATE:
+                        delattr(app.state, name)
+                    else:
+                        setattr(app.state, name, prior)
+    except BaseException as failure:  # noqa: B036 - preserve startup authority
+        if lifecycle.service is None:
+            lifecycle.startup_cleanup_pending = _has_pending_publication_cleanup(
+                failure
+            )
+        raise
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     config = load_config()
@@ -157,6 +233,7 @@ async def lifespan(app: FastAPI):
         # source-bound capability is present.
         allow_missing_native_index_authorization=True,
     )
+    runtime_lifecycle = _LocalRuntimeLifespanState()
     try:
         logger.info("Loading QA repos from %s ...", config.registry_path)
         registry.load_all()
@@ -173,11 +250,34 @@ async def lifespan(app: FastAPI):
             app.state.narrator.enabled,
             app.state.narrator.cache_dir,
         )
-        logger.info("Ready: %d repo(s) available", len(registry.list_infos()))
-        yield
+        with _configured_local_index_runtime(
+            app,
+            config,
+            registry,
+            runtime_lifecycle,
+        ) as configured:
+            if configured is not None:
+                logger.info(
+                    "Local index runtime: state=%s healthy=%s",
+                    configured.state,
+                    configured.healthy,
+                )
+            logger.info("Ready: %d repo(s) available", len(registry.list_infos()))
+            yield
     finally:
         try:
-            registry.close()
+            # A failed runtime close keeps its registry dependency reachable
+            # through the retained cleanup owner on the raised exception. Do
+            # not retire repository generations underneath a still-live loop.
+            runtime_service = runtime_lifecycle.service
+            if not runtime_lifecycle.startup_cleanup_pending and (
+                runtime_service is None or runtime_service.closed
+            ):
+                registry.close()
+            else:
+                logger.error(
+                    "Local index runtime did not settle; retaining RepoRegistry"
+                )
         finally:
             for name in ("wiki_builders", "edge_labelers", "commit_windows"):
                 cache = getattr(app.state, name, None)

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -105,17 +105,21 @@ class _LocalRuntimeLifespanState:
 
 
 class _LiveLocalIndexJobWriter:
-    """Stop admitting durable writes as soon as the owned loops fault."""
+    """Gate writes on the live repository and observable runtime health."""
 
-    __slots__ = ("_service", "_writer")
+    __slots__ = ("_registry", "_service", "_writer")
 
     def __init__(
-        self, service: LocalIndexRuntimeService, writer: IndexJobWriter
+        self,
+        service: LocalIndexRuntimeService,
+        writer: IndexJobWriter,
+        registry: RepoRegistry,
     ) -> None:
         if not isinstance(writer, IndexJobWriter):
             raise TypeError("local runtime writer does not implement its contract")
         self._service = service
         self._writer = writer
+        self._registry = registry
 
     def create(
         self,
@@ -126,15 +130,26 @@ class _LiveLocalIndexJobWriter:
         force: bool,
         idempotency_key: str,
     ) -> IndexJobStatusResponse:
-        if self._service.state != "running" or self._service.healthy is not True:
-            raise IndexJobWriteError("local index runtime is unhealthy")
-        return self._writer.create(
-            repo_id,
-            indexes=indexes,
-            mode=mode,
-            force=force,
-            idempotency_key=idempotency_key,
-        )
+        # A pin is the admission point: a concurrent reload may retire this
+        # generation afterwards, but a request that starts after retirement
+        # must not reach the lifespan-wide writer bound to the old checkout.
+        with self._registry.pin(repo_id) as bundle:
+            if bundle is None:
+                raise IndexJobNotFoundError(
+                    "Web repository is no longer configured for index updates"
+                )
+            # Health is an entry-time availability signal, not part of the
+            # catalog transaction. A job accepted just before a loop fault is
+            # durable and remains recoverable by the next service process.
+            if self._service.state != "running" or self._service.healthy is not True:
+                raise IndexJobWriteError("local index runtime is unhealthy")
+            return self._writer.create(
+                repo_id,
+                indexes=indexes,
+                mode=mode,
+                force=force,
+                idempotency_key=idempotency_key,
+            )
 
 
 def _live_local_index_capabilities(
@@ -239,7 +254,7 @@ def _configured_local_index_runtime(app, config, registry, lifecycle):
     try:
         with open_local_index_runtime_service(storage, registry) as service:
             lifecycle.service = service
-            writer = _LiveLocalIndexJobWriter(service, service.writer)
+            writer = _LiveLocalIndexJobWriter(service, service.writer, registry)
             capabilities = partial(_live_local_index_capabilities, service)
             bindings = {
                 "index_runtime_service": service,

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -73,7 +73,7 @@ from .local_index_runtime import (
 from .local_index_service import LocalIndexServiceError
 from .native_authority import authorize_local_manifest_vector
 from .ports import argparse_tcp_port
-from .repo_registry import RepoRegistry
+from .repo_registry import RepoBundle, RepoRegistry
 from .repository_files import bound_source_slice
 from .request_limits import RequestBodyLimitMiddleware
 from .schemas import (
@@ -158,20 +158,19 @@ class _LiveLocalIndexJobWriter:
 
 def _live_local_index_capabilities(
     service: LocalIndexRuntimeService,
-    registry: RepoRegistry,
     repo_id: str,
+    bundle: RepoBundle,
 ) -> Mapping[str, IndexUpdateCapability] | None:
-    """Return unavailable for an unhealthy runtime or an unbound repository."""
+    """Resolve capabilities against the bundle already pinned by the route."""
 
     if service.state != "running" or service.healthy is not True:
         return None
-    with registry.pin(repo_id) as bundle:
-        if bundle is None or not service.accepts_repository(repo_id, bundle):
-            return None
-        try:
-            return service.capabilities(repo_id)
-        except KeyError:
-            return None
+    if not service.accepts_repository(repo_id, bundle):
+        return None
+    try:
+        return service.capabilities(repo_id)
+    except KeyError:
+        return None
 
 
 def _has_pending_publication_cleanup(failure: BaseException) -> bool:
@@ -263,7 +262,7 @@ def _configured_local_index_runtime(app, config, registry, lifecycle):
         with open_local_index_runtime_service(storage, registry) as service:
             lifecycle.service = service
             writer = _LiveLocalIndexJobWriter(service, service.writer, registry)
-            capabilities = partial(_live_local_index_capabilities, service, registry)
+            capabilities = partial(_live_local_index_capabilities, service)
             bindings = {
                 "index_runtime_service": service,
                 "index_job_reader": service.reader,
@@ -444,8 +443,8 @@ def _index_job_writer() -> IndexJobWriter:
     return writer
 
 
-def _index_update_capabilities(repo_id: str):
-    """Resolve writer capabilities for one Web repository binding."""
+def _index_update_capabilities(repo_id: str, bundle: RepoBundle):
+    """Resolve writer capabilities for one pinned Web repository generation."""
 
     resolver = getattr(app.state, "index_update_capabilities_resolver", None)
     if resolver is not None and not callable(resolver):
@@ -457,7 +456,7 @@ def _index_update_capabilities(repo_id: str):
         candidate = (
             getattr(app.state, "index_update_capabilities", None)
             if resolver is None
-            else resolver(repo_id)
+            else resolver(repo_id, bundle)
         )
         return validate_index_update_capabilities(candidate)
     except Exception as exc:
@@ -860,7 +859,7 @@ async def index_status(repo_id: str) -> RepoIndexStatus:
 
     with _pinned_bundle(repo_id) as bundle:
         kwargs = {
-            "update_capabilities": _index_update_capabilities(repo_id),
+            "update_capabilities": _index_update_capabilities(repo_id, bundle),
         }
         head_resolver = getattr(app.state, "index_head_resolver", None)
         if callable(head_resolver):

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -138,6 +138,10 @@ class _LiveLocalIndexJobWriter:
                 raise IndexJobNotFoundError(
                     "Web repository is no longer configured for index updates"
                 )
+            if not self._service.accepts_repository(repo_id, bundle):
+                raise IndexJobWriteError(
+                    "Web repository no longer matches the local index runtime"
+                )
             # Health is an entry-time availability signal, not part of the
             # catalog transaction. A job accepted just before a loop fault is
             # durable and remains recoverable by the next service process.
@@ -154,16 +158,20 @@ class _LiveLocalIndexJobWriter:
 
 def _live_local_index_capabilities(
     service: LocalIndexRuntimeService,
+    registry: RepoRegistry,
     repo_id: str,
 ) -> Mapping[str, IndexUpdateCapability] | None:
     """Return unavailable for an unhealthy runtime or an unbound repository."""
 
     if service.state != "running" or service.healthy is not True:
         return None
-    try:
-        return service.capabilities(repo_id)
-    except KeyError:
-        return None
+    with registry.pin(repo_id) as bundle:
+        if bundle is None or not service.accepts_repository(repo_id, bundle):
+            return None
+        try:
+            return service.capabilities(repo_id)
+        except KeyError:
+            return None
 
 
 def _has_pending_publication_cleanup(failure: BaseException) -> bool:
@@ -255,7 +263,7 @@ def _configured_local_index_runtime(app, config, registry, lifecycle):
         with open_local_index_runtime_service(storage, registry) as service:
             lifecycle.service = service
             writer = _LiveLocalIndexJobWriter(service, service.writer, registry)
-            capabilities = partial(_live_local_index_capabilities, service)
+            capabilities = partial(_live_local_index_capabilities, service, registry)
             bindings = {
                 "index_runtime_service": service,
                 "index_job_reader": service.reader,

--- a/codenib/web/local_index_runtime.py
+++ b/codenib/web/local_index_runtime.py
@@ -1017,6 +1017,8 @@ class LocalIndexRuntimeService:
                 and bundle.entry.repo == configured.storage.repository_key
                 and lexical_repository_path(bundle.entry.repo_dir)
                 == configured.repository_root
+                and lexical_repository_path(bundle.manifest.repo_path)
+                == configured.repository_root
                 and tuple(_repository_languages(bundle)) == configured.languages
                 and _repository_selection(bundle) == configured.source_selection
                 and (not current_indexes or current_indexes == {"bm25"})

--- a/codenib/web/local_index_runtime.py
+++ b/codenib/web/local_index_runtime.py
@@ -1011,6 +1011,7 @@ class LocalIndexRuntimeService:
         if configured is None:
             return False
         try:
+            current_indexes = set(bundle.manifest.indexes)
             return (
                 bundle.entry.instance_id == repo_id
                 and bundle.entry.repo == configured.storage.repository_key
@@ -1018,6 +1019,7 @@ class LocalIndexRuntimeService:
                 == configured.repository_root
                 and tuple(_repository_languages(bundle)) == configured.languages
                 and _repository_selection(bundle) == configured.source_selection
+                and (not current_indexes or current_indexes == {"bm25"})
             )
         except (AttributeError, LocalIndexServiceError, OSError, TypeError, ValueError):
             return False

--- a/codenib/web/local_index_runtime.py
+++ b/codenib/web/local_index_runtime.py
@@ -37,6 +37,7 @@ from ..compiler.job_resources import (
 from ..languages import normalize_chunker_language
 from ..log_utils import get_logger
 from ..repository_source_selection import RepositorySourceSelection
+from ..source_fingerprint import lexical_repository_path
 from ..storage import (
     IndexJobRecord,
     IndexJobWorker,
@@ -627,6 +628,7 @@ class LocalIndexRuntimeService:
         "_capabilities",
         "_object_store_owner",
         "_reader",
+        "_repositories",
         "_topology",
         "_topology_owner",
         "_writer",
@@ -645,6 +647,7 @@ class LocalIndexRuntimeService:
         reader: CatalogIndexJobReader,
         writer: CatalogIndexJobWriter,
         capabilities: Mapping[str, Mapping[str, IndexUpdateCapability]],
+        repositories: tuple[_ConfiguredRepository, ...],
     ) -> None:
         if token is not _LOCAL_RUNTIME_TOKEN:
             raise TypeError("local index runtime service requires acquisition")
@@ -656,6 +659,9 @@ class LocalIndexRuntimeService:
         self._background_owner = background_owner
         self._reader = reader
         self._writer = writer
+        self._repositories = MappingProxyType(
+            {repository.storage.repo_id: repository for repository in repositories}
+        )
         self._capabilities = MappingProxyType(
             {
                 repo_id: MappingProxyType(dict(repo_capabilities))
@@ -958,6 +964,7 @@ class LocalIndexRuntimeService:
                 reader=reader,
                 writer=writer,
                 capabilities=capabilities,
+                repositories=selected,
             )
 
     @property
@@ -994,6 +1001,26 @@ class LocalIndexRuntimeService:
         if capabilities is None:
             raise KeyError(repo_id)
         return dict(capabilities)
+
+    def accepts_repository(self, repo_id: str, bundle: RepoBundle) -> bool:
+        """Return whether a live Web bundle matches this runtime's frozen inputs."""
+
+        if type(repo_id) is not str or type(bundle) is not RepoBundle:
+            return False
+        configured = self._repositories.get(repo_id)
+        if configured is None:
+            return False
+        try:
+            return (
+                bundle.entry.instance_id == repo_id
+                and bundle.entry.repo == configured.storage.repository_key
+                and lexical_repository_path(bundle.entry.repo_dir)
+                == configured.repository_root
+                and tuple(_repository_languages(bundle)) == configured.languages
+                and _repository_selection(bundle) == configured.source_selection
+            )
+        except (AttributeError, LocalIndexServiceError, OSError, TypeError, ValueError):
+            return False
 
     def start(self) -> None:
         """Start both loops or settle the whole local service before failing."""

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -1829,11 +1829,12 @@ class RepoRegistry:
             raise TypeError("active Web repository metadata uses an invalid type")
         if entry.instance_id != instance_id:
             raise RuntimeError("active Web repository identity changed")
-        if set(current_manifest.indexes) != {"bm25"} or not (
-            current_manifest.index_is_current("bm25")
+        current_indexes = set(current_manifest.indexes)
+        if current_indexes and (
+            current_indexes != {"bm25"} or not current_manifest.index_is_current("bm25")
         ):
             raise ValueError(
-                "retained BM25 publication cannot replace a non-BM25 generation"
+                "retained BM25 publication cannot replace an incompatible generation"
             )
 
         result = runtime_owner.result

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -28,6 +28,7 @@ from .._owned_file_publication import _CancellationSafeRLock
 from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
 from ..compiler.manifest import IndexEntry, RepoManifest
 from ..index.embedding._lifecycle import close_vector_after_failure
+from ..languages import normalize_chunker_language
 from ..log_utils import get_logger
 from ..provider_routes import normalize_endpoint, resolve_embedding_artifact_route
 from ..repository_source_selection import RepositorySourceSelection
@@ -56,6 +57,7 @@ _REGISTRY_CLEANUP_CONTEXT = local()
 _REGISTRY_RELOAD_CONTEXT = local()
 _REGISTRY_DEFERRED_DRAIN_CONTEXT = local()
 _REGISTRY_LOCK_RESULT_MISSING = object()
+_MAX_RETAINED_BM25_LANGUAGES = 64
 
 
 @dataclass(slots=True)
@@ -422,6 +424,30 @@ def _exact_manifest_source_selection(manifest: Any) -> RepositorySourceSelection
     if type(selection) is not RepositorySourceSelection:
         raise TypeError("repository manifest source selection uses an invalid type")
     return selection
+
+
+def _exact_manifest_chunker_languages(
+    manifest: Any,
+    *,
+    fallback_language: str,
+) -> tuple[str, ...]:
+    """Reconstruct the normalized language sequence frozen by the builder."""
+
+    raw_languages = tuple(getattr(manifest, "languages", ()) or ())
+    if not raw_languages and fallback_language:
+        raw_languages = (fallback_language,)
+    if not 1 <= len(raw_languages) <= _MAX_RETAINED_BM25_LANGUAGES:
+        raise ValueError("repository manifest languages are not bounded")
+    languages: list[str] = []
+    for raw_language in raw_languages:
+        if type(raw_language) is not str:
+            raise TypeError("repository manifest language must be exact text")
+        language = normalize_chunker_language(raw_language)
+        if language is None:
+            raise ValueError("repository manifest language is unsupported")
+        if language not in languages:
+            languages.append(language)
+    return tuple(languages)
 
 
 def _require_authenticated_source_paths(
@@ -1871,6 +1897,16 @@ class RepoRegistry:
         ) != _exact_manifest_source_selection(manifest):
             raise ValueError(
                 "retained BM25 source selection differs from the active Web source"
+            )
+        if _exact_manifest_chunker_languages(
+            current_manifest,
+            fallback_language=entry.language,
+        ) != _exact_manifest_chunker_languages(
+            manifest,
+            fallback_language=entry.language,
+        ):
+            raise ValueError(
+                "retained BM25 languages differ from the active Web generation"
             )
 
         if (

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -1867,9 +1867,7 @@ class RepoRegistry:
         if entry.instance_id != instance_id:
             raise RuntimeError("active Web repository identity changed")
         current_indexes = set(current_manifest.indexes)
-        if current_indexes and (
-            current_indexes != {"bm25"} or not current_manifest.index_is_current("bm25")
-        ):
+        if current_indexes and current_indexes != {"bm25"}:
             raise ValueError(
                 "retained BM25 publication cannot replace an incompatible generation"
             )

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -413,6 +413,17 @@ def _manifest_requires_authenticated_source(manifest: Any) -> bool:
     ) is RepositorySourceSelection and bool(getattr(manifest, "source_fingerprint", ""))
 
 
+def _exact_manifest_source_selection(manifest: Any) -> RepositorySourceSelection:
+    """Normalize the legacy default while rejecting malformed policy state."""
+
+    selection = getattr(manifest, "source_selection", None)
+    if selection is None:
+        return RepositorySourceSelection()
+    if type(selection) is not RepositorySourceSelection:
+        raise TypeError("repository manifest source selection uses an invalid type")
+    return selection
+
+
 def _require_authenticated_source_paths(
     paths: Any,
     source_reader: "RepositorySourceReader",
@@ -1855,6 +1866,12 @@ class RepoRegistry:
         manifest = context.manifest
         if type(manifest) is not RepoManifest:
             raise TypeError("retained BM25 manifest uses an invalid type")
+        if _exact_manifest_source_selection(
+            current_manifest
+        ) != _exact_manifest_source_selection(manifest):
+            raise ValueError(
+                "retained BM25 source selection differs from the active Web source"
+            )
 
         if (
             receipt.repository_id != binding.repository_id

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1734,9 +1734,10 @@ routing remain absent.
   so the ref-writer fence spans the actual generation swap. It rejects
   ref-generation regression, same-generation snapshot/timestamp conflict,
   storage-binding drift, and legacy registry-file replacement of an active
-  durable generation. It permits a first durable BM25 generation to replace an
-  authenticated source-only bundle while still rejecting stale or incompatible
-  indexed incumbents.
+  durable generation. It permits a durable BM25 generation to replace an
+  authenticated source-only bundle or a compatible sole-BM25 incumbent,
+  including stale and failed repair, while rejecting incompatible multi-view
+  generations.
 - The concrete local retained-BM25 publisher binds each configured storage ref
   to one canonical repository root, private workspace authority, namespace,
   object store, and retained catalog. It performs fail-fast current-result

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1473,8 +1473,9 @@ storage topology. The planner captures that same topology-guarded retained
 source and registers only its content-addressed planning identities through a
 least-authority catalog surface. An explicit local production composition now
 assembles those targets with the strict preprovisioned CAS, scheduler, retained
-publisher, polling reconciler, reader, and writer. No default Web lifespan or
-default route selects that composition yet.
+publisher, polling reconciler, reader, and writer. The production Web lifespan
+now selects that composition only when the optional local-storage block is
+present; no storage default or alternate route silently enables it.
 
 The production CLI binding exposes both trusted local adapters through
 `codenib jobs run-once` and `codenib jobs run`, with an explicit mutually
@@ -1544,10 +1545,9 @@ and its cleanup remain unleased and manual. The local Web composition explicitly
 bootstraps each configured repository shard, routes its authenticated attempt
 receipts to the matching bounded reaper, settles them after worker results under
 that route's exclusive lease, and sweeps only those configured shards before
-start and after joined shutdown. Automatic shard discovery and default server
-installation remain pending.
-Vector and graph source builders, generic builder routing, and remaining
-runtime wiring remain.
+start and after joined shutdown. Automatic shard discovery remains pending.
+Vector and graph source builders, generic builder routing, MCP/UI controls, and
+default storage routing remain.
 
 - Make every builder write to a unique staging generation.
 - Add per-view profile adapters that fail closed on incomplete compatibility
@@ -1591,8 +1591,11 @@ and polling slices are present. Typed local-storage configuration parsing and
 explicit physical topology acquisition are implemented. An explicit local
 composition now invokes the success callback from the worker, owns both
 background loops, exposes the durable reader/writer and BM25 capability, and
-settles them before CAS and topology release. Default Web lifespan ownership,
-MCP, UI controls, and default routing remain absent.
+settles them before CAS and topology release. The optional production Web
+lifespan now owns that composition
+and verifies a real first-build job through strict materialization and RCU
+replacement. MCP, UI controls, vector/graph adapters, and default storage
+routing remain absent.
 
 - The backend-neutral worker now owns advisory scan/claim, per-attempt task
   authority, independent heartbeat sessions, cancellation precedence, bounded
@@ -1661,11 +1664,11 @@ MCP, UI controls, and default routing remain absent.
   configured target, directs every at-least-once receipt to its exact shard,
   cleans it after worker results, and performs shard-policy sweeps only before
   worker start or after both background loops join. Automatic shard discovery
-  and default server installation remain pending, and legacy cleanup continues
-  to require explicit operator quiescence. Then add vector and graph source
-  adapters, install the composed service in the production server lifespan, and
-  wire MCP, UI, and default routes. Older self-publishing ingress APIs remain
-  compatibility paths and are never nested inside the worker.
+  remains pending, and legacy cleanup continues to require explicit operator
+  quiescence. Add vector and graph source adapters and wire MCP, UI, and default
+  routes.
+  Older self-publishing ingress APIs remain compatibility paths and are never
+  nested inside the worker.
 - Complete the #266 job and update APIs with accurate incremental versus rebuild
   behavior; the first read-only status slice is described below.
 - `RepoRegistry.load_all()` now reconciles each complete registry snapshot,
@@ -1682,8 +1685,9 @@ MCP, UI controls, and default routing remain absent.
   cancellation-class cleanup failures never demoted behind ordinary errors.
   Bundle-derived Wiki, edge-label, and commit-window helpers are generation
   keyed and stale entries are pruned after replacement, removal, and shutdown.
-  The remaining #266 work is to own the composed service in the production
-  server lifespan and expose its status/results to the UI.
+  The production server lifespan now owns the existing reconciliation loop and
+  invokes its callback only after an attested update job succeeds. The remaining
+  #266 work is to expose status/results and update controls in the UI.
 - The first #266 read slice exposes one pinned, detached status snapshot for
   exactly BM25, vector, and symbol-graph surfaces. It reports manifest/current
   commit drift and retained incremental metrics without exposing mutable bundle
@@ -1716,8 +1720,8 @@ MCP, UI controls, and default routing remain absent.
   ref-writer exclusion until that transfer returns. Only that guarded transfer
   can advance reconciliation state; missing, repeated, out-of-scope, skipped,
   or failed guard/transfer calls fail closed. Publication failures remain
-  retryable and secret-free. Server wiring and the final runtime refresh
-  callback remain separate gates.
+  retryable and secret-free. The optional production lifespan now supplies this
+  final runtime refresh callback.
 - The retained BM25 registry boundary now accepts one exact snapshot-loaded
   runtime owner together with its full job activation and prepares the complete
   sparse runtime. It exposes the source-revalidated, lock-protected RCU pointer
@@ -1725,7 +1729,9 @@ MCP, UI controls, and default routing remain absent.
   so the ref-writer fence spans the actual generation swap. It rejects
   ref-generation regression, same-generation snapshot/timestamp conflict,
   storage-binding drift, and legacy registry-file replacement of an active
-  durable generation. The production server loop remains a separate gate.
+  durable generation. It permits a first durable BM25 generation to replace an
+  authenticated source-only bundle while still rejecting stale or incompatible
+  indexed incumbents.
 - The concrete local retained-BM25 publisher binds each configured storage ref
   to one canonical repository root, private workspace authority, namespace,
   object store, and retained catalog. It performs fail-fast current-result
@@ -1760,8 +1766,11 @@ MCP, UI controls, and default routing remain absent.
   retry. The explicit composition now opens the strict preprovisioned CAS,
   freezes loaded repository inputs, builds matching BM25 worker/runtime targets,
   owns the fair scheduler and guarded reconciliation loop, and releases them in
-  background/reaper/CAS/topology order. Lifespan installation remains a
-  separate gate.
+  background/reaper/CAS/topology order. The production lifespan installs
+  its reader, writer, capability resolver, and service only for that live
+  interval, restores prior application state on exit, and closes the registry
+  only after runtime settlement. An incomplete startup or shutdown cleanup owner
+  retains the registry dependency instead of retiring it under a live loop.
 - An explicitly injected Web reader can now project authorized durable jobs and
   at most 64 events without exposing worker owner IDs, fencing tokens, or raw
   executor errors or event keys. Each event is rebound to the exact job, a

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1690,8 +1690,9 @@ routing remain absent.
   hybrid-mode storage startup until vector publication exists, stops admitting
   and advertising updates when either owned loop faults, reports unbound
   repositories as unavailable, and rejects a retained BM25 replacement whose
-  source-selection policy differs from the active Web generation. The remaining
-  #266 work is to expose status/results and update controls in the UI.
+  source-selection policy or normalized language sequence differs from the
+  active Web generation. The remaining #266 work is to expose status/results
+  and update controls in the UI.
 - The first #266 read slice exposes one pinned, detached status snapshot for
   exactly BM25, vector, and symbol-graph surfaces. It reports manifest/current
   commit drift and retained incremental metrics without exposing mutable bundle

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1686,7 +1686,11 @@ routing remain absent.
   Bundle-derived Wiki, edge-label, and commit-window helpers are generation
   keyed and stale entries are pruned after replacement, removal, and shutdown.
   The production server lifespan now owns the existing reconciliation loop and
-  invokes its callback only after an attested update job succeeds. The remaining
+  invokes its callback only after an attested update job succeeds. It refuses
+  hybrid-mode storage startup until vector publication exists, stops admitting
+  and advertising updates when either owned loop faults, reports unbound
+  repositories as unavailable, and rejects a retained BM25 replacement whose
+  source-selection policy differs from the active Web generation. The remaining
   #266 work is to expose status/results and update controls in the UI.
 - The first #266 read slice exposes one pinned, detached status snapshot for
   exactly BM25, vector, and symbol-graph surfaces. It reports manifest/current

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1689,10 +1689,11 @@ routing remain absent.
   invokes its callback only after an attested update job succeeds. It refuses
   hybrid-mode storage startup until vector publication exists, stops admitting
   and advertising updates when either owned loop faults, reports unbound
-  repositories as unavailable, and rejects a retained BM25 replacement whose
-  source-selection policy or normalized language sequence differs from the
-  active Web generation. The remaining #266 work is to expose status/results
-  and update controls in the UI.
+  repositories as unavailable, and advertises writes only for a source-only or
+  sole-BM25 generation whose repository identity, entry and manifest roots,
+  source-selection policy, and normalized languages still match the frozen
+  runtime inputs. The remaining #266 work is to expose status/results and
+  update controls in the UI.
 - The first #266 read slice exposes one pinned, detached status snapshot for
   exactly BM25, vector, and symbol-graph surfaces. It reports manifest/current
   commit drift and retained incremental metrics without exposing mutable bundle

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -113,6 +113,7 @@ def test_lifespan_owns_configured_local_index_runtime(monkeypatch):
             return "created"
 
     writer = Writer()
+    original_bundle = object()
 
     def capabilities(repo_id):
         if repo_id != "demo":
@@ -129,6 +130,10 @@ def test_lifespan_owns_configured_local_index_runtime(monkeypatch):
             self.writer = writer
             self.capabilities = capabilities
 
+        @staticmethod
+        def accepts_repository(repo_id, bundle):
+            return repo_id == "demo" and bundle is original_bundle
+
     runtime = Runtime()
     config = SimpleNamespace(
         registry_path="/tmp/qa_registry.json",
@@ -144,14 +149,14 @@ def test_lifespan_owns_configured_local_index_runtime(monkeypatch):
 
     class Registry:
         def __init__(self, _config, **_kwargs):
-            self.active = {"demo"}
+            self.active = {"demo": original_bundle}
 
         def load_all(self):
             events.append("registry-load")
 
         @contextmanager
         def pin(self, repo_id):
-            yield object() if repo_id in self.active else None
+            yield self.active.get(repo_id)
 
         def list_infos(self):
             return []
@@ -214,6 +219,16 @@ def test_lifespan_owns_configured_local_index_runtime(monkeypatch):
                     idempotency_key="unhealthy",
                 )
             runtime.healthy = True
+            application.state.registry.active["demo"] = object()
+            assert bound_capabilities("demo") is None
+            with pytest.raises(web_app.IndexJobWriteError, match="no longer matches"):
+                bound_writer.create(
+                    "demo",
+                    indexes=("bm25",),
+                    mode="full",
+                    force=False,
+                    idempotency_key="reloaded",
+                )
             application.state.registry.active.clear()
             with pytest.raises(web_app.IndexJobNotFoundError, match="no longer"):
                 bound_writer.create(

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -144,10 +144,14 @@ def test_lifespan_owns_configured_local_index_runtime(monkeypatch):
 
     class Registry:
         def __init__(self, _config, **_kwargs):
-            pass
+            self.active = {"demo"}
 
         def load_all(self):
             events.append("registry-load")
+
+        @contextmanager
+        def pin(self, repo_id):
+            yield object() if repo_id in self.active else None
 
         def list_infos(self):
             return []
@@ -210,6 +214,15 @@ def test_lifespan_owns_configured_local_index_runtime(monkeypatch):
                     idempotency_key="unhealthy",
                 )
             runtime.healthy = True
+            application.state.registry.active.clear()
+            with pytest.raises(web_app.IndexJobNotFoundError, match="no longer"):
+                bound_writer.create(
+                    "demo",
+                    indexes=("bm25",),
+                    mode="full",
+                    force=False,
+                    idempotency_key="retired",
+                )
 
     asyncio.run(run_lifespan())
 
@@ -220,6 +233,7 @@ def test_lifespan_owns_configured_local_index_runtime(monkeypatch):
         "runtime-close",
         "registry-close",
     ]
+    assert [repo_id for repo_id, _kwargs in writer.calls] == ["demo"]
     assert application.state.index_job_reader is previous_reader
     for name in (
         "index_runtime_service",

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -103,9 +103,20 @@ def test_lifespan_owns_configured_local_index_runtime(monkeypatch):
     storage = object()
     previous_reader = object()
     reader = object()
-    writer = object()
+
+    class Writer:
+        def __init__(self):
+            self.calls = []
+
+        def create(self, repo_id, **kwargs):
+            self.calls.append((repo_id, kwargs))
+            return "created"
+
+    writer = Writer()
 
     def capabilities(repo_id):
+        if repo_id != "demo":
+            raise KeyError(repo_id)
         return {"repo_id": repo_id}
 
     class Runtime:
@@ -128,6 +139,7 @@ def test_lifespan_owns_configured_local_index_runtime(monkeypatch):
         wiki_generation_api_key=None,
         wiki_generation_options={},
         index_storage=storage,
+        mode="sparse",
     )
 
     class Registry:
@@ -171,8 +183,33 @@ def test_lifespan_owns_configured_local_index_runtime(monkeypatch):
             events.append("serve")
             assert application.state.index_runtime_service is runtime
             assert application.state.index_job_reader is reader
-            assert application.state.index_job_writer is writer
-            assert application.state.index_update_capabilities_resolver is capabilities
+            bound_writer = application.state.index_job_writer
+            bound_capabilities = application.state.index_update_capabilities_resolver
+            assert bound_writer is not writer
+            assert bound_capabilities is not capabilities
+            assert bound_capabilities("demo") == {"repo_id": "demo"}
+            assert bound_capabilities("unbound") is None
+            assert (
+                bound_writer.create(
+                    "demo",
+                    indexes=("bm25",),
+                    mode="full",
+                    force=False,
+                    idempotency_key="healthy",
+                )
+                == "created"
+            )
+            runtime.healthy = False
+            assert bound_capabilities("demo") is None
+            with pytest.raises(web_app.IndexJobWriteError, match="unhealthy"):
+                bound_writer.create(
+                    "demo",
+                    indexes=("bm25",),
+                    mode="full",
+                    force=False,
+                    idempotency_key="unhealthy",
+                )
+            runtime.healthy = True
 
     asyncio.run(run_lifespan())
 
@@ -192,11 +229,34 @@ def test_lifespan_owns_configured_local_index_runtime(monkeypatch):
         assert not hasattr(application.state, name)
 
 
+def test_configured_lifespan_rejects_hybrid_before_runtime_open(monkeypatch):
+    @contextmanager
+    def reject_open(*_args, **_kwargs):
+        pytest.fail("hybrid Web mode must fail before runtime acquisition")
+        yield  # pragma: no cover - contextmanager generator marker
+
+    monkeypatch.setattr(web_app, "open_local_index_runtime_service", reject_open)
+    application = SimpleNamespace(state=SimpleNamespace())
+    config = SimpleNamespace(index_storage=object(), mode="hybrid")
+    lifecycle = web_app._LocalRuntimeLifespanState()
+
+    with pytest.raises(web_app.LocalIndexServiceError, match="sparse Web mode"):
+        with web_app._configured_local_index_runtime(
+            application,
+            config,
+            object(),
+            lifecycle,
+        ):
+            pytest.fail("hybrid Web mode reached request serving")
+
+    assert lifecycle.service is None
+
+
 def test_lifespan_retains_registry_when_runtime_close_is_incomplete(monkeypatch):
     events = []
     runtime = SimpleNamespace(
         reader=object(),
-        writer=object(),
+        writer=SimpleNamespace(create=lambda *_args, **_kwargs: None),
         capabilities=lambda _repo_id: {},
         state="running",
         healthy=True,

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -196,8 +196,8 @@ def test_lifespan_owns_configured_local_index_runtime(monkeypatch):
             bound_capabilities = application.state.index_update_capabilities_resolver
             assert bound_writer is not writer
             assert bound_capabilities is not capabilities
-            assert bound_capabilities("demo") == {"repo_id": "demo"}
-            assert bound_capabilities("unbound") is None
+            assert bound_capabilities("demo", original_bundle) == {"repo_id": "demo"}
+            assert bound_capabilities("unbound", original_bundle) is None
             assert (
                 bound_writer.create(
                     "demo",
@@ -209,7 +209,7 @@ def test_lifespan_owns_configured_local_index_runtime(monkeypatch):
                 == "created"
             )
             runtime.healthy = False
-            assert bound_capabilities("demo") is None
+            assert bound_capabilities("demo", original_bundle) is None
             with pytest.raises(web_app.IndexJobWriteError, match="unhealthy"):
                 bound_writer.create(
                     "demo",
@@ -220,7 +220,10 @@ def test_lifespan_owns_configured_local_index_runtime(monkeypatch):
                 )
             runtime.healthy = True
             application.state.registry.active["demo"] = object()
-            assert bound_capabilities("demo") is None
+            assert (
+                bound_capabilities("demo", application.state.registry.active["demo"])
+                is None
+            )
             with pytest.raises(web_app.IndexJobWriteError, match="no longer matches"):
                 bound_writer.create(
                     "demo",

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -68,6 +68,13 @@ def test_lifespan_injects_local_native_authority_resolver(monkeypatch):
 
     monkeypatch.setattr(web_app, "load_config", lambda: config)
     monkeypatch.setattr(web_app, "RepoRegistry", Registry)
+    monkeypatch.setattr(
+        web_app,
+        "open_local_index_runtime_service",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("disabled local runtime was opened")
+        ),
+    )
     monkeypatch.setattr(web_app, "authorize_local_manifest_vector", resolver)
     monkeypatch.setattr(
         web_app,
@@ -89,6 +96,236 @@ def test_lifespan_injects_local_native_authority_resolver(monkeypatch):
         "loaded": True,
         "closed": True,
     }
+
+
+def test_lifespan_owns_configured_local_index_runtime(monkeypatch):
+    events = []
+    storage = object()
+    previous_reader = object()
+    reader = object()
+    writer = object()
+
+    def capabilities(repo_id):
+        return {"repo_id": repo_id}
+
+    class Runtime:
+        state = "running"
+        healthy = True
+        closed = False
+
+        def __init__(self):
+            self.reader = reader
+            self.writer = writer
+            self.capabilities = capabilities
+
+    runtime = Runtime()
+    config = SimpleNamespace(
+        registry_path="/tmp/qa_registry.json",
+        data_dir="/tmp/data",
+        wiki_generation_model="model",
+        wiki_agent=False,
+        wiki_generation_api_base=None,
+        wiki_generation_api_key=None,
+        wiki_generation_options={},
+        index_storage=storage,
+    )
+
+    class Registry:
+        def __init__(self, _config, **_kwargs):
+            pass
+
+        def load_all(self):
+            events.append("registry-load")
+
+        def list_infos(self):
+            return []
+
+        def close(self):
+            events.append("registry-close")
+
+    @contextmanager
+    def open_runtime(supplied_storage, registry):
+        assert supplied_storage is storage
+        assert isinstance(registry, Registry)
+        events.append("runtime-open")
+        try:
+            yield runtime
+        finally:
+            events.append("runtime-close")
+            runtime.closed = True
+
+    monkeypatch.setattr(web_app, "load_config", lambda: config)
+    monkeypatch.setattr(web_app, "RepoRegistry", Registry)
+    monkeypatch.setattr(web_app, "open_local_index_runtime_service", open_runtime)
+    monkeypatch.setattr(
+        web_app,
+        "_wiki_narrator",
+        lambda _config: SimpleNamespace(model="model", enabled=False, cache_dir=None),
+    )
+    application = SimpleNamespace(
+        state=SimpleNamespace(index_job_reader=previous_reader)
+    )
+
+    async def run_lifespan():
+        async with web_app.lifespan(application):
+            events.append("serve")
+            assert application.state.index_runtime_service is runtime
+            assert application.state.index_job_reader is reader
+            assert application.state.index_job_writer is writer
+            assert application.state.index_update_capabilities_resolver is capabilities
+
+    asyncio.run(run_lifespan())
+
+    assert events == [
+        "registry-load",
+        "runtime-open",
+        "serve",
+        "runtime-close",
+        "registry-close",
+    ]
+    assert application.state.index_job_reader is previous_reader
+    for name in (
+        "index_runtime_service",
+        "index_job_writer",
+        "index_update_capabilities_resolver",
+    ):
+        assert not hasattr(application.state, name)
+
+
+def test_lifespan_retains_registry_when_runtime_close_is_incomplete(monkeypatch):
+    events = []
+    runtime = SimpleNamespace(
+        reader=object(),
+        writer=object(),
+        capabilities=lambda _repo_id: {},
+        state="running",
+        healthy=True,
+        closed=False,
+    )
+    config = SimpleNamespace(
+        registry_path="/tmp/qa_registry.json",
+        data_dir="/tmp/data",
+        wiki_generation_model="model",
+        wiki_agent=False,
+        wiki_generation_api_base=None,
+        wiki_generation_api_key=None,
+        wiki_generation_options={},
+        index_storage=object(),
+    )
+
+    class Registry:
+        def __init__(self, _config, **_kwargs):
+            pass
+
+        def load_all(self):
+            events.append("registry-load")
+
+        def list_infos(self):
+            return []
+
+        def close(self):
+            events.append("registry-close")
+
+    @contextmanager
+    def open_runtime(_storage, _registry):
+        events.append("runtime-open")
+        try:
+            yield runtime
+        finally:
+            events.append("runtime-close")
+            raise RuntimeError("runtime close failed")
+
+    monkeypatch.setattr(web_app, "load_config", lambda: config)
+    monkeypatch.setattr(web_app, "RepoRegistry", Registry)
+    monkeypatch.setattr(web_app, "open_local_index_runtime_service", open_runtime)
+    monkeypatch.setattr(
+        web_app,
+        "_wiki_narrator",
+        lambda _config: SimpleNamespace(model="model", enabled=False, cache_dir=None),
+    )
+    application = SimpleNamespace(state=SimpleNamespace())
+
+    async def run_lifespan():
+        async with web_app.lifespan(application):
+            events.append("serve")
+
+    with pytest.raises(RuntimeError, match="runtime close failed"):
+        asyncio.run(run_lifespan())
+
+    assert events == [
+        "registry-load",
+        "runtime-open",
+        "serve",
+        "runtime-close",
+    ]
+
+
+@pytest.mark.parametrize("cleanup_pending", (False, True))
+def test_lifespan_preserves_registry_for_incomplete_runtime_startup(
+    monkeypatch,
+    cleanup_pending,
+):
+    events = []
+    config = SimpleNamespace(
+        registry_path="/tmp/qa_registry.json",
+        data_dir="/tmp/data",
+        wiki_generation_model="model",
+        wiki_agent=False,
+        wiki_generation_api_base=None,
+        wiki_generation_api_key=None,
+        wiki_generation_options={},
+        index_storage=object(),
+    )
+
+    class Registry:
+        def __init__(self, _config, **_kwargs):
+            pass
+
+        def load_all(self):
+            events.append("registry-load")
+
+        def list_infos(self):
+            return []
+
+        def close(self):
+            events.append("registry-close")
+
+    @contextmanager
+    def open_runtime(_storage, _registry):
+        events.append("runtime-open")
+        failure = RuntimeError("runtime startup failed")
+        if cleanup_pending:
+            owner = SimpleNamespace(closed=False, close=lambda: None)
+            BaseException.__setattr__(
+                failure,
+                "publication_cleanup_owners",
+                (owner,),
+            )
+        raise failure
+        yield  # pragma: no cover - contextmanager generator marker
+
+    monkeypatch.setattr(web_app, "load_config", lambda: config)
+    monkeypatch.setattr(web_app, "RepoRegistry", Registry)
+    monkeypatch.setattr(web_app, "open_local_index_runtime_service", open_runtime)
+    monkeypatch.setattr(
+        web_app,
+        "_wiki_narrator",
+        lambda _config: SimpleNamespace(model="model", enabled=False, cache_dir=None),
+    )
+    application = SimpleNamespace(state=SimpleNamespace())
+
+    async def run_lifespan():
+        async with web_app.lifespan(application):
+            pytest.fail("failed runtime startup reached request serving")
+
+    with pytest.raises(RuntimeError, match="runtime startup failed"):
+        asyncio.run(run_lifespan())
+
+    assert events == [
+        "registry-load",
+        "runtime-open",
+        *([] if cleanup_pending else ["registry-close"]),
+    ]
 
 
 def test_lifespan_closes_registry_when_startup_is_cancelled(monkeypatch):

--- a/test/web/test_index_status.py
+++ b/test/web/test_index_status.py
@@ -233,7 +233,7 @@ def test_index_status_endpoint_resolves_update_capabilities_per_repository(
     monkeypatch,
 ) -> None:
     bundle = _bundle({"bm25": _entry("bm25")})
-    observed: list[str] = []
+    observed: list[tuple[str, object]] = []
 
     class Registry:
         @contextmanager
@@ -241,8 +241,8 @@ def test_index_status_endpoint_resolves_update_capabilities_per_repository(
             assert repo_id == "repo"
             yield bundle
 
-    def resolve(repo_id: str):
-        observed.append(repo_id)
+    def resolve(repo_id: str, pinned_bundle):
+        observed.append((repo_id, pinned_bundle))
         return None
 
     async def inline(function, *args, **kwargs):
@@ -274,7 +274,7 @@ def test_index_status_endpoint_resolves_update_capabilities_per_repository(
 
     status = asyncio.run(web_app.index_status("repo"))
 
-    assert observed == ["repo"]
+    assert observed == [("repo", bundle)]
     assert status.indexes[0].updates_enabled is False
     assert status.indexes[0].update_mode == "unavailable"
 
@@ -304,7 +304,7 @@ def test_index_status_endpoint_sanitizes_invalid_resolver_capabilities(
     monkeypatch.setattr(
         web_app.app.state,
         "index_update_capabilities_resolver",
-        lambda _repo_id: invalid_capabilities,
+        lambda _repo_id, _bundle: invalid_capabilities,
         raising=False,
     )
 

--- a/test/web/test_local_index_runtime.py
+++ b/test/web/test_local_index_runtime.py
@@ -876,7 +876,10 @@ def test_web_lifespan_executes_job_and_guards_registry_generation(
             writer = application.state.index_job_writer
             if reload_drift is not None:
                 assert (
-                    application.state.index_update_capabilities_resolver("demo") is None
+                    application.state.index_update_capabilities_resolver(
+                        "demo", expected_active
+                    )
+                    is None
                 )
                 with pytest.raises(
                     web_app.IndexJobWriteError,

--- a/test/web/test_local_index_runtime.py
+++ b/test/web/test_local_index_runtime.py
@@ -267,6 +267,7 @@ def test_local_index_runtime_rejects_loaded_repository_identity_mismatch(
     (
         "repository-key",
         "repository-root",
+        "manifest-root",
         "languages",
         "source-selection",
         "multi-view",
@@ -287,6 +288,10 @@ def test_local_index_runtime_rejects_reloaded_build_input_drift(
         replacement_root = tmp_path / "replacement-repository"
         replacement_root.mkdir()
         entry = replace(entry, repo_dir=str(replacement_root))
+    elif drift == "manifest-root":
+        replacement_root = tmp_path / "replacement-manifest-repository"
+        replacement_root.mkdir()
+        manifest = replace(manifest, repo_path=str(replacement_root))
     elif drift == "languages":
         manifest = replace(manifest, languages=["javascript"])
     elif drift == "source-selection":

--- a/test/web/test_local_index_runtime.py
+++ b/test/web/test_local_index_runtime.py
@@ -682,9 +682,15 @@ def test_local_index_runtime_executes_submitted_bm25_job(
     )
 
 
-def test_web_lifespan_executes_job_and_publishes_registry_generation(
+@pytest.mark.parametrize(
+    "source_policy_drift",
+    (False, True),
+    ids=("matching-policy", "reloaded-policy"),
+)
+def test_web_lifespan_executes_job_and_guards_registry_generation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    source_policy_drift: bool,
 ) -> None:
     activation_failures = []
     monkeypatch.setattr(
@@ -748,6 +754,29 @@ def test_web_lifespan_executes_job_and_publishes_registry_generation(
             initial = registry.get("demo")
             assert initial is not None
             assert initial.index_job_activation is None
+            expected_active = initial
+            if source_policy_drift:
+                reloaded_selection = RepositorySourceSelection(
+                    (*selection.exclude_subtrees, "policy-change")
+                )
+                reloaded_source = fingerprint_repository(
+                    repository,
+                    selection=reloaded_selection,
+                )
+                RepoManifest(
+                    repo_path=str(repository),
+                    commit=commit,
+                    last_indexed_commit=commit,
+                    source_fingerprint=reloaded_source.value,
+                    source_selection=reloaded_selection,
+                    languages=["python"],
+                    file_count=reloaded_source.file_count,
+                ).save(manifest_path)
+                registry.load_all()
+                expected_active = registry.get("demo")
+                assert expected_active is not None
+                assert expected_active is not initial
+                assert expected_active.index_job_activation is None
 
             created = application.state.index_job_writer.create(
                 "demo",
@@ -763,7 +792,14 @@ def test_web_lifespan_executes_job_and_publishes_registry_generation(
                 observed = application.state.index_job_reader.get(created.job_id)
                 active = registry.get("demo")
                 activation = None if active is None else active.index_job_activation
-                if (
+                if source_policy_drift:
+                    if activation is not None:
+                        pytest.fail(
+                            "drifted source policy reached registry publication"
+                        )
+                    if observed.status == "succeeded" and activation_failures:
+                        break
+                elif (
                     observed.status == "succeeded"
                     and activation is not None
                     and activation.snapshot_id == observed.result_snapshot_id
@@ -782,10 +818,24 @@ def test_web_lifespan_executes_job_and_publishes_registry_generation(
                     pytest.fail("lifespan runtime did not publish the BM25 result")
                 await asyncio.sleep(0.02)
 
-            assert active is not initial
             assert active is not None
-            assert active.bm25 is not None
-            assert active.index_job_activation.job_id == created.job_id
+            if source_policy_drift:
+                assert active is expected_active
+                assert active.index_job_activation is None
+                assert active.manifest.source_selection != selection
+                assert activation_failures
+                failure_chain = []
+                failure = activation_failures[-1]
+                while failure is not None:
+                    failure_chain.append(str(failure))
+                    failure = failure.__cause__
+                assert any(
+                    "source selection differs" in message for message in failure_chain
+                )
+            else:
+                assert active is not initial
+                assert active.bm25 is not None
+                assert active.index_job_activation.job_id == created.job_id
             assert service.healthy is True
 
     asyncio.run(run_lifespan())

--- a/test/web/test_local_index_runtime.py
+++ b/test/web/test_local_index_runtime.py
@@ -683,14 +683,14 @@ def test_local_index_runtime_executes_submitted_bm25_job(
 
 
 @pytest.mark.parametrize(
-    "source_policy_drift",
-    (False, True),
-    ids=("matching-policy", "reloaded-policy"),
+    "reload_drift",
+    (None, "source-selection", "languages"),
+    ids=("matching-generation", "reloaded-policy", "reloaded-languages"),
 )
 def test_web_lifespan_executes_job_and_guards_registry_generation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    source_policy_drift: bool,
+    reload_drift: str | None,
 ) -> None:
     activation_failures = []
     monkeypatch.setattr(
@@ -755,9 +755,13 @@ def test_web_lifespan_executes_job_and_guards_registry_generation(
             assert initial is not None
             assert initial.index_job_activation is None
             expected_active = initial
-            if source_policy_drift:
-                reloaded_selection = RepositorySourceSelection(
-                    (*selection.exclude_subtrees, "policy-change")
+            if reload_drift is not None:
+                reloaded_selection = (
+                    RepositorySourceSelection(
+                        (*selection.exclude_subtrees, "policy-change")
+                    )
+                    if reload_drift == "source-selection"
+                    else selection
                 )
                 reloaded_source = fingerprint_repository(
                     repository,
@@ -769,7 +773,9 @@ def test_web_lifespan_executes_job_and_guards_registry_generation(
                     last_indexed_commit=commit,
                     source_fingerprint=reloaded_source.value,
                     source_selection=reloaded_selection,
-                    languages=["python"],
+                    languages=(
+                        ["javascript"] if reload_drift == "languages" else ["python"]
+                    ),
                     file_count=reloaded_source.file_count,
                 ).save(manifest_path)
                 registry.load_all()
@@ -792,10 +798,10 @@ def test_web_lifespan_executes_job_and_guards_registry_generation(
                 observed = application.state.index_job_reader.get(created.job_id)
                 active = registry.get("demo")
                 activation = None if active is None else active.index_job_activation
-                if source_policy_drift:
+                if reload_drift is not None:
                     if activation is not None:
                         pytest.fail(
-                            "drifted source policy reached registry publication"
+                            "drifted runtime inputs reached registry publication"
                         )
                     if observed.status == "succeeded" and activation_failures:
                         break
@@ -819,19 +825,22 @@ def test_web_lifespan_executes_job_and_guards_registry_generation(
                 await asyncio.sleep(0.02)
 
             assert active is not None
-            if source_policy_drift:
+            if reload_drift is not None:
                 assert active is expected_active
                 assert active.index_job_activation is None
-                assert active.manifest.source_selection != selection
+                if reload_drift == "source-selection":
+                    assert active.manifest.source_selection != selection
+                    expected_failure = "source selection differs"
+                else:
+                    assert active.manifest.languages == ["javascript"]
+                    expected_failure = "languages differ"
                 assert activation_failures
                 failure_chain = []
                 failure = activation_failures[-1]
                 while failure is not None:
                     failure_chain.append(str(failure))
                     failure = failure.__cause__
-                assert any(
-                    "source selection differs" in message for message in failure_chain
-                )
+                assert any(expected_failure in message for message in failure_chain)
             else:
                 assert active is not initial
                 assert active.bm25 is not None

--- a/test/web/test_local_index_runtime.py
+++ b/test/web/test_local_index_runtime.py
@@ -16,7 +16,7 @@ import pytest
 
 import codenib.web.app as web_app
 import codenib.web.local_index_runtime as local_runtime_module
-from codenib.compiler.manifest import RepoManifest
+from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.repository_source_selection import RepositorySourceSelection
 from codenib.source_fingerprint import fingerprint_repository
 from codenib.storage import (
@@ -259,6 +259,56 @@ def test_local_index_runtime_rejects_loaded_repository_identity_mismatch(
         with pytest.raises(LocalIndexServiceError, match="identity differs"):
             LocalIndexRuntimeService.acquire(storage, registry)
     finally:
+        registry.close()
+
+
+@pytest.mark.parametrize(
+    "drift",
+    ("repository-key", "repository-root", "languages", "source-selection"),
+)
+def test_local_index_runtime_rejects_reloaded_build_input_drift(
+    tmp_path: Path,
+    drift: str,
+) -> None:
+    storage, registry = _runtime_fixture(tmp_path)
+    service = LocalIndexRuntimeService.acquire(storage, registry)
+    original = registry._bundles["demo"]
+    entry = original.entry
+    manifest = original.manifest
+    if drift == "repository-key":
+        entry = replace(entry, repo="org/other")
+    elif drift == "repository-root":
+        replacement_root = tmp_path / "replacement-repository"
+        replacement_root.mkdir()
+        entry = replace(entry, repo_dir=str(replacement_root))
+    elif drift == "languages":
+        manifest = replace(manifest, languages=["javascript"])
+    else:
+        manifest = replace(
+            manifest,
+            source_selection=RepositorySourceSelection(
+                (*manifest.source_selection.exclude_subtrees, "policy-change")
+            ),
+        )
+    replacement = RepoBundle(entry=entry, manifest=manifest)
+    equivalent = RepoBundle(
+        entry=replace(original.entry),
+        manifest=replace(
+            original.manifest,
+            languages=list(original.manifest.languages),
+            source_selection=RepositorySourceSelection(
+                original.manifest.source_selection.exclude_subtrees
+            ),
+        ),
+    )
+
+    try:
+        assert service.accepts_repository("demo", original) is True
+        assert service.accepts_repository("demo", equivalent) is True
+        assert service.accepts_repository("demo", replacement) is False
+        assert service.accepts_repository("other", original) is False
+    finally:
+        service.close()
         registry.close()
 
 
@@ -683,14 +733,27 @@ def test_local_index_runtime_executes_submitted_bm25_job(
 
 
 @pytest.mark.parametrize(
-    "reload_drift",
-    (None, "source-selection", "languages"),
-    ids=("matching-generation", "reloaded-policy", "reloaded-languages"),
+    ("reload_drift", "incumbent_status"),
+    (
+        (None, None),
+        (None, "stale"),
+        (None, "failed"),
+        ("source-selection", None),
+        ("languages", None),
+    ),
+    ids=(
+        "matching-generation",
+        "stale-bm25",
+        "failed-bm25",
+        "reloaded-policy",
+        "reloaded-languages",
+    ),
 )
 def test_web_lifespan_executes_job_and_guards_registry_generation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     reload_drift: str | None,
+    incumbent_status: str | None,
 ) -> None:
     activation_failures = []
     monkeypatch.setattr(
@@ -708,7 +771,7 @@ def test_web_lifespan_executes_job_and_guards_registry_generation(
 
     source = fingerprint_repository(repository, selection=selection)
     manifest_path = tmp_path / "artifacts" / "repo_manifest.json"
-    RepoManifest(
+    initial_manifest = RepoManifest(
         repo_path=str(repository),
         commit=commit,
         last_indexed_commit=commit,
@@ -716,7 +779,17 @@ def test_web_lifespan_executes_job_and_guards_registry_generation(
         source_selection=selection,
         languages=["python"],
         file_count=source.file_count,
-    ).save(manifest_path)
+    )
+    if incumbent_status is not None:
+        initial_manifest.indexes["bm25"] = IndexEntry(
+            index_type="bm25",
+            path=str(tmp_path / "stale-bm25"),
+            built_at="2026-08-30T00:00:00Z",
+            built_at_epoch=0.0,
+            status=incumbent_status,
+        )
+        assert initial_manifest.index_is_current("bm25") is False
+    initial_manifest.save(manifest_path)
     config = QAConfig(
         mode="sparse",
         data_dir=str(tmp_path / "web-data"),
@@ -784,7 +857,26 @@ def test_web_lifespan_executes_job_and_guards_registry_generation(
                 assert expected_active is not initial
                 assert expected_active.index_job_activation is None
 
-            created = application.state.index_job_writer.create(
+            writer = application.state.index_job_writer
+            if reload_drift is not None:
+                assert (
+                    application.state.index_update_capabilities_resolver("demo") is None
+                )
+                with pytest.raises(
+                    web_app.IndexJobWriteError,
+                    match="no longer matches",
+                ):
+                    writer.create(
+                        "demo",
+                        indexes=("bm25",),
+                        mode="full",
+                        force=False,
+                        idempotency_key="reloaded-runtime-binding",
+                    )
+                # Model work durably accepted immediately before the reload.
+                # The publication guard must still reject that old-input result.
+                writer = service.writer
+            created = writer.create(
                 "demo",
                 indexes=("bm25",),
                 mode="full",

--- a/test/web/test_local_index_runtime.py
+++ b/test/web/test_local_index_runtime.py
@@ -4,17 +4,21 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import subprocess
 import time
 from dataclasses import replace
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+import codenib.web.app as web_app
 import codenib.web.local_index_runtime as local_runtime_module
 from codenib.compiler.manifest import RepoManifest
 from codenib.repository_source_selection import RepositorySourceSelection
+from codenib.source_fingerprint import fingerprint_repository
 from codenib.storage import (
     INDEX_JOB_REQUEST_CONTRACT,
     CatalogError,
@@ -33,6 +37,7 @@ from codenib.web.config import (
     LocalIndexWorkerConfig,
     QAConfig,
     RepoEntry,
+    save_registry,
 )
 from codenib.web.local_index_runtime import (
     LocalIndexRuntimeService,
@@ -675,3 +680,121 @@ def test_local_index_runtime_executes_submitted_bm25_job(
     assert not any(
         "attempt-root orphan" in record.getMessage() for record in caplog.records
     )
+
+
+def test_web_lifespan_executes_job_and_publishes_registry_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    activation_failures = []
+    monkeypatch.setattr(
+        local_runtime_module,
+        "_safe_runtime_failure",
+        activation_failures.append,
+    )
+    storage, seed_registry = _runtime_fixture(tmp_path)
+    seed_bundle = seed_registry.get("demo")
+    assert seed_bundle is not None
+    repository = Path(seed_bundle.entry.repo_dir)
+    commit = seed_bundle.entry.base_commit
+    selection = seed_bundle.manifest.source_selection
+    seed_registry.close()
+
+    source = fingerprint_repository(repository, selection=selection)
+    manifest_path = tmp_path / "artifacts" / "repo_manifest.json"
+    RepoManifest(
+        repo_path=str(repository),
+        commit=commit,
+        last_indexed_commit=commit,
+        source_fingerprint=source.value,
+        source_selection=selection,
+        languages=["python"],
+        file_count=source.file_count,
+    ).save(manifest_path)
+    config = QAConfig(
+        mode="sparse",
+        data_dir=str(tmp_path / "web-data"),
+        wiki_agent=False,
+        index_storage=storage,
+    )
+    save_registry(
+        config.registry_path,
+        [
+            RepoEntry(
+                instance_id="demo",
+                repo="org/repo",
+                base_commit=commit,
+                language="python",
+                repo_dir=str(repository),
+                manifest_path=str(manifest_path),
+            )
+        ],
+    )
+    monkeypatch.setattr(web_app, "load_config", lambda: config)
+    monkeypatch.setattr(
+        web_app,
+        "_wiki_narrator",
+        lambda _config: SimpleNamespace(model="model", enabled=False, cache_dir=None),
+    )
+    application = SimpleNamespace(state=SimpleNamespace())
+    captured = {}
+
+    async def run_lifespan() -> None:
+        async with web_app.lifespan(application):
+            registry = application.state.registry
+            service = application.state.index_runtime_service
+            captured["registry"] = registry
+            captured["service"] = service
+            initial = registry.get("demo")
+            assert initial is not None
+            assert initial.index_job_activation is None
+
+            created = application.state.index_job_writer.create(
+                "demo",
+                indexes=("bm25",),
+                mode="full",
+                force=False,
+                idempotency_key="lifespan-integration-job",
+            )
+            deadline = time.monotonic() + 15
+            observed = created
+            active = initial
+            while True:
+                observed = application.state.index_job_reader.get(created.job_id)
+                active = registry.get("demo")
+                activation = None if active is None else active.index_job_activation
+                if (
+                    observed.status == "succeeded"
+                    and activation is not None
+                    and activation.snapshot_id == observed.result_snapshot_id
+                ):
+                    break
+                if observed.status == "failed":
+                    pytest.fail("lifespan BM25 job failed")
+                if time.monotonic() >= deadline:
+                    if activation_failures:
+                        chain = []
+                        failure = activation_failures[-1]
+                        while failure is not None:
+                            chain.append(f"{type(failure).__name__}: {failure}")
+                            failure = failure.__cause__
+                        pytest.fail(" <- ".join(chain))
+                    pytest.fail("lifespan runtime did not publish the BM25 result")
+                await asyncio.sleep(0.02)
+
+            assert active is not initial
+            assert active is not None
+            assert active.bm25 is not None
+            assert active.index_job_activation.job_id == created.job_id
+            assert service.healthy is True
+
+    asyncio.run(run_lifespan())
+
+    assert captured["service"].closed is True
+    for name in (
+        "index_runtime_service",
+        "index_job_reader",
+        "index_job_writer",
+        "index_update_capabilities_resolver",
+    ):
+        assert not hasattr(application.state, name)

--- a/test/web/test_local_index_runtime.py
+++ b/test/web/test_local_index_runtime.py
@@ -264,7 +264,13 @@ def test_local_index_runtime_rejects_loaded_repository_identity_mismatch(
 
 @pytest.mark.parametrize(
     "drift",
-    ("repository-key", "repository-root", "languages", "source-selection"),
+    (
+        "repository-key",
+        "repository-root",
+        "languages",
+        "source-selection",
+        "multi-view",
+    ),
 )
 def test_local_index_runtime_rejects_reloaded_build_input_drift(
     tmp_path: Path,
@@ -283,12 +289,17 @@ def test_local_index_runtime_rejects_reloaded_build_input_drift(
         entry = replace(entry, repo_dir=str(replacement_root))
     elif drift == "languages":
         manifest = replace(manifest, languages=["javascript"])
-    else:
+    elif drift == "source-selection":
         manifest = replace(
             manifest,
             source_selection=RepositorySourceSelection(
                 (*manifest.source_selection.exclude_subtrees, "policy-change")
             ),
+        )
+    else:
+        manifest = replace(
+            manifest,
+            indexes={"bm25": object(), "vector": object()},
         )
     replacement = RepoBundle(entry=entry, manifest=manifest)
     equivalent = RepoBundle(


### PR DESCRIPTION
## Summary
Install the explicit local indexing composition in the production FastAPI lifespan only when the optional local-storage block is configured. The runtime reader, availability-gated writer, repository-scoped capability resolver, worker, reconciler, per-repository attempt routes, and guarded RepoRegistry publication share one owned lifetime, including repair of stale or failed BM25 generations.

This branch is restacked directly on main after #747 merged. No storage default, vector/graph adapter, MCP route, or UI control is enabled here.

## Changes
- reject configured hybrid Web mode before opening or exposing the sparse-only local runtime
- open the local index runtime after repository loading and narrator initialization
- resolve index status and update capabilities from the same pinned repository generation
- expose the service, job reader, availability-gated writer, and repository-scoped capability resolver only for the live runtime interval
- reject new writes after a configured repository is retired from the live registry
- reject writes and hide capabilities when a same-ID reload changes the frozen repository key, entry and manifest checkout roots, language set, or source-selection policy
- treat runtime health as an entry-time availability signal while preserving the durable queue's restart-recovery contract
- stop advertising updates when either background loop faults or the service leaves running state
- return unavailable update capabilities for loaded repositories outside the configured storage subset
- restore or preserve embedding-application state by exact identity when the service exits
- stop exposing runtime handles before synchronously joining worker and reconciler loops
- close RepoRegistry only after runtime and routed attempt cleanup settle
- retain the registry dependency when startup or shutdown leaves a retryable publication-cleanup owner
- preserve ordinary startup cancellation and failure cleanup behavior
- allow one guarded durable BM25 generation to replace an authenticated source-only, stale-BM25, or failed-BM25 bundle while rejecting incompatible multi-view incumbents
- keep activation-time source-selection, language, repository identity, and path guards for reloads racing an already accepted durable job
- cover disabled, configured, replacement-state, startup-failure, close-failure, cancellation, health-failure, retirement, storage-subset, reload-drift, stale/failed repair, and real job-to-RCU lifespan paths
- document production lifespan ownership and the remaining #266/vector/default-routing work

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- complete Web suite: 674 passed, 1 skipped with pytest-xdist
- focused runtime, status, admission, stale/failed repair, and activation regressions: 86 passed
- Black, isort, flake8, Python 3.10 bytecode compilation, and diff checks pass on the changed Python surface

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published



