### PR TITLE
feat(storage): lease BM25 attempt pools

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -336,6 +336,8 @@ jobs:
                 assert (lease_directory / "child").is_dir()
                 _workspace_owner._close_directory_fd_owner(directory_owner)
                 assert _workspace_owner._directory_fd_owner_closed(directory_owner)
+                (lease_directory / "child").rmdir()
+                lease_directory.rmdir()
 
                 success_root = root / "success"
                 success_root.mkdir(mode=0o700)
@@ -819,6 +821,8 @@ jobs:
               assert (lease_directory / "child").is_dir()
               _workspace_owner._close_directory_fd_owner(directory_owner)
               assert _workspace_owner._directory_fd_owner_closed(directory_owner)
+              (lease_directory / "child").rmdir()
+              lease_directory.rmdir()
               destination = root / "published"
               provider = LocalWorkspaceProvider(root)
               provider.require_support()

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -128,6 +128,21 @@ jobs:
 
             assert platform.machine() == '${{ matrix.arch }}'
             assert implementation.workspace_owner_protocol_version == 6
+            assert implementation.directory_fd_owner_protocol_version == 1
+            assert implementation.directory_fd_owner_supported == 1
+            directory_fd_owner_symbols = (
+                "create_directory_fd_owner_exact",
+                "open_directory_fd_exact",
+                "borrow_directory_fd_exact",
+                "mkdir_directory_fd_child_exact",
+                "close_directory_fd_owner_exact",
+                "directory_fd_owner_closed_exact",
+                "fail_fork_child_if_directory_fd_owner_active_exact",
+            )
+            assert all(
+                callable(getattr(implementation, name, None))
+                for name in directory_fd_owner_symbols
+            )
             protocol_v6_symbols = (
                 "provision_owner_interruptibly_exact",
                 "capture_owner_destination_exact",
@@ -166,6 +181,8 @@ jobs:
             )
             assert implementation.require_support() is None
             assert _workspace_owner.require_support() is None
+            assert _workspace_owner._directory_fd_owner_protocol_available
+            assert _workspace_owner._require_directory_fd_owner_support() is None
 
             plan_digest = hashlib.sha256(b"cibuildwheel-protocol-v6").hexdigest()
             plan_digest_bytes = plan_digest.encode("ascii")
@@ -293,6 +310,32 @@ jobs:
 
             with TemporaryDirectory() as temporary:
                 root = Path(temporary)
+
+                lease_directory = root / "lease"
+                lease_directory.mkdir(mode=0o700)
+                directory_owner = _workspace_owner._create_directory_fd_owner()
+                _workspace_owner._open_directory_fd(
+                    directory_owner,
+                    os.fsencode(lease_directory),
+                )
+                directory_descriptor = _workspace_owner._borrow_directory_fd(
+                    directory_owner
+                )
+                assert stat.S_ISDIR(os.fstat(directory_descriptor).st_mode)
+                assert not os.get_inheritable(directory_descriptor)
+                assert _workspace_owner._mkdir_directory_fd_child(
+                    directory_owner,
+                    b"child",
+                    lambda: None,
+                )
+                assert not _workspace_owner._mkdir_directory_fd_child(
+                    directory_owner,
+                    b"child",
+                    lambda: None,
+                )
+                assert (lease_directory / "child").is_dir()
+                _workspace_owner._close_directory_fd_owner(directory_owner)
+                assert _workspace_owner._directory_fd_owner_closed(directory_owner)
 
                 success_root = root / "success"
                 success_root.mkdir(mode=0o700)
@@ -607,6 +650,12 @@ jobs:
               pass
           else:
               raise SystemExit("workspace support did not fail closed")
+          try:
+              _workspace_owner._require_directory_fd_owner_support()
+          except RuntimeError:
+              pass
+          else:
+              raise SystemExit("directory-fd-owner support did not fail closed")
 
           with TemporaryDirectory() as root:
               provider = LocalWorkspaceProvider(Path(root))
@@ -683,6 +732,21 @@ jobs:
 
           assert Path(implementation.__file__).name == "_workspace_owner_impl.abi3.so"
           assert implementation.workspace_owner_protocol_version == 6
+          assert implementation.directory_fd_owner_protocol_version == 1
+          assert implementation.directory_fd_owner_supported == 1
+          directory_fd_owner_symbols = (
+              "create_directory_fd_owner_exact",
+              "open_directory_fd_exact",
+              "borrow_directory_fd_exact",
+              "mkdir_directory_fd_child_exact",
+              "close_directory_fd_owner_exact",
+              "directory_fd_owner_closed_exact",
+              "fail_fork_child_if_directory_fd_owner_active_exact",
+          )
+          assert all(
+              callable(getattr(implementation, name, None))
+              for name in directory_fd_owner_symbols
+          )
           protocol_v6_symbols = (
               "provision_owner_interruptibly_exact",
               "capture_owner_destination_exact",
@@ -703,6 +767,8 @@ jobs:
           )
           assert implementation.require_support() is None
           assert _workspace_owner.require_support() is None
+          assert _workspace_owner._directory_fd_owner_protocol_available
+          assert _workspace_owner._require_directory_fd_owner_support() is None
           facade_v6_symbols = (
               "provision_owner",
               "capture_owner_destination",
@@ -728,6 +794,31 @@ jobs:
               root.mkdir(mode=0o700)
               root.chmod(0o700)
               assert stat.S_IMODE(root.stat().st_mode) == 0o700
+              lease_directory = root / "lease"
+              lease_directory.mkdir(mode=0o700)
+              directory_owner = _workspace_owner._create_directory_fd_owner()
+              _workspace_owner._open_directory_fd(
+                  directory_owner,
+                  os.fsencode(lease_directory),
+              )
+              directory_descriptor = _workspace_owner._borrow_directory_fd(
+                  directory_owner
+              )
+              assert stat.S_ISDIR(os.fstat(directory_descriptor).st_mode)
+              assert not os.get_inheritable(directory_descriptor)
+              assert _workspace_owner._mkdir_directory_fd_child(
+                  directory_owner,
+                  b"child",
+                  lambda: None,
+              )
+              assert not _workspace_owner._mkdir_directory_fd_child(
+                  directory_owner,
+                  b"child",
+                  lambda: None,
+              )
+              assert (lease_directory / "child").is_dir()
+              _workspace_owner._close_directory_fd_owner(directory_owner)
+              assert _workspace_owner._directory_fd_owner_closed(directory_owner)
               destination = root / "published"
               provider = LocalWorkspaceProvider(root)
               provider.require_support()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ All notable user-facing changes are recorded here. CodeNib follows
 
 ## [Unreleased]
 
+### Added
+
+- Repository-bound BM25 source-attempt shards with cooperative shared writer
+  and exclusive reaper leases, plus a default-off post-operation-return cleanup
+  pass that retains legacy workspace cleanup as an explicit compatibility step.
+
+### Security
+
+- Native directory descriptors are committed to opaque owners before returning
+  to Python, and writer/reaper leases remain coupled to retryable cleanup and
+  exact repository, workspace, and shard identities. Attempt-pool bootstrap
+  rejects nested or independently selected mount views before shard creation
+  within its documented controlled, quiescent path-and-mount contract.
+
 ## [0.2.2] - 2026-08-21
 
 ### Added

--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -9563,6 +9563,9 @@ class QuiescentDirectoryReclaimer:
         parent: Path,
         *,
         expected_parent_identity: tuple[int, ...],
+        _construction_owner: (
+            Callable[[QuiescentDirectoryReclaimer], None] | None
+        ) = None,
     ) -> None:
         if type(self) is not QuiescentDirectoryReclaimer:
             raise TypeError("quiescent directory reclaimer cannot be subclassed")
@@ -9576,6 +9579,10 @@ class QuiescentDirectoryReclaimer:
             or any(type(value) is not int for value in expected_parent_identity)
         ):
             raise TypeError("quiescent directory reclaimer parent identity is invalid")
+        if _construction_owner is not None and not callable(_construction_owner):
+            raise TypeError(
+                "quiescent directory reclaimer construction owner must be callable"
+            )
         _require_quiescent_reclaimer_support()
         lexical = lexical_directory_path(parent)
         self._parent = lexical
@@ -9586,6 +9593,8 @@ class QuiescentDirectoryReclaimer:
         self._active: _QuiescentDirectoryReclaimOperation | None = None
         self._closed = False
         try:
+            if _construction_owner is not None:
+                _construction_owner(self)
             authority = _open_publication_authority(
                 lexical,
                 parent_resource=None,

--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -5932,18 +5932,13 @@ def _snapshot_owned_path_build_directories() -> tuple[OwnedPathBuildDirectory, .
     )
 
 
-def retry_retained_owned_path_build_cleanup(
+def _run_retained_owned_path_build_cleanup(
     accept_orphan: Callable[[DirectoryOrphan], None],
+    *,
+    retention_group: object | None,
+    filter_by_retention_group: bool,
 ) -> None:
-    """Close retained path builds after their worker scope is quiescent.
-
-    This explicit boundary also settles a build whose successful ``prepare``
-    return was interrupted before its caller could receive the owner.  The
-    callback accepts each authenticated orphan before its full owner is
-    released. Delivery is at least once, so the callback must be idempotent and
-    must not recursively invoke this retry boundary. The first owner or sink
-    failure ends the round; every later owner remains registered for retry.
-    """
+    """Run one serialized all-owner or exact-group cleanup round."""
 
     if not callable(accept_orphan):
         raise TypeError("owned path build orphan acceptor must be callable")
@@ -5958,12 +5953,52 @@ def retry_retained_owned_path_build_cleanup(
     def retry_round() -> None:
         owners = _snapshot_owned_path_build_directories()
         for owner in owners:
+            if filter_by_retention_group and not (
+                type(owner) is OwnedPathBuildDirectory
+                and owner._retention_group is retention_group
+            ):
+                continue
             owner._retry_quiescent_cleanup(accept_orphan)
 
     _run_with_owned_path_build_lease(
         retry_lease,
         retry_round,
         release_label="owned path build retry lease release also failed",
+    )
+
+
+def retry_retained_owned_path_build_cleanup(
+    accept_orphan: Callable[[DirectoryOrphan], None],
+) -> None:
+    """Close retained path builds after their worker scope is quiescent.
+
+    This explicit boundary also settles a build whose successful ``prepare``
+    return was interrupted before its caller could receive the owner.  The
+    callback accepts each authenticated orphan before its full owner is
+    released. Delivery is at least once, so the callback must be idempotent and
+    must not recursively invoke this retry boundary. The first owner or sink
+    failure ends the round; every later owner remains registered for retry.
+    """
+
+    _run_retained_owned_path_build_cleanup(
+        accept_orphan,
+        retention_group=None,
+        filter_by_retention_group=False,
+    )
+
+
+def _retry_retained_owned_path_build_cleanup_for_group(
+    group_token: object,
+    accept_orphan: Callable[[DirectoryOrphan], None],
+) -> None:
+    """Close only owners carrying one exact opaque retention-group token."""
+
+    if group_token is None:
+        raise TypeError("owned path build retention group must not be None")
+    _run_retained_owned_path_build_cleanup(
+        accept_orphan,
+        retention_group=group_token,
+        filter_by_retention_group=True,
     )
 
 
@@ -6024,6 +6059,7 @@ class OwnedPathBuildDirectory:
         *,
         require_private_parent: bool,
         expected_parent_identity: tuple[int, ...] | None = None,
+        _retention_group: object | None = None,
     ) -> None:
         if type(self) is not OwnedPathBuildDirectory:
             raise TypeError(
@@ -6035,6 +6071,10 @@ class OwnedPathBuildDirectory:
             or any(type(value) is not int for value in expected_parent_identity)
         ):
             raise TypeError("owned path build parent identity is invalid")
+        # The token is caller authority, not a value derived from the path.
+        # Install it before registry publication so an interrupted constructor
+        # handoff can never expose an untagged retained owner for this route.
+        self._retention_group = _retention_group
         self._destination = destination
         self._path = destination
         self._require_private_parent = require_private_parent
@@ -6060,6 +6100,7 @@ class OwnedPathBuildDirectory:
         create_parent: bool = False,
         require_private_parent: bool = True,
         expected_parent_identity: tuple[int, ...] | None = None,
+        _retention_group: object | None = None,
     ) -> OwnedPathBuildDirectory:
         """Create a fresh private build root under one retained authority.
 
@@ -6093,6 +6134,7 @@ class OwnedPathBuildDirectory:
             lexical,
             require_private_parent=require_private_parent,
             expected_parent_identity=expected_parent_identity,
+            _retention_group=_retention_group,
         )
         cleanup = _OrderedAction(
             label="owned path build preparation cleanup also failed",

--- a/codenib/_workspace_owner.py
+++ b/codenib/_workspace_owner.py
@@ -12,9 +12,11 @@ filesystem mutation and must never select a path-based fallback.
 
 from __future__ import annotations
 
+import os
 from typing import Any, Callable
 
 _EXPECTED_WORKSPACE_OWNER_PROTOCOL_VERSION = 6
+_EXPECTED_DIRECTORY_FD_OWNER_PROTOCOL_VERSION = 1
 _IMPORT_ERROR: BaseException | None = None
 
 try:
@@ -31,6 +33,12 @@ def _implementation_attribute(name: str) -> Any:
 
 
 _protocol_version = _implementation_attribute("workspace_owner_protocol_version")
+_directory_fd_owner_protocol_version = _implementation_attribute(
+    "directory_fd_owner_protocol_version"
+)
+_directory_fd_owner_supported = _implementation_attribute(
+    "directory_fd_owner_supported"
+)
 _require_support_exact = _implementation_attribute("require_support")
 _create_owner_exact = _implementation_attribute("create_owner_exact")
 _claim_owner_publish_permit_exact = _implementation_attribute(
@@ -41,6 +49,23 @@ _claim_owner_replacement_permit_exact = _implementation_attribute(
 )
 _require_owner_exact = _implementation_attribute("require_owner_exact")
 _close_owner_exact = _implementation_attribute("close_owner_exact")
+_create_directory_fd_owner_exact = _implementation_attribute(
+    "create_directory_fd_owner_exact"
+)
+_open_directory_fd_exact = _implementation_attribute("open_directory_fd_exact")
+_borrow_directory_fd_exact = _implementation_attribute("borrow_directory_fd_exact")
+_mkdir_directory_fd_child_exact = _implementation_attribute(
+    "mkdir_directory_fd_child_exact"
+)
+_close_directory_fd_owner_exact = _implementation_attribute(
+    "close_directory_fd_owner_exact"
+)
+_directory_fd_owner_closed_exact = _implementation_attribute(
+    "directory_fd_owner_closed_exact"
+)
+_fail_fork_child_if_directory_fd_owner_active_exact = _implementation_attribute(
+    "fail_fork_child_if_directory_fd_owner_active_exact"
+)
 _provision_owner_exact = _implementation_attribute("provision_owner_exact")
 _provision_owner_interruptibly_exact = _implementation_attribute(
     "provision_owner_interruptibly_exact"
@@ -150,6 +175,24 @@ _workspace_owner_protocol_available = (
     )
 )
 
+_directory_fd_owner_protocol_available = (
+    type(_directory_fd_owner_protocol_version) is int
+    and _directory_fd_owner_protocol_version
+    == _EXPECTED_DIRECTORY_FD_OWNER_PROTOCOL_VERSION
+    and all(
+        callable(symbol)
+        for symbol in (
+            _create_directory_fd_owner_exact,
+            _open_directory_fd_exact,
+            _borrow_directory_fd_exact,
+            _mkdir_directory_fd_child_exact,
+            _close_directory_fd_owner_exact,
+            _directory_fd_owner_closed_exact,
+            _fail_fork_child_if_directory_fd_owner_active_exact,
+        )
+    )
+)
+
 if not _workspace_owner_protocol_available:
     _require_support_exact = None
     _create_owner_exact = None
@@ -186,6 +229,28 @@ if not _workspace_owner_protocol_available:
     _quarantine_owner_exact = None
     _owner_state_exact = None
     _owner_closed_exact = None
+
+if not _directory_fd_owner_protocol_available:
+    _create_directory_fd_owner_exact = None
+    _open_directory_fd_exact = None
+    _borrow_directory_fd_exact = None
+    _mkdir_directory_fd_child_exact = None
+    _close_directory_fd_owner_exact = None
+    _directory_fd_owner_closed_exact = None
+    _fail_fork_child_if_directory_fd_owner_active_exact = None
+
+
+# Register the immutable native callable in the facade that creates these
+# owners.  A raw facade consumer must receive the same fork boundary as the
+# higher-level lease wrapper, and mutable implementation dispatch must not be
+# consulted from the child callback.
+_NATIVE_FORK_CHILD_DIRECTORY_OWNER_GUARD = (
+    _fail_fork_child_if_directory_fd_owner_active_exact
+)
+if hasattr(os, "register_at_fork") and callable(
+    _NATIVE_FORK_CHILD_DIRECTORY_OWNER_GUARD
+):
+    os.register_at_fork(after_in_child=_NATIVE_FORK_CHILD_DIRECTORY_OWNER_GUARD)
 
 
 def require_support() -> None:
@@ -289,6 +354,107 @@ def close_owner_exact(candidate: object) -> None:
     result = _close_owner_exact(candidate)
     if result is not None:
         raise RuntimeError("native workspace close result changed")
+
+
+def _create_directory_fd_owner() -> object:
+    """Create a native owner before its directory descriptor is opened."""
+
+    _require_directory_fd_owner_support()
+    assert _create_directory_fd_owner_exact is not None
+    return _create_directory_fd_owner_exact()
+
+
+def _open_directory_fd(owner: object, path: bytes) -> None:
+    """Open exact bytes directly into a precreated native owner."""
+
+    _require_directory_fd_owner_support()
+    if type(path) is not bytes:
+        raise TypeError("directory descriptor path must be exact bytes")
+    assert _open_directory_fd_exact is not None
+    result = _open_directory_fd_exact(owner, path)
+    if result is not None:
+        raise RuntimeError("native directory descriptor open result changed")
+
+
+def _borrow_directory_fd(owner: object) -> int:
+    """Borrow the open descriptor; the native owner remains responsible."""
+
+    _require_directory_fd_owner_support()
+    assert _borrow_directory_fd_exact is not None
+    return _require_descriptor(
+        _borrow_directory_fd_exact(owner),
+        "directory-owner descriptor",
+    )
+
+
+def _mkdir_directory_fd_child(
+    owner: object,
+    name: bytes,
+    pre_mutation_check: Callable[[], None],
+) -> bool:
+    """Create one child directly after an exact native-bound policy check."""
+
+    _require_directory_fd_owner_support()
+    if type(name) is not bytes:
+        raise TypeError("directory child name must be exact bytes")
+    if not callable(pre_mutation_check):
+        raise TypeError("directory pre-mutation check must be callable")
+    assert _mkdir_directory_fd_child_exact is not None
+    result = _mkdir_directory_fd_child_exact(
+        owner,
+        name,
+        pre_mutation_check,
+    )
+    if type(result) is not bool:
+        raise RuntimeError("native directory child creation result changed")
+    return result
+
+
+def _close_directory_fd_owner(owner: object) -> None:
+    """Settle an exact directory owner without mutable instance dispatch."""
+
+    _require_directory_fd_owner_support()
+    assert _close_directory_fd_owner_exact is not None
+    result = _close_directory_fd_owner_exact(owner)
+    if result is not None:
+        raise RuntimeError("native directory descriptor close result changed")
+
+
+def _directory_fd_owner_closed(owner: object) -> bool:
+    """Return whether an exact directory owner has been settled."""
+
+    _require_directory_fd_owner_support()
+    assert _directory_fd_owner_closed_exact is not None
+    result = _directory_fd_owner_closed_exact(owner)
+    if type(result) is not bool:
+        raise RuntimeError("native directory descriptor closed result changed")
+    return result
+
+
+def _fail_fork_child_if_directory_fd_owner_active() -> None:
+    """Fail-stop a child before it can use an inherited directory owner."""
+
+    _require_directory_fd_owner_support()
+    assert _fail_fork_child_if_directory_fd_owner_active_exact is not None
+    result = _fail_fork_child_if_directory_fd_owner_active_exact()
+    if result is not None:
+        raise RuntimeError("native directory fork guard result changed")
+
+
+def _require_directory_fd_owner_support() -> None:
+    """Require the additive exact directory-descriptor owner ABI."""
+
+    if not _directory_fd_owner_protocol_available:
+        raise RuntimeError(
+            "private directory leases require the CodeNib directory-fd-owner "
+            "extension ABI"
+        ) from _IMPORT_ERROR
+    if type(_directory_fd_owner_supported) is not int or (
+        _directory_fd_owner_supported != 1
+    ):
+        raise RuntimeError(
+            "private directory leases require native directory open flags"
+        )
 
 
 def _require_none_result(result: object, label: str) -> None:

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -3996,13 +3996,41 @@ def _run_with_local_compiler_cache_job_worker(
         raise
 
 
-def _reclaim_local_bm25_source_attempt_pool(target) -> None:
+def _reclaim_local_bm25_source_attempt_pool(target, reaper_route) -> None:
     """Run one count-only explicit-quiescent sweep and report it on stderr."""
 
-    from .compiler.job_resources import LocalBM25AttemptPoolCoordinator
+    from .compiler.job_resources import (
+        BM25AttemptPoolReclamation,
+        LocalBM25AttemptPoolCoordinator,
+    )
 
-    reclamation = LocalBM25AttemptPoolCoordinator(target).reclaim(
+    routed = LocalBM25AttemptPoolCoordinator(
+        target,
+        reaper_route=reaper_route,
+    ).reclaim(
         caller_asserts_quiescence=True,
+    )
+    reaper_route._verify()
+    legacy = LocalBM25AttemptPoolCoordinator(
+        target,
+        _legacy_workspace=True,
+    ).reclaim(
+        caller_asserts_quiescence=True,
+    )
+    reaper_route._verify()
+    if legacy.scanned_children < 1 or legacy.retained_unrelated_children < 1:
+        raise RuntimeError(
+            "BM25 attempt-pool permanent shard disappeared during legacy sweep"
+        )
+    reclamation = BM25AttemptPoolReclamation(
+        scanned_children=(routed.scanned_children + legacy.scanned_children - 1),
+        reclaimed_children=(routed.reclaimed_children + legacy.reclaimed_children),
+        current_children=routed.current_children + legacy.current_children,
+        legacy_children=routed.legacy_children + legacy.legacy_children,
+        discarded_children=(routed.discarded_children + legacy.discarded_children),
+        retained_unrelated_children=(
+            routed.retained_unrelated_children + legacy.retained_unrelated_children - 1
+        ),
     )
     print(
         "BM25 attempt-pool reclamation: "
@@ -4022,6 +4050,7 @@ def _run_local_bm25_source_worker_operation(
     operation,
     worker,
     target,
+    reaper_route,
     topology_verifier: Callable[[], None],
 ):
     """Run once, then optionally sweep only after worker resources settle."""
@@ -4029,7 +4058,7 @@ def _run_local_bm25_source_worker_operation(
     result = operation(worker)
     topology_verifier()
     if getattr(args, "reclaim_quiescent_attempts", False):
-        _reclaim_local_bm25_source_attempt_pool(target)
+        _reclaim_local_bm25_source_attempt_pool(target, reaper_route)
         topology_verifier()
     return result
 
@@ -4043,6 +4072,7 @@ def _run_with_local_bm25_source_job_worker(
     from . import LocalWorkspaceProvider
     from ._atomic_directory import _OrderedAction, _run_context_with_cleanup_actions
     from .artifacts.runtime import SourceBindingCleanupOwner
+    from .compiler.bm25_attempt_pool import bootstrap_local_bm25_attempt_pool
     from .compiler.index_builders import BM25IndexBuilder
     from .compiler.job_resolver import BM25SourceJobResolver
     from .compiler.job_resources import (
@@ -4051,6 +4081,7 @@ def _run_with_local_bm25_source_job_worker(
     )
     from .source_fingerprint import pin_repository_source_root
     from .storage import IndexJobWorker, LocalCAS
+    from .storage.models import NamespaceIdentity, RepositoryIdentity
 
     repository, namespace = _retained_materialization_identity(
         args.repository,
@@ -4124,6 +4155,18 @@ def _run_with_local_bm25_source_job_worker(
             attempt_topology_verifier = _bm25_source_job_infrastructure_guard(
                 topology.verify
             )
+            namespace_identity = NamespaceIdentity(namespace)
+            repository_identity = RepositoryIdentity(
+                namespace_id=namespace_identity.namespace_id,
+                repository_key=repository,
+            )
+            attempt_pool_binding = bootstrap_local_bm25_attempt_pool(
+                workspace_root=paths.workspace_root,
+                workspace_identity=topology.workspace_binding.identity,
+                repository_id=repository_identity.repository_id,
+                repository_authority=repository_authority,
+                topology_verifier=attempt_topology_verifier,
+            )
             target = LocalBM25SourceJobTarget(
                 repository_root=paths.repo_path,
                 workspace_provider=provider,
@@ -4141,6 +4184,7 @@ def _run_with_local_bm25_source_job_worker(
                 ),
                 workspace_parent_identity=topology.workspace_binding.identity,
                 topology_verifier=attempt_topology_verifier,
+                attempt_pool_writer_route=attempt_pool_binding.writer_route,
             )
             resources = LocalBM25SourceJobResourceFactory((target,))
             worker = IndexJobWorker(
@@ -4167,6 +4211,7 @@ def _run_with_local_bm25_source_job_worker(
                 operation,
                 worker,
                 target,
+                attempt_pool_binding.reaper_route,
                 topology.verify,
             )
         if result is missing_result:  # pragma: no cover - callback always returns

--- a/codenib/compiler/_directory_lease.py
+++ b/codenib/compiler/_directory_lease.py
@@ -1,0 +1,759 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Retained POSIX ``flock`` leases bound to private directory inodes.
+
+The route is deliberately authority-free: callers must retain and supply the
+exact four-field directory identity themselves.  Acquisition only proves that
+the visible path and opened directory still name that identity; it never
+silently substitutes a newly observed inode.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import stat
+import sys
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+try:  # pragma: no cover - selected by the platform support gate
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+
+from .. import _workspace_owner as _native_workspace_owner
+from .._atomic_directory import (
+    _OrderedAction,
+    _publication_cleanup_owner_carrier,
+    _publication_exception_prior_link,
+    _run_context_with_cleanup_actions,
+)
+from . import cache_lock as _cache_lock
+
+_DIRECTORY_LEASE_RETRY_SECONDS = 0.05
+_FORK_CLEANUP_FAILURE_EXIT_CODE = 70
+_HOST_PATH_TYPE = type(Path())
+_OWNER_CONSTRUCTION_TOKEN = object()
+_DESCRIPTOR_CONSTRUCTION_TOKEN = object()
+_DIRECTORY_LEASE_THREAD_CLAIMS = threading.local()
+_ACTIVE_DIRECTORY_LEASE_OWNERS: set[PrivateDirectoryLeaseOwner] = set()
+_ACTIVE_PRIVATE_DIRECTORY_DESCRIPTOR_OWNERS: set[_PrivateDirectoryDescriptorOwner] = (
+    set()
+)
+
+DirectoryInodeIdentity = tuple[int, int, int, int]
+_ThreadDirectoryLeaseClaim = tuple[
+    int,
+    DirectoryInodeIdentity,
+    object,
+    dict[DirectoryInodeIdentity, object],
+]
+
+
+class DirectoryLeaseMode(Enum):
+    """The exact advisory-lock capability requested for one directory."""
+
+    SHARED = "shared"
+    EXCLUSIVE = "exclusive"
+
+
+def _require_exact_identity(value: object) -> DirectoryInodeIdentity:
+    if (
+        type(value) is not tuple
+        or len(value) != 4
+        or any(type(member) is not int for member in value)
+    ):
+        raise TypeError("private directory lease identity must be an exact 4-tuple")
+    identity = value
+    if identity[0] <= 0 or identity[1] <= 0:
+        raise ValueError("private directory lease identity must use stable inode IDs")
+    if identity[2] != stat.S_IFDIR:
+        raise ValueError("private directory lease identity must name a directory")
+    if identity[3] < 0:
+        raise ValueError("private directory lease identity attributes are invalid")
+    return identity
+
+
+@dataclass(frozen=True, slots=True)
+class PrivateDirectoryLeaseRoute:
+    """One exact, process-bound path-to-directory-inode route."""
+
+    path: Path
+    identity: DirectoryInodeIdentity
+    owner_pid: int
+
+    def __post_init__(self) -> None:
+        if type(self) is not PrivateDirectoryLeaseRoute:
+            raise TypeError("private directory lease route must use the exact type")
+        if type(self.path) is not _HOST_PATH_TYPE:
+            raise TypeError("private directory lease path must be an exact Path")
+        if not self.path.is_absolute() or ".." in self.path.parts:
+            raise ValueError(
+                "private directory lease path must be absolute and lexical"
+            )
+        _require_exact_identity(self.identity)
+        if type(self.owner_pid) is not int:
+            raise TypeError("private directory lease owner PID must be an exact int")
+        if self.owner_pid != os.getpid():
+            raise ValueError("private directory lease route crossed a PID boundary")
+
+
+def require_private_directory_lease_support() -> None:
+    """Fail before shard creation when the required POSIX surface is absent."""
+
+    supported = (
+        sys.platform.startswith("linux")
+        and os.name == "posix"
+        and fcntl is not None
+        and hasattr(fcntl, "flock")
+        and hasattr(fcntl, "LOCK_SH")
+        and hasattr(fcntl, "LOCK_EX")
+        and hasattr(fcntl, "LOCK_NB")
+        and hasattr(fcntl, "LOCK_UN")
+        and hasattr(os, "O_DIRECTORY")
+        and hasattr(os, "O_NOFOLLOW")
+        and hasattr(os, "O_CLOEXEC")
+        and hasattr(os, "register_at_fork")
+        and hasattr(os, "geteuid")
+    )
+    if not supported:
+        raise RuntimeError(
+            "private directory leases require Linux directory-inode flock support"
+        )
+    _native_workspace_owner._require_directory_fd_owner_support()
+
+
+def _directory_inode_identity(metadata: os.stat_result) -> DirectoryInodeIdentity:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        stat.S_IFMT(metadata.st_mode),
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+def _validate_private_directory_metadata(
+    metadata: os.stat_result,
+    route: PrivateDirectoryLeaseRoute,
+    *,
+    opened: bool,
+) -> None:
+    path = route.path
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or (not opened and stat.S_ISLNK(metadata.st_mode))
+        or getattr(metadata, "st_file_attributes", 0)
+    ):
+        raise RuntimeError(f"private directory lease path is not real: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise RuntimeError(f"private directory lease path has another owner: {path}")
+    if stat.S_IMODE(metadata.st_mode) != 0o700:
+        raise RuntimeError(f"private directory lease path is not mode 0700: {path}")
+    if _directory_inode_identity(metadata) != route.identity:
+        raise RuntimeError(f"private directory lease path changed: {path}")
+
+
+def _validate_visible_directory(route: PrivateDirectoryLeaseRoute) -> None:
+    try:
+        metadata = route.path.lstat()
+    except OSError as exc:
+        raise RuntimeError(
+            f"could not inspect private directory lease path: {route.path}"
+        ) from exc
+    _validate_private_directory_metadata(metadata, route, opened=False)
+
+
+def _validate_opened_directory(
+    descriptor: int,
+    route: PrivateDirectoryLeaseRoute,
+) -> None:
+    try:
+        metadata = os.fstat(descriptor)
+    except OSError as exc:
+        raise RuntimeError(
+            f"could not inspect opened private directory lease: {route.path}"
+        ) from exc
+    _validate_private_directory_metadata(metadata, route, opened=True)
+
+
+def _validate_identity_sandwich(
+    descriptor: int,
+    route: PrivateDirectoryLeaseRoute,
+) -> None:
+    _validate_opened_directory(descriptor, route)
+    _validate_visible_directory(route)
+    _validate_opened_directory(descriptor, route)
+
+
+def _require_route_process(route: PrivateDirectoryLeaseRoute) -> None:
+    if route.owner_pid != os.getpid():
+        raise RuntimeError("private directory lease route crossed a PID boundary")
+
+
+def _open_registered_directory(owner: PrivateDirectoryLeaseOwner) -> int:
+    route = owner._route
+    path_bytes = os.fsencode(route.path)
+    with _cache_lock._PosixLifecycleGuardLease() as acquire_interruption:
+        if acquire_interruption is not None:
+            raise acquire_interruption
+        _require_route_process(route)
+        if owner._generation != _cache_lock._POSIX_FORK_GENERATION:
+            raise RuntimeError("private directory lease fork generation changed")
+        if not owner._acquisition_pending:
+            raise RuntimeError("private directory lease was closed before acquisition")
+        _validate_visible_directory(route)
+        _require_route_process(route)
+        # Publish the already-installed Python owner to the fork callback and
+        # mark the native acquisition attempt before entering C.  The native
+        # owner stores a successful open before returning, closing the raw
+        # integer-fd return-to-first-STORE seam that Python cannot own.
+        _ACTIVE_DIRECTORY_LEASE_OWNERS.add(owner)
+        owner._native_open_started = True
+        _native_workspace_owner._open_directory_fd(
+            owner._native_descriptor_owner,
+            path_bytes,
+        )
+        descriptor = _native_workspace_owner._borrow_directory_fd(
+            owner._native_descriptor_owner
+        )
+        owner._descriptor_owner.append(descriptor)
+        _validate_identity_sandwich(descriptor, route)
+        _require_route_process(route)
+        if owner._generation != _cache_lock._POSIX_FORK_GENERATION:
+            raise RuntimeError("private directory lease fork generation changed")
+        return descriptor
+    raise AssertionError("unreachable private directory lease lifecycle guard")
+
+
+def _claim_thread_directory_lease(owner: PrivateDirectoryLeaseOwner) -> None:
+    identity = owner.identity
+    generation = _cache_lock._POSIX_FORK_GENERATION
+    state = getattr(_DIRECTORY_LEASE_THREAD_CLAIMS, "state", None)
+    if state is None or state[0] != generation:
+        tokens: dict[DirectoryInodeIdentity, object] = {}
+        _DIRECTORY_LEASE_THREAD_CLAIMS.state = (generation, tokens)
+    else:
+        tokens = state[1]
+        if type(tokens) is not dict:
+            raise RuntimeError("private directory lease thread claims are invalid")
+    if identity in tokens:
+        raise RuntimeError("private directory lease is already held by this thread")
+    token = object()
+    claim = (generation, identity, token, tokens)
+    # Publish cleanup authority before the token mutation.  If cancellation
+    # lands after dict insertion but before its return, the acquisition's
+    # prebuilt cleanup owner can still reconcile the exact token.
+    owner._claim_owner.append(claim)
+    tokens[identity] = token
+
+
+def _release_claim_for_cleanup(owner: PrivateDirectoryLeaseOwner) -> None:
+    if not _descriptor_cleanup_complete(owner):
+        raise RuntimeError(
+            "private directory lease claim cannot outlive an open descriptor"
+        )
+    deferred: BaseException | None = None
+    while owner._claim_owner:
+        claim = owner._claim_owner[-1]
+        generation, identity, token, tokens = claim
+        try:
+            if generation == owner._generation and tokens.get(identity) is token:
+                tokens.pop(identity, None)
+        except BaseException as error:  # noqa: B036 - reconcile cancellation
+            if isinstance(error, Exception):
+                raise
+            deferred = _cache_lock._remember_cleanup_interruption(deferred, error)
+            continue
+        try:
+            owner._claim_owner.pop()
+        except BaseException as error:  # noqa: B036 - recheck ambiguous pop
+            if isinstance(error, Exception):
+                raise
+            deferred = _cache_lock._remember_cleanup_interruption(deferred, error)
+            continue
+    if deferred is not None:
+        raise deferred
+
+
+def _close_descriptor_for_cleanup(owner: PrivateDirectoryLeaseOwner) -> None:
+    if _descriptor_cleanup_complete(owner):
+        return
+    if owner._generation != _cache_lock._POSIX_FORK_GENERATION:
+        raise RuntimeError("private directory lease fork generation changed")
+    deferred: BaseException | None = None
+    with _cache_lock._PosixLifecycleGuardLease() as acquire_interruption:
+        deferred = acquire_interruption
+        native_closed = _native_workspace_owner._directory_fd_owner_closed(
+            owner._native_descriptor_owner
+        )
+        if not native_closed:
+            try:
+                # Closing both authenticated descriptors releases the flock.
+                # Do not unlock first: a nonterminal native-close failure must
+                # retain the cooperative exclusion capability for cleanup retry.
+                _native_workspace_owner._close_directory_fd_owner(
+                    owner._native_descriptor_owner
+                )
+            except BaseException as error:  # noqa: B036 - native close is terminal
+                deferred = _cache_lock._remember_cleanup_interruption(
+                    deferred,
+                    error,
+                )
+        native_closed = _native_workspace_owner._directory_fd_owner_closed(
+            owner._native_descriptor_owner
+        )
+        if native_closed:
+            owner._locked = False
+            owner._acquisition_pending = False
+            deferred = _cache_lock._retry_cleanup_interruption(
+                owner._descriptor_owner.clear,
+                deferred,
+            )
+            deferred = _cache_lock._retry_cleanup_interruption(
+                _ACTIVE_DIRECTORY_LEASE_OWNERS.discard,
+                deferred,
+                owner,
+            )
+    if deferred is not None:
+        raise deferred
+
+
+def _descriptor_cleanup_complete(owner: PrivateDirectoryLeaseOwner) -> bool:
+    if owner._acquisition_pending:
+        return False
+    native_closed = _native_workspace_owner._directory_fd_owner_closed(
+        owner._native_descriptor_owner
+    )
+    return bool(
+        native_closed
+        and not owner._descriptor_owner
+        and owner not in _ACTIVE_DIRECTORY_LEASE_OWNERS
+    )
+
+
+def _private_descriptor_cleanup_complete(
+    owner: _PrivateDirectoryDescriptorOwner,
+) -> bool:
+    native_closed = (
+        not owner._native_open_started
+        or _native_workspace_owner._directory_fd_owner_closed(
+            owner._native_descriptor_owner
+        )
+    )
+    return bool(
+        native_closed
+        and not owner._descriptor_owner
+        and owner not in _ACTIVE_PRIVATE_DIRECTORY_DESCRIPTOR_OWNERS
+    )
+
+
+def _close_private_descriptor_for_cleanup(
+    owner: _PrivateDirectoryDescriptorOwner,
+) -> None:
+    if _private_descriptor_cleanup_complete(owner):
+        return
+    if owner._generation != _cache_lock._POSIX_FORK_GENERATION:
+        raise RuntimeError("private directory descriptor fork generation changed")
+    deferred: BaseException | None = None
+    with _cache_lock._PosixLifecycleGuardLease() as acquire_interruption:
+        deferred = acquire_interruption
+        native_closed = (
+            not owner._native_open_started
+            or _native_workspace_owner._directory_fd_owner_closed(
+                owner._native_descriptor_owner
+            )
+        )
+        if not native_closed:
+            try:
+                _native_workspace_owner._close_directory_fd_owner(
+                    owner._native_descriptor_owner
+                )
+            except BaseException as error:  # noqa: B036 - native close is terminal
+                deferred = _cache_lock._remember_cleanup_interruption(
+                    deferred,
+                    error,
+                )
+        native_closed = (
+            not owner._native_open_started
+            or _native_workspace_owner._directory_fd_owner_closed(
+                owner._native_descriptor_owner
+            )
+        )
+        if native_closed:
+            deferred = _cache_lock._retry_cleanup_interruption(
+                owner._descriptor_owner.clear,
+                deferred,
+            )
+            deferred = _cache_lock._retry_cleanup_interruption(
+                _ACTIVE_PRIVATE_DIRECTORY_DESCRIPTOR_OWNERS.discard,
+                deferred,
+                owner,
+            )
+    if deferred is not None:
+        raise deferred
+
+
+class _PrivateDirectoryDescriptorOwner:
+    """Retain one exact native directory fd without acquiring a lock."""
+
+    __slots__ = (
+        "_descriptor_owner",
+        "_generation",
+        "_native_descriptor_owner",
+        "_native_open_started",
+        "_route",
+    )
+
+    def __init__(
+        self,
+        route: PrivateDirectoryLeaseRoute,
+        *,
+        _token: object,
+    ) -> None:
+        if type(self) is not _PrivateDirectoryDescriptorOwner or (
+            _token is not _DESCRIPTOR_CONSTRUCTION_TOKEN
+        ):
+            raise TypeError("private directory descriptor owners cannot be forged")
+        if type(route) is not PrivateDirectoryLeaseRoute:
+            raise TypeError("private directory descriptor route is invalid")
+        route.__post_init__()
+        self._route = route
+        self._generation = _cache_lock._POSIX_FORK_GENERATION
+        self._native_descriptor_owner = (
+            _native_workspace_owner._create_directory_fd_owner()
+        )
+        self._native_open_started = False
+        self._descriptor_owner: list[int] = []
+
+    def _require_process(self) -> None:
+        if self._route.owner_pid != os.getpid():
+            raise RuntimeError(
+                "private directory descriptor owner crossed a PID boundary"
+            )
+
+    def _open(self) -> int:
+        self._require_process()
+        if self._native_open_started:
+            raise RuntimeError("private directory descriptor owner is already open")
+        route = self._route
+        path_bytes = os.fsencode(route.path)
+        with _cache_lock._PosixLifecycleGuardLease() as acquire_interruption:
+            if acquire_interruption is not None:
+                raise acquire_interruption
+            _require_route_process(route)
+            if self._generation != _cache_lock._POSIX_FORK_GENERATION:
+                raise RuntimeError(
+                    "private directory descriptor fork generation changed"
+                )
+            _validate_visible_directory(route)
+            _ACTIVE_PRIVATE_DIRECTORY_DESCRIPTOR_OWNERS.add(self)
+            self._native_open_started = True
+            _native_workspace_owner._open_directory_fd(
+                self._native_descriptor_owner,
+                path_bytes,
+            )
+            descriptor = _native_workspace_owner._borrow_directory_fd(
+                self._native_descriptor_owner
+            )
+            self._descriptor_owner.append(descriptor)
+            _validate_identity_sandwich(descriptor, route)
+            _require_route_process(route)
+            if self._generation != _cache_lock._POSIX_FORK_GENERATION:
+                raise RuntimeError(
+                    "private directory descriptor fork generation changed"
+                )
+            return descriptor
+        raise AssertionError("unreachable private directory descriptor lifecycle guard")
+
+    def _mkdir_child(
+        self,
+        name: bytes,
+        pre_mutation_check: Callable[[], None],
+    ) -> bool:
+        """Create one child after a native-bound final policy callback."""
+
+        self._require_process()
+        if not self._native_open_started or self.closed:
+            raise RuntimeError("private directory descriptor owner is not open")
+        return _native_workspace_owner._mkdir_directory_fd_child(
+            self._native_descriptor_owner,
+            name,
+            pre_mutation_check,
+        )
+
+    @property
+    def closed(self) -> bool:
+        return _private_descriptor_cleanup_complete(self)
+
+    def close(self) -> None:
+        self._require_process()
+        if self.closed:
+            return
+        cleanup = _OrderedAction(
+            label="private directory descriptor cleanup also failed",
+            action=lambda: _close_private_descriptor_for_cleanup(self),
+            complete=lambda: _private_descriptor_cleanup_complete(self),
+            retry_incomplete="cancellation",
+            incomplete_owner=self,
+        )
+        with _run_context_with_cleanup_actions((cleanup,)):
+            pass
+        if not self.closed:
+            raise RuntimeError("private directory descriptor cleanup did not complete")
+
+
+def _create_private_directory_descriptor_owner(
+    route: PrivateDirectoryLeaseRoute,
+) -> _PrivateDirectoryDescriptorOwner:
+    """Create an unopened retained owner for one exact directory route."""
+
+    require_private_directory_lease_support()
+    return _PrivateDirectoryDescriptorOwner(
+        route,
+        _token=_DESCRIPTOR_CONSTRUCTION_TOKEN,
+    )
+
+
+class PrivateDirectoryLeaseOwner:
+    """The exact retained owner of one directory-inode advisory lock."""
+
+    __slots__ = (
+        "_acquisition_pending",
+        "_claim_owner",
+        "_descriptor_owner",
+        "_generation",
+        "_locked",
+        "_mode",
+        "_native_descriptor_owner",
+        "_native_open_started",
+        "_route",
+    )
+
+    def __init__(
+        self,
+        route: PrivateDirectoryLeaseRoute,
+        mode: DirectoryLeaseMode,
+        *,
+        _token: object,
+    ) -> None:
+        if type(self) is not PrivateDirectoryLeaseOwner or (
+            _token is not _OWNER_CONSTRUCTION_TOKEN
+        ):
+            raise TypeError("private directory lease owners cannot be forged")
+        self._route = route
+        self._mode = mode
+        self._generation = _cache_lock._POSIX_FORK_GENERATION
+        self._native_descriptor_owner = (
+            _native_workspace_owner._create_directory_fd_owner()
+        )
+        self._native_open_started = False
+        self._acquisition_pending = True
+        self._descriptor_owner: list[int] = []
+        self._claim_owner: list[_ThreadDirectoryLeaseClaim] = []
+        self._locked = False
+
+    def _require_process(self) -> None:
+        if self._route.owner_pid != os.getpid():
+            raise RuntimeError("private directory lease owner crossed a PID boundary")
+
+    @property
+    def path(self) -> Path:
+        return self._route.path
+
+    @property
+    def identity(self) -> DirectoryInodeIdentity:
+        return self._route.identity
+
+    @property
+    def mode(self) -> DirectoryLeaseMode:
+        return self._mode
+
+    @property
+    def closed(self) -> bool:
+        return _descriptor_cleanup_complete(self) and not self._claim_owner
+
+    def __enter__(self) -> PrivateDirectoryLeaseOwner:
+        self._require_process()
+        if self.closed:
+            raise RuntimeError("private directory lease owner is closed")
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        _traceback: object,
+    ) -> None:
+        if exc is None:
+            self.close()
+            return
+        prior_link, _ = _publication_exception_prior_link(exc)
+        try:
+            self.close()
+        except BaseException as cleanup_error:  # noqa: B036 - keep body primary
+            carrier = _publication_cleanup_owner_carrier(
+                (self,),
+                cleanup_error,
+                prior_link,
+                forbidden=exc,
+                label="private directory lease context cleanup recovery",
+            )
+            raise exc from carrier
+
+    def close(self) -> None:
+        self._require_process()
+        if self.closed:
+            return
+        actions = (
+            _OrderedAction(
+                label="private directory lease descriptor cleanup also failed",
+                action=lambda: _close_descriptor_for_cleanup(self),
+                complete=lambda: _descriptor_cleanup_complete(self),
+                retry_incomplete="cancellation",
+                incomplete_owner=self,
+            ),
+            _OrderedAction(
+                label="private directory lease thread claim cleanup also failed",
+                action=lambda: _release_claim_for_cleanup(self),
+                complete=lambda: not self._claim_owner,
+                retry_incomplete="cancellation",
+                incomplete_owner=self,
+            ),
+        )
+        with _run_context_with_cleanup_actions(actions):
+            pass
+        if not self.closed:
+            raise RuntimeError("private directory lease cleanup did not complete")
+
+
+def _acquire_flock(
+    owner: PrivateDirectoryLeaseOwner,
+    *,
+    blocking: bool,
+    check_cancelled: Callable[[], None] | None,
+) -> None:
+    descriptor = _native_workspace_owner._borrow_directory_fd(
+        owner._native_descriptor_owner
+    )
+    assert fcntl is not None  # narrowed by support preflight
+    lock_mode = (
+        fcntl.LOCK_SH if owner._mode is DirectoryLeaseMode.SHARED else fcntl.LOCK_EX
+    )
+    if blocking and check_cancelled is None:
+        fcntl.flock(descriptor, lock_mode)
+    else:
+        while True:
+            if check_cancelled is not None:
+                check_cancelled()
+            try:
+                fcntl.flock(descriptor, lock_mode | fcntl.LOCK_NB)
+            except OSError as error:
+                if error.errno not in {errno.EACCES, errno.EAGAIN}:
+                    raise
+                if not blocking:
+                    raise BlockingIOError(
+                        errno.EWOULDBLOCK,
+                        f"private directory lease is unavailable: {owner.path}",
+                    ) from None
+                time.sleep(_DIRECTORY_LEASE_RETRY_SECONDS)
+                continue
+            break
+    owner._locked = True
+    if check_cancelled is not None:
+        check_cancelled()
+
+
+def _acquire_into_owner(
+    owner: PrivateDirectoryLeaseOwner,
+    *,
+    blocking: bool,
+    check_cancelled: Callable[[], None] | None,
+) -> None:
+    descriptor = _open_registered_directory(owner)
+    _claim_thread_directory_lease(owner)
+    _validate_identity_sandwich(descriptor, owner._route)
+    _acquire_flock(
+        owner,
+        blocking=blocking,
+        check_cancelled=check_cancelled,
+    )
+    _validate_identity_sandwich(descriptor, owner._route)
+    _require_route_process(owner._route)
+    if owner._generation != _cache_lock._POSIX_FORK_GENERATION:
+        raise RuntimeError("private directory lease fork generation changed")
+
+
+def _complete_owner_acquisition(owner: PrivateDirectoryLeaseOwner) -> None:
+    with _cache_lock._PosixLifecycleGuardLease() as acquire_interruption:
+        if acquire_interruption is not None:
+            raise acquire_interruption
+        if not owner._acquisition_pending:
+            raise RuntimeError("private directory lease was closed during acquisition")
+        if (
+            not owner._native_open_started
+            or not owner._descriptor_owner
+            or not owner._claim_owner
+            or not owner._locked
+            or _native_workspace_owner._directory_fd_owner_closed(
+                owner._native_descriptor_owner
+            )
+        ):
+            raise RuntimeError("private directory lease acquisition is incomplete")
+        owner._acquisition_pending = False
+
+
+def acquire_private_directory_lease(
+    route: PrivateDirectoryLeaseRoute,
+    *,
+    mode: DirectoryLeaseMode,
+    blocking: bool,
+    check_cancelled: Callable[[], None] | None = None,
+    _construction_owner: Callable[[PrivateDirectoryLeaseOwner], None] | None = None,
+) -> PrivateDirectoryLeaseOwner:
+    """Acquire a retained shared or exclusive lease for one exact route."""
+
+    require_private_directory_lease_support()
+    if type(route) is not PrivateDirectoryLeaseRoute:
+        raise TypeError("private directory lease requires an exact route")
+    # Revalidate the frozen record because hostile code can use
+    # ``object.__setattr__`` to bypass dataclass construction.
+    route.__post_init__()
+    if type(mode) is not DirectoryLeaseMode:
+        raise TypeError("private directory lease mode must use the exact enum")
+    if type(blocking) is not bool:
+        raise TypeError("private directory lease blocking policy must be exact bool")
+    if check_cancelled is not None and not callable(check_cancelled):
+        raise TypeError("private directory lease cancellation check must be callable")
+    if not callable(_construction_owner):
+        raise TypeError("private directory lease requires a construction owner")
+
+    owner = PrivateDirectoryLeaseOwner(
+        route,
+        mode,
+        _token=_OWNER_CONSTRUCTION_TOKEN,
+    )
+    cleanup = _OrderedAction(
+        label="private directory lease acquisition cleanup also failed",
+        action=owner.close,
+        complete=lambda: owner.closed,
+        retry_incomplete="cancellation",
+        incomplete_owner=owner,
+    )
+    with _run_context_with_cleanup_actions((cleanup,), cleanup_on_success=False):
+        _construction_owner(owner)
+        _acquire_into_owner(
+            owner,
+            blocking=blocking,
+            check_cancelled=check_cancelled,
+        )
+        _complete_owner_acquisition(owner)
+    if type(owner) is not PrivateDirectoryLeaseOwner or owner.closed:
+        raise RuntimeError("private directory lease acquisition did not retain owner")
+    return owner

--- a/codenib/compiler/bm25_attempt_pool.py
+++ b/codenib/compiler/bm25_attempt_pool.py
@@ -1,0 +1,862 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Repository-bound local BM25 attempt-pool shards and lease capabilities."""
+
+from __future__ import annotations
+
+import os
+import posixpath
+import re
+import stat
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Callable, final
+
+from .._atomic_directory import (
+    _linux_mount_points,
+    _mountinfo_path,
+    _path_is_mount_point,
+    _run_quiescent_directory_resource_scope,
+    lexical_directory_path,
+    publication_parent_identity,
+)
+from ..source_fingerprint import RepositorySourceRootAuthority
+from ..storage.models import StorageIntegrityError, StorageValidationError
+from ._directory_lease import (
+    DirectoryLeaseMode,
+    PrivateDirectoryLeaseOwner,
+    PrivateDirectoryLeaseRoute,
+    _create_private_directory_descriptor_owner,
+    _PrivateDirectoryDescriptorOwner,
+    acquire_private_directory_lease,
+    require_private_directory_lease_support,
+)
+
+_BM25_ATTEMPT_POOL_LAYOUT = "codenib-bm25-attempt-pool-v1"
+_BM25_ATTEMPT_POOL_SHARD_PREFIX = f".{_BM25_ATTEMPT_POOL_LAYOUT}-"
+_REPOSITORY_ID = re.compile(r"repo_[0-9a-f]{64}\Z")
+_MAX_BM25_MOUNTINFO_ENTRIES = 65_536
+_MAX_BM25_MOUNTINFO_LINE_BYTES = 64 * 1024
+
+
+def _require_identity(
+    value: object,
+    *,
+    length: int,
+    label: str,
+) -> tuple[int, ...]:
+    if (
+        type(value) is not tuple
+        or len(value) != length
+        or any(type(item) is not int for item in value)
+    ):
+        raise TypeError(f"{label} must be an exact {length}-integer tuple")
+    return value
+
+
+def _require_private_directory(
+    metadata: os.stat_result,
+    *,
+    label: str,
+    parent_device: int | None = None,
+) -> None:
+    mode = stat.S_IMODE(metadata.st_mode)
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or mode != 0o700
+        or (parent_device is not None and metadata.st_dev != parent_device)
+    ):
+        raise PermissionError(f"{label} must be an owner-controlled 0700 directory")
+
+
+def _publication_parent_identity_from_metadata(
+    metadata: os.stat_result,
+) -> tuple[int, ...]:
+    """Project one already-no-follow directory stat into the binding tuple."""
+
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        stat.S_IFMT(metadata.st_mode),
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+def _require_unmounted_attempt_pool_shard(path: Path) -> None:
+    """Reject a nested mount before it can become attempt authority."""
+
+    mount_points = _linux_mount_points()
+    if not mount_points:
+        raise StorageIntegrityError(
+            "BM25 attempt-pool mount topology could not be authenticated"
+        )
+    if _path_is_mount_point(path, mount_points=mount_points):
+        raise StorageIntegrityError("BM25 attempt-pool shard must not be a mount point")
+
+
+def _require_symlink_free_lexical_path(path: Path, *, label: str) -> None:
+    """Reject a lexical authority whose ancestry resolves through a symlink."""
+
+    try:
+        resolved = Path(os.path.realpath(path))
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise StorageIntegrityError(f"{label} could not be resolved safely") from exc
+    if resolved != path:
+        raise StorageIntegrityError(f"{label} must not traverse a symbolic link")
+
+
+def _require_opened_workspace_lexical_path(
+    descriptor: int,
+    *,
+    workspace_root: Path,
+) -> None:
+    try:
+        observed = Path(os.readlink(f"/proc/self/fd/{descriptor}"))
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise StorageIntegrityError(
+            "BM25 attempt-pool opened workspace path could not be authenticated"
+        ) from exc
+    if observed != workspace_root:
+        raise StorageIntegrityError(
+            "BM25 attempt-pool workspace ancestry changed while opening"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _BM25LinuxMountMapping:
+    mount_id: int
+    device: tuple[int, int]
+    root: PurePosixPath
+    mount_point: Path
+
+
+@dataclass(frozen=True, slots=True)
+class _BM25LinuxPhysicalPath:
+    mount_id: int
+    device: tuple[int, int]
+    path: PurePosixPath
+
+
+def _bm25_linux_mount_mappings() -> tuple[_BM25LinuxMountMapping, ...]:
+    """Read one bounded mount snapshot for repository/workspace alias checks."""
+
+    mountinfo_path = Path("/proc/self/mountinfo")
+    if os.name != "posix" or not mountinfo_path.is_file():
+        raise StorageIntegrityError(
+            "BM25 attempt-pool mount topology could not be authenticated"
+        )
+    mappings: list[_BM25LinuxMountMapping] = []
+    try:
+        with open(mountinfo_path, "rb") as mountinfo:
+            for index, line in enumerate(mountinfo):
+                if index >= _MAX_BM25_MOUNTINFO_ENTRIES:
+                    raise StorageIntegrityError(
+                        "BM25 attempt-pool mount table exceeds its safe entry limit"
+                    )
+                if len(line) > _MAX_BM25_MOUNTINFO_LINE_BYTES:
+                    raise StorageIntegrityError(
+                        "BM25 attempt-pool mount table contains an oversized entry"
+                    )
+                fields = line.split()
+                try:
+                    separator = fields.index(b"-")
+                except ValueError as exc:
+                    raise StorageIntegrityError(
+                        "BM25 attempt-pool mount table contains a malformed entry"
+                    ) from exc
+                if separator < 6 or len(fields) < separator + 4:
+                    raise StorageIntegrityError(
+                        "BM25 attempt-pool mount table contains a malformed entry"
+                    )
+                try:
+                    mount_id = int(fields[0])
+                    raw_device = os.fsdecode(fields[2])
+                    device_parts = raw_device.split(":", 1)
+                    device = tuple(int(part) for part in device_parts)
+                except (TypeError, ValueError) as exc:
+                    raise StorageIntegrityError(
+                        "BM25 attempt-pool mount table contains an invalid identity"
+                    ) from exc
+                if (
+                    mount_id < 1
+                    or len(device_parts) != 2
+                    or len(device) != 2
+                    or any(part < 0 for part in device)
+                ):
+                    raise StorageIntegrityError(
+                        "BM25 attempt-pool mount table contains an invalid identity"
+                    )
+                root = PurePosixPath(
+                    posixpath.normpath(_mountinfo_path(os.fsdecode(fields[3])))
+                )
+                mount_point = Path(
+                    os.path.normpath(_mountinfo_path(os.fsdecode(fields[4])))
+                )
+                if not root.is_absolute():
+                    continue
+                if not mount_point.is_absolute():
+                    raise StorageIntegrityError(
+                        "BM25 attempt-pool mount table contains a relative path"
+                    )
+                mappings.append(
+                    _BM25LinuxMountMapping(
+                        mount_id=mount_id,
+                        device=(device[0], device[1]),
+                        root=root,
+                        mount_point=mount_point,
+                    )
+                )
+    except StorageIntegrityError:
+        raise
+    except (OSError, UnicodeError) as exc:
+        raise StorageIntegrityError(
+            "BM25 attempt-pool mount topology could not be authenticated"
+        ) from exc
+    if not mappings:
+        raise StorageIntegrityError("BM25 attempt-pool mount table is empty")
+    return tuple(mappings)
+
+
+def _bm25_linux_physical_path(
+    path: Path,
+    *,
+    expected_device: int,
+    mappings: tuple[_BM25LinuxMountMapping, ...],
+) -> _BM25LinuxPhysicalPath:
+    candidates = tuple(
+        mapping
+        for mapping in mappings
+        if path == mapping.mount_point or mapping.mount_point in path.parents
+    )
+    if not candidates:
+        raise StorageIntegrityError(
+            "BM25 attempt-pool path has no authenticated mount mapping"
+        )
+    deepest = max(len(mapping.mount_point.parts) for mapping in candidates)
+    selected_candidates = tuple(
+        mapping for mapping in candidates if len(mapping.mount_point.parts) == deepest
+    )
+    if len(selected_candidates) != 1:
+        raise StorageIntegrityError(
+            "BM25 attempt-pool path has an ambiguous stacked mount mapping"
+        )
+    selected = selected_candidates[0]
+    expected = (os.major(expected_device), os.minor(expected_device))
+    if selected.device != expected:
+        raise StorageIntegrityError("BM25 attempt-pool mount mapping device changed")
+    try:
+        relative = path.relative_to(selected.mount_point)
+    except ValueError as exc:  # pragma: no cover - candidates prove containment
+        raise StorageIntegrityError("BM25 attempt-pool mount mapping changed") from exc
+    physical = PurePosixPath(
+        posixpath.normpath(
+            posixpath.join(selected.root.as_posix(), relative.as_posix())
+        )
+    )
+    if not physical.is_absolute():  # pragma: no cover - normalized absolute root
+        raise StorageIntegrityError(
+            "BM25 attempt-pool mount mapping produced a relative path"
+        )
+    return _BM25LinuxPhysicalPath(selected.mount_id, selected.device, physical)
+
+
+def _bm25_physical_paths_overlap(
+    first: _BM25LinuxPhysicalPath,
+    second: _BM25LinuxPhysicalPath,
+) -> bool:
+    return first.device == second.device and (
+        first.path == second.path
+        or first.path in second.path.parents
+        or second.path in first.path.parents
+    )
+
+
+def _require_repository_workspace_disjoint(
+    *,
+    repository_root: Path,
+    repository_root_identity: tuple[int, ...],
+    workspace_root: Path,
+    workspace_identity: tuple[int, ...],
+) -> tuple[_BM25LinuxPhysicalPath, _BM25LinuxPhysicalPath]:
+    if repository_root_identity[:2] == workspace_identity[:2]:
+        raise StorageIntegrityError(
+            "BM25 attempt-pool workspace physically aliases the repository"
+        )
+    mappings = _bm25_linux_mount_mappings()
+    if any(repository_root in mapping.mount_point.parents for mapping in mappings):
+        # A workspace backing directory can otherwise be bind-mounted below
+        # the repository while its own lexical root remains disjoint.  Any
+        # bootstrap mutation would then be visible inside source.  Source
+        # capture rejects nested mounts too, but bootstrap runs first and must
+        # enforce the same boundary before creating the permanent shard.
+        raise StorageIntegrityError(
+            "BM25 attempt-pool repository contains a nested mount"
+        )
+    repository_physical = _bm25_linux_physical_path(
+        repository_root,
+        expected_device=repository_root_identity[0],
+        mappings=mappings,
+    )
+    workspace_physical = _bm25_linux_physical_path(
+        workspace_root,
+        expected_device=workspace_identity[0],
+        mappings=mappings,
+    )
+    if repository_physical.mount_id != workspace_physical.mount_id:
+        # Mountinfo root/device mapping proves aliases inside one mounted
+        # namespace, including ordinary bind mounts.  It cannot authenticate
+        # external backing paths for a distinct overlay, FUSE, network, or
+        # custom filesystem.  Phase A therefore stays deliberately narrow:
+        # repository and workspace must be disjoint paths in one selected
+        # mount, rather than guessing about two independently mounted views.
+        raise StorageIntegrityError(
+            "BM25 attempt-pool repository and workspace must share one mount"
+        )
+    if _bm25_physical_paths_overlap(repository_physical, workspace_physical):
+        raise StorageIntegrityError(
+            "BM25 attempt-pool workspace physically overlaps the repository"
+        )
+    return repository_physical, workspace_physical
+
+
+@dataclass(frozen=True, slots=True)
+class _BM25AttemptPoolRouteState:
+    """Immutable identity shared by least-authority writer/reaper routes."""
+
+    repository_id: str
+    repository_root: Path
+    repository_root_identity: tuple[int, ...]
+    workspace_root: Path
+    workspace_identity: tuple[int, ...]
+    repository_physical: _BM25LinuxPhysicalPath
+    workspace_physical: _BM25LinuxPhysicalPath
+    shard_path: Path
+    shard_identity: tuple[int, ...]
+    directory_lease_route: PrivateDirectoryLeaseRoute = field(repr=False)
+    repository_authority: RepositorySourceRootAuthority = field(
+        repr=False,
+        compare=False,
+    )
+    topology_verifier: Callable[[], None] = field(repr=False, compare=False)
+    token: object = field(repr=False, compare=False)
+    owner_pid: int = field(repr=False, compare=False)
+
+    def verify(self) -> None:
+        if os.getpid() != self.owner_pid:
+            raise RuntimeError("BM25 attempt-pool route cannot cross a PID boundary")
+        expected_shard = self.workspace_root / (
+            _BM25_ATTEMPT_POOL_SHARD_PREFIX + self.repository_id
+        )
+        if (
+            self.shard_path != expected_shard
+            or self.directory_lease_route.path != self.shard_path
+            or self.directory_lease_route.identity != self.shard_identity
+            or self.directory_lease_route.owner_pid != self.owner_pid
+        ):
+            raise StorageIntegrityError("BM25 attempt-pool route binding changed")
+        self.directory_lease_route.__post_init__()
+        self.topology_verifier()
+        self.repository_authority.verify()
+        if self.repository_authority.root != self.repository_root:
+            raise StorageIntegrityError("BM25 attempt-pool repository root changed")
+        if tuple(self.repository_authority.root_identity) != (
+            self.repository_root_identity
+        ):
+            raise StorageIntegrityError("BM25 attempt-pool repository identity changed")
+        _require_symlink_free_lexical_path(
+            self.repository_root,
+            label="BM25 attempt-pool repository root",
+        )
+        _require_symlink_free_lexical_path(
+            self.workspace_root,
+            label="BM25 attempt-pool workspace root",
+        )
+        try:
+            workspace_metadata = self.workspace_root.lstat()
+        except OSError as exc:
+            raise StorageIntegrityError(
+                "BM25 attempt-pool workspace is no longer visible"
+            ) from exc
+        _require_private_directory(
+            workspace_metadata,
+            label="BM25 attempt-pool workspace",
+        )
+        if (
+            _publication_parent_identity_from_metadata(workspace_metadata)
+            != self.workspace_identity
+        ):
+            raise StorageIntegrityError("BM25 attempt-pool workspace identity changed")
+        observed_physical = _require_repository_workspace_disjoint(
+            repository_root=self.repository_root,
+            repository_root_identity=self.repository_root_identity,
+            workspace_root=self.workspace_root,
+            workspace_identity=self.workspace_identity,
+        )
+        if observed_physical != (
+            self.repository_physical,
+            self.workspace_physical,
+        ):
+            raise StorageIntegrityError("BM25 attempt-pool physical topology changed")
+        try:
+            shard_metadata = self.shard_path.lstat()
+        except OSError as exc:
+            raise StorageIntegrityError(
+                "BM25 attempt-pool shard is no longer visible"
+            ) from exc
+        _require_private_directory(
+            shard_metadata,
+            label="BM25 attempt-pool shard",
+            parent_device=self.workspace_identity[0],
+        )
+        if (
+            _publication_parent_identity_from_metadata(shard_metadata)
+            != self.shard_identity
+        ):
+            raise StorageIntegrityError("BM25 attempt-pool shard identity changed")
+        _require_unmounted_attempt_pool_shard(self.shard_path)
+        try:
+            shard_metadata = self.shard_path.lstat()
+        except OSError as exc:
+            raise StorageIntegrityError(
+                "BM25 attempt-pool shard is no longer visible"
+            ) from exc
+        _require_private_directory(
+            shard_metadata,
+            label="BM25 attempt-pool shard",
+            parent_device=self.workspace_identity[0],
+        )
+        if (
+            _publication_parent_identity_from_metadata(shard_metadata)
+            != self.shard_identity
+        ):
+            raise StorageIntegrityError("BM25 attempt-pool shard identity changed")
+        _require_unmounted_attempt_pool_shard(self.shard_path)
+        self.topology_verifier()
+
+
+@final
+class _LocalBM25AttemptPoolWriterRoute:
+    """Opaque capability that admits only shared attempt writers."""
+
+    __slots__ = ("_state",)
+
+    def __init__(self, state: _BM25AttemptPoolRouteState) -> None:
+        if type(state) is not _BM25AttemptPoolRouteState:
+            raise TypeError("BM25 attempt-pool writer route state is invalid")
+        self._state = state
+
+    @property
+    def _route_token(self) -> object:
+        return self._state.token
+
+    @property
+    def _repository_id(self) -> str:
+        return self._state.repository_id
+
+    @property
+    def _repository_root(self) -> Path:
+        return self._state.repository_root
+
+    @property
+    def _repository_root_identity(self) -> tuple[int, ...]:
+        return self._state.repository_root_identity
+
+    @property
+    def _workspace_root(self) -> Path:
+        return self._state.workspace_root
+
+    @property
+    def _workspace_identity(self) -> tuple[int, ...]:
+        return self._state.workspace_identity
+
+    @property
+    def _shard_path(self) -> Path:
+        return self._state.shard_path
+
+    @property
+    def _shard_identity(self) -> tuple[int, ...]:
+        return self._state.shard_identity
+
+    def _verify(self) -> None:
+        self._state.verify()
+
+    def _acquire(
+        self,
+        *,
+        check_cancelled: Callable[[], None] | None,
+        construction_owner: Callable[[PrivateDirectoryLeaseOwner], None],
+    ) -> PrivateDirectoryLeaseOwner:
+        if not callable(construction_owner):
+            raise TypeError("BM25 attempt-pool lease construction owner is invalid")
+        self._state.verify()
+        owner = acquire_private_directory_lease(
+            self._state.directory_lease_route,
+            mode=DirectoryLeaseMode.SHARED,
+            blocking=True,
+            check_cancelled=check_cancelled,
+            _construction_owner=construction_owner,
+        )
+        try:
+            self._state.verify()
+        except BaseException as primary:  # noqa: B036 - settle admitted lease
+            try:
+                owner.close()
+            except BaseException as cleanup:  # noqa: B036 - preserve exact primary
+                raise primary from cleanup
+            raise
+        return owner
+
+
+@final
+class _LocalBM25AttemptPoolReaperRoute:
+    """Opaque capability that admits only exclusive shard reapers."""
+
+    __slots__ = ("_state",)
+
+    def __init__(self, state: _BM25AttemptPoolRouteState) -> None:
+        if type(state) is not _BM25AttemptPoolRouteState:
+            raise TypeError("BM25 attempt-pool reaper route state is invalid")
+        self._state = state
+
+    @property
+    def _route_token(self) -> object:
+        return self._state.token
+
+    @property
+    def _repository_id(self) -> str:
+        return self._state.repository_id
+
+    @property
+    def _shard_path(self) -> Path:
+        return self._state.shard_path
+
+    @property
+    def _shard_identity(self) -> tuple[int, ...]:
+        return self._state.shard_identity
+
+    def _verify(self) -> None:
+        self._state.verify()
+
+    def _acquire(
+        self,
+        *,
+        blocking: bool,
+        check_cancelled: Callable[[], None] | None,
+        construction_owner: Callable[[PrivateDirectoryLeaseOwner], None],
+    ) -> PrivateDirectoryLeaseOwner:
+        if not callable(construction_owner):
+            raise TypeError("BM25 attempt-pool lease construction owner is invalid")
+        self._state.verify()
+        owner = acquire_private_directory_lease(
+            self._state.directory_lease_route,
+            mode=DirectoryLeaseMode.EXCLUSIVE,
+            blocking=blocking,
+            check_cancelled=check_cancelled,
+            _construction_owner=construction_owner,
+        )
+        try:
+            self._state.verify()
+        except BaseException as primary:  # noqa: B036 - settle admitted lease
+            try:
+                owner.close()
+            except BaseException as cleanup:  # noqa: B036 - preserve exact primary
+                raise primary from cleanup
+            raise
+        return owner
+
+
+@dataclass(frozen=True, slots=True)
+class LocalBM25AttemptPoolBinding:
+    """Paired least-authority routes for one permanent repository shard."""
+
+    _writer_route: _LocalBM25AttemptPoolWriterRoute = field(repr=False)
+    _reaper_route: _LocalBM25AttemptPoolReaperRoute = field(repr=False)
+
+    def __post_init__(self) -> None:
+        if type(self) is not LocalBM25AttemptPoolBinding:
+            raise TypeError("local BM25 attempt-pool binding must use the exact type")
+        if (
+            type(self._writer_route) is not _LocalBM25AttemptPoolWriterRoute
+            or type(self._reaper_route) is not _LocalBM25AttemptPoolReaperRoute
+        ):
+            raise TypeError("local BM25 attempt-pool routes are invalid")
+        if self._writer_route._state is not self._reaper_route._state:
+            raise ValueError("local BM25 attempt-pool routes have different authority")
+
+    @property
+    def writer_route(self) -> _LocalBM25AttemptPoolWriterRoute:
+        return self._writer_route
+
+    @property
+    def reaper_route(self) -> _LocalBM25AttemptPoolReaperRoute:
+        return self._reaper_route
+
+
+@final
+class _BM25AttemptPoolBootstrapResources:
+    """Retain native root/shard fds across every Python return handoff."""
+
+    __slots__ = ("_owners",)
+
+    def __init__(self) -> None:
+        self._owners: list[_PrivateDirectoryDescriptorOwner] = []
+
+    def _open(
+        self,
+        path: Path,
+        identity: tuple[int, ...],
+    ) -> tuple[_PrivateDirectoryDescriptorOwner, int]:
+        route = PrivateDirectoryLeaseRoute(
+            path=path,
+            identity=identity,
+            owner_pid=os.getpid(),
+        )
+        owner = _create_private_directory_descriptor_owner(route)
+        self._owners.append(owner)
+        return owner, owner._open()
+
+    @property
+    def closed(self) -> bool:
+        return all(owner.closed for owner in self._owners)
+
+    def close(self) -> None:
+        for owner in reversed(self._owners):
+            if not owner.closed:
+                owner.close()
+        if not self.closed:
+            raise RuntimeError("BM25 attempt-pool bootstrap cleanup did not settle")
+
+
+def _bootstrap_bm25_attempt_pool_shard(
+    resources: _BM25AttemptPoolBootstrapResources,
+    *,
+    repository_root: Path,
+    repository_root_identity: tuple[int, ...],
+    repository_authority: RepositorySourceRootAuthority,
+    workspace_root: Path,
+    workspace_identity: tuple[int, ...],
+    physical_topology: tuple[_BM25LinuxPhysicalPath, _BM25LinuxPhysicalPath],
+    shard_name: str,
+    topology_verifier: Callable[[], None],
+) -> tuple[Path, tuple[int, ...]]:
+    try:
+        visible_root = workspace_root.lstat()
+    except OSError as exc:
+        raise StorageIntegrityError(
+            "BM25 attempt-pool workspace could not be inspected"
+        ) from exc
+    _require_private_directory(visible_root, label="BM25 attempt-pool workspace")
+    if _publication_parent_identity_from_metadata(visible_root) != workspace_identity:
+        raise StorageIntegrityError("BM25 attempt-pool workspace identity changed")
+    root_owner, root_descriptor = resources._open(
+        workspace_root,
+        workspace_identity,
+    )
+    _require_opened_workspace_lexical_path(
+        root_descriptor,
+        workspace_root=workspace_root,
+    )
+    root_metadata = os.fstat(root_descriptor)
+    _require_private_directory(root_metadata, label="BM25 attempt-pool workspace")
+    if publication_parent_identity(root_descriptor) != workspace_identity:
+        raise StorageIntegrityError("BM25 attempt-pool workspace identity changed")
+
+    shard_path = workspace_root / shard_name
+
+    def pre_mutation_check() -> None:
+        """Reattest every retained topology binding in the native mkdir frame."""
+
+        topology_verifier()
+        repository_authority.verify()
+        _require_symlink_free_lexical_path(
+            repository_root,
+            label="BM25 attempt-pool repository root",
+        )
+        _require_symlink_free_lexical_path(
+            workspace_root,
+            label="BM25 attempt-pool workspace root",
+        )
+        _require_opened_workspace_lexical_path(
+            root_descriptor,
+            workspace_root=workspace_root,
+        )
+        visible = workspace_root.lstat()
+        _require_private_directory(visible, label="BM25 attempt-pool workspace")
+        if _publication_parent_identity_from_metadata(visible) != workspace_identity:
+            raise StorageIntegrityError(
+                "BM25 attempt-pool workspace identity changed before mutation"
+            )
+        if (
+            _require_repository_workspace_disjoint(
+                repository_root=repository_root,
+                repository_root_identity=repository_root_identity,
+                workspace_root=workspace_root,
+                workspace_identity=workspace_identity,
+            )
+            != physical_topology
+        ):
+            raise StorageIntegrityError(
+                "BM25 attempt-pool physical topology changed before mutation"
+            )
+
+    try:
+        before = os.stat(shard_name, dir_fd=root_descriptor, follow_symlinks=False)
+    except FileNotFoundError:
+        root_owner._mkdir_child(os.fsencode(shard_name), pre_mutation_check)
+        before = os.stat(shard_name, dir_fd=root_descriptor, follow_symlinks=False)
+    _require_private_directory(
+        before,
+        label="BM25 attempt-pool shard",
+        parent_device=root_metadata.st_dev,
+    )
+    _require_unmounted_attempt_pool_shard(shard_path)
+    shard_identity = _publication_parent_identity_from_metadata(before)
+    _shard_owner, shard_descriptor = resources._open(
+        shard_path,
+        shard_identity,
+    )
+    opened = os.fstat(shard_descriptor)
+    _require_private_directory(
+        opened,
+        label="BM25 attempt-pool shard",
+        parent_device=root_metadata.st_dev,
+    )
+    if publication_parent_identity(shard_descriptor) != shard_identity:
+        raise StorageIntegrityError("BM25 attempt-pool shard changed while opening")
+    _require_unmounted_attempt_pool_shard(shard_path)
+    os.fsync(shard_descriptor)
+    os.fsync(root_descriptor)
+    after = os.stat(shard_name, dir_fd=root_descriptor, follow_symlinks=False)
+    if _publication_parent_identity_from_metadata(after) != shard_identity:
+        raise StorageIntegrityError(
+            "BM25 attempt-pool shard changed after synchronization"
+        )
+    _require_unmounted_attempt_pool_shard(shard_path)
+    if publication_parent_identity(root_descriptor) != workspace_identity:
+        raise StorageIntegrityError(
+            "BM25 attempt-pool workspace changed after bootstrap"
+        )
+    return shard_path, shard_identity
+
+
+def bootstrap_local_bm25_attempt_pool(
+    *,
+    workspace_root: Path,
+    workspace_identity: tuple[int, ...],
+    repository_id: str,
+    repository_authority: RepositorySourceRootAuthority,
+    topology_verifier: Callable[[], None],
+) -> LocalBM25AttemptPoolBinding:
+    """Create/reopen one shard under caller-quiescent path and mount topology."""
+
+    require_private_directory_lease_support()
+    if type(workspace_root) is not type(Path()):
+        raise TypeError("BM25 attempt-pool workspace root must be an exact Path")
+    workspace_root = lexical_directory_path(workspace_root)
+    workspace_identity = _require_identity(
+        workspace_identity,
+        length=4,
+        label="BM25 attempt-pool workspace identity",
+    )
+    if (
+        type(repository_id) is not str
+        or _REPOSITORY_ID.fullmatch(repository_id) is None
+    ):
+        raise StorageValidationError("BM25 attempt-pool repository ID is invalid")
+    if type(repository_authority) is not RepositorySourceRootAuthority:
+        raise TypeError("BM25 attempt-pool repository authority is invalid")
+    if not callable(topology_verifier):
+        raise TypeError("BM25 attempt-pool topology verifier must be callable")
+    repository_authority.verify()
+    repository_root = repository_authority.root
+    repository_root_identity = _require_identity(
+        repository_authority.root_identity,
+        length=2,
+        label="BM25 attempt-pool repository identity",
+    )
+    _require_symlink_free_lexical_path(
+        repository_root,
+        label="BM25 attempt-pool repository root",
+    )
+    _require_symlink_free_lexical_path(
+        workspace_root,
+        label="BM25 attempt-pool workspace root",
+    )
+    topology_verifier()
+    physical_topology = _require_repository_workspace_disjoint(
+        repository_root=repository_root,
+        repository_root_identity=repository_root_identity,
+        workspace_root=workspace_root,
+        workspace_identity=workspace_identity,
+    )
+    shard_name = _BM25_ATTEMPT_POOL_SHARD_PREFIX + repository_id
+    if len(os.fsencode(shard_name)) > 255:
+        raise StorageValidationError("BM25 attempt-pool shard name is too long")
+    if not _linux_mount_points():
+        raise StorageIntegrityError(
+            "BM25 attempt-pool mount topology could not be authenticated"
+        )
+    resources = _BM25AttemptPoolBootstrapResources()
+    shard_path, shard_identity = _run_quiescent_directory_resource_scope(
+        resources,
+        lambda: _bootstrap_bm25_attempt_pool_shard(
+            resources,
+            repository_root=repository_root,
+            repository_root_identity=repository_root_identity,
+            repository_authority=repository_authority,
+            workspace_root=workspace_root,
+            workspace_identity=workspace_identity,
+            physical_topology=physical_topology,
+            shard_name=shard_name,
+            topology_verifier=topology_verifier,
+        ),
+        label="BM25 attempt-pool bootstrap cleanup also failed",
+    )
+    topology_verifier()
+    repository_authority.verify()
+    if (
+        _require_repository_workspace_disjoint(
+            repository_root=repository_root,
+            repository_root_identity=repository_root_identity,
+            workspace_root=workspace_root,
+            workspace_identity=workspace_identity,
+        )
+        != physical_topology
+    ):
+        raise StorageIntegrityError(
+            "BM25 attempt-pool physical topology changed during bootstrap"
+        )
+    owner_pid = os.getpid()
+    directory_route = PrivateDirectoryLeaseRoute(
+        path=shard_path,
+        identity=shard_identity,
+        owner_pid=owner_pid,
+    )
+    state = _BM25AttemptPoolRouteState(
+        repository_id=repository_id,
+        repository_root=repository_root,
+        repository_root_identity=repository_root_identity,
+        workspace_root=workspace_root,
+        workspace_identity=workspace_identity,
+        repository_physical=physical_topology[0],
+        workspace_physical=physical_topology[1],
+        shard_path=shard_path,
+        shard_identity=shard_identity,
+        directory_lease_route=directory_route,
+        repository_authority=repository_authority,
+        topology_verifier=topology_verifier,
+        token=object(),
+        owner_pid=owner_pid,
+    )
+    state.verify()
+    return LocalBM25AttemptPoolBinding(
+        _LocalBM25AttemptPoolWriterRoute(state),
+        _LocalBM25AttemptPoolReaperRoute(state),
+    )
+
+
+__all__ = ["LocalBM25AttemptPoolBinding", "bootstrap_local_bm25_attempt_pool"]

--- a/codenib/compiler/job_resources.py
+++ b/codenib/compiler/job_resources.py
@@ -14,11 +14,12 @@ from contextlib import contextmanager
 from dataclasses import InitVar, dataclass, field
 from pathlib import Path
 from types import MappingProxyType
-from typing import Callable, Iterator, Mapping
+from typing import Callable, Iterator, Mapping, final
 
 from .._atomic_directory import (
     DirectoryOrphan,
     QuiescentDirectoryReclaimer,
+    _annotate_secondary_error,
     _attach_publication_cleanup_owner,
     _OrderedAction,
     _run_callback_with_post_validations,
@@ -30,6 +31,7 @@ from .._atomic_directory import (
 from .._captured_directory import (
     OwnedPathBuildDirectory,
     PublishedWorkspaceReceiptOwner,
+    _retry_retained_owned_path_build_cleanup_for_group,
 )
 from .._local_workspace_provider import LocalWorkspaceProvider
 from .._workspace_provider import StrictWorkspaceRequest, StrictWorkspaceSession
@@ -58,6 +60,11 @@ from ..storage.protocols import (
     InterruptibleReceiptVerifyingObjectStore,
     InterruptibleStreamingObjectStore,
     RetainedImportObjectStore,
+)
+from ._directory_lease import DirectoryLeaseMode, PrivateDirectoryLeaseOwner
+from .bm25_attempt_pool import (
+    _LocalBM25AttemptPoolReaperRoute,
+    _LocalBM25AttemptPoolWriterRoute,
 )
 from .cache_import import (
     CompilerCacheJobExecutor,
@@ -379,6 +386,11 @@ class LocalBM25SourceJobTarget:
         repr=False,
         compare=False,
     )
+    attempt_pool_writer_route: _LocalBM25AttemptPoolWriterRoute | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
     _repository_id: str = field(init=False, repr=False)
     _builder: _BM25BuilderConfiguration = field(init=False, repr=False)
     _profile_id: str = field(init=False, repr=False)
@@ -436,6 +448,12 @@ class LocalBM25SourceJobTarget:
         attempt_orphan_sink = self.attempt_orphan_sink
         if attempt_orphan_sink is not None and not callable(attempt_orphan_sink):
             raise TypeError("BM25 source target orphan sink is invalid")
+        attempt_pool_writer_route = self.attempt_pool_writer_route
+        if (
+            attempt_pool_writer_route is not None
+            and type(attempt_pool_writer_route) is not _LocalBM25AttemptPoolWriterRoute
+        ):
+            raise TypeError("BM25 source target attempt-pool writer route is invalid")
         namespace = NamespaceIdentity(self.namespace_name)
         repository = RepositoryIdentity(
             namespace_id=namespace.namespace_id,
@@ -458,6 +476,28 @@ class LocalBM25SourceJobTarget:
             raise StorageValidationError(
                 "BM25 source target repository key is not canonical"
             )
+        if attempt_pool_writer_route is not None:
+            if repository_authority is None:
+                raise StorageValidationError(
+                    "routed BM25 source target requires a repository authority"
+                )
+            if workspace_parent_identity is None or len(workspace_parent_identity) != 4:
+                raise StorageValidationError(
+                    "routed BM25 source target requires an exact workspace identity"
+                )
+            attempt_pool_writer_route._verify()
+            if (
+                attempt_pool_writer_route._repository_id != repository.repository_id
+                or attempt_pool_writer_route._repository_root != repository_root
+                or attempt_pool_writer_route._repository_root_identity
+                != tuple(repository_authority.root_identity)
+                or attempt_pool_writer_route._workspace_root != workspace_root
+                or attempt_pool_writer_route._workspace_identity
+                != tuple(workspace_parent_identity)
+            ):
+                raise StorageValidationError(
+                    "BM25 source target attempt-pool route binding is inconsistent"
+                )
         configuration = _snapshot_builder(builder)
         profile = configuration.profile()
         object.__setattr__(self, "repository_root", repository_root)
@@ -492,12 +532,18 @@ class LocalBM25SourceJobTarget:
     def attempt_pool_root(self) -> Path:
         """Return the private parent that owns source-job attempt roots."""
 
+        route = self.attempt_pool_writer_route
+        if route is not None:
+            return route._shard_path
         return self.workspace_provider.allowed_root
 
     @property
     def attempt_pool_identity(self) -> tuple[int, ...] | None:
         """Return the retained identity for the source-job attempt parent."""
 
+        route = self.attempt_pool_writer_route
+        if route is not None:
+            return route._shard_identity
         return self.workspace_parent_identity
 
     @property
@@ -631,11 +677,136 @@ class BM25AttemptPoolReclamation:
     retained_unrelated_children: int
 
 
+@final
+class _BM25AttemptPoolReaperCleanupOwner:
+    """Keep EX held until its exact reclaimer and topology checks settle."""
+
+    __slots__ = ("_lease", "_reclaimer", "_route")
+
+    def __init__(self, route: _LocalBM25AttemptPoolReaperRoute) -> None:
+        if type(self) is not _BM25AttemptPoolReaperCleanupOwner:
+            raise TypeError("BM25 attempt-pool reaper cleanup must use the exact type")
+        if type(route) is not _LocalBM25AttemptPoolReaperRoute:
+            raise TypeError("BM25 attempt-pool reaper cleanup route is invalid")
+        self._route = route
+        self._lease: PrivateDirectoryLeaseOwner | None = None
+        self._reclaimer: QuiescentDirectoryReclaimer | None = None
+
+    def _install_lease(self, lease: PrivateDirectoryLeaseOwner) -> None:
+        if type(lease) is not PrivateDirectoryLeaseOwner:
+            raise TypeError("BM25 attempt-pool reaper lease has an invalid type")
+        if self._lease is not None:
+            raise RuntimeError("BM25 attempt-pool reaper lease is already installed")
+        if (
+            lease.mode is not DirectoryLeaseMode.EXCLUSIVE
+            or lease.path != self._route._shard_path
+            or lease.identity != self._route._shard_identity
+        ):
+            raise StorageIntegrityError(
+                "BM25 attempt-pool reaper lease authority is inconsistent"
+            )
+        self._lease = lease
+
+    def _acquire(self) -> None:
+        if self._lease is not None:
+            raise RuntimeError("BM25 attempt-pool reaper lease is already acquired")
+        lease = self._route._acquire(
+            blocking=True,
+            check_cancelled=None,
+            construction_owner=self._install_lease,
+        )
+        if self._lease is not lease:
+            raise StorageIntegrityError(
+                "BM25 attempt-pool reaper lease handoff is inconsistent"
+            )
+
+    def _install_reclaimer(self, reclaimer: QuiescentDirectoryReclaimer) -> None:
+        if type(reclaimer) is not QuiescentDirectoryReclaimer:
+            raise TypeError("BM25 attempt-pool reclaimer has an invalid type")
+        if self._reclaimer is not None:
+            raise RuntimeError("BM25 attempt-pool reclaimer is already installed")
+        self._reclaimer = reclaimer
+
+    def _open_reclaimer(self) -> QuiescentDirectoryReclaimer:
+        lease = self._lease
+        if lease is None or lease.closed:
+            raise StorageIntegrityError(
+                "BM25 attempt-pool reclaimer requires an active exclusive lease"
+            )
+        reclaimer = QuiescentDirectoryReclaimer(
+            self._route._shard_path,
+            expected_parent_identity=self._route._shard_identity,
+            _construction_owner=self._install_reclaimer,
+        )
+        if self._reclaimer is not reclaimer:
+            raise StorageIntegrityError(
+                "BM25 attempt-pool reclaimer handoff is inconsistent"
+            )
+        return reclaimer
+
+    @property
+    def closed(self) -> bool:
+        lease = self._lease
+        reclaimer = self._reclaimer
+        return bool(
+            (lease is None or lease.closed) and (reclaimer is None or reclaimer.closed)
+        )
+
+    def close(self) -> None:
+        lease = self._lease
+        if lease is None:
+            return
+        reclaimer = self._reclaimer
+        if lease.closed and reclaimer is not None and not reclaimer.closed:
+            raise StorageIntegrityError(
+                "BM25 attempt-pool EX lease closed before its reclaimer"
+            )
+        primary_error: BaseException | None = None
+        if reclaimer is not None and not reclaimer.closed:
+            try:
+                reclaimer.close()
+            except BaseException as error:  # noqa: B036 - inspect exact settlement
+                if not reclaimer.closed:
+                    raise
+                primary_error = error
+        if reclaimer is not None and not reclaimer.closed:
+            raise StorageIntegrityError(
+                "BM25 attempt-pool reclaimer remained active under its EX lease"
+            )
+        try:
+            self._route._verify()
+        except BaseException as error:  # noqa: B036 - unlock after validation fault
+            if primary_error is None:
+                primary_error = error
+            else:
+                _annotate_secondary_error(
+                    primary_error,
+                    "BM25 attempt-pool route validation also failed",
+                    error,
+                )
+        try:
+            lease.close()
+        except BaseException as cleanup_error:  # noqa: B036 - preserve validation
+            if primary_error is not None:
+                raise primary_error from cleanup_error
+            raise
+        if primary_error is not None:
+            raise primary_error
+        if not self.closed:
+            raise RuntimeError("BM25 attempt-pool reaper cleanup did not settle")
+
+
 @dataclass(frozen=True, slots=True)
 class LocalBM25AttemptPoolCoordinator:
     """Apply exact BM25 name policy under a caller-asserted quiescent boundary."""
 
     target: LocalBM25SourceJobTarget
+    reaper_route: _LocalBM25AttemptPoolReaperRoute | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    _legacy_workspace: bool = field(default=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         if type(self) is not LocalBM25AttemptPoolCoordinator:
@@ -644,19 +815,70 @@ class LocalBM25AttemptPoolCoordinator:
             raise TypeError(
                 "local BM25 attempt-pool coordinator requires an exact target"
             )
+        if (
+            self.reaper_route is not None
+            and type(self.reaper_route) is not _LocalBM25AttemptPoolReaperRoute
+        ):
+            raise TypeError("local BM25 attempt-pool reaper route is invalid")
+        if type(self._legacy_workspace) is not bool:
+            raise TypeError("local BM25 legacy-pool selection must be exact bool")
+        if self.reaper_route is not None and self._legacy_workspace:
+            raise StorageValidationError(
+                "leased and legacy BM25 attempt-pool routes are mutually exclusive"
+            )
 
-    def _require_target(self) -> tuple[Path, tuple[int, ...]]:
+    def _require_target(
+        self,
+    ) -> tuple[
+        Path,
+        tuple[int, ...],
+        _BM25AttemptPoolReaperCleanupOwner | None,
+    ]:
         target = self.target
         if target.topology_verifier is None:
             raise StorageValidationError(
                 "BM25 attempt-pool reclamation requires retained topology"
             )
-        attempt_pool_root = target.attempt_pool_root
-        if attempt_pool_root != target.workspace_root:
+        reaper_route = self.reaper_route
+        writer_route = target.attempt_pool_writer_route
+        if reaper_route is None and writer_route is not None:
+            if not self._legacy_workspace:
+                raise StorageValidationError(
+                    "routed BM25 attempt-pool reclamation requires its reaper route"
+                )
+        elif self._legacy_workspace:
+            raise StorageValidationError(
+                "legacy BM25 attempt-pool selection requires a routed target"
+            )
+        if reaper_route is None:
+            attempt_pool_root = target.workspace_root
+            identity = target.workspace_parent_identity
+        else:
+            if type(writer_route) is not _LocalBM25AttemptPoolWriterRoute:
+                raise StorageValidationError(
+                    "leased BM25 attempt-pool reclamation requires its writer route"
+                )
+            writer_route._verify()
+            reaper_route._verify()
+            if (
+                writer_route._route_token is not reaper_route._route_token
+                or writer_route._repository_id != reaper_route._repository_id
+                or writer_route._shard_path != reaper_route._shard_path
+                or writer_route._shard_identity != reaper_route._shard_identity
+            ):
+                raise StorageValidationError(
+                    "BM25 attempt-pool writer and reaper routes are inconsistent"
+                )
+            attempt_pool_root = reaper_route._shard_path
+            identity = reaper_route._shard_identity
+        if (
+            reaper_route is None
+            and target.attempt_pool_writer_route is None
+            and target.attempt_pool_root != target.workspace_root
+        ):
             raise StorageValidationError(
                 "BM25 attempt-pool reclamation target changed its workspace root"
             )
-        identity = target.attempt_pool_identity
         if (
             type(identity) is not tuple
             or len(identity) != 4
@@ -665,7 +887,12 @@ class LocalBM25AttemptPoolCoordinator:
             raise StorageValidationError(
                 "BM25 attempt-pool reclamation requires an exact parent identity"
             )
-        return attempt_pool_root, identity
+        cleanup = (
+            None
+            if reaper_route is None
+            else _BM25AttemptPoolReaperCleanupOwner(reaper_route)
+        )
+        return attempt_pool_root, identity, cleanup
 
     def reclaim(
         self,
@@ -680,26 +907,35 @@ class LocalBM25AttemptPoolCoordinator:
             raise StorageValidationError(
                 "BM25 attempt-pool reclamation requires caller-asserted quiescence"
             )
-        attempt_pool_root, identity = self._require_target()
+        attempt_pool_root, identity, reaper_cleanup = self._require_target()
         target = self.target
 
-        def run_with_topology(label: str, callback):
+        def verify_topology() -> None:
             target.verify_topology()
+            if self.reaper_route is not None:
+                self.reaper_route._verify()
+
+        def run_with_topology(label: str, callback):
+            verify_topology()
             return _run_callback_with_post_validations(
                 callback,
                 (
                     (
                         f"BM25 attempt-pool {label} topology validation also failed",
-                        target.verify_topology,
+                        verify_topology,
                     ),
                 ),
             )
 
         def sweep() -> BM25AttemptPoolReclamation:
-            with QuiescentDirectoryReclaimer(
-                attempt_pool_root,
-                expected_parent_identity=identity,
-            ) as reclaimer:
+            if reaper_cleanup is None:
+                reclaimer = QuiescentDirectoryReclaimer(
+                    attempt_pool_root,
+                    expected_parent_identity=identity,
+                )
+            else:
+                reclaimer = reaper_cleanup._open_reclaimer()
+            with reclaimer:
                 child_names = run_with_topology(
                     "snapshot",
                     reclaimer.snapshot_child_names,
@@ -751,10 +987,24 @@ class LocalBM25AttemptPoolCoordinator:
                 retained_unrelated_children=len(retained),
             )
 
-        return run_with_topology(
-            "reclaimer lifetime",
-            sweep,
+        if reaper_cleanup is None:
+            return run_with_topology(
+                "reclaimer lifetime",
+                sweep,
+            )
+        cleanup_action = _OrderedAction(
+            label="BM25 attempt-pool leased reclaimer cleanup also failed",
+            action=reaper_cleanup.close,
+            complete=lambda: reaper_cleanup.closed,
+            retry_incomplete="cancellation",
+            incomplete_owner=reaper_cleanup,
         )
+        with _run_context_with_cleanup_actions((cleanup_action,)):
+            reaper_cleanup._acquire()
+            return run_with_topology(
+                "reclaimer lifetime",
+                sweep,
+            )
 
 
 @dataclass(slots=True)
@@ -874,6 +1124,158 @@ class _BM25AttemptRootCleanupOwner:
         if not owner.closed:
             raise RuntimeError("BM25 source job attempt root did not close")
         self._closed = True
+
+
+@final
+class _BM25AttemptPoolWriterCleanupOwner:
+    """Settle one routed attempt completely before releasing its shared lease."""
+
+    __slots__ = (
+        "_accept_orphan",
+        "_admitted",
+        "_attempt_root",
+        "_child_owners",
+        "_lease",
+        "_retention_group",
+        "_route",
+    )
+
+    def __init__(
+        self,
+        *,
+        route: _LocalBM25AttemptPoolWriterRoute,
+        retention_group: object,
+        child_owners: tuple[_AttemptWorkspaceCleanupOwner, ...],
+        attempt_root: _BM25AttemptRootCleanupOwner,
+        accept_orphan: Callable[[DirectoryOrphan], None],
+    ) -> None:
+        if type(self) is not _BM25AttemptPoolWriterCleanupOwner:
+            raise TypeError("BM25 attempt-pool writer cleanup must use the exact type")
+        if type(route) is not _LocalBM25AttemptPoolWriterRoute:
+            raise TypeError("BM25 attempt-pool writer cleanup route is invalid")
+        if type(child_owners) is not tuple or any(
+            type(owner) is not _AttemptWorkspaceCleanupOwner for owner in child_owners
+        ):
+            raise TypeError("BM25 attempt-pool child cleanup owners are invalid")
+        if type(attempt_root) is not _BM25AttemptRootCleanupOwner:
+            raise TypeError("BM25 attempt-pool root cleanup owner is invalid")
+        if not callable(accept_orphan):
+            raise TypeError("BM25 attempt-pool orphan sink is invalid")
+        self._route = route
+        self._retention_group = retention_group
+        self._child_owners = child_owners
+        self._attempt_root = attempt_root
+        self._accept_orphan = accept_orphan
+        self._lease: PrivateDirectoryLeaseOwner | None = None
+        self._admitted = False
+
+    def _install_lease(self, lease: PrivateDirectoryLeaseOwner) -> None:
+        if type(lease) is not PrivateDirectoryLeaseOwner:
+            raise TypeError("BM25 attempt-pool writer lease has an invalid type")
+        if self._lease is not None:
+            raise RuntimeError("BM25 attempt-pool writer lease is already installed")
+        if (
+            lease.mode is not DirectoryLeaseMode.SHARED
+            or lease.path != self._route._shard_path
+            or lease.identity != self._route._shard_identity
+        ):
+            raise StorageIntegrityError(
+                "BM25 attempt-pool writer lease authority is inconsistent"
+            )
+        self._lease = lease
+
+    def _acquire(self, check_cancelled: Callable[[], None]) -> None:
+        if not callable(check_cancelled):
+            raise TypeError("BM25 attempt-pool writer stop check must be callable")
+        if self._lease is not None:
+            raise RuntimeError("BM25 attempt-pool writer lease is already acquired")
+        lease = self._route._acquire(
+            check_cancelled=check_cancelled,
+            construction_owner=self._install_lease,
+        )
+        if self._lease is not lease:
+            raise StorageIntegrityError(
+                "BM25 attempt-pool writer lease handoff is inconsistent"
+            )
+        self._admitted = True
+
+    @property
+    def closed(self) -> bool:
+        lease = self._lease
+        if lease is None:
+            return True
+        return bool(
+            lease.closed
+            and all(owner.closed for owner in self._child_owners)
+            and self._attempt_root.closed
+        )
+
+    def _settle_attempt(self) -> None:
+        for child in self._child_owners:
+            if not child.closed:
+                child.close()
+        if self._attempt_root.owner is None:
+            _retry_retained_owned_path_build_cleanup_for_group(
+                self._retention_group,
+                self._accept_orphan,
+            )
+        if not self._attempt_root.closed:
+            self._attempt_root.close()
+        if any(not child.closed for child in self._child_owners):
+            raise StorageIntegrityError(
+                "BM25 source job child cleanup remained active under its writer lease"
+            )
+        if not self._attempt_root.closed:
+            raise StorageIntegrityError(
+                "BM25 source job attempt root remained active under its writer lease"
+            )
+
+    def _settle_unstarted_attempt(self) -> None:
+        for child in self._child_owners:
+            if not child.closed:
+                child.close()
+        if not self._attempt_root.closed:
+            self._attempt_root.close()
+
+    def close(self) -> None:
+        lease = self._lease
+        if lease is None:
+            return
+        if not self._admitted:
+            # The route publishes the live lease before returning it.  A
+            # cancellation at that return handoff therefore owns no attempt
+            # yet and must not enter the process-global retained-build retry
+            # boundary merely to release SH.
+            self._settle_unstarted_attempt()
+        elif lease.closed:
+            if not self.closed:
+                raise StorageIntegrityError(
+                    "BM25 attempt-pool writer lease closed before attempt cleanup"
+                )
+            return
+        else:
+            self._settle_attempt()
+        if lease.closed:
+            if not self.closed:
+                raise StorageIntegrityError(
+                    "BM25 attempt-pool writer lease closed before attempt cleanup"
+                )
+            return
+        validation_error: BaseException | None = None
+        try:
+            self._route._verify()
+        except BaseException as error:  # noqa: B036 - unlock after validation fault
+            validation_error = error
+        try:
+            lease.close()
+        except BaseException as cleanup_error:  # noqa: B036 - preserve validation
+            if validation_error is not None:
+                raise validation_error from cleanup_error
+            raise
+        if validation_error is not None:
+            raise validation_error
+        if not lease.closed:
+            raise RuntimeError("BM25 attempt-pool writer lease did not close")
 
 
 def _cleanup_owner_pending(owner: object) -> bool:
@@ -1324,36 +1726,63 @@ class LocalBM25SourceJobResourceFactory:
             target.accept_attempt_orphan,
         )
         source_owner = SourceBindingCleanupOwner()
-        cleanup_owners = (
-            *child_cleanups,
-            attempt_root_cleanup,
-            source_owner,
-        )
-        cleanup_actions = tuple(
-            _OrderedAction(
-                label=f"BM25 source job {cleanup.label} cleanup also failed",
-                action=cleanup.close,
-                complete=lambda cleanup=cleanup: cleanup.closed,
-                retry_incomplete="cancellation",
-                incomplete_owner=cleanup,
+        writer_route = target.attempt_pool_writer_route
+        retention_group = object()
+        writer_cleanup = (
+            None
+            if writer_route is None
+            else _BM25AttemptPoolWriterCleanupOwner(
+                route=writer_route,
+                retention_group=retention_group,
+                child_owners=child_cleanups,
+                attempt_root=attempt_root_cleanup,
+                accept_orphan=target.accept_attempt_orphan,
             )
-            for cleanup in child_cleanups
-        ) + (
-            _OrderedAction(
-                label="BM25 source job attempt root cleanup also failed",
-                action=attempt_root_cleanup.close,
-                complete=lambda: attempt_root_cleanup.closed,
-                retry_incomplete="cancellation",
-                incomplete_owner=attempt_root_cleanup,
-            ),
-            _OrderedAction(
-                label="BM25 source job source cleanup also failed",
-                action=source_owner.close,
-                complete=lambda: source_owner.closed,
-                retry_incomplete="cancellation",
-                incomplete_owner=source_owner,
-            ),
         )
+        source_cleanup_action = _OrderedAction(
+            label="BM25 source job source cleanup also failed",
+            action=source_owner.close,
+            complete=lambda: source_owner.closed,
+            retry_incomplete="cancellation",
+            incomplete_owner=source_owner,
+        )
+        if writer_cleanup is None:
+            cleanup_owners = (
+                *child_cleanups,
+                attempt_root_cleanup,
+                source_owner,
+            )
+            cleanup_actions = tuple(
+                _OrderedAction(
+                    label=f"BM25 source job {cleanup.label} cleanup also failed",
+                    action=cleanup.close,
+                    complete=lambda cleanup=cleanup: cleanup.closed,
+                    retry_incomplete="cancellation",
+                    incomplete_owner=cleanup,
+                )
+                for cleanup in child_cleanups
+            ) + (
+                _OrderedAction(
+                    label="BM25 source job attempt root cleanup also failed",
+                    action=attempt_root_cleanup.close,
+                    complete=lambda: attempt_root_cleanup.closed,
+                    retry_incomplete="cancellation",
+                    incomplete_owner=attempt_root_cleanup,
+                ),
+                source_cleanup_action,
+            )
+        else:
+            cleanup_owners = (writer_cleanup, source_owner)
+            cleanup_actions = (
+                _OrderedAction(
+                    label="BM25 source job leased attempt cleanup also failed",
+                    action=writer_cleanup.close,
+                    complete=lambda: writer_cleanup.closed,
+                    retry_incomplete="cancellation",
+                    incomplete_owner=writer_cleanup,
+                ),
+                source_cleanup_action,
+            )
 
         try:
             with _run_context_with_cleanup_actions(cleanup_actions):
@@ -1380,9 +1809,19 @@ class LocalBM25SourceJobResourceFactory:
                     )
                 check_cancelled()
                 target.verify_topology()
+                if writer_cleanup is None:
+                    attempt_pool_root = target.attempt_pool_root
+                    attempt_pool_identity = target.workspace_parent_identity
+                    retained_group = None
+                else:
+                    writer_cleanup._acquire(check_cancelled)
+                    attempt_pool_root = writer_route._shard_path
+                    attempt_pool_identity = writer_route._shard_identity
+                    retained_group = retention_group
                 attempt_root = OwnedPathBuildDirectory.prepare(
-                    target.attempt_pool_root / prefix,
-                    expected_parent_identity=target.workspace_parent_identity,
+                    attempt_pool_root / prefix,
+                    expected_parent_identity=attempt_pool_identity,
+                    _retention_group=retained_group,
                 )
                 attempt_root_cleanup.install(attempt_root)
                 target.verify_topology()

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -378,9 +378,10 @@ source. `--exclude-dir PATH` is repeatable and defines the exact custom subtree
 exclusions for this worker profile; `--clear-exclude-dirs` explicitly selects
 none. These source-only options are rejected with `--cache-dir`.
 
-`--scan-limit` may select 1 through 256 candidates. Lease and heartbeat timing
-are configurable, but the heartbeat must remain less than one third of the
-lease. The default text output reports disposition, job ID, and attempt; use
+`--scan-limit` may select 1 through 256 candidates. Catalog job-lease and
+heartbeat timing are configurable, but the heartbeat must remain less than one
+third of the lease. The default text output reports disposition, job ID, and
+attempt; use
 `--json` for one compact canonical object. A processed retry, failure,
 cancellation, or authority loss is a durable worker disposition rather than a
 CLI infrastructure failure. Storage-integrity, topology, and cleanup failures
@@ -392,6 +393,43 @@ outputs; cache imports own BM25/vector and context outputs as applicable. After
 CAS ingestion and worker-owned publication, receipt authorities close and the
 exact owned directories are atomically moved to authenticated orphan names for
 later quiescent GC; the command never recursively deletes a mutable path.
+
+Source mode creates or reopens one permanent owner-only `0700` attempt-pool
+shard named `.codenib-bm25-attempt-pool-v1-repo_<64-hex>` for the exact
+repository below the retained workspace. Bootstrap requires Linux directory
+`flock` support and the additive native directory-FD-owner protocol v1; the
+core workspace-owner protocol remains v6. Repository and workspace must be
+disjoint paths selected by the same authenticated Linux mount; nested
+repository mounts and independently mounted overlay/FUSE/network views are
+rejected before shard creation because their backing paths cannot be proven
+disjoint. The caller must keep the repository/workspace path ancestry and
+selected mount namespace controlled and externally quiescent from bootstrap
+until every routed writer/reaper owner has closed; CodeNib does not claim safety
+against an in-process trace callback or same-euid/privileged actor renaming
+those ancestors or changing mounts during a filesystem mutation. The native
+bootstrap recheck and `mkdirat` share one C frame to close ordinary Python
+opcode, cancellation, and signal-delivery handoffs within that contract. The
+native owner retains the exact
+directory descriptor before returning it to Python. A native at-fork guard
+fail-stops a child while any such owner is live, before `os.fork()` can return
+to application code. Earlier-registered child callbacks may already have
+changed enumerable descriptor numbers, so the guard deliberately closes none
+of them and terminates the child instead; fork can continue normally again
+after every owner settles.
+
+A routed source writer takes `LOCK_SH` immediately before outer-attempt
+preparation and holds it through child/root cleanup, lost-return recovery,
+orphan delivery and acknowledgement, and final route validation. With
+`--reclaim-quiescent-attempts`, the post-success coordinator takes `LOCK_EX`
+before constructing the descriptor-bound reclaimer and keeps it through the
+bounded shard sweep, reclaimer close, and post-validation. It then performs a
+separate unleased compatibility sweep of the legacy workspace-root pool, so
+the operator must still keep that legacy namespace quiescent. The flag never
+runs after an exceptional worker or infrastructure unwind; normal returned
+failed, requeued, cancelled, or lost-authority dispositions have already
+settled their resource scopes and may still be followed by the requested
+sweep. It does not discover other repository shards or install a default or
+background reaper. Automatic multi-target shard routing remains future work.
 
 `codenib jobs run` retains the same authorities while traversing the complete
 runnable keyspace frozen at the start of each cycle. The catalog first records

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -306,6 +306,18 @@ points unchanged for non-interruptible callers. The native directory-plan and
 directory-`fsync` loops poll only after the current record or syscall has been
 attested and before future work, preserving both exact callback identity and
 storage-error precedence.
+The BM25 attempt-pool lease uses a separate additive
+`directory_fd_owner_protocol_version == 1` ABI; the core
+`workspace_owner_protocol_version` remains 6. The additive surface precreates
+an opaque native owner, opens exact path bytes with
+`O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC` directly into that owner
+before control returns to Python, and exposes only owner-retained borrow,
+final-check-plus-child-`mkdirat`, close, and closed operations. Missing symbols
+or native open flags fail the
+Linux lease preflight before shard bootstrap. A pinned native at-fork callback
+fail-stops any child that inherits a live directory owner instead of guessing
+whether an earlier child callback reused its enumerable descriptor numbers;
+fork resumes normally once all owners are closed.
 Its success states are `destination-captured` -> `destination-leased` ->
 `replacement-provisioning` -> `replacement-provisioned` ->
 `replacement-adopted` -> `replacement-exchanged-unreceipted` ->
@@ -1366,20 +1378,44 @@ owner, cleanup failure, and prior cause. Expected-empty checks use the retained
 directory descriptor directly
 and fail closed on any name under the declared quiescence contract, without
 claiming a hostile-writer allocation budget. Interrupted rename, removal, and
-synchronization likewise retain an explicit retry owner. It acquires no
-cross-process lease and contains no BM25 name discovery or policy. A separate
-target-bound BM25 coordinator now supplies that policy only after successful
-worker settlement and an exact caller assertion that no other cooperative
-process can enter the pool. It snapshots and classifies the complete bounded
-parent before mutation, recognizes only the fixed current and legacy
+synchronization likewise retain an explicit retry owner. The generic reclaimer
+itself acquires no cross-process lease and contains no BM25 name discovery or
+policy. The phase-A target-bound BM25 binding creates or reopens one permanent
+owner-only `0700` shard named
+`.codenib-bm25-attempt-pool-v1-repo_<64-hex>` per repository below the retained
+workspace and binds exact repository, workspace, and shard identities into
+paired opaque routes. Phase A admits only disjoint repository/workspace paths
+selected by one authenticated Linux mount and rejects repository-descendant
+mounts before creation; independently mounted backing stores remain pending
+rather than trusting incomplete overlay/FUSE/network physical mappings. The
+caller must retain controlled, externally quiescent repository/workspace path
+ancestry and mount topology from bootstrap through routed-owner close;
+in-process tracing or a same-euid/privileged actor that renames those ancestors
+or changes mounts during mutation is outside this phase's authority contract.
+Native final revalidation and child `mkdirat` share one C frame to remove
+ordinary Python opcode/cancellation handoffs, but do not pretend to lock the
+kernel namespace. A
+routed writer takes blocking `LOCK_SH` immediately
+before attempt-root preparation and holds it through child and outer-root
+cleanup, exact-group lost-return retry, orphan delivery and acknowledgement,
+and final route validation. The paired reaper takes blocking `LOCK_EX` before
+reclaimer construction and holds it through the complete bounded sweep,
+reclaimer close, and post-sweep route validation; incomplete cleanup retains
+the exact composite owner and lease.
+
+Within that boundary the coordinator snapshots and classifies the complete
+bounded parent before mutation, recognizes only the fixed current and legacy
 source-attempt lineages, rejects malformed reserved and provenance-free hashed
 fallback names, routes only already-discarded lineage to direct cleanup, and
 requires the final snapshot to contain exactly the original unrelated names.
-It carries no catalog, publication, or global retained-owner routing authority;
-automatic multi-target cleanup and a cross-process writer/reaper lease remain
-pending. The legacy one-shot directory-discard and plain stage-construction
-return contracts remain unchanged; cancellation-safe integrations must use the
-retained owner and explicit receipt acknowledgement.
+This supplies cooperative cross-process writer/reaper exclusion only for that
+routed repository shard and grants no catalog, publication, global
+target-discovery, or default/background reaping authority. Automatic
+multi-target shard discovery/routing and default reaping remain pending. The
+workspace-root legacy pool remains a separate manual, caller-quiescent,
+unleased compatibility cleanup. The legacy one-shot directory-discard and
+plain stage-construction return contracts remain unchanged; cancellation-safe
+integrations must use the retained owner and explicit receipt acknowledgement.
 
 The compiler-cache bridge now also has a resource-scoped resolver seam. It
 attests the canonical running request before opening attempt resources, accepts
@@ -1429,8 +1465,10 @@ storage topology. The planner captures that same topology-guarded retained
 source and registers only its content-addressed planning identities through a
 least-authority catalog surface. The guarded result reconciler, retained
 publisher, and polling loop remain dependency-injected; no default Web lifespan
-installation, local storage configuration, or default route selects either
-production binding yet.
+installation, acquired local-storage service composition, or default route
+selects either production binding yet. Typed local-storage configuration parsing
+is implemented, but it remains a side-effect-free opt-in until those runtime
+ownership gates are installed.
 
 The production CLI binding exposes both trusted local adapters through
 `codenib jobs run-once` and `codenib jobs run`, with an explicit mutually
@@ -1443,19 +1481,27 @@ passes that authority into every fresh capture, and accepts only the exact FULL
 BM25 builder profile selected by its language and exclusion arguments. It also
 re-resolves display provenance per attempt and rejects HEAD drift before fenced
 publication rather than stamping later source bytes with the startup commit.
-The source candidate filter rechecks retained topology before lease acquisition,
+The source candidate filter rechecks retained topology before catalog job-lease
+acquisition,
 and every later attempt verifier promotes topology loss to a storage-integrity
 alarm, so a continuous scheduler terminates instead of consuming job retries.
-A default-off `--reclaim-quiescent-attempts` source-mode flag runs the bounded
-coordinator exactly once after a successful `run-once` worker return or
-continuous-scheduler shutdown, while retained topology and CAS owners are still
-open. The flag is an operator assertion that no other cooperative process can
-enter that workspace through the post-worker sweep; exceptional worker unwind
-never invokes it, cache mode rejects it before path or storage setup, stdout
-remains unchanged, and stderr receives only bounded count diagnostics.
+A default-off `--reclaim-quiescent-attempts` source-mode flag runs exactly once
+after a successful `run-once` worker return or continuous-scheduler shutdown,
+while retained topology and CAS owners are still open. Phase A first takes the
+configured repository shard's blocking exclusive route, waiting for
+cooperative routed writers, and sweeps that shard; it then scans the
+workspace-root legacy pool separately without a lease. The coordinator calls
+remain explicitly caller-authorized, but current-shard writer exclusion comes
+from `LOCK_EX`; the legacy pass still depends on actual operator-enforced
+workspace quiescence. The permanent shard is retained and excluded from
+combined count diagnostics. Exceptional worker unwind never invokes either
+pass, cache mode rejects the flag before path or storage setup, stdout remains
+unchanged, and stderr receives only bounded count diagnostics. Other
+repository shards are not discovered, and no default or background reaper is
+installed.
 A trusted candidate filter runs on a detached canonical job before owner
-allocation or lease acquisition, so foreign repositories and unsupported view
-requests remain untouched. `run-once`
+allocation or catalog job-lease acquisition, so foreign repositories and
+unsupported view requests remain untouched. `run-once`
 examines one bounded advisory page and executes at most one eligible job. The
 continuous scheduler freezes an attested catalog insertion watermark for each
 cycle, carries an attested keyset cursor across its bounded pages, wraps only
@@ -1484,9 +1530,12 @@ caller-owned path-build root whose authenticated cleanup receipt is accepted
 before ownership is released. The descriptor-owned quiescent directory
 reclamation primitive, bounded descriptor child snapshot, and direct
 already-quarantined-child cleanup are implemented. Exact BM25 attempt-name
-classification, the caller-asserted post-worker coordinator, and default-off
-CLI wiring are also implemented; automatic multi-target retry routing and a
-cross-process writer/reaper lease remain pending.
+classification, phase-A per-repository shard bootstrap and paired
+writer/reaper routes, exact-group retained-owner retry routing, and the
+default-off two-pass CLI sweep are implemented. The production routed source
+path writes only into its leased shard; the compatibility workspace-root path
+and its cleanup remain unleased and manual. Automatic multi-target shard
+discovery/routing and default/background reaping remain pending.
 Vector and graph source builders, generic builder routing, and remaining
 runtime wiring remain.
 
@@ -1527,7 +1576,8 @@ generation identity.
 The first #266 status, durable-read, explicitly injected one-view write,
 retained-source BM25 planning, guarded reconciliation, retained publication,
 and polling slices are present. The success callback exists but is not installed
-by the default server; Web lifespan ownership, local storage configuration,
+by the default server. Typed local-storage configuration parsing is present;
+physical topology acquisition, service composition, Web lifespan ownership,
 MCP, UI controls, and default routing remain absent.
 
 - The backend-neutral worker now owns advisory scan/claim, per-attempt task
@@ -1580,18 +1630,25 @@ MCP, UI controls, and default routing remain absent.
   entry, and explicit Web planner are implemented. The generic descriptor-bound
   quiescent directory reclamation primitive, bounded descriptor child snapshot,
   and direct already-quarantined cleanup remain policy-free and carry no
-  publication authority. A separate exact-target coordinator and default-off
-  CLI flag now add bounded BM25 attempt-name policy only after successful worker
-  settlement under caller-asserted process quiescence. The planner captures the
-  same frozen local target as the worker, revalidates source after planning, and
-  uses a separate least-authority catalog surface that can register only
-  content-addressed source/profile identities and read one ref generation. Add
-  a cooperative cross-process writer/reaper lease and automatic multi-target
-  routing, then add vector and graph source adapters, install the existing
-  reconciler and polling loop in the production server lifespan, invoke its
-  callback from attested worker success, and wire MCP, UI, and default routes.
-  Older self-publishing ingress APIs remain compatibility paths and are never
-  nested inside the worker.
+  publication authority. The production retained-source binding assigns its
+  exact repository to one permanent shard and paired least-authority routes.
+  Writers hold `LOCK_SH` from attempt-root preparation through receipt
+  acknowledgement, retryable cleanup, and route validation; the reaper holds
+  `LOCK_EX` from before reclaimer construction through reclaimer close and
+  post-validation. The default-off CLI runs this leased shard sweep only after
+  successful worker settlement or shutdown, then performs the separate
+  unleased legacy-root pass. The planner captures the same frozen local target
+  as the worker, revalidates source after planning, and uses a separate
+  least-authority catalog surface that can register only content-addressed
+  source/profile identities and read one ref generation. The generic
+  descriptor reclaimer remains policy-free and carries no publication
+  authority. Automatic multi-target shard discovery/routing and installed
+  default/background reaping remain pending, and legacy cleanup continues to
+  require explicit operator quiescence. Then add vector and graph source
+  adapters, install the existing reconciler and polling loop in the production
+  server lifespan, invoke its callback from attested worker success, and wire
+  MCP, UI, and default routes. Older self-publishing ingress APIs remain
+  compatibility paths and are never nested inside the worker.
 - Complete the #266 job and update APIs with accurate incremental versus rebuild
   behavior; the first read-only status slice is described below.
 - `RepoRegistry.load_all()` now reconciles each complete registry snapshot,

--- a/native/workspace_owner.c
+++ b/native/workspace_owner.c
@@ -27,6 +27,12 @@
 #include <sys/syscall.h>
 #endif
 
+#if defined(O_CLOEXEC) && defined(O_DIRECTORY) && defined(O_NOFOLLOW)
+#define CODENIB_DIRECTORY_FD_OPEN_SUPPORTED 1
+#else
+#define CODENIB_DIRECTORY_FD_OPEN_SUPPORTED 0
+#endif
+
 #ifndef O_CLOEXEC
 #define O_CLOEXEC 0
 #endif
@@ -64,6 +70,8 @@
 #define CODENIB_ORPHAN_ATTEMPTS 64
 #define CODENIB_MAX_FILE_WRITE_BYTES (8 * 1024 * 1024)
 #define CODENIB_FD_SAFETY_MARGIN 64
+#define CODENIB_DIRECTORY_FD_CLOSED -1
+#define CODENIB_DIRECTORY_FD_UNOPENED -2
 
 enum workspace_namespace_state {
   WORKSPACE_EMPTY = 0,
@@ -174,6 +182,20 @@ typedef struct WorkspaceOwner {
   int replacement_lock_active;
   uint64_t receipt_generation;
 } WorkspaceOwner;
+
+typedef struct {
+  PyObject_HEAD int fd;
+  int guard_fd;
+  pid_t owner_pid;
+  dev_t device;
+  ino_t inode;
+  int identity_known;
+  int exposed;
+  int active_registered;
+} DirectoryFdOwner;
+
+static Py_ssize_t active_directory_fd_owner_count = 0;
+static pid_t active_directory_fd_owner_pid = 0;
 
 typedef struct {
   PyObject_HEAD WorkspaceOwner *owner;
@@ -641,6 +663,19 @@ static int raw_close_terminal(int descriptor) {
 #else
   (void)descriptor;
   return ENOSYS;
+#endif
+}
+
+static int close_directory_fd_terminal(int descriptor) {
+#if defined(__linux__) && defined(SYS_close)
+  return raw_close_terminal(descriptor);
+#else
+  int result;
+  if (descriptor < 0) {
+    return 0;
+  }
+  result = close(descriptor);
+  return result == 0 ? 0 : (errno == 0 ? EIO : errno);
 #endif
 }
 
@@ -5179,6 +5214,439 @@ static PyType_Spec WorkspaceOwner_spec = {
 
 static PyObject *WorkspaceOwnerTypeObject = NULL;
 
+static int require_directory_fd_owner_pid(DirectoryFdOwner *self) {
+  if (getpid() == self->owner_pid) {
+    return 0;
+  }
+  PyErr_SetString(
+      PyExc_RuntimeError,
+      "native directory descriptor owner cannot cross a PID boundary");
+  return -1;
+}
+
+static void register_active_directory_fd_owner(DirectoryFdOwner *self) {
+  if (!self->active_registered) {
+    if (active_directory_fd_owner_count == 0) {
+      active_directory_fd_owner_pid = self->owner_pid;
+    }
+    self->active_registered = 1;
+    active_directory_fd_owner_count += 1;
+  }
+}
+
+static void
+settle_active_directory_fd_owner_registration(DirectoryFdOwner *self) {
+  if (self->fd == CODENIB_DIRECTORY_FD_CLOSED &&
+      self->guard_fd == CODENIB_DIRECTORY_FD_CLOSED &&
+      self->active_registered) {
+    self->active_registered = 0;
+    if (active_directory_fd_owner_count > 0) {
+      active_directory_fd_owner_count -= 1;
+    }
+    if (active_directory_fd_owner_count == 0) {
+      active_directory_fd_owner_pid = 0;
+    }
+  }
+}
+
+enum directory_fd_slot_state {
+  DIRECTORY_FD_SLOT_ERROR = -1,
+  DIRECTORY_FD_SLOT_DIFFERENT = 0,
+  DIRECTORY_FD_SLOT_EXACT = 1,
+  DIRECTORY_FD_SLOT_CLOSED = 2,
+  DIRECTORY_FD_SLOT_POLICY_CHANGED = 3,
+};
+
+static int inspect_directory_fd_slot(DirectoryFdOwner *self, int descriptor) {
+  struct stat metadata;
+  int flags;
+
+  if (descriptor < 0) {
+    return DIRECTORY_FD_SLOT_CLOSED;
+  }
+  if (native_fstat_retry(descriptor, &metadata) < 0) {
+    if (errno == EBADF) {
+      return DIRECTORY_FD_SLOT_CLOSED;
+    }
+    return DIRECTORY_FD_SLOT_ERROR;
+  }
+  if (!self->identity_known || !S_ISDIR(metadata.st_mode) ||
+      metadata.st_dev != self->device || metadata.st_ino != self->inode) {
+    return DIRECTORY_FD_SLOT_DIFFERENT;
+  }
+  flags = native_fcntl_getfd_retry(descriptor);
+  if (flags < 0) {
+    if (errno == EBADF) {
+      return DIRECTORY_FD_SLOT_CLOSED;
+    }
+    return DIRECTORY_FD_SLOT_ERROR;
+  }
+  if ((flags & FD_CLOEXEC) == 0) {
+    /* The integer can still name the owned OFD.  Keep this distinct from a
+       foreign inode so cleanup never drops an inheritable original merely
+       because its descriptor policy was tampered with. */
+    return DIRECTORY_FD_SLOT_POLICY_CHANGED;
+  }
+  return DIRECTORY_FD_SLOT_EXACT;
+}
+
+static int require_exact_directory_fd_slot(DirectoryFdOwner *self,
+                                           int descriptor) {
+  int state = inspect_directory_fd_slot(self, descriptor);
+  if (state == DIRECTORY_FD_SLOT_EXACT) {
+    return 0;
+  }
+  if (state == DIRECTORY_FD_SLOT_CLOSED) {
+    return EBADF;
+  }
+  if (state == DIRECTORY_FD_SLOT_DIFFERENT) {
+    return ESTALE;
+  }
+  if (state == DIRECTORY_FD_SLOT_POLICY_CHANGED) {
+    return EPERM;
+  }
+  return errno == 0 ? EIO : errno;
+}
+
+static int close_directory_fd_slot(DirectoryFdOwner *self, int *slot) {
+  int descriptor = *slot;
+  int close_error;
+  int state;
+
+  if (descriptor < 0) {
+    *slot = CODENIB_DIRECTORY_FD_CLOSED;
+    return 0;
+  }
+  close_error = close_directory_fd_terminal(descriptor);
+  if (close_error == 0) {
+    *slot = CODENIB_DIRECTORY_FD_CLOSED;
+    return 0;
+  }
+
+  /* Linux normally releases an fd before reporting a late close error, but
+     seccomp can reject close before the syscall executes.  Reinspect the
+     exact slot: retain a still-owned descriptor for a later retry, while an
+     already-closed or foreign replacement is terminal for this owner. */
+  state = inspect_directory_fd_slot(self, descriptor);
+  if (state == DIRECTORY_FD_SLOT_CLOSED ||
+      state == DIRECTORY_FD_SLOT_DIFFERENT) {
+    *slot = CODENIB_DIRECTORY_FD_CLOSED;
+  }
+  return close_error;
+}
+
+static int settle_directory_fd_owner(DirectoryFdOwner *self) {
+  int descriptor = self->fd;
+  int guard = self->guard_fd;
+  int inherited = getpid() != self->owner_pid;
+  int descriptor_error = 0;
+  int guard_error = 0;
+  int verification_error = 0;
+  int descriptor_state;
+  int guard_state;
+
+  if (inherited) {
+    int comparison;
+    if (descriptor == CODENIB_DIRECTORY_FD_UNOPENED &&
+        guard == CODENIB_DIRECTORY_FD_UNOPENED) {
+      self->fd = CODENIB_DIRECTORY_FD_CLOSED;
+      self->guard_fd = CODENIB_DIRECTORY_FD_CLOSED;
+      settle_active_directory_fd_owner_registration(self);
+      return 0;
+    }
+    if (descriptor == CODENIB_DIRECTORY_FD_CLOSED &&
+        guard == CODENIB_DIRECTORY_FD_CLOSED) {
+      return 0;
+    }
+    if (descriptor < 0 || guard < 0) {
+      return ESTALE;
+    }
+    comparison = compare_open_file_description_for_cleanup(descriptor, guard);
+    if (comparison == OFD_COMPARISON_ERROR) {
+      return errno == 0 ? EIO : errno;
+    }
+    if (comparison == OFD_DIFFERENT) {
+      /* An earlier fork-child callback may have replaced either number.  PID
+         mismatch cannot prove which side remains ours, so leave both alone
+         and let the Python at-fork boundary fail-stop the child. */
+      return ESTALE;
+    }
+    verification_error = require_exact_directory_fd_slot(self, descriptor);
+    if (verification_error == 0) {
+      verification_error = require_exact_directory_fd_slot(self, guard);
+    }
+    if (verification_error != 0) {
+      /* Even an OFD-same pair can have been installed by an earlier child
+         callback.  Never close identity-mismatched inherited numbers. */
+      return verification_error == EBADF ? ESTALE : verification_error;
+    }
+  } else if (!self->exposed && descriptor >= 0) {
+    /* Native open publishes the primary slot before its guard and identity
+       acquisition can fail.  Reconstruct missing identity on cleanup, then
+       settle only descriptors still authenticated to that exact directory.
+       Until this succeeds the active registration keeps fork fail-stopped. */
+    if (!self->identity_known) {
+      if (record_identity(descriptor, &self->device, &self->inode, S_IFDIR) <
+          0) {
+        return errno == 0 ? EIO : errno;
+      }
+      self->identity_known = 1;
+    }
+    verification_error = require_exact_directory_fd_slot(self, descriptor);
+    if (verification_error != 0) {
+      return verification_error == EBADF ? ESTALE : verification_error;
+    }
+    if (guard >= 0) {
+      int comparison =
+          compare_open_file_description_for_cleanup(descriptor, guard);
+      if (comparison == OFD_COMPARISON_ERROR) {
+        return errno == 0 ? EIO : errno;
+      }
+      if (comparison == OFD_DIFFERENT) {
+        return ESTALE;
+      }
+      verification_error = require_exact_directory_fd_slot(self, guard);
+      if (verification_error != 0) {
+        return verification_error == EBADF ? ESTALE : verification_error;
+      }
+    }
+    descriptor_error = close_directory_fd_slot(self, &self->fd);
+    if (self->fd == CODENIB_DIRECTORY_FD_CLOSED) {
+      if (self->guard_fd >= 0) {
+        guard_error = close_directory_fd_slot(self, &self->guard_fd);
+      } else {
+        self->guard_fd = CODENIB_DIRECTORY_FD_CLOSED;
+      }
+    }
+    if (self->fd == CODENIB_DIRECTORY_FD_CLOSED &&
+        self->guard_fd == CODENIB_DIRECTORY_FD_CLOSED) {
+      self->identity_known = 0;
+      settle_active_directory_fd_owner_registration(self);
+    }
+    if (descriptor_error != 0) {
+      return descriptor_error;
+    }
+    return guard_error;
+  } else if (descriptor < 0) {
+    if (descriptor == CODENIB_DIRECTORY_FD_UNOPENED &&
+        guard == CODENIB_DIRECTORY_FD_UNOPENED) {
+      self->fd = CODENIB_DIRECTORY_FD_CLOSED;
+      self->guard_fd = CODENIB_DIRECTORY_FD_CLOSED;
+      self->identity_known = 0;
+      settle_active_directory_fd_owner_registration(self);
+      return 0;
+    }
+    self->fd = CODENIB_DIRECTORY_FD_CLOSED;
+    if (guard >= 0) {
+      verification_error = require_exact_directory_fd_slot(self, guard);
+      if (verification_error != 0) {
+        return verification_error == EBADF ? ESTALE : verification_error;
+      }
+      guard_error = close_directory_fd_slot(self, &self->guard_fd);
+    } else {
+      self->guard_fd = CODENIB_DIRECTORY_FD_CLOSED;
+    }
+    if (self->guard_fd == CODENIB_DIRECTORY_FD_CLOSED) {
+      self->identity_known = 0;
+      settle_active_directory_fd_owner_registration(self);
+    }
+    return guard_error;
+  }
+  if (!inherited && guard >= 0 && self->exposed) {
+    int comparison =
+        compare_open_file_description_for_cleanup(descriptor, guard);
+    if (comparison == OFD_COMPARISON_ERROR) {
+      int comparison_error = errno == 0 ? EIO : errno;
+      descriptor_state = inspect_directory_fd_slot(self, descriptor);
+      guard_state = inspect_directory_fd_slot(self, guard);
+      if ((descriptor_state == DIRECTORY_FD_SLOT_CLOSED ||
+           descriptor_state == DIRECTORY_FD_SLOT_DIFFERENT) &&
+          (guard_state == DIRECTORY_FD_SLOT_CLOSED ||
+           guard_state == DIRECTORY_FD_SLOT_DIFFERENT)) {
+        /* Neither integer can still name the recorded owned directory.  Do
+           not touch a foreign replacement, but retire the stale slots and
+           active registration so later forks are not poisoned forever. */
+        self->fd = CODENIB_DIRECTORY_FD_CLOSED;
+        self->guard_fd = CODENIB_DIRECTORY_FD_CLOSED;
+        self->identity_known = 0;
+        settle_active_directory_fd_owner_registration(self);
+        return ESTALE;
+      }
+      if (comparison_error == EBADF &&
+          descriptor_state == DIRECTORY_FD_SLOT_CLOSED &&
+          guard_state == DIRECTORY_FD_SLOT_EXACT) {
+        self->fd = CODENIB_DIRECTORY_FD_CLOSED;
+        guard_error = close_directory_fd_slot(self, &self->guard_fd);
+        if (self->guard_fd == CODENIB_DIRECTORY_FD_CLOSED) {
+          self->identity_known = 0;
+          settle_active_directory_fd_owner_registration(self);
+        }
+        return guard_error != 0 ? guard_error : ESTALE;
+      }
+      /* Keep the complete pair when the comparison itself was inconclusive.
+         A later explicit cleanup retry can authenticate it; dropping the
+         guard would make the exposed descriptor number unsafe to close. */
+      return comparison_error;
+    }
+    if (comparison == OFD_DIFFERENT) {
+      descriptor_state = inspect_directory_fd_slot(self, descriptor);
+      guard_state = inspect_directory_fd_slot(self, guard);
+      if ((descriptor_state == DIRECTORY_FD_SLOT_CLOSED ||
+           descriptor_state == DIRECTORY_FD_SLOT_DIFFERENT) &&
+          (guard_state == DIRECTORY_FD_SLOT_CLOSED ||
+           guard_state == DIRECTORY_FD_SLOT_DIFFERENT)) {
+        self->fd = CODENIB_DIRECTORY_FD_CLOSED;
+        self->guard_fd = CODENIB_DIRECTORY_FD_CLOSED;
+        self->identity_known = 0;
+        settle_active_directory_fd_owner_registration(self);
+        return ESTALE;
+      }
+      if (descriptor_state == DIRECTORY_FD_SLOT_ERROR) {
+        return errno == 0 ? EIO : errno;
+      }
+      if (descriptor_state == DIRECTORY_FD_SLOT_EXACT ||
+          descriptor_state == DIRECTORY_FD_SLOT_POLICY_CHANGED) {
+        /* The public slot can still be the original OFD while an enumerable
+           hidden-guard number was independently reopened onto the same inode.
+           Exact metadata does not prove OFD continuity: retain both slots and
+           the fork guard until a caller restores an OFD-same pair. */
+        return ESTALE;
+      }
+      if (guard_state != DIRECTORY_FD_SLOT_EXACT) {
+        /* Either side may have been replaced.  Without an exact hidden guard
+           there is no remaining capability that identifies the owned OFD. */
+        return guard_state == DIRECTORY_FD_SLOT_ERROR
+                   ? (errno == 0 ? EIO : errno)
+                   : ESTALE;
+      }
+      /* The exposed integer was closed and reused.  Close only the hidden
+         original; never touch the foreign descriptor now using that number. */
+      self->fd = CODENIB_DIRECTORY_FD_CLOSED;
+      guard_error = close_directory_fd_slot(self, &self->guard_fd);
+      if (self->guard_fd == CODENIB_DIRECTORY_FD_CLOSED) {
+        self->identity_known = 0;
+        settle_active_directory_fd_owner_registration(self);
+      }
+      return guard_error != 0 ? guard_error : ESTALE;
+    }
+  }
+  if (guard < 0 && self->exposed) {
+    return ESTALE;
+  }
+  if (!self->identity_known) {
+    verification_error = ESTALE;
+  } else {
+    verification_error = require_exact_directory_fd_slot(self, descriptor);
+    if (verification_error == 0) {
+      verification_error = require_exact_directory_fd_slot(self, guard);
+    }
+  }
+  if (verification_error != 0) {
+    /* Authentication failures never authorize a close.  This is especially
+       important in a fork child, where earlier callbacks may have reused both
+       stored numbers for an unrelated OFD. */
+    return verification_error == EBADF ? ESTALE : verification_error;
+  }
+
+  descriptor_error = close_directory_fd_slot(self, &self->fd);
+  if (self->fd == CODENIB_DIRECTORY_FD_CLOSED) {
+    guard_error = close_directory_fd_slot(self, &self->guard_fd);
+  }
+  if (self->fd == CODENIB_DIRECTORY_FD_CLOSED &&
+      self->guard_fd == CODENIB_DIRECTORY_FD_CLOSED) {
+    self->identity_known = 0;
+    settle_active_directory_fd_owner_registration(self);
+  }
+  if (descriptor_error != 0) {
+    return descriptor_error;
+  }
+  return guard_error;
+}
+
+static PyObject *DirectoryFdOwner_new(PyTypeObject *type, PyObject *args,
+                                      PyObject *keywords) {
+  (void)type;
+  (void)args;
+  (void)keywords;
+  PyErr_SetString(PyExc_TypeError,
+                  "native directory descriptor owners cannot be constructed");
+  return NULL;
+}
+
+static void DirectoryFdOwner_dealloc(DirectoryFdOwner *self) {
+  freefunc release;
+  PyObject *error_type;
+  PyObject *error_value;
+  PyObject *error_traceback;
+  int settle_error;
+
+  PyErr_Fetch(&error_type, &error_value, &error_traceback);
+  settle_error = settle_directory_fd_owner(self);
+  (void)settle_error;
+  release = (freefunc)PyType_GetSlot(Py_TYPE(self), Py_tp_free);
+  if (release != NULL) {
+    release((PyObject *)self);
+  }
+  PyErr_Restore(error_type, error_value, error_traceback);
+}
+
+static PyType_Slot DirectoryFdOwner_slots[] = {
+    {Py_tp_new, DirectoryFdOwner_new},
+    {Py_tp_dealloc, DirectoryFdOwner_dealloc},
+    {Py_tp_doc, "Opaque native owner for one directory descriptor."},
+    {0, NULL},
+};
+
+static PyType_Spec DirectoryFdOwner_spec = {
+    "codenib._workspace_owner_impl._DirectoryFdOwner",
+    sizeof(DirectoryFdOwner),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE,
+    DirectoryFdOwner_slots,
+};
+
+static PyObject *DirectoryFdOwnerTypeObject = NULL;
+
+static DirectoryFdOwner *require_directory_fd_owner_exact(PyObject *candidate) {
+  if (DirectoryFdOwnerTypeObject == NULL ||
+      Py_TYPE(candidate) != (PyTypeObject *)DirectoryFdOwnerTypeObject) {
+    PyErr_SetString(PyExc_TypeError,
+                    "directory descriptor owner has an invalid native type");
+    return NULL;
+  }
+  return (DirectoryFdOwner *)candidate;
+}
+
+static PyObject *new_directory_fd_owner(void) {
+  allocfunc allocate;
+  DirectoryFdOwner *owner;
+
+  if (DirectoryFdOwnerTypeObject == NULL) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native directory descriptor owner type is unavailable");
+    return NULL;
+  }
+  allocate = (allocfunc)PyType_GetSlot(
+      (PyTypeObject *)DirectoryFdOwnerTypeObject, Py_tp_alloc);
+  if (allocate == NULL) {
+    return NULL;
+  }
+  owner = (DirectoryFdOwner *)allocate(
+      (PyTypeObject *)DirectoryFdOwnerTypeObject, 0);
+  if (owner == NULL) {
+    return NULL;
+  }
+  owner->fd = CODENIB_DIRECTORY_FD_UNOPENED;
+  owner->guard_fd = CODENIB_DIRECTORY_FD_UNOPENED;
+  owner->owner_pid = getpid();
+  owner->device = 0;
+  owner->inode = 0;
+  owner->identity_known = 0;
+  owner->exposed = 0;
+  owner->active_registered = 0;
+  return (PyObject *)owner;
+}
+
 static PyObject *WorkspacePublishPermit_new(PyTypeObject *type, PyObject *args,
                                             PyObject *keywords) {
   (void)type;
@@ -5835,7 +6303,312 @@ static PyObject *module_require_owner_exact(PyObject *module, PyObject *owner) {
   return owner;
 }
 
+static PyObject *
+module_create_directory_fd_owner_exact(PyObject *module,
+                                       PyObject *Py_UNUSED(ignored)) {
+  (void)module;
+  return new_directory_fd_owner();
+}
+
+static PyObject *module_open_directory_fd_exact(PyObject *module,
+                                                PyObject *args) {
+  DirectoryFdOwner *owner;
+  PyObject *path_object;
+  char *path;
+  Py_ssize_t path_size;
+  int descriptor = -1;
+  int guard = -1;
+  int error;
+  int attempts;
+  dev_t device;
+  ino_t inode;
+
+  (void)module;
+  if (!PyTuple_CheckExact(args) || PyTuple_Size(args) != 2) {
+    PyErr_SetString(PyExc_TypeError,
+                    "open_directory_fd_exact requires exactly 2 arguments");
+    return NULL;
+  }
+  owner = require_directory_fd_owner_exact(PyTuple_GetItem(args, 0));
+  path_object = PyTuple_GetItem(args, 1);
+  if (owner == NULL || path_object == NULL) {
+    return NULL;
+  }
+  if (require_directory_fd_owner_pid(owner) < 0) {
+    return NULL;
+  }
+  if (owner->fd != CODENIB_DIRECTORY_FD_UNOPENED) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native directory descriptor owner cannot be reopened");
+    return NULL;
+  }
+  if (!CODENIB_DIRECTORY_FD_OPEN_SUPPORTED) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native directory descriptor open flags are unavailable");
+    return NULL;
+  }
+  if (!PyBytes_CheckExact(path_object)) {
+    PyErr_SetString(PyExc_TypeError,
+                    "directory descriptor path must be exact bytes");
+    return NULL;
+  }
+  if (PyBytes_AsStringAndSize(path_object, &path, &path_size) < 0) {
+    return NULL;
+  }
+  if (path_size <= 0 || path_size > CODENIB_MAX_PATH_BYTES ||
+      memchr(path, '\0', (size_t)path_size) != NULL) {
+    PyErr_SetString(
+        PyExc_ValueError,
+        "directory descriptor path is empty, unbounded, or contains NUL");
+    return NULL;
+  }
+  for (attempts = 0; attempts < 64; ++attempts) {
+    descriptor = open(path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    if (descriptor >= 0 || errno != EINTR) {
+      break;
+    }
+  }
+  if (descriptor < 0) {
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  /* Commit the first exact fd and fork-failstop registration before guard
+     duplication, identity capture, or any cleanup attempt can fail.  Python's
+     precreated construction owner can therefore settle every partial state. */
+  owner->fd = descriptor;
+  register_active_directory_fd_owner(owner);
+  guard = duplicate_cloexec(descriptor);
+  if (guard < 0) {
+    error = errno == 0 ? EIO : errno;
+    if (record_identity(descriptor, &device, &inode, S_IFDIR) == 0) {
+      owner->device = device;
+      owner->inode = inode;
+      owner->identity_known = 1;
+    }
+    errno = error;
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  owner->guard_fd = guard;
+  if (record_identity(descriptor, &device, &inode, S_IFDIR) < 0) {
+    error = errno == 0 ? EIO : errno;
+    errno = error;
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  /* This assignment is the ownership commit point.  No Python operation can
+     observe either descriptor between successful acquisition and native
+     retention.  The hidden duplicate authenticates the exposed integer at
+     every later borrow and close. */
+  owner->device = device;
+  owner->inode = inode;
+  owner->identity_known = 1;
+  /* Authenticate every later close, even before the explicit Python borrow.
+     An earlier-registered fork-child callback can inspect, close, and reuse a
+     process fd number after native open returns but before Python stores it. */
+  owner->exposed = 1;
+  Py_RETURN_NONE;
+}
+
+static PyObject *module_borrow_directory_fd_exact(PyObject *module,
+                                                  PyObject *candidate) {
+  DirectoryFdOwner *owner;
+  int comparison;
+  struct stat metadata;
+
+  (void)module;
+  owner = require_directory_fd_owner_exact(candidate);
+  if (owner == NULL) {
+    return NULL;
+  }
+  if (require_directory_fd_owner_pid(owner) < 0) {
+    return NULL;
+  }
+  if (owner->fd < 0 || owner->guard_fd < 0 || !owner->identity_known) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native directory descriptor owner is not open");
+    return NULL;
+  }
+  comparison =
+      compare_open_file_description_for_cleanup(owner->fd, owner->guard_fd);
+  if (comparison != OFD_SAME) {
+    if (comparison == OFD_DIFFERENT || errno == 0) {
+      errno = ESTALE;
+    }
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  if (native_fstat_retry(owner->fd, &metadata) < 0) {
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  if (!S_ISDIR(metadata.st_mode) || metadata.st_dev != owner->device ||
+      metadata.st_ino != owner->inode) {
+    errno = ESTALE;
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  /* Mark the number exposed before allocating its Python representation so a
+     failed return handoff still forces authenticated cleanup. */
+  owner->exposed = 1;
+  return PyLong_FromLong(owner->fd);
+}
+
+static PyObject *module_mkdir_directory_fd_child_exact(PyObject *module,
+                                                       PyObject *args) {
+  DirectoryFdOwner *owner;
+  PyObject *name_object;
+  PyObject *pre_mutation_check;
+  PyObject *check_result;
+  char *name;
+  Py_ssize_t name_size;
+  int comparison;
+  int attempts;
+  int verification_error;
+
+  (void)module;
+  if (!PyTuple_CheckExact(args) || PyTuple_Size(args) != 3) {
+    PyErr_SetString(
+        PyExc_TypeError,
+        "mkdir_directory_fd_child_exact requires exactly 3 arguments");
+    return NULL;
+  }
+  owner = require_directory_fd_owner_exact(PyTuple_GetItem(args, 0));
+  name_object = PyTuple_GetItem(args, 1);
+  pre_mutation_check = PyTuple_GetItem(args, 2);
+  if (owner == NULL || name_object == NULL || pre_mutation_check == NULL) {
+    return NULL;
+  }
+  if (require_directory_fd_owner_pid(owner) < 0) {
+    return NULL;
+  }
+  if (owner->fd < 0 || owner->guard_fd < 0 || !owner->identity_known) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native directory descriptor owner is not open");
+    return NULL;
+  }
+  if (!PyBytes_CheckExact(name_object)) {
+    PyErr_SetString(PyExc_TypeError,
+                    "directory child name must be exact bytes");
+    return NULL;
+  }
+  if (PyBytes_AsStringAndSize(name_object, &name, &name_size) < 0) {
+    return NULL;
+  }
+  if (name_size <= 0 || name_size > CODENIB_MAX_COMPONENT_BYTES ||
+      memchr(name, '\0', (size_t)name_size) != NULL ||
+      memchr(name, '/', (size_t)name_size) != NULL ||
+      (name_size == 1 && name[0] == '.') ||
+      (name_size == 2 && name[0] == '.' && name[1] == '.')) {
+    PyErr_SetString(PyExc_ValueError,
+                    "directory child name is invalid or unbounded");
+    return NULL;
+  }
+  if (!PyCallable_Check(pre_mutation_check)) {
+    PyErr_SetString(PyExc_TypeError,
+                    "directory pre-mutation check must be callable");
+    return NULL;
+  }
+
+  check_result = PyObject_CallNoArgs(pre_mutation_check);
+  if (check_result == NULL) {
+    return NULL;
+  }
+  if (check_result != Py_None) {
+    Py_DECREF(check_result);
+    PyErr_SetString(PyExc_RuntimeError,
+                    "directory pre-mutation check returned a result");
+    return NULL;
+  }
+  Py_DECREF(check_result);
+
+  /* No ordinary Python instruction, signal poll, or caller-controlled decref
+     occurs in this native frame between the final topology check and mkdirat.
+     Reauthenticate the opaque owner after the callback in case it settled the
+     descriptor itself.  Python tracing and separately privileged actors can
+     still mutate path or mount topology at callback boundaries, so callers
+     must retain the documented controlled, quiescent-namespace contract. */
+  comparison =
+      compare_open_file_description_for_cleanup(owner->fd, owner->guard_fd);
+  if (comparison != OFD_SAME) {
+    if (comparison == OFD_DIFFERENT || errno == 0) {
+      errno = ESTALE;
+    }
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  verification_error = require_exact_directory_fd_slot(owner, owner->fd);
+  if (verification_error == 0) {
+    verification_error =
+        require_exact_directory_fd_slot(owner, owner->guard_fd);
+  }
+  if (verification_error != 0) {
+    errno = verification_error;
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  for (attempts = 0; attempts < 64; ++attempts) {
+    if (mkdirat(owner->fd, name, 0700) == 0) {
+      Py_RETURN_TRUE;
+    }
+    if (errno == EEXIST) {
+      Py_RETURN_FALSE;
+    }
+    if (errno != EINTR) {
+      break;
+    }
+  }
+  return PyErr_SetFromErrno(PyExc_OSError);
+}
+
+static PyObject *module_close_directory_fd_owner_exact(PyObject *module,
+                                                       PyObject *candidate) {
+  DirectoryFdOwner *owner;
+  int close_error;
+
+  (void)module;
+  owner = require_directory_fd_owner_exact(candidate);
+  if (owner == NULL) {
+    return NULL;
+  }
+  if (owner->fd == CODENIB_DIRECTORY_FD_CLOSED &&
+      owner->guard_fd == CODENIB_DIRECTORY_FD_CLOSED) {
+    Py_RETURN_NONE;
+  }
+  close_error = settle_directory_fd_owner(owner);
+  if (close_error != 0) {
+    errno = close_error;
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  Py_RETURN_NONE;
+}
+
+static PyObject *module_directory_fd_owner_closed_exact(PyObject *module,
+                                                        PyObject *candidate) {
+  DirectoryFdOwner *owner;
+
+  (void)module;
+  owner = require_directory_fd_owner_exact(candidate);
+  if (owner == NULL) {
+    return NULL;
+  }
+  return PyBool_FromLong(owner->fd == CODENIB_DIRECTORY_FD_CLOSED &&
+                         owner->guard_fd == CODENIB_DIRECTORY_FD_CLOSED);
+}
+
+static PyObject *module_fail_fork_child_if_directory_fd_owner_active_exact(
+    PyObject *module, PyObject *Py_UNUSED(ignored)) {
+  (void)module;
+  if (active_directory_fd_owner_count > 0) {
+    if (active_directory_fd_owner_pid == getpid()) {
+      PyErr_SetString(
+          PyExc_RuntimeError,
+          "native directory fork guard requires a fork-child process");
+      return NULL;
+    }
+    /* The Python facade registers this exact C callable directly.  It never
+       guesses which enumerable fd numbers survived an earlier child callback:
+       process exit releases every inherited OFD without affecting the parent.
+     */
+    _exit(70);
+  }
+  Py_RETURN_NONE;
+}
+
 #define CODENIB_WORKSPACE_OWNER_PROTOCOL_VERSION 6
+#define CODENIB_DIRECTORY_FD_OWNER_PROTOCOL_VERSION 1
 
 static PyObject *module_require_support(PyObject *module,
                                         PyObject *Py_UNUSED(ignored)) {
@@ -5876,6 +6649,26 @@ static PyMethodDef workspace_module_methods[] = {
      "Create the internally pinned exact native owner type."},
     {"require_owner_exact", (PyCFunction)module_require_owner_exact, METH_O,
      "Authenticate against the internally pinned native owner type."},
+    {"create_directory_fd_owner_exact",
+     (PyCFunction)module_create_directory_fd_owner_exact, METH_NOARGS,
+     "Create one pre-open exact native directory descriptor owner."},
+    {"open_directory_fd_exact", (PyCFunction)module_open_directory_fd_exact,
+     METH_VARARGS, "Open a directory directly into its exact native owner."},
+    {"borrow_directory_fd_exact", (PyCFunction)module_borrow_directory_fd_exact,
+     METH_O,
+     "Borrow the descriptor retained by an exact native directory owner."},
+    {"mkdir_directory_fd_child_exact",
+     (PyCFunction)module_mkdir_directory_fd_child_exact, METH_VARARGS,
+     "Create one child after an exact final pre-mutation callback."},
+    {"close_directory_fd_owner_exact",
+     (PyCFunction)module_close_directory_fd_owner_exact, METH_O,
+     "Close an exact native directory descriptor owner."},
+    {"directory_fd_owner_closed_exact",
+     (PyCFunction)module_directory_fd_owner_closed_exact, METH_O,
+     "Return whether an exact native directory owner was settled."},
+    {"fail_fork_child_if_directory_fd_owner_active_exact",
+     (PyCFunction)module_fail_fork_child_if_directory_fd_owner_active_exact,
+     METH_NOARGS, "Fail-stop a fork child that inherited a live owner."},
     {"provision_owner_exact", (PyCFunction)module_provision_owner_exact,
      METH_VARARGS, "Provision through exact native-owner dispatch."},
     {"provision_owner_interruptibly_exact",
@@ -5982,6 +6775,7 @@ PyMODINIT_FUNC PyInit__workspace_owner_impl(void) {
   PyObject *publish_permit_type;
   PyObject *replacement_permit_type;
   PyObject *receipt_token_type;
+  PyObject *directory_fd_owner_type;
 
   module = PyModule_Create(&workspace_owner_module);
   if (module == NULL) {
@@ -5989,6 +6783,17 @@ PyMODINIT_FUNC PyInit__workspace_owner_impl(void) {
   }
   if (PyModule_AddIntConstant(module, "workspace_owner_protocol_version",
                               CODENIB_WORKSPACE_OWNER_PROTOCOL_VERSION) < 0) {
+    Py_DECREF(module);
+    return NULL;
+  }
+  if (PyModule_AddIntConstant(module, "directory_fd_owner_protocol_version",
+                              CODENIB_DIRECTORY_FD_OWNER_PROTOCOL_VERSION) <
+      0) {
+    Py_DECREF(module);
+    return NULL;
+  }
+  if (PyModule_AddIntConstant(module, "directory_fd_owner_supported",
+                              CODENIB_DIRECTORY_FD_OPEN_SUPPORTED) < 0) {
     Py_DECREF(module);
     return NULL;
   }
@@ -6018,9 +6823,19 @@ PyMODINIT_FUNC PyInit__workspace_owner_impl(void) {
     Py_DECREF(module);
     return NULL;
   }
+  directory_fd_owner_type = PyType_FromSpec(&DirectoryFdOwner_spec);
+  if (directory_fd_owner_type == NULL) {
+    Py_DECREF(receipt_token_type);
+    Py_DECREF(replacement_permit_type);
+    Py_DECREF(publish_permit_type);
+    Py_DECREF(owner_type);
+    Py_DECREF(module);
+    return NULL;
+  }
   /* Keep the exact type private: every operation enters through a pinned
      module-level wrapper, never through mutable attribute dispatch. */
   WorkspaceOwnerTypeObject = owner_type;
+  DirectoryFdOwnerTypeObject = directory_fd_owner_type;
   WorkspacePublishPermitTypeObject = publish_permit_type;
   WorkspaceReplacementPermitTypeObject = replacement_permit_type;
   WorkspaceReceiptTokenTypeObject = receipt_token_type;

--- a/test/compiler/test_bm25_attempt_pool_binding.py
+++ b/test/compiler/test_bm25_attempt_pool_binding.py
@@ -1,0 +1,1023 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import stat
+import threading
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+import codenib._atomic_directory as atomic_directory_module
+import codenib.compiler._directory_lease as directory_lease_module
+import codenib.compiler.bm25_attempt_pool as bm25_attempt_pool_module
+import codenib.compiler.job_resources as job_resources_module
+from codenib import LocalWorkspaceProvider
+from codenib._atomic_directory import (
+    QuiescentDirectoryReclaimer,
+    publication_parent_identity,
+)
+from codenib.compiler._directory_lease import (
+    DirectoryLeaseMode,
+    PrivateDirectoryLeaseOwner,
+    PrivateDirectoryLeaseRoute,
+    acquire_private_directory_lease,
+)
+from codenib.compiler.bm25_attempt_pool import bootstrap_local_bm25_attempt_pool
+from codenib.compiler.index_builders import BM25IndexBuilder
+from codenib.compiler.job_resources import (
+    BM25AttemptPoolReclamation,
+    LocalBM25AttemptPoolCoordinator,
+    LocalBM25SourceJobTarget,
+)
+from codenib.source_fingerprint import pin_repository_source_root
+from codenib.storage.models import (
+    NamespaceIdentity,
+    RepositoryIdentity,
+    StorageIntegrityError,
+    StorageValidationError,
+)
+
+
+def _directory_identity(path: Path) -> tuple[int, ...]:
+    descriptor = os.open(path, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        return publication_parent_identity(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _repository_id() -> str:
+    namespace = NamespaceIdentity("default")
+    return RepositoryIdentity(
+        namespace_id=namespace.namespace_id,
+        repository_key="owner/repository",
+    ).repository_id
+
+
+def _open_descriptors_for_identity(identity: tuple[int, ...]) -> tuple[int, ...]:
+    descriptors: list[int] = []
+    for raw_descriptor in os.listdir("/proc/self/fd"):
+        try:
+            descriptor = int(raw_descriptor)
+            metadata = os.fstat(descriptor)
+        except (OSError, ValueError):
+            continue
+        observed = (
+            metadata.st_dev,
+            metadata.st_ino,
+            stat.S_IFMT(metadata.st_mode),
+            getattr(metadata, "st_file_attributes", 0),
+        )
+        if observed == identity:
+            descriptors.append(descriptor)
+    return tuple(sorted(descriptors))
+
+
+def _probe_raw_lease(route, mode: DirectoryLeaseMode) -> BaseException | None:
+    outcomes: list[BaseException | None] = []
+
+    def acquire() -> None:
+        installed: list[PrivateDirectoryLeaseOwner] = []
+        try:
+            owner = acquire_private_directory_lease(
+                route,
+                mode=mode,
+                blocking=False,
+                _construction_owner=installed.append,
+            )
+        except BaseException as error:  # noqa: B036 - contention is asserted
+            outcomes.append(error)
+            return
+        try:
+            outcomes.append(None)
+        finally:
+            owner.close()
+
+    thread = threading.Thread(target=acquire)
+    thread.start()
+    thread.join(timeout=10)
+    assert not thread.is_alive()
+    assert len(outcomes) == 1
+    return outcomes[0]
+
+
+def test_bm25_attempt_pool_bootstrap_creates_stable_private_shard(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    workspace_identity = _directory_identity(workspace)
+    topology_checks: list[bool] = []
+
+    def verify_topology() -> None:
+        assert _directory_identity(workspace) == workspace_identity
+        topology_checks.append(True)
+
+    with pin_repository_source_root(repository) as repository_authority:
+        first = bootstrap_local_bm25_attempt_pool(
+            workspace_root=workspace,
+            workspace_identity=workspace_identity,
+            repository_id=_repository_id(),
+            repository_authority=repository_authority,
+            topology_verifier=verify_topology,
+        )
+        second = bootstrap_local_bm25_attempt_pool(
+            workspace_root=workspace,
+            workspace_identity=workspace_identity,
+            repository_id=_repository_id(),
+            repository_authority=repository_authority,
+            topology_verifier=verify_topology,
+        )
+
+        shard = workspace / f".codenib-bm25-attempt-pool-v1-{_repository_id()}"
+        assert first.writer_route._shard_path == shard
+        assert second.writer_route._shard_path == shard
+        assert first.writer_route._shard_identity == second.writer_route._shard_identity
+        assert stat.S_IMODE(shard.stat().st_mode) == 0o700
+        assert tuple(workspace.iterdir()) == (shard,)
+        assert topology_checks
+
+
+def test_bm25_attempt_pool_bootstrap_rejects_malformed_existing_shard(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    workspace_identity = _directory_identity(workspace)
+    shard = workspace / f".codenib-bm25-attempt-pool-v1-{_repository_id()}"
+    shard.write_text("foreign", encoding="utf-8")
+
+    with pin_repository_source_root(repository) as repository_authority:
+        with pytest.raises(PermissionError, match="owner-controlled 0700 directory"):
+            bootstrap_local_bm25_attempt_pool(
+                workspace_root=workspace,
+                workspace_identity=workspace_identity,
+                repository_id=_repository_id(),
+                repository_authority=repository_authority,
+                topology_verifier=lambda: None,
+            )
+
+    assert shard.read_text(encoding="utf-8") == "foreign"
+
+
+def test_bm25_attempt_pool_bootstrap_rejects_parent_identity_before_creation(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    wrong_identity = list(_directory_identity(workspace))
+    wrong_identity[1] += 1
+
+    with pin_repository_source_root(repository) as repository_authority:
+        with pytest.raises(StorageIntegrityError, match="workspace identity changed"):
+            bootstrap_local_bm25_attempt_pool(
+                workspace_root=workspace,
+                workspace_identity=tuple(wrong_identity),
+                repository_id=_repository_id(),
+                repository_authority=repository_authority,
+                topology_verifier=lambda: None,
+            )
+
+    assert not tuple(workspace.iterdir())
+
+
+def test_bm25_attempt_pool_bootstrap_rejects_repository_as_workspace(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    repository_identity = _directory_identity(repository)
+
+    with pin_repository_source_root(repository) as repository_authority:
+        with pytest.raises(
+            StorageIntegrityError,
+            match="physically aliases the repository",
+        ):
+            bootstrap_local_bm25_attempt_pool(
+                workspace_root=repository,
+                workspace_identity=repository_identity,
+                repository_id=_repository_id(),
+                repository_authority=repository_authority,
+                topology_verifier=lambda: None,
+            )
+
+    assert tuple(repository.iterdir()) == ()
+
+
+def test_bm25_attempt_pool_bootstrap_rejects_mapped_repository_subtree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    workspace_identity = _directory_identity(workspace)
+    device = (os.major(workspace_identity[0]), os.minor(workspace_identity[0]))
+    mappings = (
+        bm25_attempt_pool_module._BM25LinuxMountMapping(
+            mount_id=1,
+            device=device,
+            root=PurePosixPath("/physical/repository"),
+            mount_point=repository,
+        ),
+        bm25_attempt_pool_module._BM25LinuxMountMapping(
+            mount_id=2,
+            device=device,
+            root=PurePosixPath("/physical/repository/subtree"),
+            mount_point=workspace,
+        ),
+    )
+    monkeypatch.setattr(
+        bm25_attempt_pool_module,
+        "_bm25_linux_mount_mappings",
+        lambda: mappings,
+    )
+
+    with pin_repository_source_root(repository) as repository_authority:
+        with pytest.raises(
+            StorageIntegrityError,
+            match="must share one mount",
+        ):
+            bootstrap_local_bm25_attempt_pool(
+                workspace_root=workspace,
+                workspace_identity=workspace_identity,
+                repository_id=_repository_id(),
+                repository_authority=repository_authority,
+                topology_verifier=lambda: None,
+            )
+
+    assert tuple(workspace.iterdir()) == ()
+
+
+def test_bm25_attempt_pool_bootstrap_rejects_separate_mount_authorities(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    repository_identity = _directory_identity(repository)
+    workspace_identity = _directory_identity(workspace)
+    mappings = (
+        bm25_attempt_pool_module._BM25LinuxMountMapping(
+            mount_id=1,
+            device=(
+                os.major(repository_identity[0]),
+                os.minor(repository_identity[0]),
+            ),
+            root=PurePosixPath("/physical/repository"),
+            mount_point=repository,
+        ),
+        bm25_attempt_pool_module._BM25LinuxMountMapping(
+            mount_id=2,
+            device=(
+                os.major(workspace_identity[0]),
+                os.minor(workspace_identity[0]),
+            ),
+            root=PurePosixPath("/physical/workspace"),
+            mount_point=workspace,
+        ),
+    )
+    monkeypatch.setattr(
+        bm25_attempt_pool_module,
+        "_bm25_linux_mount_mappings",
+        lambda: mappings,
+    )
+
+    with pin_repository_source_root(repository) as repository_authority:
+        with pytest.raises(StorageIntegrityError, match="must share one mount"):
+            bootstrap_local_bm25_attempt_pool(
+                workspace_root=workspace,
+                workspace_identity=workspace_identity,
+                repository_id=_repository_id(),
+                repository_authority=repository_authority,
+                topology_verifier=lambda: None,
+            )
+
+    assert tuple(workspace.iterdir()) == ()
+
+
+def test_bm25_attempt_pool_bootstrap_rejects_repository_descendant_mount(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    nested = repository / "nested"
+    nested.mkdir(mode=0o700)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    workspace_identity = _directory_identity(workspace)
+    repository_identity = _directory_identity(repository)
+    workspace_device = (
+        os.major(workspace_identity[0]),
+        os.minor(workspace_identity[0]),
+    )
+    repository_device = (
+        os.major(repository_identity[0]),
+        os.minor(repository_identity[0]),
+    )
+    mappings = (
+        bm25_attempt_pool_module._BM25LinuxMountMapping(
+            mount_id=1,
+            device=repository_device,
+            root=PurePosixPath("/physical/repository"),
+            mount_point=repository,
+        ),
+        bm25_attempt_pool_module._BM25LinuxMountMapping(
+            mount_id=2,
+            device=workspace_device,
+            root=PurePosixPath("/physical/workspace"),
+            mount_point=nested,
+        ),
+        bm25_attempt_pool_module._BM25LinuxMountMapping(
+            mount_id=3,
+            device=workspace_device,
+            root=PurePosixPath("/physical/workspace"),
+            mount_point=workspace,
+        ),
+    )
+    monkeypatch.setattr(
+        bm25_attempt_pool_module,
+        "_bm25_linux_mount_mappings",
+        lambda: mappings,
+    )
+
+    with pin_repository_source_root(repository) as repository_authority:
+        with pytest.raises(
+            StorageIntegrityError,
+            match="repository contains a nested mount",
+        ):
+            bootstrap_local_bm25_attempt_pool(
+                workspace_root=workspace,
+                workspace_identity=workspace_identity,
+                repository_id=_repository_id(),
+                repository_authority=repository_authority,
+                topology_verifier=lambda: None,
+            )
+
+    assert tuple(workspace.iterdir()) == ()
+
+
+def test_bm25_attempt_pool_bootstrap_rejects_symlinked_workspace_ancestry(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    nested_workspace = repository / "workspace"
+    nested_workspace.mkdir(mode=0o700)
+    alias = tmp_path / "alias"
+    alias.symlink_to(repository, target_is_directory=True)
+    lexical_workspace = alias / "workspace"
+    workspace_identity = _directory_identity(nested_workspace)
+
+    with pin_repository_source_root(repository) as repository_authority:
+        with pytest.raises(
+            StorageIntegrityError,
+            match="must not traverse a symbolic link",
+        ):
+            bootstrap_local_bm25_attempt_pool(
+                workspace_root=lexical_workspace,
+                workspace_identity=workspace_identity,
+                repository_id=_repository_id(),
+                repository_authority=repository_authority,
+                topology_verifier=lambda: None,
+            )
+
+    assert tuple(nested_workspace.iterdir()) == ()
+
+
+def test_bm25_attempt_pool_rechecks_topology_after_open_before_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    workspace_identity = _directory_identity(workspace)
+    shard = workspace / f".codenib-bm25-attempt-pool-v1-{_repository_id()}"
+    real_opened_check = bm25_attempt_pool_module._require_opened_workspace_lexical_path
+    real_disjoint_check = (
+        bm25_attempt_pool_module._require_repository_workspace_disjoint
+    )
+    root_opened = False
+
+    def mark_root_opened(
+        descriptor: int,
+        *,
+        workspace_root: Path,
+    ) -> None:
+        nonlocal root_opened
+        real_opened_check(descriptor, workspace_root=workspace_root)
+        root_opened = True
+
+    def reject_changed_topology(**kwargs):
+        if root_opened:
+            raise StorageIntegrityError(
+                "BM25 attempt-pool repository contains a nested mount"
+            )
+        return real_disjoint_check(**kwargs)
+
+    monkeypatch.setattr(
+        bm25_attempt_pool_module,
+        "_require_opened_workspace_lexical_path",
+        mark_root_opened,
+    )
+    monkeypatch.setattr(
+        bm25_attempt_pool_module,
+        "_require_repository_workspace_disjoint",
+        reject_changed_topology,
+    )
+    with pin_repository_source_root(repository) as repository_authority:
+        with pytest.raises(
+            StorageIntegrityError,
+            match="repository contains a nested mount",
+        ):
+            bootstrap_local_bm25_attempt_pool(
+                workspace_root=workspace,
+                workspace_identity=workspace_identity,
+                repository_id=_repository_id(),
+                repository_authority=repository_authority,
+                topology_verifier=lambda: None,
+            )
+
+    assert root_opened
+    assert not shard.exists()
+    assert tuple(workspace.iterdir()) == ()
+
+
+def test_bm25_attempt_pool_bootstrap_rejects_mounted_shard_before_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    workspace_identity = _directory_identity(workspace)
+    shard = workspace / f".codenib-bm25-attempt-pool-v1-{_repository_id()}"
+    shard.mkdir(mode=0o700)
+    real_mount_check = bm25_attempt_pool_module._path_is_mount_point
+    observed: list[Path] = []
+
+    def classify_mount(path: Path, *, mount_points) -> bool:
+        observed.append(path)
+        if path == shard:
+            return True
+        return real_mount_check(path, mount_points=mount_points)
+
+    monkeypatch.setattr(
+        bm25_attempt_pool_module,
+        "_path_is_mount_point",
+        classify_mount,
+    )
+    with pin_repository_source_root(repository) as repository_authority:
+        with pytest.raises(StorageIntegrityError, match="must not be a mount point"):
+            bootstrap_local_bm25_attempt_pool(
+                workspace_root=workspace,
+                workspace_identity=workspace_identity,
+                repository_id=_repository_id(),
+                repository_authority=repository_authority,
+                topology_verifier=lambda: None,
+            )
+
+    assert observed == [shard]
+    assert tuple(shard.iterdir()) == ()
+    assert _open_descriptors_for_identity(_directory_identity(shard)) == ()
+
+
+@pytest.mark.parametrize("interrupted_open", (1, 2))
+def test_bm25_attempt_pool_bootstrap_native_open_handoff_retains_descriptors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    interrupted_open: int,
+) -> None:
+    class Interrupted(BaseException):
+        pass
+
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    workspace_identity = _directory_identity(workspace)
+    shard = workspace / f".codenib-bm25-attempt-pool-v1-{_repository_id()}"
+    primary = Interrupted(f"native bootstrap open {interrupted_open} interrupted")
+    calls = 0
+    real_open = directory_lease_module._native_workspace_owner._open_directory_fd
+
+    def open_then_interrupt(owner: object, path: bytes) -> None:
+        nonlocal calls
+        real_open(owner, path)
+        calls += 1
+        if calls == interrupted_open:
+            raise primary
+
+    monkeypatch.setattr(
+        directory_lease_module._native_workspace_owner,
+        "_open_directory_fd",
+        open_then_interrupt,
+    )
+    with pin_repository_source_root(repository) as repository_authority:
+        with pytest.raises(Interrupted) as caught:
+            bootstrap_local_bm25_attempt_pool(
+                workspace_root=workspace,
+                workspace_identity=workspace_identity,
+                repository_id=_repository_id(),
+                repository_authority=repository_authority,
+                topology_verifier=lambda: None,
+            )
+
+    assert caught.value is primary
+    assert calls == interrupted_open
+    assert _open_descriptors_for_identity(workspace_identity) == ()
+    if shard.exists():
+        assert _open_descriptors_for_identity(_directory_identity(shard)) == ()
+
+
+def test_bm25_attempt_pool_route_rejects_mount_tamper_before_lease(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    workspace_identity = _directory_identity(workspace)
+
+    with pin_repository_source_root(repository) as repository_authority:
+        binding = bootstrap_local_bm25_attempt_pool(
+            workspace_root=workspace,
+            workspace_identity=workspace_identity,
+            repository_id=_repository_id(),
+            repository_authority=repository_authority,
+            topology_verifier=lambda: None,
+        )
+        shard = binding.writer_route._shard_path
+
+        def classify_mount(path: Path, *, mount_points) -> bool:
+            assert mount_points
+            return path == shard
+
+        monkeypatch.setattr(
+            bm25_attempt_pool_module,
+            "_path_is_mount_point",
+            classify_mount,
+        )
+        monkeypatch.setattr(
+            bm25_attempt_pool_module,
+            "acquire_private_directory_lease",
+            lambda *_args, **_kwargs: pytest.fail(
+                "lease acquisition must follow mount rejection"
+            ),
+        )
+
+        with pytest.raises(StorageIntegrityError, match="must not be a mount point"):
+            binding.writer_route._acquire(
+                check_cancelled=None,
+                construction_owner=lambda _owner: None,
+            )
+
+        assert tuple(shard.iterdir()) == ()
+
+
+def test_bm25_source_target_accepts_only_its_exact_writer_route(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    workspace_identity = _directory_identity(workspace)
+    provider = LocalWorkspaceProvider(workspace)
+
+    with pin_repository_source_root(repository) as repository_authority:
+        binding = bootstrap_local_bm25_attempt_pool(
+            workspace_root=workspace,
+            workspace_identity=workspace_identity,
+            repository_id=_repository_id(),
+            repository_authority=repository_authority,
+            topology_verifier=lambda: None,
+        )
+        target = LocalBM25SourceJobTarget(
+            repository_root=repository,
+            workspace_provider=provider,
+            repository_key="owner/repository",
+            display_commit="d" * 40,
+            builder=BM25IndexBuilder(),
+            repository_root_authority=repository_authority,
+            workspace_parent_identity=workspace_identity,
+            topology_verifier=lambda: None,
+            attempt_pool_writer_route=binding.writer_route,
+        )
+
+    assert target.attempt_pool_root == binding.writer_route._shard_path
+    assert target.attempt_pool_identity == binding.writer_route._shard_identity
+    assert target.attempt_pool_writer_route is binding.writer_route
+    assert binding.writer_route._shard_path.parent == workspace
+
+
+def test_leased_attempt_pool_reclaims_shard_only_under_exclusive_route(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    workspace_identity = _directory_identity(workspace)
+    provider = LocalWorkspaceProvider(workspace)
+    close_observations: list[type[BaseException] | None] = []
+
+    with pin_repository_source_root(repository) as repository_authority:
+        binding = bootstrap_local_bm25_attempt_pool(
+            workspace_root=workspace,
+            workspace_identity=workspace_identity,
+            repository_id=_repository_id(),
+            repository_authority=repository_authority,
+            topology_verifier=lambda: None,
+        )
+        target = LocalBM25SourceJobTarget(
+            repository_root=repository,
+            workspace_provider=provider,
+            repository_key="owner/repository",
+            display_commit="d" * 40,
+            builder=BM25IndexBuilder(),
+            repository_root_authority=repository_authority,
+            workspace_parent_identity=workspace_identity,
+            topology_verifier=lambda: None,
+            attempt_pool_writer_route=binding.writer_route,
+        )
+        discarded_name = (
+            "..codenib-source-job-"
+            + "a" * 32
+            + ".normalize-"
+            + "b" * 24
+            + ".discarded-"
+            + "c" * 32
+        )
+        discarded = binding.writer_route._shard_path / discarded_name
+        discarded.mkdir(mode=0o700)
+        (discarded / "payload.txt").write_text("payload", encoding="utf-8")
+
+        with pytest.raises(
+            StorageValidationError,
+            match="requires its reaper route",
+        ):
+            LocalBM25AttemptPoolCoordinator(target).reclaim(
+                caller_asserts_quiescence=True,
+            )
+
+        real_close = job_resources_module.QuiescentDirectoryReclaimer._close
+
+        def observe_close(reclaimer) -> None:
+            before = _probe_raw_lease(
+                binding.reaper_route._state.directory_lease_route,
+                DirectoryLeaseMode.SHARED,
+            )
+            close_observations.append(type(before) if before is not None else None)
+            real_close(reclaimer)
+            after = _probe_raw_lease(
+                binding.reaper_route._state.directory_lease_route,
+                DirectoryLeaseMode.SHARED,
+            )
+            close_observations.append(type(after) if after is not None else None)
+
+        monkeypatch.setattr(
+            job_resources_module.QuiescentDirectoryReclaimer,
+            "_close",
+            observe_close,
+        )
+        result = LocalBM25AttemptPoolCoordinator(
+            target,
+            reaper_route=binding.reaper_route,
+        ).reclaim(caller_asserts_quiescence=True)
+
+        assert result == BM25AttemptPoolReclamation(
+            scanned_children=1,
+            reclaimed_children=1,
+            current_children=1,
+            legacy_children=0,
+            discarded_children=1,
+            retained_unrelated_children=0,
+        )
+        assert close_observations == [BlockingIOError, BlockingIOError]
+        assert tuple(binding.writer_route._shard_path.iterdir()) == ()
+        assert (
+            _probe_raw_lease(
+                binding.reaper_route._state.directory_lease_route,
+                DirectoryLeaseMode.SHARED,
+            )
+            is None
+        )
+
+        legacy = LocalBM25AttemptPoolCoordinator(
+            target,
+            _legacy_workspace=True,
+        ).reclaim(caller_asserts_quiescence=True)
+        assert legacy == BM25AttemptPoolReclamation(
+            scanned_children=1,
+            reclaimed_children=0,
+            current_children=0,
+            legacy_children=0,
+            discarded_children=0,
+            retained_unrelated_children=1,
+        )
+
+
+def test_reclaimer_construction_owner_precedes_authority_and_can_settle_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent = tmp_path / "parent"
+    parent.mkdir(mode=0o700)
+    identity = _directory_identity(parent)
+    installed: list[QuiescentDirectoryReclaimer] = []
+    failure = OSError("reclaimer authority open failed")
+
+    def fail_open(*_args, **_kwargs):
+        assert len(installed) == 1
+        assert type(installed[0]) is QuiescentDirectoryReclaimer
+        raise failure
+
+    monkeypatch.setattr(
+        atomic_directory_module,
+        "_open_publication_authority",
+        fail_open,
+    )
+    with pytest.raises(OSError) as caught:
+        QuiescentDirectoryReclaimer(
+            parent,
+            expected_parent_identity=identity,
+            _construction_owner=installed.append,
+        )
+
+    assert caught.value is failure
+    assert len(installed) == 1
+    installed[0].close()
+    assert installed[0].closed
+
+
+def test_reclaimer_construction_owner_failure_precedes_authority_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent = tmp_path / "parent"
+    parent.mkdir(mode=0o700)
+    identity = _directory_identity(parent)
+    installed: list[QuiescentDirectoryReclaimer] = []
+    failure = RuntimeError("reclaimer construction owner refused handoff")
+
+    def reject(reclaimer: QuiescentDirectoryReclaimer) -> None:
+        installed.append(reclaimer)
+        raise failure
+
+    monkeypatch.setattr(
+        atomic_directory_module,
+        "_open_publication_authority",
+        lambda *_args, **_kwargs: pytest.fail(
+            "authority open must follow construction-owner handoff"
+        ),
+    )
+    with pytest.raises(RuntimeError) as caught:
+        QuiescentDirectoryReclaimer(
+            parent,
+            expected_parent_identity=identity,
+            _construction_owner=reject,
+        )
+
+    assert caught.value is failure
+    assert len(installed) == 1
+    installed[0].close()
+    assert installed[0].closed
+
+
+@pytest.mark.parametrize("foreign_mode", (DirectoryLeaseMode.SHARED, None))
+def test_reaper_cleanup_rejects_wrong_lease_authority_before_install(
+    tmp_path: Path,
+    foreign_mode: DirectoryLeaseMode | None,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    workspace_identity = _directory_identity(workspace)
+
+    with pin_repository_source_root(repository) as repository_authority:
+        binding = bootstrap_local_bm25_attempt_pool(
+            workspace_root=workspace,
+            workspace_identity=workspace_identity,
+            repository_id=_repository_id(),
+            repository_authority=repository_authority,
+            topology_verifier=lambda: None,
+        )
+        route = binding.reaper_route._state.directory_lease_route
+        mode = foreign_mode
+        if mode is None:
+            foreign = tmp_path / "foreign"
+            foreign.mkdir(mode=0o700)
+            route = PrivateDirectoryLeaseRoute(
+                foreign,
+                _directory_identity(foreign),
+                os.getpid(),
+            )
+            mode = DirectoryLeaseMode.EXCLUSIVE
+        installed: list[PrivateDirectoryLeaseOwner] = []
+        lease = acquire_private_directory_lease(
+            route,
+            mode=mode,
+            blocking=True,
+            _construction_owner=installed.append,
+        )
+        cleanup = job_resources_module._BM25AttemptPoolReaperCleanupOwner(
+            binding.reaper_route
+        )
+        try:
+            with pytest.raises(
+                StorageIntegrityError,
+                match="lease authority is inconsistent",
+            ):
+                cleanup._install_lease(lease)
+            assert cleanup.closed
+            with pytest.raises(
+                StorageIntegrityError,
+                match="active exclusive lease",
+            ):
+                cleanup._open_reclaimer()
+        finally:
+            lease.close()
+
+
+def test_incomplete_reclaimer_close_retains_exclusive_lease(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    workspace_identity = _directory_identity(workspace)
+
+    with pin_repository_source_root(repository) as repository_authority:
+        binding = bootstrap_local_bm25_attempt_pool(
+            workspace_root=workspace,
+            workspace_identity=workspace_identity,
+            repository_id=_repository_id(),
+            repository_authority=repository_authority,
+            topology_verifier=lambda: None,
+        )
+        cleanup = job_resources_module._BM25AttemptPoolReaperCleanupOwner(
+            binding.reaper_route
+        )
+        cleanup._acquire()
+        reclaimer = cleanup._open_reclaimer()
+        real_close = job_resources_module.QuiescentDirectoryReclaimer.close
+        monkeypatch.setattr(
+            job_resources_module.QuiescentDirectoryReclaimer,
+            "close",
+            lambda _reclaimer: None,
+        )
+
+        with pytest.raises(
+            StorageIntegrityError,
+            match="remained active under its EX lease",
+        ):
+            cleanup.close()
+
+        assert not cleanup.closed
+        assert not reclaimer.closed
+        assert (
+            type(
+                _probe_raw_lease(
+                    binding.reaper_route._state.directory_lease_route,
+                    DirectoryLeaseMode.SHARED,
+                )
+            )
+            is BlockingIOError
+        )
+        monkeypatch.setattr(
+            job_resources_module.QuiescentDirectoryReclaimer,
+            "close",
+            real_close,
+        )
+        cleanup.close()
+        assert cleanup.closed
+        assert (
+            _probe_raw_lease(
+                binding.reaper_route._state.directory_lease_route,
+                DirectoryLeaseMode.SHARED,
+            )
+            is None
+        )
+
+
+def test_reclaim_failure_retains_composite_and_exclusive_lease(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    workspace_identity = _directory_identity(workspace)
+    provider = LocalWorkspaceProvider(workspace)
+    removal_failure = OSError("attempt payload removal failed")
+    real_reclaim_entry = atomic_directory_module._quiescent_reclaim_entry
+
+    with pin_repository_source_root(repository) as repository_authority:
+        binding = bootstrap_local_bm25_attempt_pool(
+            workspace_root=workspace,
+            workspace_identity=workspace_identity,
+            repository_id=_repository_id(),
+            repository_authority=repository_authority,
+            topology_verifier=lambda: None,
+        )
+        target = LocalBM25SourceJobTarget(
+            repository_root=repository,
+            workspace_provider=provider,
+            repository_key="owner/repository",
+            display_commit="d" * 40,
+            builder=BM25IndexBuilder(),
+            repository_root_authority=repository_authority,
+            workspace_parent_identity=workspace_identity,
+            topology_verifier=lambda: None,
+            attempt_pool_writer_route=binding.writer_route,
+        )
+        discarded_name = (
+            "..codenib-source-job-"
+            + "a" * 32
+            + ".normalize-"
+            + "b" * 24
+            + ".discarded-"
+            + "c" * 32
+        )
+        discarded = binding.writer_route._shard_path / discarded_name
+        discarded.mkdir(mode=0o700)
+        (discarded / "payload.txt").write_text("payload", encoding="utf-8")
+
+        def fail_payload(_operation):
+            raise removal_failure
+
+        monkeypatch.setattr(
+            atomic_directory_module,
+            "_quiescent_reclaim_entry",
+            fail_payload,
+        )
+        with pytest.raises(OSError) as caught:
+            LocalBM25AttemptPoolCoordinator(
+                target,
+                reaper_route=binding.reaper_route,
+            ).reclaim(caller_asserts_quiescence=True)
+
+        assert caught.value is removal_failure
+        cleanup = next(
+            owner
+            for owner in getattr(
+                caught.value,
+                "publication_cleanup_owners",
+                (),
+            )
+            if type(owner) is job_resources_module._BM25AttemptPoolReaperCleanupOwner
+        )
+        assert {name for name in dir(cleanup) if not name.startswith("_")} == {
+            "close",
+            "closed",
+        }
+        assert not cleanup.closed
+        assert (
+            type(
+                _probe_raw_lease(
+                    binding.reaper_route._state.directory_lease_route,
+                    DirectoryLeaseMode.SHARED,
+                )
+            )
+            is BlockingIOError
+        )
+
+        monkeypatch.setattr(
+            atomic_directory_module,
+            "_quiescent_reclaim_entry",
+            real_reclaim_entry,
+        )
+        cleanup.close()
+        assert cleanup.closed
+        assert not discarded.exists()
+        assert (
+            _probe_raw_lease(
+                binding.reaper_route._state.directory_lease_route,
+                DirectoryLeaseMode.SHARED,
+            )
+            is None
+        )

--- a/test/compiler/test_directory_lease.py
+++ b/test/compiler/test_directory_lease.py
@@ -1,0 +1,1472 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import ctypes.util
+import errno
+import multiprocessing
+import os
+import queue
+import stat
+import subprocess
+import sys
+import textwrap
+import threading
+from pathlib import Path
+
+import pytest
+
+from codenib.compiler import _directory_lease as lease_module
+from codenib.compiler._directory_lease import (
+    DirectoryLeaseMode,
+    PrivateDirectoryLeaseOwner,
+    PrivateDirectoryLeaseRoute,
+    acquire_private_directory_lease,
+    require_private_directory_lease_support,
+)
+
+try:  # pragma: no cover - selected by module support tests
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+
+
+pytestmark = pytest.mark.skipif(
+    not sys.platform.startswith("linux") or fcntl is None,
+    reason="requires Linux flock",
+)
+
+
+def _identity_from_metadata(
+    metadata: os.stat_result,
+) -> tuple[int, int, int, int]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        stat.S_IFMT(metadata.st_mode),
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+def _identity(path: Path) -> tuple[int, int, int, int]:
+    return _identity_from_metadata(path.lstat())
+
+
+def _private_directory(path: Path) -> Path:
+    path.mkdir(mode=0o700)
+    path.chmod(0o700)
+    return path
+
+
+def _route(path: Path) -> PrivateDirectoryLeaseRoute:
+    return PrivateDirectoryLeaseRoute(path, _identity(path), os.getpid())
+
+
+def _acquire(
+    route: PrivateDirectoryLeaseRoute,
+    mode: DirectoryLeaseMode,
+    *,
+    blocking: bool = True,
+):
+    installed: list[PrivateDirectoryLeaseOwner] = []
+    owner = acquire_private_directory_lease(
+        route,
+        mode=mode,
+        blocking=blocking,
+        _construction_owner=installed.append,
+    )
+    assert installed == [owner]
+    return owner
+
+
+def _exception_link_graph_is_acyclic(error: BaseException) -> bool:
+    pending: list[tuple[BaseException, bool]] = [(error, False)]
+    visiting: set[int] = set()
+    complete: set[int] = set()
+    while pending:
+        current, leaving = pending.pop()
+        identity = id(current)
+        if leaving:
+            visiting.discard(identity)
+            complete.add(identity)
+            continue
+        if identity in visiting:
+            return False
+        if identity in complete:
+            continue
+        if len(visiting) + len(complete) >= 64:
+            return False
+        visiting.add(identity)
+        pending.append((current, True))
+        for attribute in ("__context__", "__cause__"):
+            linked = vars(BaseException)[attribute].__get__(current, type(current))
+            if isinstance(linked, BaseException):
+                pending.append((linked, False))
+    return True
+
+
+def _bounded_exception_recovery_graph(error: BaseException) -> tuple[object, ...]:
+    pending: list[object] = [error]
+    seen: set[int] = set()
+    recovered: list[object] = []
+    while pending:
+        current = pending.pop()
+        identity = id(current)
+        if identity in seen:
+            continue
+        assert len(seen) < 128
+        seen.add(identity)
+        recovered.append(current)
+        if isinstance(current, BaseException):
+            for attribute in ("__cause__", "__context__"):
+                linked = vars(BaseException)[attribute].__get__(current, type(current))
+                if isinstance(linked, BaseException):
+                    pending.append(linked)
+            if type(current) is RuntimeError:
+                args = BaseException.__getattribute__(current, "args")
+                assert type(args) is tuple and len(args) <= 64
+                pending.append(args)
+        elif type(current) is tuple:
+            assert len(current) <= 64
+            pending.extend(current)
+    return tuple(recovered)
+
+
+def _spawn_hold_lease(
+    path_text: str,
+    identity: tuple[int, int, int, int],
+    mode_value: str,
+    ready,
+    release,
+) -> None:
+    path = Path(path_text)
+    route = PrivateDirectoryLeaseRoute(path, identity, os.getpid())
+    mode = DirectoryLeaseMode(mode_value)
+    installed: list[PrivateDirectoryLeaseOwner] = []
+    owner = acquire_private_directory_lease(
+        route,
+        mode=mode,
+        blocking=True,
+        _construction_owner=installed.append,
+    )
+    ready.set()
+    try:
+        if not release.wait(timeout=20):
+            raise TimeoutError("lease release was not signaled")
+    finally:
+        owner.close()
+
+
+def _spawn_wait_for_lease(
+    path_text: str,
+    identity: tuple[int, int, int, int],
+    mode_value: str,
+    ready,
+    acquired,
+) -> None:
+    path = Path(path_text)
+    route = PrivateDirectoryLeaseRoute(path, identity, os.getpid())
+    ready.set()
+    installed: list[PrivateDirectoryLeaseOwner] = []
+    owner = acquire_private_directory_lease(
+        route,
+        mode=DirectoryLeaseMode(mode_value),
+        blocking=True,
+        _construction_owner=installed.append,
+    )
+    try:
+        acquired.set()
+    finally:
+        owner.close()
+
+
+def test_support_probe_accepts_current_platform() -> None:
+    require_private_directory_lease_support()
+
+
+def test_support_probe_rejects_unsupported_platform_before_touching_a_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(lease_module.os, "name", "nt")
+    with pytest.raises(RuntimeError, match="Linux directory-inode flock"):
+        require_private_directory_lease_support()
+
+
+def test_owner_retains_exact_diagnostics_and_closes(tmp_path: Path) -> None:
+    route = _route(_private_directory(tmp_path / "shard"))
+    owner = _acquire(route, DirectoryLeaseMode.SHARED)
+
+    assert type(owner) is PrivateDirectoryLeaseOwner
+    assert owner.path is route.path
+    assert owner.identity is route.identity
+    assert owner.mode is DirectoryLeaseMode.SHARED
+    assert not owner.closed
+
+    owner.close()
+    owner.close()
+    assert owner.closed
+
+
+def test_owner_context_manager_unlocks_after_body_failure(tmp_path: Path) -> None:
+    route = _route(_private_directory(tmp_path / "shard"))
+    failure = RuntimeError("lease body failed")
+    installed: list[PrivateDirectoryLeaseOwner] = []
+
+    with pytest.raises(RuntimeError) as caught:
+        with acquire_private_directory_lease(
+            route,
+            mode=DirectoryLeaseMode.EXCLUSIVE,
+            blocking=True,
+            _construction_owner=installed.append,
+        ) as owner:
+            assert owner.closed is False
+            raise failure
+
+    assert caught.value is failure
+    assert owner.closed
+    replacement = acquire_private_directory_lease(
+        route,
+        mode=DirectoryLeaseMode.EXCLUSIVE,
+        blocking=False,
+        _construction_owner=installed.append,
+    )
+    replacement.close()
+    assert replacement.closed
+
+
+def test_owner_context_manager_retains_body_and_owner_on_close_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    route = _route(_private_directory(tmp_path / "shard"))
+    body_failure = RuntimeError("lease body failed")
+    prior = LookupError("lease body prior")
+    cleanup_failure = OSError(errno.EIO, "lease descriptor close failed")
+    installed: list[PrivateDirectoryLeaseOwner] = []
+    real_close = lease_module._close_descriptor_for_cleanup
+
+    def fail_close(_owner: PrivateDirectoryLeaseOwner) -> None:
+        raise cleanup_failure
+
+    monkeypatch.setattr(lease_module, "_close_descriptor_for_cleanup", fail_close)
+    with pytest.raises(RuntimeError) as caught:
+        with acquire_private_directory_lease(
+            route,
+            mode=DirectoryLeaseMode.EXCLUSIVE,
+            blocking=True,
+            _construction_owner=installed.append,
+        ) as owner:
+            raise body_failure from prior
+
+    assert caught.value is body_failure
+    assert _exception_link_graph_is_acyclic(body_failure)
+    recovered = _bounded_exception_recovery_graph(body_failure)
+    assert owner in recovered
+    assert cleanup_failure in recovered
+    assert prior in recovered
+    assert not owner.closed
+    monkeypatch.setattr(lease_module, "_close_descriptor_for_cleanup", real_close)
+    with pytest.raises(RuntimeError, match="already held by this thread"):
+        _acquire(route, DirectoryLeaseMode.EXCLUSIVE, blocking=False)
+
+    owner.close()
+    replacement = _acquire(route, DirectoryLeaseMode.EXCLUSIVE, blocking=False)
+    replacement.close()
+
+
+def test_construction_owner_is_installed_before_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    route = _route(_private_directory(tmp_path / "shard"))
+    installed: list[PrivateDirectoryLeaseOwner] = []
+    real_open = lease_module._native_workspace_owner._open_directory_fd
+
+    def observed_open(native_owner: object, path: bytes) -> None:
+        assert len(installed) == 1
+        assert type(installed[0]) is PrivateDirectoryLeaseOwner
+        assert installed[0] in lease_module._ACTIVE_DIRECTORY_LEASE_OWNERS
+        assert native_owner is installed[0]._native_descriptor_owner
+        assert path == os.fsencode(route.path)
+        with pytest.raises(RuntimeError, match="not open"):
+            lease_module._native_workspace_owner._borrow_directory_fd(native_owner)
+        real_open(native_owner, path)
+
+    monkeypatch.setattr(
+        lease_module._native_workspace_owner,
+        "_open_directory_fd",
+        observed_open,
+    )
+    owner = acquire_private_directory_lease(
+        route,
+        mode=DirectoryLeaseMode.SHARED,
+        blocking=True,
+        _construction_owner=installed.append,
+    )
+    try:
+        assert installed == [owner]
+        assert not owner.closed
+    finally:
+        owner.close()
+
+
+def test_construction_owner_failure_retains_a_closed_owner(tmp_path: Path) -> None:
+    route = _route(_private_directory(tmp_path / "shard"))
+    installed: list[PrivateDirectoryLeaseOwner] = []
+    primary = RuntimeError("construction handoff failed")
+
+    def install(owner: PrivateDirectoryLeaseOwner) -> None:
+        installed.append(owner)
+        raise primary
+
+    with pytest.raises(RuntimeError) as raised:
+        acquire_private_directory_lease(
+            route,
+            mode=DirectoryLeaseMode.SHARED,
+            blocking=True,
+            _construction_owner=install,
+        )
+    assert raised.value is primary
+    assert len(installed) == 1
+    assert installed[0].closed
+
+
+@pytest.mark.parametrize("close_in_thread", (False, True))
+def test_construction_owner_close_prevents_acquisition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    close_in_thread: bool,
+) -> None:
+    route = _route(_private_directory(tmp_path / "shard"))
+    installed: list[PrivateDirectoryLeaseOwner] = []
+    close_errors: list[BaseException] = []
+
+    def close_owner(owner: PrivateDirectoryLeaseOwner) -> None:
+        try:
+            owner.close()
+        except BaseException as error:  # noqa: B036 - report thread failure
+            close_errors.append(error)
+
+    def install(owner: PrivateDirectoryLeaseOwner) -> None:
+        installed.append(owner)
+        if close_in_thread:
+            closer = threading.Thread(target=close_owner, args=(owner,))
+            closer.start()
+            closer.join()
+        else:
+            close_owner(owner)
+        assert not close_errors
+        assert owner.closed
+
+    def reject_open(_owner: object, _path: bytes) -> None:
+        raise AssertionError("closed construction owner reached native open")
+
+    monkeypatch.setattr(
+        lease_module._native_workspace_owner,
+        "_open_directory_fd",
+        reject_open,
+    )
+    with pytest.raises(RuntimeError, match="closed before acquisition"):
+        acquire_private_directory_lease(
+            route,
+            mode=DirectoryLeaseMode.SHARED,
+            blocking=True,
+            _construction_owner=install,
+        )
+
+    assert len(installed) == 1
+    assert installed[0].closed
+    assert not lease_module._ACTIVE_DIRECTORY_LEASE_OWNERS
+
+
+def test_acquire_requires_preexisting_construction_owner(tmp_path: Path) -> None:
+    route = _route(_private_directory(tmp_path / "shard"))
+
+    with pytest.raises(TypeError, match="requires a construction owner"):
+        acquire_private_directory_lease(
+            route,
+            mode=DirectoryLeaseMode.SHARED,
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    (
+        ("path", "not-a-path", TypeError),
+        ("identity", (1, 2, stat.S_IFDIR), TypeError),
+        ("identity", (1, 2, stat.S_IFDIR, False), TypeError),
+        ("identity", (1, 2, stat.S_IFREG, 0), ValueError),
+        ("owner_pid", True, TypeError),
+        ("owner_pid", -1, ValueError),
+    ),
+)
+def test_route_rejects_inexact_fields(
+    tmp_path: Path,
+    field: str,
+    value: object,
+    error: type[BaseException],
+) -> None:
+    path = _private_directory(tmp_path / "shard")
+    values = {"path": path, "identity": _identity(path), "owner_pid": os.getpid()}
+    values[field] = value
+    with pytest.raises(error):
+        PrivateDirectoryLeaseRoute(**values)  # type: ignore[arg-type]
+
+
+def test_route_rejects_path_subclass_and_relative_path(tmp_path: Path) -> None:
+    path = _private_directory(tmp_path / "shard")
+    concrete_path_type = type(Path())
+
+    class DerivedPath(concrete_path_type):
+        pass
+
+    with pytest.raises(TypeError, match="exact Path"):
+        PrivateDirectoryLeaseRoute(
+            DerivedPath(path),
+            _identity(path),
+            os.getpid(),
+        )
+    with pytest.raises(ValueError, match="absolute"):
+        PrivateDirectoryLeaseRoute(
+            Path("relative-shard"),
+            _identity(path),
+            os.getpid(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    (
+        ({"mode": "shared", "blocking": True}, "mode"),
+        ({"mode": DirectoryLeaseMode.SHARED, "blocking": 1}, "blocking"),
+        (
+            {
+                "mode": DirectoryLeaseMode.SHARED,
+                "blocking": True,
+                "check_cancelled": object(),
+            },
+            "cancellation",
+        ),
+        (
+            {
+                "mode": DirectoryLeaseMode.SHARED,
+                "blocking": True,
+                "_construction_owner": object(),
+            },
+            "construction owner",
+        ),
+    ),
+)
+def test_acquire_rejects_inexact_policy_before_constructing_owner(
+    tmp_path: Path,
+    kwargs: dict[str, object],
+    message: str,
+) -> None:
+    route = _route(_private_directory(tmp_path / "shard"))
+    with pytest.raises(TypeError, match=message):
+        acquire_private_directory_lease(route, **kwargs)  # type: ignore[arg-type]
+
+
+def test_rejects_wrong_retained_identity_without_opening_lock(
+    tmp_path: Path,
+) -> None:
+    path = _private_directory(tmp_path / "shard")
+    identity = _identity(path)
+    wrong = (identity[0], identity[1] + 1, identity[2], identity[3])
+    route = PrivateDirectoryLeaseRoute(path, wrong, os.getpid())
+    with pytest.raises(RuntimeError, match="changed"):
+        _acquire(route, DirectoryLeaseMode.SHARED)
+
+
+def test_rejects_non_private_directory_mode(tmp_path: Path) -> None:
+    path = _private_directory(tmp_path / "shard")
+    route = _route(path)
+    path.chmod(0o750)
+    with pytest.raises(RuntimeError, match="mode 0700"):
+        _acquire(route, DirectoryLeaseMode.SHARED)
+
+
+def test_rejects_directory_owned_by_another_euid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = _private_directory(tmp_path / "shard")
+    route = _route(path)
+    monkeypatch.setattr(lease_module.os, "geteuid", lambda: path.stat().st_uid + 1)
+    with pytest.raises(RuntimeError, match="another owner"):
+        _acquire(route, DirectoryLeaseMode.SHARED)
+
+
+def test_rejects_symlink_and_regular_file_routes(tmp_path: Path) -> None:
+    target = _private_directory(tmp_path / "target")
+    link = tmp_path / "link"
+    link.symlink_to(target, target_is_directory=True)
+    link_route = PrivateDirectoryLeaseRoute(link, _identity(target), os.getpid())
+    with pytest.raises(RuntimeError, match="not real"):
+        _acquire(link_route, DirectoryLeaseMode.SHARED)
+
+    regular = tmp_path / "regular"
+    regular.write_bytes(b"")
+    regular.chmod(0o700)
+    target_identity = _identity(target)
+    file_route = PrivateDirectoryLeaseRoute(
+        regular,
+        (
+            regular.stat().st_dev,
+            regular.stat().st_ino,
+            stat.S_IFDIR,
+            target_identity[3],
+        ),
+        os.getpid(),
+    )
+    with pytest.raises(RuntimeError, match="not real"):
+        _acquire(file_route, DirectoryLeaseMode.EXCLUSIVE)
+
+
+def test_same_thread_reentry_fails_fast_for_same_inode(tmp_path: Path) -> None:
+    route = _route(_private_directory(tmp_path / "shard"))
+    owner = _acquire(route, DirectoryLeaseMode.SHARED)
+    try:
+        with pytest.raises(RuntimeError, match="already held by this thread"):
+            _acquire(route, DirectoryLeaseMode.SHARED)
+    finally:
+        owner.close()
+
+    replacement = _acquire(route, DirectoryLeaseMode.EXCLUSIVE)
+    replacement.close()
+
+
+def test_owner_may_close_on_another_thread_without_stranding_claim(
+    tmp_path: Path,
+) -> None:
+    route = _route(_private_directory(tmp_path / "shard"))
+    owner = _acquire(route, DirectoryLeaseMode.SHARED)
+    failures: list[BaseException] = []
+
+    def close() -> None:
+        try:
+            owner.close()
+        except BaseException as error:  # noqa: B036 - asserted below
+            failures.append(error)
+
+    closer = threading.Thread(target=close)
+    closer.start()
+    closer.join(timeout=10)
+    assert not closer.is_alive()
+    assert not failures
+    assert owner.closed
+
+    reacquired = _acquire(route, DirectoryLeaseMode.EXCLUSIVE)
+    reacquired.close()
+
+
+def test_shared_leases_coexist_across_threads(tmp_path: Path) -> None:
+    route = _route(_private_directory(tmp_path / "shard"))
+    first = _acquire(route, DirectoryLeaseMode.SHARED)
+    result: queue.Queue[object] = queue.Queue()
+
+    def acquire_second() -> None:
+        try:
+            second = _acquire(route, DirectoryLeaseMode.SHARED, blocking=False)
+            result.put(second)
+        except BaseException as error:  # noqa: B036 - asserted below
+            result.put(error)
+
+    thread = threading.Thread(target=acquire_second)
+    thread.start()
+    thread.join(timeout=10)
+    assert not thread.is_alive()
+    observed = result.get_nowait()
+    try:
+        assert type(observed) is PrivateDirectoryLeaseOwner
+    finally:
+        if type(observed) is PrivateDirectoryLeaseOwner:
+            observed.close()
+        first.close()
+
+
+def test_shared_excludes_exclusive_across_processes(tmp_path: Path) -> None:
+    context = multiprocessing.get_context("spawn")
+    path = _private_directory(tmp_path / "shard")
+    identity = _identity(path)
+    ready = context.Event()
+    release = context.Event()
+    holder = context.Process(
+        target=_spawn_hold_lease,
+        args=(
+            str(path),
+            identity,
+            DirectoryLeaseMode.SHARED.value,
+            ready,
+            release,
+        ),
+    )
+    holder.start()
+    try:
+        assert ready.wait(timeout=10)
+        route = PrivateDirectoryLeaseRoute(path, identity, os.getpid())
+        with pytest.raises(BlockingIOError):
+            _acquire(route, DirectoryLeaseMode.EXCLUSIVE, blocking=False)
+    finally:
+        release.set()
+        holder.join(timeout=10)
+        if holder.is_alive():
+            holder.terminate()
+            holder.join(timeout=10)
+    assert holder.exitcode == 0
+
+
+def test_exclusive_blocks_shared_process_until_close(tmp_path: Path) -> None:
+    context = multiprocessing.get_context("spawn")
+    path = _private_directory(tmp_path / "shard")
+    identity = _identity(path)
+    route = PrivateDirectoryLeaseRoute(path, identity, os.getpid())
+    owner = _acquire(route, DirectoryLeaseMode.EXCLUSIVE)
+    ready = context.Event()
+    acquired = context.Event()
+    waiter = context.Process(
+        target=_spawn_wait_for_lease,
+        args=(
+            str(path),
+            identity,
+            DirectoryLeaseMode.SHARED.value,
+            ready,
+            acquired,
+        ),
+    )
+    waiter.start()
+    try:
+        assert ready.wait(timeout=10)
+        assert not acquired.wait(timeout=0.25)
+        owner.close()
+        assert acquired.wait(timeout=10)
+    finally:
+        if not owner.closed:
+            owner.close()
+        waiter.join(timeout=10)
+        if waiter.is_alive():
+            waiter.terminate()
+            waiter.join(timeout=10)
+    assert waiter.exitcode == 0
+
+
+def test_distinct_directory_inodes_do_not_contend(tmp_path: Path) -> None:
+    first_route = _route(_private_directory(tmp_path / "first"))
+    second_route = _route(_private_directory(tmp_path / "second"))
+    first = _acquire(first_route, DirectoryLeaseMode.EXCLUSIVE)
+    try:
+        second = _acquire(
+            second_route,
+            DirectoryLeaseMode.EXCLUSIVE,
+            blocking=False,
+        )
+        second.close()
+    finally:
+        first.close()
+
+
+def test_path_replacement_rejects_stale_route(tmp_path: Path) -> None:
+    path = _private_directory(tmp_path / "shard")
+    route = _route(path)
+    path.rename(tmp_path / "old-shard")
+    _private_directory(path)
+
+    with pytest.raises(RuntimeError, match="changed"):
+        _acquire(route, DirectoryLeaseMode.SHARED)
+
+
+def test_replacement_during_acquisition_releases_old_inode_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = _private_directory(tmp_path / "shard")
+    old_path = tmp_path / "old-shard"
+    route = _route(path)
+    real_acquire_flock = lease_module._acquire_flock
+    replaced = False
+
+    def acquire_then_replace(owner, **kwargs) -> None:
+        nonlocal replaced
+        real_acquire_flock(owner, **kwargs)
+        if not replaced:
+            replaced = True
+            path.rename(old_path)
+            _private_directory(path)
+
+    monkeypatch.setattr(lease_module, "_acquire_flock", acquire_then_replace)
+    with pytest.raises(RuntimeError, match="changed"):
+        _acquire(route, DirectoryLeaseMode.EXCLUSIVE)
+
+    descriptor = os.open(
+        old_path,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+    )
+    try:
+        assert fcntl is not None
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+    finally:
+        os.close(descriptor)
+
+
+def test_interruptible_wait_cancels_and_releases_all_resources(
+    tmp_path: Path,
+) -> None:
+    class Cancelled(BaseException):
+        pass
+
+    route = _route(_private_directory(tmp_path / "shard"))
+    holder = _acquire(route, DirectoryLeaseMode.EXCLUSIVE)
+    failures: list[BaseException] = []
+    checks = 0
+
+    def wait_for_shared() -> None:
+        def check_cancelled() -> None:
+            nonlocal checks
+            checks += 1
+            if checks >= 2:
+                raise Cancelled
+
+        try:
+            installed: list[PrivateDirectoryLeaseOwner] = []
+            acquire_private_directory_lease(
+                route,
+                mode=DirectoryLeaseMode.SHARED,
+                blocking=True,
+                check_cancelled=check_cancelled,
+                _construction_owner=installed.append,
+            )
+        except BaseException as error:  # noqa: B036 - exact cancellation asserted
+            failures.append(error)
+
+    waiter = threading.Thread(target=wait_for_shared)
+    waiter.start()
+    waiter.join(timeout=10)
+    try:
+        assert not waiter.is_alive()
+        assert len(failures) == 1
+        assert type(failures[0]) is Cancelled
+        assert checks == 2
+    finally:
+        holder.close()
+
+    replacement = _acquire(route, DirectoryLeaseMode.EXCLUSIVE)
+    replacement.close()
+
+
+def test_cancellation_after_successful_flock_releases_lease(tmp_path: Path) -> None:
+    class Cancelled(BaseException):
+        pass
+
+    route = _route(_private_directory(tmp_path / "shard"))
+    checks = 0
+
+    def check_cancelled() -> None:
+        nonlocal checks
+        checks += 1
+        if checks == 2:
+            raise Cancelled
+
+    installed: list[PrivateDirectoryLeaseOwner] = []
+    with pytest.raises(Cancelled):
+        acquire_private_directory_lease(
+            route,
+            mode=DirectoryLeaseMode.EXCLUSIVE,
+            blocking=True,
+            check_cancelled=check_cancelled,
+            _construction_owner=installed.append,
+        )
+    assert checks == 2
+
+    owner = _acquire(route, DirectoryLeaseMode.EXCLUSIVE, blocking=False)
+    owner.close()
+
+
+def test_native_open_return_failure_closes_preinstalled_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Interrupted(BaseException):
+        pass
+
+    route = _route(_private_directory(tmp_path / "shard"))
+    interruption = Interrupted("native directory open return interrupted")
+    installed: list[PrivateDirectoryLeaseOwner] = []
+    real_open = lease_module._native_workspace_owner._open_directory_fd
+
+    def open_then_interrupt(native_owner: object, path: bytes) -> None:
+        real_open(native_owner, path)
+        raise interruption
+
+    monkeypatch.setattr(
+        lease_module._native_workspace_owner,
+        "_open_directory_fd",
+        open_then_interrupt,
+    )
+    with pytest.raises(Interrupted) as caught:
+        acquire_private_directory_lease(
+            route,
+            mode=DirectoryLeaseMode.EXCLUSIVE,
+            blocking=True,
+            _construction_owner=installed.append,
+        )
+
+    assert caught.value is interruption
+    assert len(installed) == 1
+    assert installed[0].closed
+    assert not lease_module._ACTIVE_DIRECTORY_LEASE_OWNERS
+    monkeypatch.setattr(
+        lease_module._native_workspace_owner,
+        "_open_directory_fd",
+        real_open,
+    )
+    replacement = _acquire(route, DirectoryLeaseMode.EXCLUSIVE, blocking=False)
+    replacement.close()
+
+
+def test_descriptor_close_failure_retains_same_thread_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    route = _route(_private_directory(tmp_path / "shard"))
+    owner = _acquire(route, DirectoryLeaseMode.SHARED)
+    close_failure = OSError(errno.EIO, "lease descriptor close failed")
+    real_close = lease_module._close_descriptor_for_cleanup
+
+    def fail_close(_owner: PrivateDirectoryLeaseOwner) -> None:
+        raise close_failure
+
+    monkeypatch.setattr(
+        lease_module,
+        "_close_descriptor_for_cleanup",
+        fail_close,
+    )
+    with pytest.raises(OSError) as caught:
+        owner.close()
+
+    assert caught.value is close_failure
+    assert owner._descriptor_owner
+    assert owner._claim_owner
+    monkeypatch.setattr(lease_module, "_close_descriptor_for_cleanup", real_close)
+    with pytest.raises(RuntimeError, match="already held by this thread"):
+        _acquire(route, DirectoryLeaseMode.EXCLUSIVE, blocking=False)
+
+    owner.close()
+    replacement = _acquire(route, DirectoryLeaseMode.EXCLUSIVE, blocking=False)
+    replacement.close()
+
+
+def test_native_close_failure_retains_flock_until_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    route = _route(_private_directory(tmp_path / "shard"))
+    owner = _acquire(route, DirectoryLeaseMode.EXCLUSIVE)
+    close_failure = OSError(errno.EPERM, "lease descriptor close denied")
+    real_close = lease_module._native_workspace_owner._close_directory_fd_owner
+    retained_native_owner = owner._native_descriptor_owner
+
+    def fail_before_close(candidate: object) -> None:
+        if candidate is retained_native_owner:
+            raise close_failure
+        real_close(candidate)
+
+    monkeypatch.setattr(
+        lease_module._native_workspace_owner,
+        "_close_directory_fd_owner",
+        fail_before_close,
+    )
+    with pytest.raises(OSError) as caught:
+        owner.close()
+
+    assert caught.value is close_failure
+    assert not owner.closed
+    result: queue.Queue[object] = queue.Queue()
+
+    def try_shared() -> None:
+        try:
+            result.put(_acquire(route, DirectoryLeaseMode.SHARED, blocking=False))
+        except BaseException as error:  # noqa: B036 - asserted below
+            result.put(error)
+
+    contender = threading.Thread(target=try_shared)
+    contender.start()
+    contender.join(timeout=10)
+    assert not contender.is_alive()
+    observed = result.get_nowait()
+    try:
+        assert type(observed) is BlockingIOError
+    finally:
+        if type(observed) is PrivateDirectoryLeaseOwner:
+            observed.close()
+
+    monkeypatch.setattr(
+        lease_module._native_workspace_owner,
+        "_close_directory_fd_owner",
+        real_close,
+    )
+    owner.close()
+    replacement = _acquire(route, DirectoryLeaseMode.SHARED, blocking=False)
+    replacement.close()
+    assert not lease_module._ACTIVE_DIRECTORY_LEASE_OWNERS
+
+
+@pytest.mark.skipif(
+    not Path("/proc/self/fd").is_dir(),
+    reason="requires procfs descriptor accounting",
+)
+def test_success_failure_and_cancellation_do_not_leak_descriptors(
+    tmp_path: Path,
+) -> None:
+    path = _private_directory(tmp_path / "shard")
+    route = _route(path)
+
+    def matching_descriptors() -> tuple[int, ...]:
+        matches: list[int] = []
+        for raw_descriptor in os.listdir("/proc/self/fd"):
+            try:
+                descriptor = int(raw_descriptor)
+                metadata = os.fstat(descriptor)
+            except (OSError, ValueError):
+                continue
+            if _identity_from_metadata(metadata) == route.identity:
+                matches.append(descriptor)
+        return tuple(matches)
+
+    assert matching_descriptors() == ()
+
+    for _ in range(20):
+        owner = _acquire(route, DirectoryLeaseMode.SHARED)
+        owner.close()
+    assert matching_descriptors() == ()
+    assert not lease_module._ACTIVE_DIRECTORY_LEASE_OWNERS
+
+    wrong_identity = (
+        route.identity[0],
+        route.identity[1] + 1,
+        route.identity[2],
+        route.identity[3],
+    )
+    wrong_route = PrivateDirectoryLeaseRoute(path, wrong_identity, os.getpid())
+    with pytest.raises(RuntimeError):
+        _acquire(wrong_route, DirectoryLeaseMode.SHARED)
+    assert matching_descriptors() == ()
+    assert not lease_module._ACTIVE_DIRECTORY_LEASE_OWNERS
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "fork") or not hasattr(os, "register_at_fork"),
+    reason="requires POSIX fork callbacks",
+)
+def test_fork_child_fails_closed_while_parent_retains_lock(
+    tmp_path: Path,
+) -> None:
+    path = _private_directory(tmp_path / "shard")
+    route = _route(path)
+    owner = _acquire(route, DirectoryLeaseMode.EXCLUSIVE)
+    descriptor = owner._descriptor_owner[-1]
+    child_pid = os.fork()
+    if child_pid == 0:  # pragma: no cover - native callback must exit first
+        os._exit(5)
+
+    try:
+        waited_pid, status = os.waitpid(child_pid, 0)
+        assert waited_pid == child_pid
+        assert os.waitstatus_to_exitcode(status) == (
+            lease_module._FORK_CLEANUP_FAILURE_EXIT_CODE
+        )
+        assert not owner.closed
+        assert os.fstat(descriptor).st_ino == route.identity[1]
+    finally:
+        owner.close()
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "fork") or not hasattr(os, "register_at_fork"),
+    reason="requires POSIX fork callbacks",
+)
+def test_fork_during_post_open_validation_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    route = _route(_private_directory(tmp_path / "shard"))
+    real_validate = lease_module._validate_identity_sandwich
+    forked = False
+    child_pid: int | None = None
+
+    def validate_and_fork(descriptor: int, observed_route) -> None:
+        nonlocal child_pid, forked
+        real_validate(descriptor, observed_route)
+        if forked:
+            return
+        forked = True
+        child_pid = os.fork()
+        if child_pid == 0:  # pragma: no cover - native callback must exit first
+            os._exit(5)
+        waited_pid, status = os.waitpid(child_pid, 0)
+        child_pid = None
+        assert waited_pid > 0
+        assert os.waitstatus_to_exitcode(status) == (
+            lease_module._FORK_CLEANUP_FAILURE_EXIT_CODE
+        )
+
+    monkeypatch.setattr(
+        lease_module,
+        "_validate_identity_sandwich",
+        validate_and_fork,
+    )
+    try:
+        owner = _acquire(route, DirectoryLeaseMode.EXCLUSIVE)
+        owner.close()
+    finally:
+        if child_pid not in (None, 0):
+            os.kill(child_pid, 9)
+            os.waitpid(child_pid, 0)
+    assert forked
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "fork") or not hasattr(os, "register_at_fork"),
+    reason="requires POSIX fork callbacks",
+)
+def test_fork_after_directory_owner_close_can_continue(tmp_path: Path) -> None:
+    path = _private_directory(tmp_path / "shard")
+    owner = _acquire(_route(path), DirectoryLeaseMode.EXCLUSIVE)
+    owner.close()
+
+    child_pid = os.fork()
+    if child_pid == 0:  # pragma: no cover - disposable fork child
+        os._exit(0)
+    waited_pid, status = os.waitpid(child_pid, 0)
+    assert waited_pid == child_pid
+    assert os.waitstatus_to_exitcode(status) == 0
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "fork") or ctypes.util.find_library("seccomp") is None,
+    reason="requires Linux fork and libseccomp",
+)
+def test_fork_child_fails_closed_when_ofd_comparison_is_permanently_denied(
+    tmp_path: Path,
+) -> None:
+    path = _private_directory(tmp_path / "shard")
+    script = textwrap.dedent(
+        """
+        import ctypes
+        import ctypes.util
+        import errno
+        import fcntl
+        import os
+        import stat
+        import sys
+        from pathlib import Path
+
+        from codenib.compiler import _directory_lease as lease_module
+        from codenib.compiler._directory_lease import (
+            DirectoryLeaseMode,
+            PrivateDirectoryLeaseRoute,
+            acquire_private_directory_lease,
+        )
+
+        path = Path(sys.argv[1])
+        metadata = path.lstat()
+        route = PrivateDirectoryLeaseRoute(
+            path,
+            (
+                metadata.st_dev,
+                metadata.st_ino,
+                stat.S_IFMT(metadata.st_mode),
+                getattr(metadata, "st_file_attributes", 0),
+            ),
+            os.getpid(),
+        )
+        installed = []
+        owner = acquire_private_directory_lease(
+            route,
+            mode=DirectoryLeaseMode.EXCLUSIVE,
+            blocking=True,
+            _construction_owner=installed.append,
+        )
+        descriptor = owner._descriptor_owner[-1]
+
+        library_name = ctypes.util.find_library("seccomp") or "libseccomp.so.2"
+        library = ctypes.CDLL(library_name, use_errno=True)
+        library.seccomp_init.argtypes = [ctypes.c_uint32]
+        library.seccomp_init.restype = ctypes.c_void_p
+        library.seccomp_syscall_resolve_name.argtypes = [ctypes.c_char_p]
+        library.seccomp_syscall_resolve_name.restype = ctypes.c_int
+        library.seccomp_rule_add.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint32,
+            ctypes.c_int,
+            ctypes.c_uint,
+        ]
+        library.seccomp_rule_add.restype = ctypes.c_int
+        library.seccomp_rule_add_array.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint32,
+            ctypes.c_int,
+            ctypes.c_uint,
+            ctypes.c_void_p,
+        ]
+        library.seccomp_rule_add_array.restype = ctypes.c_int
+        library.seccomp_load.argtypes = [ctypes.c_void_p]
+        library.seccomp_load.restype = ctypes.c_int
+        library.seccomp_release.argtypes = [ctypes.c_void_p]
+
+        class ArgCmp(ctypes.Structure):
+            _fields_ = [
+                ("arg", ctypes.c_uint),
+                ("op", ctypes.c_int),
+                ("datum_a", ctypes.c_uint64),
+                ("datum_b", ctypes.c_uint64),
+            ]
+
+        allow = 0x7FFF0000
+        deny = 0x00050000 | errno.EPERM
+        context = library.seccomp_init(allow)
+        if not context:
+            os._exit(77)
+        kcmp_number = library.seccomp_syscall_resolve_name(b"kcmp")
+        fcntl_number = library.seccomp_syscall_resolve_name(b"fcntl")
+        if kcmp_number < 0 or fcntl_number < 0:
+            os._exit(77)
+        if library.seccomp_rule_add(context, deny, kcmp_number, 0) != 0:
+            os._exit(77)
+        comparison = ArgCmp(1, 4, fcntl.F_SETFL, 0)
+        if library.seccomp_rule_add_array(
+            context,
+            deny,
+            fcntl_number,
+            1,
+            ctypes.byref(comparison),
+        ) != 0:
+            os._exit(77)
+        if library.seccomp_load(context) != 0:
+            os._exit(77)
+        library.seccomp_release(context)
+
+        child_pid = os.fork()
+        if child_pid == 0:
+            os._exit(5)
+        waited_pid, status = os.waitpid(child_pid, 0)
+        child_status = os.waitstatus_to_exitcode(status)
+        expected = lease_module._FORK_CLEANUP_FAILURE_EXIT_CODE
+        os._exit(0 if waited_pid == child_pid and child_status == expected else 4)
+        """
+    )
+    repository_root = Path(__file__).resolve().parents[2]
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (str(repository_root), environment.get("PYTHONPATH", ""))
+    )
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-c", script, os.fspath(path)],
+            cwd=repository_root,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired as error:
+        pytest.fail(f"fork child hung in inherited directory cleanup: {error}")
+    if completed.returncode == 77:
+        pytest.skip("libseccomp filter could not be installed")
+    assert completed.returncode == 0, (completed.stdout, completed.stderr)
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "fork") or not hasattr(os, "register_at_fork"),
+    reason="requires POSIX fork callbacks",
+)
+@pytest.mark.parametrize(
+    "replacement_target",
+    ("public", "guard", "both", "both-same-ofd"),
+)
+def test_fork_child_fails_closed_after_earlier_callback_reuses_fd_pair(
+    tmp_path: Path,
+    replacement_target: str,
+) -> None:
+    path = _private_directory(tmp_path / "shard")
+    foreign = _private_directory(tmp_path / "foreign")
+    script = textwrap.dedent(
+        """
+        import os
+        import stat
+        import sys
+        from pathlib import Path
+
+        callback_state = {}
+
+        def replace_one(descriptor):
+            os.close(descriptor)
+            source = os.open(
+                callback_state["foreign"],
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            )
+            if source != descriptor:
+                os.dup2(source, descriptor, inheritable=False)
+
+        def replace_inherited_descriptor():
+            target = callback_state["target"]
+            if target == "both-same-ofd":
+                public = callback_state["public"]
+                guard = callback_state["guard"]
+                os.close(public)
+                os.close(guard)
+                source = os.open(
+                    callback_state["path"],
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+                )
+                if source != public:
+                    os.dup2(source, public, inheritable=False)
+                if source != guard:
+                    os.dup2(source, guard, inheritable=False)
+                return
+            if target in {"public", "both"}:
+                replace_one(callback_state["public"])
+            if target in {"guard", "both"}:
+                replace_one(callback_state["guard"])
+
+        os.register_at_fork(after_in_child=replace_inherited_descriptor)
+
+        from codenib.compiler import _directory_lease as lease_module
+        from codenib.compiler._directory_lease import (
+            DirectoryLeaseMode,
+            PrivateDirectoryLeaseRoute,
+            acquire_private_directory_lease,
+        )
+
+        path = Path(sys.argv[1])
+        foreign = Path(sys.argv[2])
+        metadata = path.lstat()
+        route = PrivateDirectoryLeaseRoute(
+            path,
+            (
+                metadata.st_dev,
+                metadata.st_ino,
+                stat.S_IFMT(metadata.st_mode),
+                getattr(metadata, "st_file_attributes", 0),
+            ),
+            os.getpid(),
+        )
+        installed = []
+        owner = acquire_private_directory_lease(
+            route,
+            mode=DirectoryLeaseMode.EXCLUSIVE,
+            blocking=True,
+            _construction_owner=installed.append,
+        )
+        public = owner._descriptor_owner[-1]
+        matching = []
+        for raw_descriptor in os.listdir("/proc/self/fd"):
+            try:
+                descriptor = int(raw_descriptor)
+                observed = os.fstat(descriptor)
+            except (OSError, ValueError):
+                continue
+            if observed.st_dev == metadata.st_dev and observed.st_ino == metadata.st_ino:
+                matching.append(descriptor)
+        guard = next(descriptor for descriptor in matching if descriptor != public)
+        callback_state.update(
+            public=public,
+            guard=guard,
+            foreign=os.fspath(foreign),
+            path=os.fspath(path),
+            target=sys.argv[3],
+        )
+
+        child_pid = os.fork()
+        if child_pid == 0:
+            os._exit(5)
+        waited_pid, status = os.waitpid(child_pid, 0)
+        child_status = os.waitstatus_to_exitcode(status)
+        owner.close()
+        expected = lease_module._FORK_CLEANUP_FAILURE_EXIT_CODE
+        os._exit(0 if waited_pid == child_pid and child_status == expected else 4)
+        """
+    )
+    repository_root = Path(__file__).resolve().parents[2]
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (str(repository_root), environment.get("PYTHONPATH", ""))
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            script,
+            os.fspath(path),
+            os.fspath(foreign),
+            replacement_target,
+        ],
+        cwd=repository_root,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert completed.returncode == 0, (completed.stdout, completed.stderr)
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "fork") or not hasattr(os, "register_at_fork"),
+    reason="requires POSIX fork callbacks",
+)
+def test_fork_after_native_open_authenticates_reused_unborrowed_fd(
+    tmp_path: Path,
+) -> None:
+    path = _private_directory(tmp_path / "shard")
+    foreign = _private_directory(tmp_path / "foreign")
+    script = textwrap.dedent(
+        """
+        import os
+        import stat
+        import sys
+        from pathlib import Path
+
+        callback_state = {"armed": False, "reused": -1}
+
+        def replace_unborrowed_descriptor():
+            if not callback_state["armed"]:
+                return
+            matches = []
+            for raw_descriptor in os.listdir("/proc/self/fd"):
+                try:
+                    descriptor = int(raw_descriptor)
+                    metadata = os.fstat(descriptor)
+                except (OSError, ValueError):
+                    continue
+                if (
+                    metadata.st_dev == callback_state["device"]
+                    and metadata.st_ino == callback_state["inode"]
+                    and descriptor not in callback_state["baseline"]
+                ):
+                    matches.append(descriptor)
+            descriptor = min(matches)
+            os.close(descriptor)
+            source = os.open(
+                callback_state["foreign"],
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            )
+            if source != descriptor:
+                os.dup2(source, descriptor, inheritable=False)
+            callback_state["reused"] = descriptor
+
+        os.register_at_fork(after_in_child=replace_unborrowed_descriptor)
+
+        from codenib.compiler import _directory_lease as lease_module
+        from codenib.compiler._directory_lease import (
+            DirectoryLeaseMode,
+            PrivateDirectoryLeaseRoute,
+            acquire_private_directory_lease,
+        )
+
+        path = Path(sys.argv[1])
+        foreign = Path(sys.argv[2])
+        metadata = path.lstat()
+        route = PrivateDirectoryLeaseRoute(
+            path,
+            (
+                metadata.st_dev,
+                metadata.st_ino,
+                stat.S_IFMT(metadata.st_mode),
+                getattr(metadata, "st_file_attributes", 0),
+            ),
+            os.getpid(),
+        )
+        baseline = set()
+        for raw_descriptor in os.listdir("/proc/self/fd"):
+            try:
+                descriptor = int(raw_descriptor)
+                os.fstat(descriptor)
+            except (OSError, ValueError):
+                continue
+            baseline.add(descriptor)
+        callback_state.update(
+            device=metadata.st_dev,
+            inode=metadata.st_ino,
+            foreign=os.fspath(foreign),
+            baseline=baseline,
+        )
+        installed = []
+        real_open = lease_module._native_workspace_owner._open_directory_fd
+        forked = False
+
+        def open_and_fork(native_owner, path_bytes):
+            global forked
+            real_open(native_owner, path_bytes)
+            if forked:
+                return
+            forked = True
+            callback_state["armed"] = True
+            child_pid = os.fork()
+            if child_pid == 0:
+                os._exit(5)
+            waited_pid, status = os.waitpid(child_pid, 0)
+            child_status = os.waitstatus_to_exitcode(status)
+            expected = lease_module._FORK_CLEANUP_FAILURE_EXIT_CODE
+            if waited_pid != child_pid or child_status != expected:
+                raise AssertionError(
+                    "fork-child unborrowed fd cleanup did not fail closed: "
+                    f"status={child_status}"
+                )
+            callback_state["armed"] = False
+
+        lease_module._native_workspace_owner._open_directory_fd = open_and_fork
+        owner = acquire_private_directory_lease(
+            route,
+            mode=DirectoryLeaseMode.EXCLUSIVE,
+            blocking=True,
+            _construction_owner=installed.append,
+        )
+        owner.close()
+        os._exit(0 if forked else 4)
+        """
+    )
+    repository_root = Path(__file__).resolve().parents[2]
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (str(repository_root), environment.get("PYTHONPATH", ""))
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script, os.fspath(path), os.fspath(foreign)],
+        cwd=repository_root,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert completed.returncode == 0, (completed.stdout, completed.stderr)
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "fork") or not hasattr(os, "register_at_fork"),
+    reason="requires POSIX fork callbacks",
+)
+def test_fork_child_fails_closed_with_inherited_private_descriptor_owner(
+    tmp_path: Path,
+) -> None:
+    route = _route(_private_directory(tmp_path / "shard"))
+    owner = lease_module._create_private_directory_descriptor_owner(route)
+    owner._open()
+    child_pid = os.fork()
+    if child_pid == 0:  # pragma: no cover - native callback must exit first
+        os._exit(5)
+
+    try:
+        waited_pid, status = os.waitpid(child_pid, 0)
+        assert waited_pid == child_pid
+        assert os.waitstatus_to_exitcode(status) == (
+            lease_module._FORK_CLEANUP_FAILURE_EXIT_CODE
+        )
+        assert not owner.closed
+    finally:
+        owner.close()

--- a/test/compiler/test_source_job.py
+++ b/test/compiler/test_source_job.py
@@ -21,6 +21,7 @@ import pytest
 
 import codenib.cli as cli_module
 import codenib.compiler as compiler_module
+import codenib.compiler.bm25_attempt_pool as bm25_attempt_pool_module
 import codenib.compiler.cache_import as cache_import_module
 import codenib.compiler.job_resolver as job_resolver_module
 import codenib.compiler.job_resources as job_resources_module
@@ -33,6 +34,13 @@ from codenib._captured_directory import (
 )
 from codenib.code_chunker import CodeChunker
 from codenib.code_chunking.base import BaseCodeChunker
+from codenib.compiler._directory_lease import (
+    DirectoryLeaseMode,
+    PrivateDirectoryLeaseOwner,
+    PrivateDirectoryLeaseRoute,
+    acquire_private_directory_lease,
+)
+from codenib.compiler.bm25_attempt_pool import bootstrap_local_bm25_attempt_pool
 from codenib.compiler.index_builders import BM25IndexBuilder
 from codenib.compiler.job_resolver import (
     BM25SourceJobResolver,
@@ -69,6 +77,7 @@ from codenib.storage import (
     StorageValidationError,
     ViewProfile,
 )
+from codenib.storage.models import NamespaceIdentity, RepositoryIdentity
 
 _COMMIT = "a" * 40
 _REPOSITORY_KEY = "owner/repo"
@@ -161,6 +170,80 @@ def _source_fixture(
         attempt_provider=LocalWorkspaceProvider(tmp_path),
         owners=[],
     )
+
+
+def _directory_identity(path: Path) -> tuple[int, ...]:
+    descriptor = os.open(path, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        return publication_parent_identity(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _source_repository_id() -> str:
+    namespace = NamespaceIdentity("default")
+    return RepositoryIdentity(
+        namespace_id=namespace.namespace_id,
+        repository_key=_REPOSITORY_KEY,
+    ).repository_id
+
+
+def _probe_nonblocking_reaper(reaper_route) -> BaseException | None:
+    results: list[BaseException | None] = []
+
+    def acquire() -> None:
+        installed: list[object] = []
+        try:
+            owner = reaper_route._acquire(
+                blocking=False,
+                check_cancelled=None,
+                construction_owner=installed.append,
+            )
+        except BaseException as error:  # noqa: B036 - exact contention is asserted
+            results.append(error)
+            return
+        try:
+            results.append(None)
+        finally:
+            owner.close()
+
+    thread = threading.Thread(target=acquire)
+    thread.start()
+    thread.join(timeout=10)
+    assert not thread.is_alive()
+    assert len(results) == 1
+    return results[0]
+
+
+def _probe_nonblocking_directory_lease(
+    route: PrivateDirectoryLeaseRoute,
+    mode: DirectoryLeaseMode,
+) -> BaseException | None:
+    results: list[BaseException | None] = []
+
+    def acquire() -> None:
+        installed: list[PrivateDirectoryLeaseOwner] = []
+        try:
+            owner = acquire_private_directory_lease(
+                route,
+                mode=mode,
+                blocking=False,
+                _construction_owner=installed.append,
+            )
+        except BaseException as error:  # noqa: B036 - contention is asserted
+            results.append(error)
+            return
+        try:
+            results.append(None)
+        finally:
+            owner.close()
+
+    thread = threading.Thread(target=acquire)
+    thread.start()
+    thread.join(timeout=10)
+    assert not thread.is_alive()
+    assert len(results) == 1
+    return results[0]
 
 
 def _git_head(repository: Path) -> str:
@@ -1920,7 +2003,9 @@ def test_jobs_run_once_source_bm25_executes_matching_catalog_job(
         }
         assert not tuple(fixture.workspace.glob(".codenib-source-job-*"))
         assert not tuple(fixture.workspace.glob(".codenib-source-worker-topology-*"))
-        orphans = tuple(fixture.workspace.glob(".*.discarded-*"))
+        shards = tuple(fixture.workspace.glob(".codenib-bm25-attempt-pool-v1-repo_*"))
+        assert len(shards) == 1
+        orphans = tuple(shards[0].glob(".*.discarded-*"))
         if reclaim_quiescent_attempts:
             assert orphans == ()
             assert captured.err.endswith(
@@ -2229,6 +2314,616 @@ def test_local_bm25_source_scope_threads_repository_root_authority(
             assert observed == [authority]
             assert len(accepted_orphans) == 1
             assert accepted_orphans[0].reopen(lambda reader: reader.inventory()) == ()
+    finally:
+        fixture.close()
+
+
+def test_routed_bm25_source_scope_holds_shared_lease_through_orphan_ack(
+    tmp_path: Path,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    workspace_identity = _directory_identity(fixture.workspace)
+    accepted_orphans: list[DirectoryOrphan] = []
+    try:
+        with (
+            pin_repository_source_root(fixture.repository) as authority,
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            binding = bootstrap_local_bm25_attempt_pool(
+                workspace_root=fixture.workspace,
+                workspace_identity=workspace_identity,
+                repository_id=_source_repository_id(),
+                repository_authority=authority,
+                topology_verifier=lambda: None,
+            )
+
+            def accept(orphan: DirectoryOrphan) -> None:
+                contention = _probe_nonblocking_reaper(binding.reaper_route)
+                assert type(contention) is BlockingIOError
+                accepted_orphans.append(orphan)
+
+            target = LocalBM25SourceJobTarget(
+                repository_root=fixture.repository,
+                workspace_provider=fixture.provider,
+                repository_key=_REPOSITORY_KEY,
+                display_commit=_COMMIT,
+                builder=builder,
+                repository_root_authority=authority,
+                workspace_parent_identity=workspace_identity,
+                topology_verifier=lambda: None,
+                attempt_orphan_sink=accept,
+                attempt_pool_writer_route=binding.writer_route,
+                environ={},
+            )
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+
+            with resources.create_scope(
+                context, object_store=cas
+            ).resources as executor:
+                assert (
+                    executor.attempt_workspace_provider.allowed_root.parent
+                    == binding.writer_route._shard_path
+                )
+                assert type(_probe_nonblocking_reaper(binding.reaper_route)) is (
+                    BlockingIOError
+                )
+
+            assert len(accepted_orphans) == 1
+            assert accepted_orphans[0].path.parent == binding.writer_route._shard_path
+            assert _probe_nonblocking_reaper(binding.reaper_route) is None
+    finally:
+        fixture.close()
+
+
+def test_routed_bm25_source_acquisition_cancellation_settles_empty_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Cancelled(BaseException):
+        pass
+
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    workspace_identity = _directory_identity(fixture.workspace)
+    cancellation = Cancelled("writer lease acquisition cancelled")
+    real_acquire = bm25_attempt_pool_module._LocalBM25AttemptPoolWriterRoute._acquire
+    try:
+        with (
+            pin_repository_source_root(fixture.repository) as authority,
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            binding = bootstrap_local_bm25_attempt_pool(
+                workspace_root=fixture.workspace,
+                workspace_identity=workspace_identity,
+                repository_id=_source_repository_id(),
+                repository_authority=authority,
+                topology_verifier=lambda: None,
+            )
+            target = LocalBM25SourceJobTarget(
+                repository_root=fixture.repository,
+                workspace_provider=fixture.provider,
+                repository_key=_REPOSITORY_KEY,
+                display_commit=_COMMIT,
+                builder=builder,
+                repository_root_authority=authority,
+                workspace_parent_identity=workspace_identity,
+                topology_verifier=lambda: None,
+                attempt_pool_writer_route=binding.writer_route,
+                environ={},
+            )
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+
+            def cancel_acquire(route, *, check_cancelled, construction_owner):
+                assert route is binding.writer_route
+
+                def cancel() -> None:
+                    raise cancellation
+
+                return real_acquire(
+                    route,
+                    check_cancelled=cancel,
+                    construction_owner=construction_owner,
+                )
+
+            monkeypatch.setattr(
+                bm25_attempt_pool_module._LocalBM25AttemptPoolWriterRoute,
+                "_acquire",
+                cancel_acquire,
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+
+            with pytest.raises(Cancelled) as caught:
+                with resources.create_scope(context, object_store=cas).resources:
+                    pass
+
+            assert caught.value is cancellation
+            assert tuple(binding.writer_route._shard_path.iterdir()) == ()
+            assert _probe_nonblocking_reaper(binding.reaper_route) is None
+    finally:
+        fixture.close()
+
+
+def test_routed_bm25_source_route_return_cancellation_skips_global_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Cancelled(BaseException):
+        pass
+
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    workspace_identity = _directory_identity(fixture.workspace)
+    cancellation = Cancelled("writer lease route return cancelled")
+    retry_calls = 0
+    real_acquire = bm25_attempt_pool_module._LocalBM25AttemptPoolWriterRoute._acquire
+    try:
+        with (
+            pin_repository_source_root(fixture.repository) as authority,
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            binding = bootstrap_local_bm25_attempt_pool(
+                workspace_root=fixture.workspace,
+                workspace_identity=workspace_identity,
+                repository_id=_source_repository_id(),
+                repository_authority=authority,
+                topology_verifier=lambda: None,
+            )
+            target = LocalBM25SourceJobTarget(
+                repository_root=fixture.repository,
+                workspace_provider=fixture.provider,
+                repository_key=_REPOSITORY_KEY,
+                display_commit=_COMMIT,
+                builder=builder,
+                repository_root_authority=authority,
+                workspace_parent_identity=workspace_identity,
+                topology_verifier=lambda: None,
+                attempt_pool_writer_route=binding.writer_route,
+                environ={},
+            )
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+
+            def cancel_after_route_return(
+                route,
+                *,
+                check_cancelled,
+                construction_owner,
+            ):
+                real_acquire(
+                    route,
+                    check_cancelled=check_cancelled,
+                    construction_owner=construction_owner,
+                )
+                raise cancellation
+
+            def reject_global_retry(*_args, **_kwargs) -> None:
+                nonlocal retry_calls
+                retry_calls += 1
+                raise AssertionError("unstarted lease cleanup entered global retry")
+
+            monkeypatch.setattr(
+                bm25_attempt_pool_module._LocalBM25AttemptPoolWriterRoute,
+                "_acquire",
+                cancel_after_route_return,
+            )
+            monkeypatch.setattr(
+                job_resources_module,
+                "_retry_retained_owned_path_build_cleanup_for_group",
+                reject_global_retry,
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+
+            with pytest.raises(Cancelled) as caught:
+                with resources.create_scope(context, object_store=cas).resources:
+                    pass
+
+            assert caught.value is cancellation
+            assert retry_calls == 0
+            assert tuple(binding.writer_route._shard_path.iterdir()) == ()
+            assert _probe_nonblocking_reaper(binding.reaper_route) is None
+    finally:
+        fixture.close()
+
+
+def test_routed_bm25_source_failure_precedes_shared_lease(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    workspace_identity = _directory_identity(fixture.workspace)
+    source_failure = OSError("source capture failed before writer lease")
+    acquire_calls = 0
+    try:
+        with (
+            pin_repository_source_root(fixture.repository) as authority,
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            binding = bootstrap_local_bm25_attempt_pool(
+                workspace_root=fixture.workspace,
+                workspace_identity=workspace_identity,
+                repository_id=_source_repository_id(),
+                repository_authority=authority,
+                topology_verifier=lambda: None,
+            )
+            target = LocalBM25SourceJobTarget(
+                repository_root=fixture.repository,
+                workspace_provider=fixture.provider,
+                repository_key=_REPOSITORY_KEY,
+                display_commit=_COMMIT,
+                builder=builder,
+                repository_root_authority=authority,
+                workspace_parent_identity=workspace_identity,
+                topology_verifier=lambda: None,
+                attempt_pool_writer_route=binding.writer_route,
+                environ={},
+            )
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+
+            def reject_source(*_args, **_kwargs):
+                raise source_failure
+
+            def reject_acquire(*_args, **_kwargs):
+                nonlocal acquire_calls
+                acquire_calls += 1
+                pytest.fail("source failure must precede writer lease acquisition")
+
+            monkeypatch.setattr(
+                job_resources_module,
+                "capture_repository_source",
+                reject_source,
+            )
+            monkeypatch.setattr(
+                bm25_attempt_pool_module._LocalBM25AttemptPoolWriterRoute,
+                "_acquire",
+                reject_acquire,
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+
+            with pytest.raises(OSError) as caught:
+                with resources.create_scope(context, object_store=cas).resources:
+                    pass
+
+            assert caught.value is source_failure
+            assert acquire_calls == 0
+            assert tuple(binding.writer_route._shard_path.iterdir()) == ()
+            assert _probe_nonblocking_reaper(binding.reaper_route) is None
+    finally:
+        fixture.close()
+
+
+def test_routed_bm25_rejects_wrong_writer_lease_before_prepare(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    workspace_identity = _directory_identity(fixture.workspace)
+    wrong_owner: PrivateDirectoryLeaseOwner | None = None
+    try:
+        with (
+            pin_repository_source_root(fixture.repository) as authority,
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            binding = bootstrap_local_bm25_attempt_pool(
+                workspace_root=fixture.workspace,
+                workspace_identity=workspace_identity,
+                repository_id=_source_repository_id(),
+                repository_authority=authority,
+                topology_verifier=lambda: None,
+            )
+            target = LocalBM25SourceJobTarget(
+                repository_root=fixture.repository,
+                workspace_provider=fixture.provider,
+                repository_key=_REPOSITORY_KEY,
+                display_commit=_COMMIT,
+                builder=builder,
+                repository_root_authority=authority,
+                workspace_parent_identity=workspace_identity,
+                topology_verifier=lambda: None,
+                attempt_pool_writer_route=binding.writer_route,
+                environ={},
+            )
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            installed: list[PrivateDirectoryLeaseOwner] = []
+            wrong_owner = acquire_private_directory_lease(
+                binding.writer_route._state.directory_lease_route,
+                mode=DirectoryLeaseMode.EXCLUSIVE,
+                blocking=True,
+                _construction_owner=installed.append,
+            )
+
+            def hand_off_wrong_mode(
+                _route,
+                *,
+                check_cancelled,
+                construction_owner,
+            ) -> PrivateDirectoryLeaseOwner:
+                assert callable(check_cancelled)
+                construction_owner(wrong_owner)
+                return wrong_owner
+
+            monkeypatch.setattr(
+                bm25_attempt_pool_module._LocalBM25AttemptPoolWriterRoute,
+                "_acquire",
+                hand_off_wrong_mode,
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+
+            with pytest.raises(
+                StorageIntegrityError,
+                match="writer lease authority is inconsistent",
+            ):
+                with resources.create_scope(context, object_store=cas).resources:
+                    pass
+
+            assert tuple(binding.writer_route._shard_path.iterdir()) == ()
+    finally:
+        if wrong_owner is not None:
+            wrong_owner.close()
+        fixture.close()
+
+
+def test_routed_bm25_sink_failure_retains_composite_and_shared_lease(
+    tmp_path: Path,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    workspace_identity = _directory_identity(fixture.workspace)
+    accepted_orphans: list[DirectoryOrphan] = []
+    rejection = RuntimeError("routed attempt sink refused receipt")
+
+    def accept(orphan: DirectoryOrphan) -> None:
+        accepted_orphans.append(orphan)
+        if len(accepted_orphans) == 1:
+            raise rejection
+
+    try:
+        with (
+            pin_repository_source_root(fixture.repository) as authority,
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            binding = bootstrap_local_bm25_attempt_pool(
+                workspace_root=fixture.workspace,
+                workspace_identity=workspace_identity,
+                repository_id=_source_repository_id(),
+                repository_authority=authority,
+                topology_verifier=lambda: None,
+            )
+            target = LocalBM25SourceJobTarget(
+                repository_root=fixture.repository,
+                workspace_provider=fixture.provider,
+                repository_key=_REPOSITORY_KEY,
+                display_commit=_COMMIT,
+                builder=builder,
+                repository_root_authority=authority,
+                workspace_parent_identity=workspace_identity,
+                topology_verifier=lambda: None,
+                attempt_orphan_sink=accept,
+                attempt_pool_writer_route=binding.writer_route,
+                environ={},
+            )
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+
+            with pytest.raises(
+                StorageIntegrityError,
+                match="attempt resource cleanup did not settle",
+            ) as caught:
+                with resources.create_scope(context, object_store=cas).resources:
+                    pass
+
+            cleanup = next(
+                owner
+                for owner in getattr(
+                    caught.value,
+                    "publication_cleanup_owners",
+                    (),
+                )
+                if type(owner)
+                is job_resources_module._BM25AttemptPoolWriterCleanupOwner
+            )
+            assert {name for name in dir(cleanup) if not name.startswith("_")} == {
+                "close",
+                "closed",
+            }
+            assert not cleanup.closed
+            assert type(_probe_nonblocking_reaper(binding.reaper_route)) is (
+                BlockingIOError
+            )
+
+            cleanup.close()
+
+            assert cleanup.closed
+            assert len(accepted_orphans) == 2
+            assert accepted_orphans[0] is accepted_orphans[1]
+            assert _probe_nonblocking_reaper(binding.reaper_route) is None
+    finally:
+        fixture.close()
+
+
+def test_routed_bm25_shard_replacement_fails_before_writer_unlock(
+    tmp_path: Path,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    workspace_identity = _directory_identity(fixture.workspace)
+    moved_route: PrivateDirectoryLeaseRoute | None = None
+    try:
+        with (
+            pin_repository_source_root(fixture.repository) as authority,
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            binding = bootstrap_local_bm25_attempt_pool(
+                workspace_root=fixture.workspace,
+                workspace_identity=workspace_identity,
+                repository_id=_source_repository_id(),
+                repository_authority=authority,
+                topology_verifier=lambda: None,
+            )
+            shard = binding.writer_route._shard_path
+            moved = shard.with_name(shard.name + ".moved")
+
+            def replace_shard(_orphan: DirectoryOrphan) -> None:
+                nonlocal moved_route
+                shard.rename(moved)
+                shard.mkdir(mode=0o700)
+                moved_route = PrivateDirectoryLeaseRoute(
+                    moved,
+                    binding.writer_route._shard_identity,
+                    os.getpid(),
+                )
+                assert (
+                    type(
+                        _probe_nonblocking_directory_lease(
+                            moved_route,
+                            DirectoryLeaseMode.EXCLUSIVE,
+                        )
+                    )
+                    is BlockingIOError
+                )
+
+            target = LocalBM25SourceJobTarget(
+                repository_root=fixture.repository,
+                workspace_provider=fixture.provider,
+                repository_key=_REPOSITORY_KEY,
+                display_commit=_COMMIT,
+                builder=builder,
+                repository_root_authority=authority,
+                workspace_parent_identity=workspace_identity,
+                topology_verifier=lambda: None,
+                attempt_orphan_sink=replace_shard,
+                attempt_pool_writer_route=binding.writer_route,
+                environ={},
+            )
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+
+            with pytest.raises(
+                StorageIntegrityError,
+                match="shard identity changed",
+            ):
+                with resources.create_scope(context, object_store=cas).resources:
+                    pass
+
+            assert moved_route is not None
+            assert (
+                _probe_nonblocking_directory_lease(
+                    moved_route,
+                    DirectoryLeaseMode.EXCLUSIVE,
+                )
+                is None
+            )
+            with pytest.raises(
+                StorageIntegrityError,
+                match="shard identity changed",
+            ):
+                binding.writer_route._acquire(
+                    check_cancelled=None,
+                    construction_owner=lambda _owner: None,
+                )
+            assert tuple(shard.iterdir()) == ()
+    finally:
+        fixture.close()
+
+
+def test_routed_bm25_prepare_return_failure_recovers_only_its_group(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = BM25IndexBuilder()
+    fixture = _source_fixture(tmp_path)
+    workspace_identity = _directory_identity(fixture.workspace)
+    interruption = KeyboardInterrupt("attempt root prepare return interrupted")
+    accepted_orphans: list[DirectoryOrphan] = []
+    real_prepare = job_resources_module.OwnedPathBuildDirectory.prepare
+    try:
+        with (
+            pin_repository_source_root(fixture.repository) as authority,
+            LocalCAS(tmp_path / "cas") as cas,
+            SQLiteCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            binding = bootstrap_local_bm25_attempt_pool(
+                workspace_root=fixture.workspace,
+                workspace_identity=workspace_identity,
+                repository_id=_source_repository_id(),
+                repository_authority=authority,
+                topology_verifier=lambda: None,
+            )
+            target = LocalBM25SourceJobTarget(
+                repository_root=fixture.repository,
+                workspace_provider=fixture.provider,
+                repository_key=_REPOSITORY_KEY,
+                display_commit=_COMMIT,
+                builder=builder,
+                repository_root_authority=authority,
+                workspace_parent_identity=workspace_identity,
+                topology_verifier=lambda: None,
+                attempt_orphan_sink=accepted_orphans.append,
+                attempt_pool_writer_route=binding.writer_route,
+                environ={},
+            )
+            context = _execution_context(
+                catalog,
+                fixture,
+                bm25_source_job_profile(builder),
+            )
+
+            def interrupt_prepare(_cls, destination, **kwargs):
+                real_prepare(destination, **kwargs)
+                raise interruption
+
+            monkeypatch.setattr(
+                job_resources_module.OwnedPathBuildDirectory,
+                "prepare",
+                classmethod(interrupt_prepare),
+            )
+            resources = LocalBM25SourceJobResourceFactory((target,))
+
+            with pytest.raises(KeyboardInterrupt) as caught:
+                with resources.create_scope(context, object_store=cas).resources:
+                    pass
+
+            assert caught.value is interruption
+            assert len(accepted_orphans) == 1
+            assert accepted_orphans[0].path.parent == binding.writer_route._shard_path
+            assert _probe_nonblocking_reaper(binding.reaper_route) is None
     finally:
         fixture.close()
 

--- a/test/test_captured_directory.py
+++ b/test/test_captured_directory.py
@@ -1291,6 +1291,24 @@ def _retry_owned_path_build_cleanup() -> tuple[atomic_directory.DirectoryOrphan,
     return tuple(orphans)
 
 
+def _retry_owned_path_build_cleanup_for_group(
+    retention_group: object,
+) -> tuple[atomic_directory.DirectoryOrphan, ...]:
+    orphans: list[atomic_directory.DirectoryOrphan] = []
+    captured_directory._retry_retained_owned_path_build_cleanup_for_group(
+        retention_group,
+        orphans.append,
+    )
+    return tuple(orphans)
+
+
+class _OpaqueRetentionGroup:
+    """An unhashable route token whose value comparison must never run."""
+
+    def __eq__(self, _other: object) -> bool:
+        raise AssertionError("retention groups must be compared by identity")
+
+
 def test_owned_path_build_rejects_subclass_construction_before_mutation(
     tmp_path: Path,
 ) -> None:
@@ -2269,6 +2287,93 @@ def test_owned_path_build_prepare_return_handoff_is_quiescently_retryable(
     assert orphans[0].reopen(lambda reader: reader.inventory()) == ()
 
 
+def test_owned_path_build_group_is_installed_before_constructor_assignment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    retention_group = _OpaqueRetentionGroup()
+    other_group = _OpaqueRetentionGroup()
+    interruption = KeyboardInterrupt("constructor assignment handoff")
+    real_init = OwnedPathBuildDirectory.__init__
+
+    def construct_then_interrupt(owner, *args, **kwargs) -> None:
+        real_init(owner, *args, **kwargs)
+        raise interruption
+
+    monkeypatch.setattr(
+        OwnedPathBuildDirectory,
+        "__init__",
+        construct_then_interrupt,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        OwnedPathBuildDirectory.prepare(
+            parent / "attempt",
+            _retention_group=retention_group,
+        )
+
+    assert caught.value is interruption
+    retained = tuple(captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES)
+    assert len(retained) == 1
+    owner = retained[0]
+    assert owner._retention_group is retention_group
+    assert owner._state == "opening"
+    assert owner._stage is None
+    assert not tuple(parent.iterdir())
+
+    assert _retry_owned_path_build_cleanup_for_group(other_group) == ()
+    assert not owner.closed
+    assert owner in captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+
+    assert _retry_owned_path_build_cleanup_for_group(retention_group) == ()
+    assert owner.closed
+    assert not captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES
+
+
+def test_owned_path_build_group_survives_prepare_return_handoff(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    retention_group = _OpaqueRetentionGroup()
+    other_group = _OpaqueRetentionGroup()
+    interruption = KeyboardInterrupt("grouped prepare return handoff")
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_owned_path_return(
+            OwnedPathBuildDirectory.prepare.__func__,
+            lambda: OwnedPathBuildDirectory.prepare(
+                parent / "attempt",
+                _retention_group=retention_group,
+            ),
+            predicate=lambda _frame, result: isinstance(
+                result,
+                OwnedPathBuildDirectory,
+            ),
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    retained = tuple(captured_directory._RETAINED_OWNED_PATH_BUILD_DIRECTORIES)
+    assert len(retained) == 1
+    owner = retained[0]
+    assert owner._retention_group is retention_group
+    assert owner.path.is_dir()
+
+    assert _retry_owned_path_build_cleanup_for_group(other_group) == ()
+    assert not owner.closed
+    orphans = _retry_owned_path_build_cleanup_for_group(retention_group)
+
+    assert len(orphans) == 1
+    assert owner.closed
+    assert not owner.path.exists()
+    assert orphans[0].reopen(lambda reader: reader.inventory()) == ()
+
+
 def test_owned_path_build_quiescent_acceptor_failure_retains_exact_receipt(
     tmp_path: Path,
 ) -> None:
@@ -2991,6 +3096,120 @@ def test_owned_path_build_quiescent_first_failure_retains_later_owners(
     assert second.closed
 
 
+def test_owned_path_build_group_retry_is_exact_and_stops_at_first_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    group_a = _OpaqueRetentionGroup()
+    group_b = _OpaqueRetentionGroup()
+    first_a = OwnedPathBuildDirectory.prepare(
+        parent / "first-a",
+        _retention_group=group_a,
+    )
+    owner_b = OwnedPathBuildDirectory.prepare(
+        parent / "owner-b",
+        _retention_group=group_b,
+    )
+    second_a = OwnedPathBuildDirectory.prepare(
+        parent / "second-a",
+        _retention_group=group_a,
+    )
+    legacy = OwnedPathBuildDirectory.prepare(parent / "legacy")
+    owners_and_payloads = (
+        (first_a, b"first-a"),
+        (owner_b, b"owner-b"),
+        (second_a, b"second-a"),
+        (legacy, b"legacy"),
+    )
+    for owner, payload in owners_and_payloads:
+        owner.path.joinpath("payload.bin").write_bytes(payload)
+
+    none_callbacks: list[atomic_directory.DirectoryOrphan] = []
+    with pytest.raises(TypeError, match="retention group must not be None"):
+        captured_directory._retry_retained_owned_path_build_cleanup_for_group(
+            None,
+            none_callbacks.append,
+        )
+    assert not none_callbacks
+    assert all(not owner.closed for owner, _payload in owners_and_payloads)
+
+    real_retry = OwnedPathBuildDirectory._retry_quiescent_cleanup
+    failure = RuntimeError("first routed cleanup failed")
+    attempted: list[OwnedPathBuildDirectory] = []
+
+    def fail_first_a(
+        owner: OwnedPathBuildDirectory,
+        accept_orphan,
+    ) -> None:
+        attempted.append(owner)
+        if owner is first_a:
+            raise failure
+        real_retry(owner, accept_orphan)
+
+    monkeypatch.setattr(
+        OwnedPathBuildDirectory,
+        "_retry_quiescent_cleanup",
+        fail_first_a,
+    )
+
+    with pytest.raises(RuntimeError, match="first routed cleanup failed") as caught:
+        captured_directory._retry_retained_owned_path_build_cleanup_for_group(
+            group_a,
+            lambda _orphan: None,
+        )
+
+    assert caught.value is failure
+    assert attempted == [first_a]
+    assert all(not owner.closed for owner, _payload in owners_and_payloads)
+
+    monkeypatch.setattr(
+        OwnedPathBuildDirectory,
+        "_retry_quiescent_cleanup",
+        real_retry,
+    )
+    accepted_a = _retry_owned_path_build_cleanup_for_group(group_a)
+
+    assert first_a.closed
+    assert second_a.closed
+    assert not owner_b.closed
+    assert not legacy.closed
+    assert tuple(
+        orphan.reopen(lambda reader: reader.read_bytes("payload.bin", max_bytes=16))
+        for orphan in accepted_a
+    ) == (b"first-a", b"second-a")
+    assert owner_b.path.joinpath("payload.bin").read_bytes() == b"owner-b"
+    assert legacy.path.joinpath("payload.bin").read_bytes() == b"legacy"
+
+    accepted_b = _retry_owned_path_build_cleanup_for_group(group_b)
+
+    assert owner_b.closed
+    assert not legacy.closed
+    assert len(accepted_b) == 1
+    assert (
+        accepted_b[0].reopen(
+            lambda reader: reader.read_bytes("payload.bin", max_bytes=16)
+        )
+        == b"owner-b"
+    )
+
+    unfiltered_grouped = OwnedPathBuildDirectory.prepare(
+        parent / "unfiltered-grouped",
+        _retention_group=group_b,
+    )
+    unfiltered_grouped.path.joinpath("payload.bin").write_bytes(b"unfiltered")
+    accepted_unfiltered = _retry_owned_path_build_cleanup()
+
+    assert legacy.closed
+    assert unfiltered_grouped.closed
+    assert tuple(
+        orphan.reopen(lambda reader: reader.read_bytes("payload.bin", max_bytes=16))
+        for orphan in accepted_unfiltered
+    ) == (b"legacy", b"unfiltered")
+
+
 def test_owned_path_build_quiescent_return_interrupt_follows_acceptance(
     tmp_path: Path,
 ) -> None:
@@ -3513,6 +3732,73 @@ def test_owned_path_build_retained_registry_resets_forked_lock_without_cleanup(
         holder.join(timeout=5)
 
     assert not holder.is_alive()
+    assert os.WIFEXITED(status)
+    assert os.WEXITSTATUS(status) == 0
+    assert owner.path.joinpath("payload.bin").read_bytes() == b"parent"
+    assert not owner.closed
+    owner.close()
+    assert owner.closed
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_owned_path_build_group_retry_drops_inherited_owner_without_callback(
+    tmp_path: Path,
+) -> None:
+    _retry_owned_path_build_cleanup()
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    child_parent = tmp_path / "child-private"
+    child_parent.mkdir(mode=0o700)
+    group_token = _OpaqueRetentionGroup()
+    owner = OwnedPathBuildDirectory.prepare(
+        parent / "attempt",
+        _retention_group=group_token,
+    )
+    owner.path.joinpath("payload.bin").write_bytes(b"parent")
+    child = os.fork()
+    if child == 0:  # pragma: no branch - child reports exact status
+        signal.signal(signal.SIGALRM, lambda *_args: os._exit(100))
+        signal.alarm(5)
+        try:
+            inherited_callbacks: list[atomic_directory.DirectoryOrphan] = []
+            captured_directory._retry_retained_owned_path_build_cleanup_for_group(
+                group_token,
+                inherited_callbacks.append,
+            )
+            if inherited_callbacks:
+                os._exit(101)
+            if captured_directory._snapshot_owned_path_build_directories():
+                os._exit(102)
+            if owner.path.joinpath("payload.bin").read_bytes() != b"parent":
+                os._exit(103)
+            try:
+                owner.close()
+            except RuntimeError as error:
+                if "PID boundary" not in str(error):
+                    os._exit(104)
+            else:
+                os._exit(105)
+            child_owner = OwnedPathBuildDirectory.prepare(
+                child_parent / "attempt",
+                _retention_group=group_token,
+            )
+            child_owner.path.joinpath("payload.bin").write_bytes(b"child")
+            child_orphans = _retry_owned_path_build_cleanup_for_group(group_token)
+            if len(child_orphans) != 1 or not child_owner.closed:
+                os._exit(106)
+            if (
+                child_orphans[0].reopen(
+                    lambda reader: reader.read_bytes("payload.bin", max_bytes=16)
+                )
+                != b"child"
+            ):
+                os._exit(107)
+        except BaseException:  # noqa: B036 - child reports exact failure
+            os._exit(108)
+        os._exit(0)
+
+    _pid, status = os.waitpid(child, 0)
+
     assert os.WIFEXITED(status)
     assert os.WEXITSTATUS(status) == 0
     assert owner.path.joinpath("payload.bin").read_bytes() == b"parent"

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -714,7 +714,7 @@ def test_bm25_source_operation_reclaims_once_only_after_successful_return(
     monkeypatch.setattr(
         cli,
         "_reclaim_local_bm25_source_attempt_pool",
-        lambda target: events.append(f"reclaim:{target}"),
+        lambda target, route: events.append(f"reclaim:{target}:{route}"),
     )
 
     observed = cli._run_local_bm25_source_worker_operation(
@@ -722,6 +722,7 @@ def test_bm25_source_operation_reclaims_once_only_after_successful_return(
         operation,
         "worker",
         "target",
+        "route",
         lambda: events.append("verify"),
     )
 
@@ -731,7 +732,7 @@ def test_bm25_source_operation_reclaims_once_only_after_successful_return(
         "page-two",
         "operation-return",
         "verify",
-        *(("reclaim:target", "verify") if reclaim else ()),
+        *(("reclaim:target:route", "verify") if reclaim else ()),
     ]
 
 
@@ -748,13 +749,14 @@ def test_bm25_source_operation_does_not_reclaim_exceptional_unwind(
     monkeypatch.setattr(
         cli,
         "_reclaim_local_bm25_source_attempt_pool",
-        lambda _target: pytest.fail("exceptional worker must not reclaim"),
+        lambda _target, _route: pytest.fail("exceptional worker must not reclaim"),
     )
 
     with pytest.raises(RuntimeError) as caught:
         cli._run_local_bm25_source_worker_operation(
             SimpleNamespace(reclaim_quiescent_attempts=True),
             fail,
+            object(),
             object(),
             object(),
             lambda: events.append("verify"),
@@ -771,13 +773,34 @@ def test_bm25_attempt_pool_summary_is_bounded_stderr_only(
     import codenib.compiler.job_resources as job_resources_module
 
     target = object()
+    reaper_route = object()
 
     class Coordinator:
-        def __init__(self, candidate: object) -> None:
+        def __init__(
+            self,
+            candidate: object,
+            *,
+            reaper_route=None,
+            _legacy_workspace: bool = False,
+        ) -> None:
             assert candidate is target
+            self.reaper_route = reaper_route
+            self.legacy_workspace = _legacy_workspace
 
         def reclaim(self, *, caller_asserts_quiescence: bool):
             assert caller_asserts_quiescence is True
+            if self.reaper_route is None:
+                assert self.legacy_workspace is True
+                return job_resources_module.BM25AttemptPoolReclamation(
+                    scanned_children=3,
+                    reclaimed_children=1,
+                    current_children=0,
+                    legacy_children=1,
+                    discarded_children=1,
+                    retained_unrelated_children=2,
+                )
+            assert self.reaper_route is reaper_route
+            assert self.legacy_workspace is False
             return job_resources_module.BM25AttemptPoolReclamation(
                 scanned_children=7,
                 reclaimed_children=5,
@@ -787,19 +810,25 @@ def test_bm25_attempt_pool_summary_is_bounded_stderr_only(
                 retained_unrelated_children=2,
             )
 
+    class ReaperRoute:
+        def _verify(self) -> None:
+            return None
+
+    reaper_route = ReaperRoute()
+
     monkeypatch.setattr(
         job_resources_module,
         "LocalBM25AttemptPoolCoordinator",
         Coordinator,
     )
 
-    cli._reclaim_local_bm25_source_attempt_pool(target)
+    cli._reclaim_local_bm25_source_attempt_pool(target, reaper_route)
 
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == (
-        "BM25 attempt-pool reclamation: scanned=7 reclaimed=5 "
-        "current=3 legacy=2 discarded=4 retained=2\n"
+        "BM25 attempt-pool reclamation: scanned=9 reclaimed=6 "
+        "current=3 legacy=3 discarded=5 retained=3\n"
     )
 
 

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -634,6 +634,18 @@ def test_registry_publishers_use_separate_workflows() -> None:
     )
     wheel_smoke = wheel_env["CIBW_TEST_COMMAND"]
     assert "workspace_owner_protocol_version == 6" in wheel_smoke
+    assert "directory_fd_owner_protocol_version == 1" in wheel_smoke
+    assert "directory_fd_owner_supported == 1" in wheel_smoke
+    for symbol in (
+        "create_directory_fd_owner_exact",
+        "open_directory_fd_exact",
+        "borrow_directory_fd_exact",
+        "mkdir_directory_fd_child_exact",
+        "close_directory_fd_owner_exact",
+        "directory_fd_owner_closed_exact",
+        "fail_fork_child_if_directory_fd_owner_active_exact",
+    ):
+        assert symbol in wheel_smoke
     for symbol in (
         "provision_owner_interruptibly_exact",
         "capture_owner_destination_exact",
@@ -669,6 +681,19 @@ def test_registry_publishers_use_separate_workflows() -> None:
     assert "not os.get_inheritable(parent_descriptor)" in wheel_smoke
     assert "implementation.require_support() is None" in wheel_smoke
     assert "_workspace_owner.require_support()" in wheel_smoke
+    assert "_workspace_owner._directory_fd_owner_protocol_available" in wheel_smoke
+    assert "_workspace_owner._require_directory_fd_owner_support()" in wheel_smoke
+    for call in (
+        "_workspace_owner._create_directory_fd_owner()",
+        "_workspace_owner._open_directory_fd(",
+        "_workspace_owner._borrow_directory_fd(",
+        "_workspace_owner._mkdir_directory_fd_child(",
+        "_workspace_owner._close_directory_fd_owner(",
+        "_workspace_owner._directory_fd_owner_closed(",
+    ):
+        assert call in wheel_smoke
+    assert "stat.S_ISDIR(os.fstat(directory_descriptor).st_mode)" in wheel_smoke
+    assert "not os.get_inheritable(directory_descriptor)" in wheel_smoke
 
     limited_abi_job = verification["jobs"]["limited-abi-compile"]
     assert "if" not in limited_abi_job
@@ -714,6 +739,7 @@ def test_registry_publishers_use_separate_workflows() -> None:
     assert "scripts/smoke_release_install.py" in source_exercise
     assert 'find_spec("codenib._workspace_owner_impl")' in source_exercise
     assert "_workspace_owner.require_support()" in source_exercise
+    assert "_workspace_owner._require_directory_fd_owner_support()" in source_exercise
     assert "LocalWorkspaceProvider(Path(root))" in source_exercise
     assert "provider.require_support()" in source_exercise
     assert "UnsupportedWorkspaceCreation" in source_exercise
@@ -736,6 +762,18 @@ def test_registry_publishers_use_separate_workflows() -> None:
     ]
     assert 'name == "_workspace_owner_impl.abi3.so"' in abi3_exercise
     assert "workspace_owner_protocol_version == 6" in abi3_exercise
+    assert "directory_fd_owner_protocol_version == 1" in abi3_exercise
+    assert "directory_fd_owner_supported == 1" in abi3_exercise
+    for symbol in (
+        "create_directory_fd_owner_exact",
+        "open_directory_fd_exact",
+        "borrow_directory_fd_exact",
+        "mkdir_directory_fd_child_exact",
+        "close_directory_fd_owner_exact",
+        "directory_fd_owner_closed_exact",
+        "fail_fork_child_if_directory_fd_owner_active_exact",
+    ):
+        assert symbol in abi3_exercise
     for symbol in (
         "provision_owner_interruptibly_exact",
         "capture_owner_destination_exact",
@@ -753,6 +791,19 @@ def test_registry_publishers_use_separate_workflows() -> None:
         assert symbol in abi3_exercise
     assert "implementation.require_support() is None" in abi3_exercise
     assert "_workspace_owner.require_support() is None" in abi3_exercise
+    assert "_workspace_owner._directory_fd_owner_protocol_available" in abi3_exercise
+    assert "_workspace_owner._require_directory_fd_owner_support()" in abi3_exercise
+    for call in (
+        "_workspace_owner._create_directory_fd_owner()",
+        "_workspace_owner._open_directory_fd(",
+        "_workspace_owner._borrow_directory_fd(",
+        "_workspace_owner._mkdir_directory_fd_child(",
+        "_workspace_owner._close_directory_fd_owner(",
+        "_workspace_owner._directory_fd_owner_closed(",
+    ):
+        assert call in abi3_exercise
+    assert "stat.S_ISDIR(os.fstat(directory_descriptor).st_mode)" in abi3_exercise
+    assert "not os.get_inheritable(directory_descriptor)" in abi3_exercise
     assert "LocalWorkspaceProvider(root)" in abi3_exercise
     assert "run_strict_workspace(" in abi3_exercise
     assert "root.mkdir(mode=0o700)" in abi3_exercise

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -694,6 +694,8 @@ def test_registry_publishers_use_separate_workflows() -> None:
         assert call in wheel_smoke
     assert "stat.S_ISDIR(os.fstat(directory_descriptor).st_mode)" in wheel_smoke
     assert "not os.get_inheritable(directory_descriptor)" in wheel_smoke
+    assert '(lease_directory / "child").rmdir()' in wheel_smoke
+    assert "lease_directory.rmdir()" in wheel_smoke
 
     limited_abi_job = verification["jobs"]["limited-abi-compile"]
     assert "if" not in limited_abi_job
@@ -804,6 +806,8 @@ def test_registry_publishers_use_separate_workflows() -> None:
         assert call in abi3_exercise
     assert "stat.S_ISDIR(os.fstat(directory_descriptor).st_mode)" in abi3_exercise
     assert "not os.get_inheritable(directory_descriptor)" in abi3_exercise
+    assert '(lease_directory / "child").rmdir()' in abi3_exercise
+    assert "lease_directory.rmdir()" in abi3_exercise
     assert "LocalWorkspaceProvider(root)" in abi3_exercise
     assert "run_strict_workspace(" in abi3_exercise
     assert "root.mkdir(mode=0o700)" in abi3_exercise

--- a/test/test_workspace_owner.py
+++ b/test/test_workspace_owner.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import ctypes.util
+import errno
 import fcntl
 import gc
 import hashlib
@@ -1042,6 +1043,98 @@ def test_workspace_owner_facade_rejects_each_incomplete_protocol_v6_abi() -> Non
     )
 
 
+def test_directory_fd_owner_protocol_is_additive_to_workspace_protocol() -> None:
+    workspace_symbols = (
+        "require_support",
+        "create_owner_exact",
+        "claim_owner_publish_permit_exact",
+        "claim_owner_replacement_permit_exact",
+        "require_owner_exact",
+        "close_owner_exact",
+        "provision_owner_exact",
+        "provision_owner_interruptibly_exact",
+        "capture_owner_destination_exact",
+        "acquire_owner_replacement_lease_exact",
+        "provision_owner_replacement_exact",
+        "provision_owner_replacement_interruptibly_exact",
+        "verify_owner_authority_exact",
+        "verify_owner_adoption_binding_exact",
+        "verify_owner_destination_binding_exact",
+        "verify_owner_replacement_binding_exact",
+        "borrow_owner_parent_descriptor_exact",
+        "borrow_owner_root_descriptor_exact",
+        "borrow_owner_destination_descriptor_exact",
+        "borrow_owner_directory_descriptor_exact",
+        "begin_owner_file_exact",
+        "write_owner_file_exact",
+        "finish_owner_file_exact",
+        "abort_owner_file_exact",
+        "seal_owner_directories_exact",
+        "seal_owner_directories_interruptibly_exact",
+        "sync_owner_parent_exact",
+        "mark_owner_adopted_exact",
+        "rename_owner_child_noreplace_exact",
+        "exchange_owner_replacement_exact",
+        "commit_owner_receipt_exact",
+        "abort_owner_exact",
+        "quarantine_owner_exact",
+        "owner_state_exact",
+        "owner_closed_exact",
+    )
+    script = textwrap.dedent(
+        f"""
+        import sys
+        import types
+
+        implementation = types.ModuleType("codenib._workspace_owner_impl")
+        implementation.workspace_owner_protocol_version = 6
+        for name in {workspace_symbols!r}:
+            setattr(implementation, name, lambda *args, **kwargs: None)
+        sys.modules[implementation.__name__] = implementation
+
+        import codenib._workspace_owner as facade
+
+        assert facade._workspace_owner_protocol_available
+        assert not facade._directory_fd_owner_protocol_available
+        assert facade.require_support() is None
+        try:
+            facade._require_directory_fd_owner_support()
+        except RuntimeError as error:
+            assert "directory-fd-owner extension ABI" in str(error)
+        else:
+            raise AssertionError("missing additive fd-owner ABI was accepted")
+        """
+    )
+    repository_root = Path(__file__).resolve().parents[1]
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (str(repository_root), environment.get("PYTHONPATH", ""))
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repository_root,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_directory_fd_owner_support_rejects_missing_native_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        workspace_owner,
+        "_directory_fd_owner_protocol_available",
+        True,
+    )
+    monkeypatch.setattr(workspace_owner, "_directory_fd_owner_supported", 0)
+
+    with pytest.raises(RuntimeError, match="native directory open flags"):
+        workspace_owner._require_directory_fd_owner_support()
+
+
 def test_workspace_owner_cleanup_does_not_repeat_the_support_probe(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1069,6 +1162,599 @@ def test_workspace_owner_cleanup_does_not_repeat_the_support_probe(
     assert workspace_owner.require_exact_owner(candidate) is candidate
     assert workspace_owner.close_owner_exact(candidate) is None
     assert closed == [candidate]
+
+
+def test_native_directory_fd_owner_has_exact_lifecycle(tmp_path: Path) -> None:
+    if not workspace_owner._directory_fd_owner_protocol_available:
+        pytest.skip("optional workspace-owner extension is not built")
+    directory = tmp_path / "leased"
+    directory.mkdir()
+    owner = workspace_owner._create_directory_fd_owner()
+
+    assert not workspace_owner._directory_fd_owner_closed(owner)
+    with pytest.raises(RuntimeError, match="not open"):
+        workspace_owner._borrow_directory_fd(owner)
+
+    assert workspace_owner._open_directory_fd(owner, os.fsencode(directory)) is None
+    descriptor = workspace_owner._borrow_directory_fd(owner)
+    metadata = os.fstat(descriptor)
+    assert stat.S_ISDIR(metadata.st_mode)
+    assert fcntl.fcntl(descriptor, fcntl.F_GETFD) & fcntl.FD_CLOEXEC
+    assert fcntl.fcntl(descriptor, fcntl.F_GETFL) & os.O_ACCMODE == os.O_RDONLY
+    checks: list[bool] = []
+
+    def check_before_mkdir() -> None:
+        checks.append(True)
+
+    assert workspace_owner._mkdir_directory_fd_child(
+        owner,
+        b"child",
+        check_before_mkdir,
+    )
+    assert not workspace_owner._mkdir_directory_fd_child(
+        owner,
+        b"child",
+        check_before_mkdir,
+    )
+    assert checks == [True, True]
+    assert (directory / "child").is_dir()
+    with pytest.raises(RuntimeError, match="cannot be reopened"):
+        workspace_owner._open_directory_fd(owner, os.fsencode(directory))
+    assert workspace_owner._close_directory_fd_owner(owner) is None
+    assert workspace_owner._close_directory_fd_owner(owner) is None
+    assert workspace_owner._directory_fd_owner_closed(owner)
+    with pytest.raises(OSError) as caught:
+        os.fstat(descriptor)
+    assert caught.value.errno == errno.EBADF
+    with pytest.raises(RuntimeError, match="not open"):
+        workspace_owner._borrow_directory_fd(owner)
+    with pytest.raises(RuntimeError, match="cannot be reopened"):
+        workspace_owner._open_directory_fd(owner, os.fsencode(directory))
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_native_directory_fd_owner_failstops_fork_child(
+    tmp_path: Path,
+) -> None:
+    if not workspace_owner._directory_fd_owner_protocol_available:
+        pytest.skip("optional workspace-owner extension is not built")
+
+    directory = tmp_path / "leased"
+    directory.mkdir()
+    owner = workspace_owner._create_directory_fd_owner()
+    workspace_owner._open_directory_fd(owner, os.fsencode(directory))
+    descriptor = workspace_owner._borrow_directory_fd(owner)
+    child_pid = os.fork()
+    if child_pid == 0:  # pragma: no cover - native callback must exit first
+        os._exit(5)
+
+    try:
+        waited_pid, status = os.waitpid(child_pid, 0)
+        assert waited_pid == child_pid
+        assert os.waitstatus_to_exitcode(status) == 70
+        assert os.fstat(descriptor).st_ino == directory.stat().st_ino
+    finally:
+        workspace_owner._close_directory_fd_owner(owner)
+
+
+def test_native_directory_fd_owner_fork_guard_rejects_parent_call(
+    tmp_path: Path,
+) -> None:
+    if not workspace_owner._directory_fd_owner_protocol_available:
+        pytest.skip("optional workspace-owner extension is not built")
+
+    directory = tmp_path / "leased"
+    directory.mkdir()
+    owner = workspace_owner._create_directory_fd_owner()
+    workspace_owner._open_directory_fd(owner, os.fsencode(directory))
+    descriptor = workspace_owner._borrow_directory_fd(owner)
+    try:
+        with pytest.raises(RuntimeError, match="requires a fork-child process"):
+            workspace_owner._fail_fork_child_if_directory_fd_owner_active()
+        assert os.fstat(descriptor).st_ino == directory.stat().st_ino
+        assert not workspace_owner._directory_fd_owner_closed(owner)
+    finally:
+        workspace_owner._close_directory_fd_owner(owner)
+
+    assert workspace_owner._fail_fork_child_if_directory_fd_owner_active() is None
+
+
+def test_native_directory_fd_owner_does_not_close_reused_foreign_fd(
+    tmp_path: Path,
+) -> None:
+    if not workspace_owner._directory_fd_owner_protocol_available:
+        pytest.skip("optional workspace-owner extension is not built")
+    leased = tmp_path / "leased"
+    foreign = tmp_path / "foreign"
+    leased.mkdir()
+    foreign.mkdir()
+    owner = workspace_owner._create_directory_fd_owner()
+    workspace_owner._open_directory_fd(owner, os.fsencode(leased))
+    descriptor = workspace_owner._borrow_directory_fd(owner)
+    os.close(descriptor)
+    foreign_source = os.open(
+        foreign,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+    )
+    foreign_descriptor = foreign_source
+    if foreign_source != descriptor:
+        os.dup2(foreign_source, descriptor, inheritable=False)
+        foreign_descriptor = descriptor
+    try:
+        expected = os.fstat(foreign_descriptor)
+        with pytest.raises(OSError) as caught:
+            workspace_owner._close_directory_fd_owner(owner)
+
+        assert caught.value.errno == errno.ESTALE
+        assert workspace_owner._directory_fd_owner_closed(owner)
+        observed = os.fstat(foreign_descriptor)
+        assert (observed.st_dev, observed.st_ino) == (
+            expected.st_dev,
+            expected.st_ino,
+        )
+        assert workspace_owner._close_directory_fd_owner(owner) is None
+    finally:
+        os.close(foreign_descriptor)
+        if foreign_source != foreign_descriptor:
+            os.close(foreign_source)
+
+
+def test_native_directory_fd_owner_terminalizes_two_closed_slots(
+    tmp_path: Path,
+) -> None:
+    if not workspace_owner._directory_fd_owner_protocol_available:
+        pytest.skip("optional workspace-owner extension is not built")
+    directory = tmp_path / "leased"
+    directory.mkdir()
+    owner = workspace_owner._create_directory_fd_owner()
+    workspace_owner._open_directory_fd(owner, os.fsencode(directory))
+    descriptor = workspace_owner._borrow_directory_fd(owner)
+    expected = directory.stat()
+    owned_descriptors = []
+    for raw_descriptor in os.listdir("/proc/self/fd"):
+        try:
+            candidate = int(raw_descriptor)
+            observed = os.fstat(candidate)
+        except (OSError, ValueError):
+            continue
+        if (observed.st_dev, observed.st_ino) == (
+            expected.st_dev,
+            expected.st_ino,
+        ):
+            owned_descriptors.append(candidate)
+    assert descriptor in owned_descriptors
+    assert len(owned_descriptors) == 2
+    for candidate in owned_descriptors:
+        os.close(candidate)
+
+    with pytest.raises(OSError) as caught:
+        workspace_owner._close_directory_fd_owner(owner)
+
+    assert caught.value.errno == errno.ESTALE
+    assert workspace_owner._directory_fd_owner_closed(owner)
+    assert workspace_owner._fail_fork_child_if_directory_fd_owner_active() is None
+
+
+def test_native_directory_fd_owner_retains_same_inode_with_unsafe_flags(
+    tmp_path: Path,
+) -> None:
+    if not workspace_owner._directory_fd_owner_protocol_available:
+        pytest.skip("optional workspace-owner extension is not built")
+    leased = tmp_path / "leased"
+    foreign = tmp_path / "foreign"
+    leased.mkdir()
+    foreign.mkdir()
+    owner = workspace_owner._create_directory_fd_owner()
+    workspace_owner._open_directory_fd(owner, os.fsencode(leased))
+    descriptor = workspace_owner._borrow_directory_fd(owner)
+    expected = leased.stat()
+    owner_slots = []
+    for raw_descriptor in os.listdir("/proc/self/fd"):
+        try:
+            candidate = int(raw_descriptor)
+            observed = os.fstat(candidate)
+        except (OSError, ValueError):
+            continue
+        if (observed.st_dev, observed.st_ino) == (
+            expected.st_dev,
+            expected.st_ino,
+        ):
+            owner_slots.append(candidate)
+    assert len(owner_slots) == 2
+    guard = next(candidate for candidate in owner_slots if candidate != descriptor)
+    os.set_inheritable(descriptor, True)
+    os.close(guard)
+    foreign_source = os.open(
+        foreign,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+    )
+    if foreign_source != guard:
+        os.dup2(foreign_source, guard, inheritable=False)
+    try:
+        with pytest.raises(OSError) as caught:
+            workspace_owner._close_directory_fd_owner(owner)
+
+        assert caught.value.errno in (errno.EPERM, errno.ESTALE)
+        assert not workspace_owner._directory_fd_owner_closed(owner)
+        assert os.fstat(descriptor).st_ino == expected.st_ino
+    finally:
+        os.close(guard)
+        os.dup2(descriptor, guard, inheritable=False)
+        os.set_inheritable(descriptor, False)
+        if foreign_source != guard:
+            os.close(foreign_source)
+        workspace_owner._close_directory_fd_owner(owner)
+
+    assert workspace_owner._directory_fd_owner_closed(owner)
+
+
+def test_native_directory_fd_owner_retains_independently_reopened_guard(
+    tmp_path: Path,
+) -> None:
+    if not workspace_owner._directory_fd_owner_protocol_available:
+        pytest.skip("optional workspace-owner extension is not built")
+    leased = tmp_path / "leased"
+    leased.mkdir()
+    owner = workspace_owner._create_directory_fd_owner()
+    workspace_owner._open_directory_fd(owner, os.fsencode(leased))
+    descriptor = workspace_owner._borrow_directory_fd(owner)
+    expected = leased.stat()
+    owner_slots = []
+    for raw_descriptor in os.listdir("/proc/self/fd"):
+        try:
+            candidate = int(raw_descriptor)
+            observed = os.fstat(candidate)
+        except (OSError, ValueError):
+            continue
+        if (observed.st_dev, observed.st_ino) == (
+            expected.st_dev,
+            expected.st_ino,
+        ):
+            owner_slots.append(candidate)
+    assert len(owner_slots) == 2
+    guard = next(candidate for candidate in owner_slots if candidate != descriptor)
+    fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    os.close(guard)
+    replacement_source = os.open(
+        leased,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+    )
+    if replacement_source != guard:
+        os.dup2(replacement_source, guard, inheritable=False)
+    try:
+        with pytest.raises(OSError) as caught:
+            workspace_owner._close_directory_fd_owner(owner)
+
+        assert caught.value.errno == errno.ESTALE
+        assert not workspace_owner._directory_fd_owner_closed(owner)
+        assert os.fstat(descriptor).st_ino == expected.st_ino
+        assert os.fstat(guard).st_ino == expected.st_ino
+        with pytest.raises(RuntimeError, match="fork-child process"):
+            workspace_owner._fail_fork_child_if_directory_fd_owner_active()
+    finally:
+        os.close(guard)
+        os.dup2(descriptor, guard, inheritable=False)
+        if replacement_source != guard:
+            os.close(replacement_source)
+        workspace_owner._close_directory_fd_owner(owner)
+
+    assert workspace_owner._directory_fd_owner_closed(owner)
+
+
+def test_directory_fd_owner_facade_keeps_exact_functions_pinned(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if not workspace_owner._directory_fd_owner_protocol_available:
+        pytest.skip("optional workspace-owner extension is not built")
+    implementation = workspace_owner._implementation
+    assert implementation is not None
+
+    def reject_mutable_dispatch(*_args: object) -> object:
+        raise AssertionError("mutable implementation dispatch was consulted")
+
+    for name in (
+        "create_directory_fd_owner_exact",
+        "open_directory_fd_exact",
+        "borrow_directory_fd_exact",
+        "mkdir_directory_fd_child_exact",
+        "close_directory_fd_owner_exact",
+        "directory_fd_owner_closed_exact",
+        "fail_fork_child_if_directory_fd_owner_active_exact",
+    ):
+        monkeypatch.setattr(implementation, name, reject_mutable_dispatch)
+
+    owner = workspace_owner._create_directory_fd_owner()
+    workspace_owner._open_directory_fd(owner, os.fsencode(tmp_path))
+    assert workspace_owner._borrow_directory_fd(owner) >= 0
+    assert workspace_owner._mkdir_directory_fd_child(
+        owner,
+        b"pinned-child",
+        lambda: None,
+    )
+    assert not workspace_owner._directory_fd_owner_closed(owner)
+    workspace_owner._close_directory_fd_owner(owner)
+    assert workspace_owner._directory_fd_owner_closed(owner)
+
+
+def test_native_directory_fd_owner_rejects_invalid_paths(tmp_path: Path) -> None:
+    if not workspace_owner._directory_fd_owner_protocol_available:
+        pytest.skip("optional workspace-owner extension is not built")
+
+    for invalid in ("not-bytes", bytearray(b"not-exact")):
+        owner = workspace_owner._create_directory_fd_owner()
+        with pytest.raises(TypeError, match="exact bytes"):
+            workspace_owner._open_directory_fd(owner, invalid)  # type: ignore[arg-type]
+        workspace_owner._close_directory_fd_owner(owner)
+
+    for invalid in (b"", b"embedded\0nul", b"x" * 4097):
+        owner = workspace_owner._create_directory_fd_owner()
+        with pytest.raises(ValueError, match="empty, unbounded, or contains NUL"):
+            workspace_owner._open_directory_fd(owner, invalid)
+        workspace_owner._close_directory_fd_owner(owner)
+
+    target = tmp_path / "target"
+    target.mkdir()
+    symlink = tmp_path / "symlink"
+    symlink.symlink_to(target, target_is_directory=True)
+    owner = workspace_owner._create_directory_fd_owner()
+    with pytest.raises(OSError):
+        workspace_owner._open_directory_fd(owner, os.fsencode(symlink))
+    workspace_owner._close_directory_fd_owner(owner)
+
+
+def test_native_directory_fd_owner_is_exact_and_destructor_closes(
+    tmp_path: Path,
+) -> None:
+    if not workspace_owner._directory_fd_owner_protocol_available:
+        pytest.skip("optional workspace-owner extension is not built")
+    owner = workspace_owner._create_directory_fd_owner()
+    owner_type = type(owner)
+    with pytest.raises(TypeError, match="cannot be constructed"):
+        owner_type()
+    with pytest.raises(AttributeError):
+        owner.fd = -1
+    with pytest.raises(TypeError, match="invalid native type"):
+        workspace_owner._borrow_directory_fd(object())
+
+    workspace_owner._open_directory_fd(owner, os.fsencode(tmp_path))
+    descriptor = workspace_owner._borrow_directory_fd(owner)
+    del owner
+    gc.collect()
+
+    with pytest.raises(OSError) as caught:
+        os.fstat(descriptor)
+    assert caught.value.errno == errno.EBADF
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") or ctypes.util.find_library("seccomp") is None,
+    reason="requires Linux libseccomp",
+)
+def test_native_directory_fd_owner_retains_close_denied_by_seccomp(
+    tmp_path: Path,
+) -> None:
+    if not workspace_owner._directory_fd_owner_protocol_available:
+        pytest.skip("optional workspace-owner extension is not built")
+    directory = tmp_path / "leased"
+    directory.mkdir()
+    script = textwrap.dedent(
+        """
+        import ctypes
+        import ctypes.util
+        import errno
+        import fcntl
+        import os
+        import sys
+
+        import codenib._workspace_owner as workspace_owner
+
+        owner = workspace_owner._create_directory_fd_owner()
+        workspace_owner._open_directory_fd(owner, os.fsencode(sys.argv[1]))
+        descriptor = workspace_owner._borrow_directory_fd(owner)
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        expected = os.fstat(descriptor)
+
+        library_name = ctypes.util.find_library("seccomp") or "libseccomp.so.2"
+        library = ctypes.CDLL(library_name, use_errno=True)
+        library.seccomp_init.argtypes = [ctypes.c_uint32]
+        library.seccomp_init.restype = ctypes.c_void_p
+        library.seccomp_syscall_resolve_name.argtypes = [ctypes.c_char_p]
+        library.seccomp_syscall_resolve_name.restype = ctypes.c_int
+        library.seccomp_rule_add.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint32,
+            ctypes.c_int,
+            ctypes.c_uint,
+        ]
+        library.seccomp_rule_add.restype = ctypes.c_int
+        library.seccomp_load.argtypes = [ctypes.c_void_p]
+        library.seccomp_load.restype = ctypes.c_int
+        library.seccomp_release.argtypes = [ctypes.c_void_p]
+
+        allow = 0x7FFF0000
+        deny = 0x00050000 | errno.EPERM
+        context = library.seccomp_init(allow)
+        if not context:
+            os._exit(77)
+        close_number = library.seccomp_syscall_resolve_name(b"close")
+        if close_number < 0:
+            os._exit(77)
+        if library.seccomp_rule_add(context, deny, close_number, 0) != 0:
+            os._exit(77)
+        if library.seccomp_load(context) != 0:
+            os._exit(77)
+        library.seccomp_release(context)
+
+        for _ in range(2):
+            try:
+                workspace_owner._close_directory_fd_owner(owner)
+            except PermissionError as error:
+                assert error.errno == errno.EPERM
+            else:
+                os._exit(3)
+            assert not workspace_owner._directory_fd_owner_closed(owner)
+            observed = os.fstat(descriptor)
+            assert (observed.st_dev, observed.st_ino) == (
+                expected.st_dev,
+                expected.st_ino,
+            )
+        os._exit(0)
+        """
+    )
+    repository_root = Path(__file__).resolve().parents[1]
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (str(repository_root), environment.get("PYTHONPATH", ""))
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script, os.fspath(directory)],
+        cwd=repository_root,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if completed.returncode == 77:
+        pytest.skip("libseccomp filter could not be installed")
+    assert completed.returncode == 0, (completed.stdout, completed.stderr)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") or ctypes.util.find_library("seccomp") is None,
+    reason="requires Linux libseccomp",
+)
+def test_native_directory_open_failure_retains_partial_owner_and_fork_guard(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "leased"
+    directory.mkdir()
+    script = textwrap.dedent(
+        """
+        import ctypes
+        import ctypes.util
+        import errno
+        import fcntl
+        import os
+        import sys
+
+        import codenib._workspace_owner as workspace_owner
+
+        class ArgCmp(ctypes.Structure):
+            _fields_ = [
+                ("arg", ctypes.c_uint),
+                ("op", ctypes.c_int),
+                ("datum_a", ctypes.c_uint64),
+                ("datum_b", ctypes.c_uint64),
+            ]
+
+        owner = workspace_owner._create_directory_fd_owner()
+        expected = os.stat(sys.argv[1])
+        library_name = ctypes.util.find_library("seccomp") or "libseccomp.so.2"
+        library = ctypes.CDLL(library_name, use_errno=True)
+        library.seccomp_init.argtypes = [ctypes.c_uint32]
+        library.seccomp_init.restype = ctypes.c_void_p
+        library.seccomp_syscall_resolve_name.argtypes = [ctypes.c_char_p]
+        library.seccomp_syscall_resolve_name.restype = ctypes.c_int
+        library.seccomp_rule_add.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint32,
+            ctypes.c_int,
+            ctypes.c_uint,
+        ]
+        library.seccomp_rule_add.restype = ctypes.c_int
+        library.seccomp_rule_add_array.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint32,
+            ctypes.c_int,
+            ctypes.c_uint,
+            ctypes.POINTER(ArgCmp),
+        ]
+        library.seccomp_rule_add_array.restype = ctypes.c_int
+        library.seccomp_load.argtypes = [ctypes.c_void_p]
+        library.seccomp_load.restype = ctypes.c_int
+        library.seccomp_release.argtypes = [ctypes.c_void_p]
+
+        allow = 0x7FFF0000
+        deny = 0x00050000 | errno.EPERM
+        equal = 4
+        context = library.seccomp_init(allow)
+        if not context:
+            raise SystemExit(77)
+        fcntl_number = library.seccomp_syscall_resolve_name(b"fcntl")
+        close_number = library.seccomp_syscall_resolve_name(b"close")
+        comparison = ArgCmp(1, equal, fcntl.F_DUPFD_CLOEXEC, 0)
+        if (
+            fcntl_number < 0
+            or close_number < 0
+            or library.seccomp_rule_add_array(
+                context,
+                deny,
+                fcntl_number,
+                1,
+                ctypes.byref(comparison),
+            )
+            != 0
+            or library.seccomp_rule_add(context, deny, close_number, 0) != 0
+            or library.seccomp_load(context) != 0
+        ):
+            library.seccomp_release(context)
+            raise SystemExit(77)
+        library.seccomp_release(context)
+
+        try:
+            workspace_owner._open_directory_fd(owner, os.fsencode(sys.argv[1]))
+        except OSError as error:
+            assert error.errno == errno.EPERM
+        else:
+            raise AssertionError("guard-duplication denial was accepted")
+        assert not workspace_owner._directory_fd_owner_closed(owner)
+        matching = []
+        for raw_descriptor in os.listdir("/proc/self/fd"):
+            try:
+                descriptor = int(raw_descriptor)
+                observed = os.fstat(descriptor)
+            except (OSError, ValueError):
+                continue
+            if (observed.st_dev, observed.st_ino) == (
+                expected.st_dev,
+                expected.st_ino,
+            ):
+                matching.append(descriptor)
+        assert len(matching) == 1
+        try:
+            workspace_owner._close_directory_fd_owner(owner)
+        except OSError as error:
+            assert error.errno == errno.EPERM
+        else:
+            raise AssertionError("close denial was reported as terminal")
+        assert not workspace_owner._directory_fd_owner_closed(owner)
+
+        child = os.fork()
+        if child == 0:
+            os._exit(3)
+        _waited, status = os.waitpid(child, 0)
+        assert os.waitstatus_to_exitcode(status) == 70
+        """
+    )
+    repository_root = Path(__file__).resolve().parents[1]
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (str(repository_root), environment.get("PYTHONPATH", ""))
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script, os.fspath(directory)],
+        cwd=repository_root,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if completed.returncode == 77:
+        pytest.skip("libseccomp filter could not be installed")
+    assert completed.returncode == 0, (completed.stdout, completed.stderr)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

Add a cooperative per-repository lease boundary for local BM25 attempt pools. Writers retain a shared lease through attempt cleanup and sink acknowledgement, while the default-off reaper holds an exclusive lease through its bounded shard sweep and final topology validation.

## Changes

- Add an additive native directory-FD owner ABI alongside workspace-owner protocol v6, with exact descriptor identity, retained cleanup, shared/exclusive flock ownership, fail-stop fork behavior, and release-wheel verification.
- Bootstrap a private `repo_<64>` BM25 shard bound to the authenticated repository/workspace topology and route writer and reaper lifecycles through coupled cleanup owners.
- Preserve legacy manual cleanup while making `--reclaim-quiescent-attempts` sweep the routed shard after a normal worker-operation return and before retained storage owners close.
- Close cancellation, result-handoff, descriptor-reuse, partial-open, sink-redelivery, reclaimer-resume, and mount-topology failure seams with cross-version regression coverage.
- Document the controlled/quiescent namespace boundary and reconcile the storage roadmap with the implemented Web configuration tranche.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Native workspace-owner, directory-lease, and shard-binding suites: 186 passed on Python 3.10, 3.12, and 3.14.
- Fork/seccomp/FD-reuse adversarial selection: 25 passed on Python 3.10, 3.12, and 3.14.
- Source-job, captured-directory, atomic-directory, and release-artifact suites: 860 passed and 10 skipped on Python 3.12.
- Rebasing-base Web configuration/runtime slice: 77 passed; changed CLI selection: 4 passed.
- Broad Python 3.12 unit tier, excluding the unavailable local Docker module and one independently reproduced base/environment profiler node: 8,940 passed, 34 skipped, 191 deselected.
- Black 24.8.0, isort 5.13.2, flake8 7.1.1 with bugbear, clang-format 18, py_compile on Python 3.10/3.12/3.14, release ABI smoke, namespace/API review, and git diff checks passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
