### PR TITLE
feat(web): show repository index status

### DIFF
--- a/web/app/[repoId]/page.tsx
+++ b/web/app/[repoId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import Header from "@/components/Header";
+import IndexStatusControl from "@/components/IndexStatusControl";
 import Markdown from "@/components/Markdown";
 import AskBar from "@/components/AskBar";
 import { AppLink } from "@/lib/router";
@@ -631,6 +632,7 @@ export default function WikiPageView({
               <div className="rail-sub mono">Last indexed {repo.commit_short}</div>
             )
           )}
+          {!staticRuntime && <IndexStatusControl repoId={repoId} />}
           {error ? (
             <div className="page-load-error" role="alert">
               <div>Failed to load this wiki.</div>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -644,6 +644,248 @@ pre {
   outline-offset: 1px;
 }
 
+.index-status-control {
+  padding: 0 0 14px;
+  margin: 0 0 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.index-status-control > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 32px;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 650;
+  cursor: pointer;
+  list-style: none;
+}
+
+.index-status-control > summary::-webkit-details-marker {
+  display: none;
+}
+
+.index-status-control > summary::before {
+  content: "›";
+  color: var(--text-muted);
+  font-size: 18px;
+  line-height: 1;
+  transform: rotate(0deg);
+  transition: transform 0.15s ease;
+}
+
+.index-status-control[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.index-status-control > summary > :first-child {
+  margin-right: auto;
+}
+
+.index-status-summary-note {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 550;
+}
+
+.index-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.index-state::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--text-muted);
+}
+
+.index-state.built::before {
+  background: #16a34a;
+}
+
+.index-state.stale::before,
+.index-state.missing::before {
+  background: #d97706;
+}
+
+.index-state.updating::before {
+  background: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.index-state.failed::before {
+  background: #dc2626;
+}
+
+.index-status-panel {
+  margin-top: 8px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-surface);
+}
+
+.index-status-panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 9px;
+}
+
+.index-status-panel-head strong {
+  display: block;
+  color: var(--text);
+  font-size: 12px;
+}
+
+.index-status-panel-head p {
+  margin: 2px 0 0;
+  color: var(--text-secondary);
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.index-status-panel-head button {
+  padding: 3px 7px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-subtle);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 10px;
+  cursor: pointer;
+}
+
+.index-status-panel-head button:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.index-status-list {
+  display: grid;
+  gap: 7px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.index-status-row {
+  min-width: 0;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--bg-muted);
+}
+
+.index-status-row-head,
+.index-status-mode,
+.index-status-commits {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.index-status-name {
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.index-status-mode {
+  margin-top: 3px;
+  color: var(--text-secondary);
+  font-size: 10px;
+}
+
+.index-status-mode .mono {
+  color: var(--text-muted);
+}
+
+.index-status-reason {
+  margin: 5px 0 0;
+  color: var(--text-secondary);
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.index-status-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 4px 7px;
+  margin: 7px 0 0;
+  padding-top: 6px;
+  border-top: 1px solid var(--border);
+}
+
+.index-status-metrics > div {
+  min-width: 0;
+}
+
+.index-status-metrics dt {
+  color: var(--text-muted);
+  font-size: 9px;
+}
+
+.index-status-metrics dd {
+  margin: 0;
+  color: var(--text);
+  font-size: 10px;
+}
+
+.index-status-commits {
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  margin-top: 8px;
+  color: var(--text-secondary);
+  font-size: 9px;
+}
+
+.index-status-commits b {
+  color: var(--text);
+  font-weight: 550;
+}
+
+.index-status-stale {
+  color: #b45309;
+  font-weight: 650;
+}
+
+.index-status-error,
+.index-status-loading {
+  padding: 8px;
+  border-radius: 6px;
+  background: var(--bg-subtle);
+  color: var(--text-secondary);
+  font-size: 10px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.index-status-error {
+  color: #b91c1c;
+}
+
+[data-theme="dark"] .index-status-stale {
+  color: #fbbf24;
+}
+
+[data-theme="dark"] .index-status-error {
+  color: #fca5a5;
+}
+
 .toc-tree {
   list-style: none;
   margin: 0;

--- a/web/components/IndexStatusControl.test.tsx
+++ b/web/components/IndexStatusControl.test.tsx
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { RepoIndexStatus } from "@/lib/api";
+import {
+  aggregateIndexState,
+  hasCanonicalIndexSurfaces,
+  IndexStatusDetails,
+} from "./IndexStatusControl";
+
+function statusFixture(): RepoIndexStatus {
+  return {
+    repo_id: "demo",
+    last_indexed_commit: "1234567890abcdef",
+    current_head: "fedcba0987654321",
+    stale: true,
+    indexes: [
+      {
+        index_type: "bm25",
+        state: "stale",
+        stale: true,
+        indexed_commit: "1234567890abcdef",
+        built_at: "2026-08-28T00:00:00Z",
+        update_mode: "rebuild",
+        updates_enabled: true,
+        update_reason: "",
+        job_id: null,
+        metrics: null,
+      },
+      {
+        index_type: "vector",
+        state: "built",
+        stale: false,
+        indexed_commit: "fedcba0987654321",
+        built_at: "2026-08-28T00:01:00Z",
+        update_mode: "incremental",
+        updates_enabled: true,
+        update_reason: "",
+        job_id: null,
+        metrics: {
+          changed_files: 4,
+          chunks_reembedded: 12,
+          chunks_from_cache: 36,
+          cache_hit_rate: 0.75,
+          new_commit: "fedcba0987654321",
+        },
+      },
+      {
+        index_type: "symbol_graph",
+        state: "missing",
+        stale: false,
+        indexed_commit: null,
+        built_at: null,
+        update_mode: "unavailable",
+        updates_enabled: false,
+        update_reason: "No supported graph backend is configured.",
+        job_id: null,
+        metrics: null,
+      },
+    ],
+  };
+}
+
+describe("IndexStatusDetails", () => {
+  it("renders exactly the three primary surfaces and honest update modes", () => {
+    const html = renderToStaticMarkup(
+      <IndexStatusDetails status={statusFixture()} />,
+    );
+
+    expect(html.match(/class="index-status-row"/g)).toHaveLength(3);
+    expect(html).toContain("BM25");
+    expect(html).toContain("Embeddings");
+    expect(html).toContain("Symbol graph");
+    expect(html).toContain("Rebuild on update");
+    expect(html).toContain("Incremental");
+    expect(html).toContain("Updates unavailable");
+    expect(html).toContain("No supported graph backend is configured.");
+  });
+
+  it("shows incremental embedding metrics and both commit positions", () => {
+    const html = renderToStaticMarkup(
+      <IndexStatusDetails status={statusFixture()} />,
+    );
+
+    expect(html).toContain("Changed files");
+    expect(html).toContain(">4<");
+    expect(html).toContain("Re-embedded");
+    expect(html).toContain(">12<");
+    expect(html).toContain("From cache");
+    expect(html).toContain(">36<");
+    expect(html).toContain(">75%<");
+    expect(html).toContain("New commit");
+    expect(html).toContain("12345678");
+    expect(html).toContain("fedcba09");
+    expect(html).toContain("Update available");
+  });
+});
+
+describe("index status invariants", () => {
+  it("requires the canonical three-surface order", () => {
+    const canonical = statusFixture();
+    expect(hasCanonicalIndexSurfaces(canonical)).toBe(true);
+    expect(
+      hasCanonicalIndexSurfaces({
+        ...canonical,
+        indexes: canonical.indexes.slice(0, 2),
+      }),
+    ).toBe(false);
+    expect(
+      hasCanonicalIndexSurfaces({
+        ...canonical,
+        indexes: [
+          canonical.indexes[1],
+          canonical.indexes[0],
+          canonical.indexes[2],
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps failures visible above in-progress and stale surfaces", () => {
+    const status = statusFixture();
+    status.indexes[0] = { ...status.indexes[0], state: "updating" };
+    status.indexes[2] = { ...status.indexes[2], state: "failed" };
+
+    expect(aggregateIndexState(status)).toBe("failed");
+  });
+
+  it("does not hide repository-level staleness behind built surfaces", () => {
+    const status = statusFixture();
+    status.indexes = status.indexes.map((surface) => ({
+      ...surface,
+      state: "built",
+      stale: false,
+    }));
+
+    expect(aggregateIndexState(status)).toBe("stale");
+  });
+});

--- a/web/components/IndexStatusControl.tsx
+++ b/web/components/IndexStatusControl.tsx
@@ -1,0 +1,236 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  fetchIndexStatus,
+  type IndexSurfaceState,
+  type IndexSurfaceStatus,
+  type IndexType,
+  type RepoIndexStatus,
+} from "@/lib/api";
+
+const INDEX_TYPES = ["bm25", "vector", "symbol_graph"] as const;
+
+const INDEX_LABELS: Record<IndexType, string> = {
+  bm25: "BM25",
+  vector: "Embeddings",
+  symbol_graph: "Symbol graph",
+};
+
+const STATE_LABELS: Record<IndexSurfaceState, string> = {
+  built: "Built",
+  missing: "Missing",
+  stale: "Stale",
+  updating: "Updating",
+  failed: "Failed",
+};
+
+const MODE_LABELS: Record<IndexSurfaceStatus["update_mode"], string> = {
+  incremental: "Incremental",
+  patch: "Patch",
+  rebuild: "Rebuild on update",
+  unavailable: "Updates unavailable",
+};
+
+const STATE_PRIORITY: Record<IndexSurfaceState, number> = {
+  built: 0,
+  missing: 1,
+  stale: 2,
+  updating: 3,
+  failed: 4,
+};
+
+export function hasCanonicalIndexSurfaces(status: RepoIndexStatus): boolean {
+  return (
+    status.indexes.length === INDEX_TYPES.length &&
+    status.indexes.every(
+      (surface, index) => surface.index_type === INDEX_TYPES[index],
+    )
+  );
+}
+
+export function aggregateIndexState(status: RepoIndexStatus): IndexSurfaceState {
+  return status.indexes.reduce<IndexSurfaceState>(
+    (current, surface) =>
+      STATE_PRIORITY[surface.state] > STATE_PRIORITY[current]
+        ? surface.state
+        : current,
+    status.stale ? "stale" : "built",
+  );
+}
+
+function shortCommit(commit: string | null): string {
+  return commit ? commit.slice(0, 8) : "—";
+}
+
+function MetricList({ surface }: { surface: IndexSurfaceStatus }) {
+  const metrics = surface.metrics;
+  if (!metrics) return null;
+  const values = [
+    metrics.changed_files == null
+      ? null
+      : ["Changed files", String(metrics.changed_files)],
+    metrics.chunks_reembedded == null
+      ? null
+      : ["Re-embedded", String(metrics.chunks_reembedded)],
+    metrics.chunks_from_cache == null
+      ? null
+      : ["From cache", String(metrics.chunks_from_cache)],
+    metrics.cache_hit_rate == null
+      ? null
+      : ["Cache hits", `${Math.round(metrics.cache_hit_rate * 100)}%`],
+    metrics.new_commit == null
+      ? null
+      : ["New commit", shortCommit(metrics.new_commit)],
+  ].filter((item): item is string[] => item !== null);
+  if (!values.length) return null;
+  return (
+    <dl className="index-status-metrics">
+      {values.map(([label, value]) => (
+        <div key={label}>
+          <dt>{label}</dt>
+          <dd className="mono">{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+export function IndexStatusDetails({ status }: { status: RepoIndexStatus }) {
+  return (
+    <div className="index-status-details">
+      <ul className="index-status-list">
+        {status.indexes.map((surface) => (
+          <li className="index-status-row" key={surface.index_type}>
+            <div className="index-status-row-head">
+              <span className="index-status-name">
+                {INDEX_LABELS[surface.index_type]}
+              </span>
+              <span className={`index-state ${surface.state}`}>
+                {STATE_LABELS[surface.state]}
+              </span>
+            </div>
+            <div className="index-status-mode">
+              {MODE_LABELS[surface.update_mode]}
+              {surface.indexed_commit && (
+                <span className="mono">
+                  {shortCommit(surface.indexed_commit)}
+                </span>
+              )}
+            </div>
+            {!surface.updates_enabled && surface.update_reason && (
+              <p className="index-status-reason">{surface.update_reason}</p>
+            )}
+            <MetricList surface={surface} />
+          </li>
+        ))}
+      </ul>
+      <div className="index-status-commits">
+        <span>
+          Indexed <b className="mono">{shortCommit(status.last_indexed_commit)}</b>
+        </span>
+        <span>
+          HEAD <b className="mono">{shortCommit(status.current_head)}</b>
+        </span>
+        {status.stale && <span className="index-status-stale">Update available</span>}
+      </div>
+    </div>
+  );
+}
+
+export default function IndexStatusControl({ repoId }: { repoId: string }) {
+  const [status, setStatus] = useState<RepoIndexStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  // Supersede and abort old reads so repo navigation cannot publish a status
+  // snapshot for the previous route after a faster request has completed.
+  const requestId = useRef(0);
+  const activeRequest = useRef<AbortController | null>(null);
+
+  const load = useCallback(async () => {
+    activeRequest.current?.abort();
+    const controller = new AbortController();
+    activeRequest.current = controller;
+    const currentRequest = ++requestId.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await fetchIndexStatus(repoId, {
+        signal: controller.signal,
+      });
+      if (next.repo_id !== repoId || !hasCanonicalIndexSurfaces(next)) {
+        throw new Error("Index status response is incomplete");
+      }
+      if (requestId.current === currentRequest) setStatus(next);
+    } catch (failure) {
+      if (
+        controller.signal.aborted ||
+        requestId.current !== currentRequest
+      ) {
+        return;
+      }
+      setError(failure instanceof Error ? failure.message : String(failure));
+    } finally {
+      if (requestId.current === currentRequest) {
+        activeRequest.current = null;
+        setLoading(false);
+      }
+    }
+  }, [repoId]);
+
+  useEffect(() => {
+    setStatus(null);
+    void load();
+    return () => {
+      requestId.current += 1;
+      activeRequest.current?.abort();
+      activeRequest.current = null;
+    };
+  }, [load]);
+
+  const visibleStatus = status?.repo_id === repoId ? status : null;
+  const aggregate = visibleStatus ? aggregateIndexState(visibleStatus) : null;
+  return (
+    <details className="index-status-control">
+      <summary>
+        <span>Indexes</span>
+        {aggregate ? (
+          <span className={`index-state ${aggregate}`}>
+            {STATE_LABELS[aggregate]}
+          </span>
+        ) : (
+          <span className="index-status-summary-note">
+            {loading ? "Checking" : "Unavailable"}
+          </span>
+        )}
+      </summary>
+      <div className="index-status-panel">
+        <div className="index-status-panel-head">
+          <div>
+            <strong>Repository indexes</strong>
+            <p>Current derived artifacts and their safe update modes.</p>
+          </div>
+          <button type="button" onClick={() => void load()} disabled={loading}>
+            {loading ? "Checking…" : "Refresh"}
+          </button>
+        </div>
+        {error ? (
+          <div className="index-status-error" role="alert">
+            {error}
+          </div>
+        ) : visibleStatus ? (
+          <IndexStatusDetails status={visibleStatus} />
+        ) : (
+          <div className="index-status-loading" role="status">
+            Loading index status…
+          </div>
+        )}
+      </div>
+    </details>
+  );
+}


### PR DESCRIPTION
## Summary

Add the first visible #266 repository experience: a canonical three-surface index status panel in the Wiki rail. This PR is intentionally stacked on #740 for the typed API contract; job actions and polling remain the next focused slice.

## Changes

- show BM25, Embeddings, and Symbol graph in the backend-defined canonical order
- expose built, missing, stale, updating, and failed states plus honest update modes
- show indexed commit, current HEAD, disabled reasons, and vector incremental metrics
- reject incomplete or cross-repository responses and abort superseded reads
- omit dynamic index reads from static exports
- add responsive light/dark styling and pure rendering/invariant tests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- npm test (61 passed)
- npm run build
- mocked-browser repo render: 3 rows, no rail overflow, metrics and fallback copy visible
- pre-commit on every changed file

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published