### PR TITLE
fix(web): preserve slash-bearing repository IDs

### DIFF
--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -868,6 +868,13 @@ async def list_repos() -> list[RepoInfo]:
     return [await decorate(info) for info in registry.list_infos()]
 
 
+# Query aliases carry configured IDs containing "/" without a greedy path
+# converter that would shadow nested routes such as Wiki pages. Keep the
+# segment routes for existing callers.
+@app.get(
+    "/api/index-status",
+    response_model=RepoIndexStatus,
+)
 @app.get(
     "/api/repos/{repo_id}/index-status",
     response_model=RepoIndexStatus,
@@ -942,6 +949,11 @@ async def index_job_status(
         ) from exc
 
 
+@app.post(
+    "/api/index-jobs",
+    response_model=IndexJobStatusResponse,
+    status_code=202,
+)
 @app.post(
     "/api/repos/{repo_id}/index-jobs",
     response_model=IndexJobStatusResponse,

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1826,6 +1826,9 @@ routing remain absent.
   Repository status overlays queued/running jobs only after releasing its RCU
   bundle pin. The default server still has no job reader or writer, so this read
   API returns unavailable until production storage bindings are configured.
+  Status keeps the existing single-segment repository route and provides
+  `GET /api/index-status?repo_id=...` when a configured ID contains `/`; this
+  avoids a catch-all route that could consume Wiki page paths.
 - A separate least-authority job-creation catalog can now atomically enqueue an
   exact idempotent request only when its repository/ref has no queued or running
   job. Exact replay returns the existing job, while two concurrent new requests
@@ -1836,10 +1839,11 @@ routing remain absent.
   losers conflict on either an active slot or a changed ref-generation fence,
   while committed retries replay before source capture. The trusted
   source/profile planner remains an explicit injected capability.
-- The first Web write slice exposes `POST /api/repos/{repo_id}/index-jobs` with
-  a required bounded idempotency header and returns the detached durable job
-  status. Its generic catalog adapter accepts exactly one `full` BM25 or vector
-  view; the production retained-source planner currently accepts BM25 only.
+- The first Web write slice exposes `POST /api/repos/{repo_id}/index-jobs` and
+  the slash-safe `POST /api/index-jobs?repo_id=...` alias with a required
+  bounded idempotency header, returning the detached durable job status. Its
+  generic catalog adapter accepts exactly one `full` BM25 or vector view; the
+  production retained-source planner currently accepts BM25 only.
   Multi-view, incremental, symbol-graph, and forced requests fail before
   planning or catalog access. Planner identities and storage failures stay
   private, conflicts map to one public response, and an exact repository/key

--- a/test/web/test_index_job_writes.py
+++ b/test/web/test_index_job_writes.py
@@ -118,10 +118,10 @@ def _queued_job(
     )
 
 
-def _response() -> IndexJobStatusResponse:
+def _response(*, repo_id: str = "demo") -> IndexJobStatusResponse:
     return IndexJobStatusResponse(
         job_id="job_" + "a" * 64,
-        repo_id="demo",
+        repo_id=repo_id,
         status="queued",
         cancel_requested=False,
         attempt_count=0,
@@ -481,8 +481,8 @@ def test_catalog_writer_hides_unknown_bindings_and_invalid_plans() -> None:
         )
 
 
-def test_create_endpoint_requires_header_and_uses_injected_writer(monkeypatch) -> None:
-    expected = _response()
+def test_create_query_route_accepts_slash_id_and_validates_request(monkeypatch) -> None:
+    expected = _response(repo_id="owner/repo")
     calls = []
 
     class Writer:
@@ -494,26 +494,26 @@ def test_create_endpoint_requires_header_and_uses_injected_writer(monkeypatch) -
     client = TestClient(web_app.app)
 
     missing = client.post(
-        "/api/repos/demo/index-jobs",
+        "/api/index-jobs?repo_id=owner%2Frepo",
         json={"indexes": ["bm25"], "mode": "full"},
     )
     duplicate = client.post(
-        "/api/repos/demo/index-jobs",
+        "/api/index-jobs?repo_id=owner%2Frepo",
         headers={"Idempotency-Key": "request"},
         json={"indexes": ["bm25", "bm25"], "mode": "full"},
     )
     coerced_force = client.post(
-        "/api/repos/demo/index-jobs",
+        "/api/index-jobs?repo_id=owner%2Frepo",
         headers={"Idempotency-Key": "request"},
         json={"indexes": ["bm25"], "mode": "full", "force": "false"},
     )
     unknown_field = client.post(
-        "/api/repos/demo/index-jobs",
+        "/api/index-jobs?repo_id=owner%2Frepo",
         headers={"Idempotency-Key": "request"},
         json={"indexes": ["bm25"], "mode": "full", "unknown": True},
     )
     created = client.post(
-        "/api/repos/demo/index-jobs",
+        "/api/index-jobs?repo_id=owner%2Frepo",
         headers={"Idempotency-Key": "request"},
         json={"indexes": ["bm25"], "mode": "full", "force": False},
     )
@@ -526,7 +526,7 @@ def test_create_endpoint_requires_header_and_uses_injected_writer(monkeypatch) -
     assert created.json()["job_id"] == expected.job_id
     assert calls == [
         (
-            "demo",
+            "owner/repo",
             {
                 "indexes": ("bm25",),
                 "mode": "full",

--- a/test/web/test_index_status.py
+++ b/test/web/test_index_status.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from fastapi.testclient import TestClient
 
 import codenib.web.app as web_app
 from codenib.compiler.manifest import LEGACY_MANIFEST_VERSION, IndexEntry, RepoManifest
@@ -196,14 +197,26 @@ def test_status_passes_repository_path_to_head_resolver() -> None:
     assert observed == [Path("/repo")]
 
 
-def test_index_status_endpoint_pins_generation_through_projection(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    ("url", "repo_id"),
+    (
+        ("/api/repos/repo/index-status", "repo"),
+        ("/api/index-status?repo_id=owner%2Frepo", "owner/repo"),
+    ),
+)
+def test_index_status_routes_preserve_id_and_pin_generation(
+    monkeypatch,
+    url,
+    repo_id,
+) -> None:
     events: list[str] = []
     bundle = _bundle({"bm25": _entry("bm25")})
+    bundle.entry.instance_id = repo_id
 
     class Registry:
         @contextmanager
-        def pin(self, repo_id: str):
-            assert repo_id == "repo"
+        def pin(self, requested_repo_id: str):
+            assert requested_repo_id == repo_id
             events.append("pin-enter")
             try:
                 yield bundle
@@ -223,10 +236,39 @@ def test_index_status_endpoint_pins_generation_through_projection(monkeypatch) -
     monkeypatch.setattr(web_app.app.state, "index_head_resolver", head, raising=False)
     monkeypatch.setattr(web_app, "_run_pinned_thread", inline)
 
-    status = asyncio.run(web_app.index_status("repo"))
+    response = TestClient(web_app.app).get(url)
 
-    assert status.indexes[0].state == "built"
+    assert response.status_code == 200
+    assert response.json()["repo_id"] == repo_id
+    assert response.json()["indexes"][0]["state"] == "built"
     assert events == ["pin-enter", "thread", "head", "pin-exit"]
+
+
+def test_index_status_query_alias_does_not_shadow_wiki_page(monkeypatch) -> None:
+    bundle = SimpleNamespace(entry=SimpleNamespace(repo="org/repo"))
+
+    class Registry:
+        @contextmanager
+        def pin(self, repo_id: str):
+            assert repo_id == "demo"
+            yield bundle
+
+    class Builder:
+        def page(self, page_id: str):
+            assert page_id == "index-status"
+            return {"id": page_id, "media_slots": []}
+
+    async def inline(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(web_app.app.state, "registry", Registry(), raising=False)
+    monkeypatch.setattr(web_app, "_wiki", lambda _repo_id, _bundle: Builder())
+    monkeypatch.setattr(web_app, "_run_pinned_thread", inline)
+
+    response = TestClient(web_app.app).get("/api/repos/demo/wiki/index-status")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == "index-status"
 
 
 def test_index_status_endpoint_resolves_update_capabilities_per_repository(


### PR DESCRIPTION
## Summary

Preserve configured repository IDs such as `owner/repo` through index-status and index-job APIs without introducing greedy repository routes. ASGI decodes `%2F` before FastAPI path matching, so slash-bearing IDs need an unambiguous query transport; a `{repo_id:path}` route would shadow valid Wiki paths.

This PR is rewritten onto current `main` as the independently reproduced routing bugfix only. The unused typed index-control client and deferred UI stack are not part of its diff.

## Changes

- retain `GET /api/repos/{repo_id}/index-status` for existing single-segment callers
- add `GET /api/index-status?repo_id=...` for slash-bearing configured IDs
- retain `POST /api/repos/{repo_id}/index-jobs` and add the matching `POST /api/index-jobs?repo_id=...` alias
- verify repository pinning, writer delegation, request validation, and decoded `owner/repo` IDs through real ASGI requests
- prove `/api/repos/demo/wiki/index-status` still resolves to the Wiki page handler
- record the unambiguous transport contract in the storage roadmap

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- focused index-status and index-job route tests: 35 passed
- complete Web test suite: 680 passed
- Black, isort, flake8, Python 3.10 bytecode compilation, and diff checks pass

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published