### PR TITLE
feat(web): control repository index jobs

### DIFF
--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1594,7 +1594,9 @@ background loops, exposes the durable reader/writer and BM25 capability, and
 settles them before CAS and topology release. The optional production Web
 lifespan now owns that composition
 and verifies a real first-build job through strict materialization and RCU
-replacement. MCP, UI controls, vector/graph adapters, and default storage
+replacement. The dynamic repository rail now exposes the three canonical index
+surfaces, durable job progress, and one capability-bound update action. MCP,
+landing/Ask freshness controls, vector/graph adapters, and default storage
 routing remain absent.
 
 - The backend-neutral worker now owns advisory scan/claim, per-attempt task
@@ -1691,8 +1693,9 @@ routing remain absent.
   and advertising updates when either owned loop faults, reports unbound
   repositories as unavailable, and rejects a retained BM25 replacement whose
   source-selection policy or normalized language sequence differs from the
-  active Web generation. The remaining #266 work is to expose status/results
-  and update controls in the UI.
+  active Web generation. The remaining #266 work includes landing-page badges,
+  Ask freshness choices, production vector/graph update adapters, and their
+  default routing.
 - The first #266 read slice exposes one pinned, detached status snapshot for
   exactly BM25, vector, and symbol-graph surfaces. It reports manifest/current
   commit drift and retained incremental metrics without exposing mutable bundle
@@ -1806,6 +1809,18 @@ routing remain absent.
   granting active-job, event, lease, execution, or publication discovery. The
   default server continues to return unavailable because no storage/target
   binding installs the reader, writer, or planner by default.
+- The dynamic repository detail rail now renders exactly BM25, Embeddings, and
+  Symbol graph status, commit drift, update modes, disabled reasons, and retained
+  incremental metrics. Its update control selects one writable surface so it
+  stays within the current durable writer contract, maps `rebuild` to one full
+  request and `incremental`/`patch` to one incremental request, and never claims
+  unsupported force behavior. Caller-owned idempotency keys remain bound to the
+  canonical request intent across response-loss retries. The control resumes an
+  active durable job from the status overlay, polls bounded event pages with a
+  bounded retained window, displays sanitized results and failures, and refreshes
+  the repository status after terminal settlement. Static exports omit the
+  runtime-only control. The production local service currently advertises only
+  retained-source BM25 rebuilds; vector and graph writes remain unavailable.
 - Keep read-only/prebuilt paths safe through copy-on-write or explicit refusal.
 
 ### M4: Cross-file reference de-materialization

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -886,6 +886,209 @@ pre {
   color: #fca5a5;
 }
 
+.index-job-control,
+.index-job-unavailable {
+  margin-top: 10px;
+  padding-top: 9px;
+  border-top: 1px solid var(--border);
+}
+
+.index-job-control-head {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.index-job-control-head strong {
+  color: var(--text);
+  font-size: 11px;
+}
+
+.index-job-control-head span,
+.index-job-unavailable {
+  color: var(--text-secondary);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.index-job-selection {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 5px 7px;
+  margin-top: 7px;
+}
+
+.index-job-selection label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  color: var(--text-secondary);
+  font-size: 10px;
+  cursor: pointer;
+}
+
+.index-job-selection label:has(input:disabled) {
+  color: var(--text-muted);
+  cursor: not-allowed;
+}
+
+.index-job-selection input {
+  width: 13px;
+  height: 13px;
+  margin: 0;
+  accent-color: var(--accent);
+}
+
+.index-job-fallback-note {
+  margin: 7px 0 0;
+  color: #b45309;
+  font-size: 9px;
+  line-height: 1.35;
+}
+
+.index-job-actions {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.index-job-actions button,
+.index-job-request-error button {
+  min-height: 30px;
+  padding: 5px 7px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-subtle);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 9px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.index-job-actions button:first-child {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.index-job-actions button:disabled {
+  cursor: not-allowed;
+  filter: grayscale(0.35);
+  opacity: 0.55;
+}
+
+.index-job-submitting,
+.index-job-request-error {
+  margin-top: 7px;
+  padding: 6px 7px;
+  border-radius: 6px;
+  background: var(--bg-subtle);
+  color: var(--text-secondary);
+  font-size: 9px;
+}
+
+.index-job-request-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  color: #b91c1c;
+  overflow-wrap: anywhere;
+}
+
+.index-job-request-error button {
+  flex: 0 0 auto;
+  min-height: 24px;
+}
+
+.index-job-progress {
+  margin-top: 8px;
+  padding: 7px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-muted);
+}
+
+.index-job-progress-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 9px;
+}
+
+.index-job-progress .index-state.queued::before,
+.index-job-progress .index-state.running::before {
+  background: var(--accent);
+}
+
+.index-job-progress .index-state.failed::before,
+.index-job-progress .index-state.cancelled::before {
+  background: #dc2626;
+}
+
+.index-job-error {
+  margin: 6px 0 0;
+  color: #b91c1c;
+  font-size: 9px;
+  line-height: 1.4;
+}
+
+.index-job-results {
+  display: grid;
+  gap: 5px;
+  margin: 7px 0 0;
+  padding: 7px 0 0;
+  border-top: 1px solid var(--border);
+  list-style: none;
+}
+
+.index-job-results li {
+  display: grid;
+  gap: 1px;
+  color: var(--text-secondary);
+  font-size: 9px;
+}
+
+.index-job-results li > div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  color: var(--text);
+  font-weight: 650;
+}
+
+.index-job-results small {
+  color: var(--text-muted);
+  font-size: 8px;
+}
+
+.index-job-outcome {
+  color: var(--text-secondary);
+  font-size: 8px;
+  font-weight: 650;
+  text-transform: uppercase;
+}
+
+.index-job-outcome.failed {
+  color: #b91c1c;
+}
+
+[data-theme="dark"] .index-job-fallback-note {
+  color: #fbbf24;
+}
+
+[data-theme="dark"] .index-job-request-error,
+[data-theme="dark"] .index-job-error,
+[data-theme="dark"] .index-job-outcome.failed {
+  color: #fca5a5;
+}
+
 .toc-tree {
   list-style: none;
   margin: 0;

--- a/web/components/IndexJobControl.test.tsx
+++ b/web/components/IndexJobControl.test.tsx
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  IndexJobStatusResponse,
+  RepoIndexStatus,
+} from "@/lib/api";
+import IndexJobControl, {
+  activeIndexJobId,
+  indexJobRequestForSurface,
+  IndexJobProgress,
+  mergeIndexJobEvents,
+  prepareIndexJobCreate,
+} from "./IndexJobControl";
+
+function statusFixture(): RepoIndexStatus {
+  return {
+    repo_id: "demo",
+    last_indexed_commit: "a".repeat(40),
+    current_head: "b".repeat(40),
+    stale: true,
+    indexes: [
+      {
+        index_type: "bm25",
+        state: "stale",
+        stale: true,
+        indexed_commit: "a".repeat(40),
+        built_at: null,
+        update_mode: "rebuild",
+        updates_enabled: true,
+        update_reason: "",
+        job_id: null,
+        metrics: null,
+      },
+      {
+        index_type: "vector",
+        state: "stale",
+        stale: true,
+        indexed_commit: "a".repeat(40),
+        built_at: null,
+        update_mode: "incremental",
+        updates_enabled: true,
+        update_reason: "",
+        job_id: null,
+        metrics: null,
+      },
+      {
+        index_type: "symbol_graph",
+        state: "missing",
+        stale: false,
+        indexed_commit: null,
+        built_at: null,
+        update_mode: "unavailable",
+        updates_enabled: false,
+        update_reason: "Graph updates are unavailable.",
+        job_id: null,
+        metrics: null,
+      },
+    ],
+  };
+}
+
+function jobFixture(
+  overrides: Partial<IndexJobStatusResponse> = {},
+): IndexJobStatusResponse {
+  return {
+    job_id: "job-1",
+    repo_id: "demo",
+    status: "running",
+    cancel_requested: false,
+    attempt_count: 1,
+    max_attempts: 2,
+    indexes: [
+      { index_type: "bm25", requested_mode: "incremental", required: true },
+    ],
+    result_snapshot_id: null,
+    error_code: null,
+    error_message: null,
+    created_at_ms: 1,
+    updated_at_ms: 2,
+    started_at_ms: 2,
+    finished_at_ms: null,
+    events: [],
+    next_event_sequence: 0,
+    ...overrides,
+  };
+}
+
+describe("IndexJobControl", () => {
+  it("selects one writable surface and keeps unavailable ones disabled", () => {
+    const html = renderToStaticMarkup(
+      <IndexJobControl status={statusFixture()} onRefresh={vi.fn()} />,
+    );
+
+    expect(html.match(/type="radio"/g)).toHaveLength(3);
+    expect(html.match(/type="radio"[^>]*checked/g)).toHaveLength(1);
+    expect(html.match(/type="radio"[^>]*disabled/g)).toHaveLength(1);
+    expect(html).toContain("Rebuild BM25");
+    expect(html).toContain("BM25 updates require a full rebuild.");
+  });
+
+  it("maps advertised capabilities onto honest job requests", () => {
+    const status = statusFixture();
+
+    expect(indexJobRequestForSurface(status.indexes[0])).toEqual({
+      indexes: ["bm25"],
+      mode: "full",
+      force: false,
+    });
+    expect(indexJobRequestForSurface(status.indexes[1])).toEqual({
+      indexes: ["vector"],
+      mode: "incremental",
+      force: false,
+    });
+    expect(() => indexJobRequestForSurface(status.indexes[2])).toThrow(
+      "not writable",
+    );
+  });
+
+  it("renders fallback results and safe failure messages", () => {
+    const job = jobFixture({
+      status: "failed",
+      error_code: "worker_executor_failed",
+      error_message: "The index worker failed while preparing artifacts.",
+      finished_at_ms: 4,
+      events: [
+        {
+          sequence: 1,
+          attempt_count: 1,
+          event_key: "view-result-1",
+          kind: "view_result",
+          index_type: "bm25",
+          effective_mode: "rebuild_fallback",
+          outcome: "failed",
+          payload: { changed_files: 3 },
+          created_at_ms: 3,
+        },
+      ],
+      next_event_sequence: 1,
+    });
+    const html = renderToStaticMarkup(<IndexJobProgress job={job} />);
+
+    expect(html).toContain("Rebuild fallback");
+    expect(html).toContain("3 changed files");
+    expect(html).toContain(
+      "The index worker failed while preparing artifacts.",
+    );
+  });
+});
+
+describe("index job polling invariants", () => {
+  it("deduplicates event pages and retains the newest bounded window", () => {
+    const first = jobFixture({
+      events: [
+        {
+          sequence: 1,
+          attempt_count: 1,
+          event_key: "progress-1",
+          kind: "progress",
+          index_type: null,
+          effective_mode: null,
+          outcome: null,
+          payload: {},
+          created_at_ms: 1,
+        },
+      ],
+      next_event_sequence: 1,
+    });
+    const second = jobFixture({
+      events: [
+        first.events[0],
+        { ...first.events[0], sequence: 2, event_key: "progress-2" },
+      ],
+      next_event_sequence: 2,
+    });
+
+    expect(
+      mergeIndexJobEvents(first, second).events.map((event) => event.sequence),
+    ).toEqual([1, 2]);
+  });
+
+  it("accepts one active job and rejects cross-job overlays", () => {
+    const status = statusFixture();
+    status.indexes[0] = { ...status.indexes[0], job_id: "job-1" };
+    status.indexes[1] = { ...status.indexes[1], job_id: "job-1" };
+    expect(activeIndexJobId(status)).toBe("job-1");
+
+    status.indexes[1] = { ...status.indexes[1], job_id: "job-2" };
+    expect(() => activeIndexJobId(status)).toThrow(
+      "Index status names conflicting active jobs",
+    );
+  });
+
+  it("reuses an idempotency key only for the same canonical intent", () => {
+    const keyFactory = vi
+      .fn()
+      .mockReturnValueOnce("key-1")
+      .mockReturnValueOnce("key-2");
+    const first = prepareIndexJobCreate(null, "intent-a", keyFactory);
+    const retry = prepareIndexJobCreate(first, "intent-a", keyFactory);
+    const changed = prepareIndexJobCreate(retry, "intent-b", keyFactory);
+
+    expect(retry).toBe(first);
+    expect(changed.idempotencyKey).toBe("key-2");
+    expect(keyFactory).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/components/IndexJobControl.test.tsx
+++ b/web/components/IndexJobControl.test.tsx
@@ -12,6 +12,7 @@ import type {
 import IndexJobControl, {
   activeIndexJobId,
   indexJobRequestForSurface,
+  indexJobPollDisposition,
   IndexJobProgress,
   mergeIndexJobEvents,
   prepareIndexJobCreate,
@@ -181,6 +182,35 @@ describe("index job polling invariants", () => {
     expect(
       mergeIndexJobEvents(first, second).events.map((event) => event.sequence),
     ).toEqual([1, 2]);
+  });
+
+  it("drains a full terminal event page before settling", () => {
+    const event = {
+      sequence: 1,
+      attempt_count: 1,
+      event_key: "progress-1",
+      kind: "progress" as const,
+      index_type: null,
+      effective_mode: null,
+      outcome: null,
+      payload: {},
+      created_at_ms: 1,
+    };
+    const fullTerminalPage = jobFixture({
+      status: "succeeded",
+      events: Array.from({ length: 64 }, (_, index) => ({
+        ...event,
+        sequence: index + 1,
+        event_key: `progress-${index + 1}`,
+      })),
+      next_event_sequence: 64,
+    });
+
+    expect(indexJobPollDisposition(fullTerminalPage)).toBe("continue");
+    expect(
+      indexJobPollDisposition({ ...fullTerminalPage, events: [] }),
+    ).toBe("settled");
+    expect(indexJobPollDisposition(jobFixture())).toBe("wait");
   });
 
   it("accepts one active job and rejects cross-job overlays", () => {

--- a/web/components/IndexJobControl.test.tsx
+++ b/web/components/IndexJobControl.test.tsx
@@ -13,6 +13,7 @@ import IndexJobControl, {
   activeIndexJobId,
   indexJobRequestForSurface,
   indexJobPollDisposition,
+  indexJobPollingId,
   IndexJobProgress,
   mergeIndexJobEvents,
   prepareIndexJobCreate,
@@ -137,7 +138,10 @@ describe("IndexJobControl", () => {
           index_type: "bm25",
           effective_mode: "rebuild_fallback",
           outcome: "failed",
-          payload: { changed_files: 3 },
+          payload: {
+            changed_files: 3,
+            new_commit: "abcdef1234567890",
+          },
           created_at_ms: 3,
         },
       ],
@@ -147,6 +151,7 @@ describe("IndexJobControl", () => {
 
     expect(html).toContain("Rebuild fallback");
     expect(html).toContain("3 changed files");
+    expect(html).toContain("commit abcdef12");
     expect(html).toContain(
       "The index worker failed while preparing artifacts.",
     );
@@ -211,6 +216,14 @@ describe("index job polling invariants", () => {
       indexJobPollDisposition({ ...fullTerminalPage, events: [] }),
     ).toBe("settled");
     expect(indexJobPollDisposition(jobFixture())).toBe("wait");
+  });
+
+  it("follows a refreshed active job after retaining a terminal result", () => {
+    const terminal = jobFixture({ status: "succeeded" });
+
+    expect(indexJobPollingId(terminal, null, "job-2")).toBe("job-2");
+    expect(indexJobPollingId(jobFixture(), null, "job-2")).toBe("job-1");
+    expect(indexJobPollingId(terminal, "job-1", "job-2")).toBe("job-1");
   });
 
   it("accepts one active job and rejects cross-job overlays", () => {

--- a/web/components/IndexJobControl.tsx
+++ b/web/components/IndexJobControl.tsx
@@ -90,6 +90,15 @@ export function indexJobPollDisposition(
   return ACTIVE_JOB_STATES.has(next.status) ? "wait" : "settled";
 }
 
+export function indexJobPollingId(
+  job: IndexJobStatusResponse | null,
+  drainingJobId: string | null,
+  statusJobId: string | null,
+): string | null {
+  if (job && ACTIVE_JOB_STATES.has(job.status)) return job.job_id;
+  return drainingJobId ?? statusJobId;
+}
+
 function createIdempotencyKey(): string {
   const randomUUID = globalThis.crypto?.randomUUID;
   if (typeof randomUUID !== "function") {
@@ -133,6 +142,13 @@ function eventMetricSummary(event: IndexJobEvent): string | null {
   const cacheHitRate = event.payload.cache_hit_rate;
   if (typeof cacheHitRate === "number") {
     parts.push(`${Math.round(cacheHitRate * 100)}% cache hits`);
+  }
+  const newCommit = event.payload.new_commit;
+  if (
+    typeof newCommit === "string" &&
+    /^[0-9a-f]{7,64}$/.test(newCommit)
+  ) {
+    parts.push(`commit ${newCommit.slice(0, 8)}`);
   }
   return parts.length ? parts.join(" · ") : null;
 }
@@ -218,14 +234,12 @@ export default function IndexJobControl({
   const pendingCreate = useRef<PendingIndexJobCreate | null>(null);
   const statusJobId = activeIndexJobId(status);
   const jobIsActive = Boolean(job && ACTIVE_JOB_STATES.has(job.status));
-  const pollingJobId = jobIsActive
-    ? job!.job_id
-    : (drainingJobId ?? (job ? null : statusJobId));
+  const pollingJobId = indexJobPollingId(job, drainingJobId, statusJobId);
   const busy =
     submitting ||
     jobIsActive ||
     Boolean(drainingJobId) ||
-    Boolean(statusJobId && !job);
+    Boolean(statusJobId);
 
   const enabledSignature = enabledTypes.join("\u0000");
   useEffect(() => {

--- a/web/components/IndexJobControl.tsx
+++ b/web/components/IndexJobControl.tsx
@@ -81,6 +81,15 @@ export function mergeIndexJobEvents(
   };
 }
 
+export type IndexJobPollDisposition = "continue" | "wait" | "settled";
+
+export function indexJobPollDisposition(
+  next: IndexJobStatusResponse,
+): IndexJobPollDisposition {
+  if (next.events.length === EVENT_PAGE_SIZE) return "continue";
+  return ACTIVE_JOB_STATES.has(next.status) ? "wait" : "settled";
+}
+
 function createIdempotencyKey(): string {
   const randomUUID = globalThis.crypto?.randomUUID;
   if (typeof randomUUID !== "function") {
@@ -202,14 +211,21 @@ export default function IndexJobControl({
     () => enabledTypes[0] ?? null,
   );
   const [job, setJob] = useState<IndexJobStatusResponse | null>(null);
+  const [drainingJobId, setDrainingJobId] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pollRevision, setPollRevision] = useState(0);
   const pendingCreate = useRef<PendingIndexJobCreate | null>(null);
   const statusJobId = activeIndexJobId(status);
   const jobIsActive = Boolean(job && ACTIVE_JOB_STATES.has(job.status));
-  const pollingJobId = jobIsActive ? job!.job_id : job ? null : statusJobId;
-  const busy = submitting || jobIsActive || Boolean(statusJobId && !job);
+  const pollingJobId = jobIsActive
+    ? job!.job_id
+    : (drainingJobId ?? (job ? null : statusJobId));
+  const busy =
+    submitting ||
+    jobIsActive ||
+    Boolean(drainingJobId) ||
+    Boolean(statusJobId && !job);
 
   const enabledSignature = enabledTypes.join("\u0000");
   useEffect(() => {
@@ -229,6 +245,7 @@ export default function IndexJobControl({
     if (!pollingJobId) return;
     let stopped = false;
     let timer: number | undefined;
+    const controller = new AbortController();
     let cursor =
       job?.job_id === pollingJobId ? job.next_event_sequence : 0;
 
@@ -237,6 +254,7 @@ export default function IndexJobControl({
         const next = await fetchIndexJob(pollingJobId, {
           afterSequence: cursor,
           eventLimit: EVENT_PAGE_SIZE,
+          signal: controller.signal,
         });
         if (stopped) return;
         if (next.job_id !== pollingJobId || next.repo_id !== status.repo_id) {
@@ -245,26 +263,38 @@ export default function IndexJobControl({
         cursor = next.next_event_sequence;
         setJob((current) => mergeIndexJobEvents(current, next));
         setError(null);
-        const terminal = !ACTIVE_JOB_STATES.has(next.status);
-        const pageMayContinue = next.events.length === EVENT_PAGE_SIZE;
-        if (terminal) {
+        const disposition = indexJobPollDisposition(next);
+        if (disposition === "continue") {
+          if (!ACTIVE_JOB_STATES.has(next.status)) {
+            setDrainingJobId(next.job_id);
+          }
+          timer = window.setTimeout(poll, 0);
+          return;
+        }
+        if (disposition === "settled") {
+          setDrainingJobId(null);
           await onRefresh();
           return;
         }
-        timer = window.setTimeout(poll, pageMayContinue ? 0 : 1_000);
+        timer = window.setTimeout(poll, 1_000);
       } catch (failure) {
-        if (!stopped) {
+        if (!stopped && !controller.signal.aborted) {
           setError(failure instanceof Error ? failure.message : String(failure));
         }
       }
     };
 
-    timer = window.setTimeout(poll, job ? 750 : 0);
+    timer = window.setTimeout(
+      poll,
+      drainingJobId === pollingJobId ? 0 : job ? 750 : 0,
+    );
     return () => {
       stopped = true;
+      controller.abort();
       if (timer != null) window.clearTimeout(timer);
     };
   }, [
+    drainingJobId,
     job?.job_id,
     job?.status,
     onRefresh,
@@ -290,6 +320,7 @@ export default function IndexJobControl({
     pendingCreate.current = prepared;
     setSubmitting(true);
     setError(null);
+    setDrainingJobId(null);
     setJob(null);
     try {
       const created = await createIndexJob(

--- a/web/components/IndexJobControl.tsx
+++ b/web/components/IndexJobControl.tsx
@@ -1,0 +1,382 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  createIndexJob,
+  fetchIndexJob,
+  type IndexJobCreateRequest,
+  type IndexJobEvent,
+  type IndexJobStatusResponse,
+  type IndexSurfaceStatus,
+  type IndexType,
+  type RepoIndexStatus,
+} from "@/lib/api";
+
+const INDEX_LABELS: Record<IndexType, string> = {
+  bm25: "BM25",
+  vector: "Embeddings",
+  symbol_graph: "Symbol graph",
+};
+const ACTIVE_JOB_STATES = new Set<IndexJobStatusResponse["status"]>([
+  "queued",
+  "running",
+]);
+const JOB_STATE_LABELS: Record<IndexJobStatusResponse["status"], string> = {
+  queued: "Queued",
+  running: "Running",
+  succeeded: "Succeeded",
+  failed: "Failed",
+  cancelled: "Cancelled",
+};
+const EFFECTIVE_MODE_LABELS: Record<
+  NonNullable<IndexJobEvent["effective_mode"]>,
+  string
+> = {
+  full: "Full rebuild",
+  incremental: "Incremental",
+  rebuild_fallback: "Rebuild fallback",
+  unavailable: "Unavailable",
+};
+const EVENT_PAGE_SIZE = 64;
+const MAX_RETAINED_EVENTS = 64;
+
+export interface PendingIndexJobCreate {
+  signature: string;
+  idempotencyKey: string;
+}
+
+export function activeIndexJobId(status: RepoIndexStatus): string | null {
+  const jobIds = [
+    ...new Set(
+      status.indexes
+        .map((surface) => surface.job_id)
+        .filter((jobId): jobId is string => Boolean(jobId)),
+    ),
+  ];
+  if (jobIds.length > 1) {
+    throw new Error("Index status names conflicting active jobs");
+  }
+  return jobIds[0] ?? null;
+}
+
+export function mergeIndexJobEvents(
+  previous: IndexJobStatusResponse | null,
+  next: IndexJobStatusResponse,
+): IndexJobStatusResponse {
+  if (!previous || previous.job_id !== next.job_id) return next;
+  const events = new Map<number, IndexJobEvent>();
+  for (const event of [...previous.events, ...next.events]) {
+    events.set(event.sequence, event);
+  }
+  return {
+    ...next,
+    events: [...events.values()]
+      .sort((left, right) => left.sequence - right.sequence)
+      .slice(-MAX_RETAINED_EVENTS),
+  };
+}
+
+function createIdempotencyKey(): string {
+  const randomUUID = globalThis.crypto?.randomUUID;
+  if (typeof randomUUID !== "function") {
+    throw new Error("Secure index update IDs are unavailable in this browser");
+  }
+  return `web-index-${randomUUID.call(globalThis.crypto)}`;
+}
+
+export function prepareIndexJobCreate(
+  current: PendingIndexJobCreate | null,
+  signature: string,
+  keyFactory: () => string = createIdempotencyKey,
+): PendingIndexJobCreate {
+  if (current?.signature === signature) return current;
+  return { signature, idempotencyKey: keyFactory() };
+}
+
+export function indexJobRequestForSurface(
+  surface: IndexSurfaceStatus,
+): IndexJobCreateRequest {
+  if (!surface.updates_enabled || surface.update_mode === "unavailable") {
+    throw new Error("The selected index surface is not writable");
+  }
+  return {
+    indexes: [surface.index_type],
+    mode: surface.update_mode === "rebuild" ? "full" : "incremental",
+    force: false,
+  };
+}
+
+function eventMetricSummary(event: IndexJobEvent): string | null {
+  const parts: string[] = [];
+  const changedFiles = event.payload.changed_files;
+  if (typeof changedFiles === "number") {
+    parts.push(`${changedFiles} changed file${changedFiles === 1 ? "" : "s"}`);
+  }
+  const reembedded = event.payload.chunks_reembedded;
+  if (typeof reembedded === "number") parts.push(`${reembedded} re-embedded`);
+  const fromCache = event.payload.chunks_from_cache;
+  if (typeof fromCache === "number") parts.push(`${fromCache} from cache`);
+  const cacheHitRate = event.payload.cache_hit_rate;
+  if (typeof cacheHitRate === "number") {
+    parts.push(`${Math.round(cacheHitRate * 100)}% cache hits`);
+  }
+  return parts.length ? parts.join(" · ") : null;
+}
+
+export function IndexJobProgress({ job }: { job: IndexJobStatusResponse }) {
+  const resultEvents = job.events.filter(
+    (
+      event,
+    ): event is IndexJobEvent & {
+      index_type: IndexType;
+      effective_mode: NonNullable<IndexJobEvent["effective_mode"]>;
+      outcome: NonNullable<IndexJobEvent["outcome"]>;
+    } =>
+      event.kind === "view_result" &&
+      event.index_type !== null &&
+      event.effective_mode !== null &&
+      event.outcome !== null,
+  );
+  return (
+    <div className={`index-job-progress ${job.status}`} role="status">
+      <div className="index-job-progress-head">
+        <span
+          className={`index-state ${
+            job.status === "succeeded" ? "built" : job.status
+          }`}
+        >
+          {JOB_STATE_LABELS[job.status]}
+        </span>
+        <span className="mono">
+          attempt {job.attempt_count}/{job.max_attempts}
+        </span>
+      </div>
+      {job.error_message && (
+        <p className="index-job-error" role="alert">
+          {job.error_message}
+        </p>
+      )}
+      {resultEvents.length > 0 && (
+        <ul className="index-job-results">
+          {resultEvents.map((event) => {
+            const metrics = eventMetricSummary(event);
+            return (
+              <li key={event.event_key}>
+                <div>
+                  <span>{INDEX_LABELS[event.index_type]}</span>
+                  <span className={`index-job-outcome ${event.outcome}`}>
+                    {event.outcome}
+                  </span>
+                </div>
+                <span>{EFFECTIVE_MODE_LABELS[event.effective_mode]}</span>
+                {metrics && <small>{metrics}</small>}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default function IndexJobControl({
+  status,
+  onRefresh,
+}: {
+  status: RepoIndexStatus;
+  onRefresh: () => Promise<void>;
+}) {
+  const enabledTypes = useMemo(
+    () =>
+      status.indexes
+        .filter((surface) => surface.updates_enabled)
+        .map((surface) => surface.index_type),
+    [status.indexes],
+  );
+  const [selected, setSelected] = useState<IndexType | null>(
+    () => enabledTypes[0] ?? null,
+  );
+  const [job, setJob] = useState<IndexJobStatusResponse | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pollRevision, setPollRevision] = useState(0);
+  const pendingCreate = useRef<PendingIndexJobCreate | null>(null);
+  const statusJobId = activeIndexJobId(status);
+  const jobIsActive = Boolean(job && ACTIVE_JOB_STATES.has(job.status));
+  const pollingJobId = jobIsActive ? job!.job_id : job ? null : statusJobId;
+  const busy = submitting || jobIsActive || Boolean(statusJobId && !job);
+
+  const enabledSignature = enabledTypes.join("\u0000");
+  useEffect(() => {
+    const enabled = new Set<IndexType>(
+      enabledSignature
+        ? (enabledSignature.split("\u0000") as IndexType[])
+        : [],
+    );
+    setSelected((current) =>
+      current && enabled.has(current)
+        ? current
+        : (enabled.values().next().value ?? null),
+    );
+  }, [enabledSignature]);
+
+  useEffect(() => {
+    if (!pollingJobId) return;
+    let stopped = false;
+    let timer: number | undefined;
+    let cursor =
+      job?.job_id === pollingJobId ? job.next_event_sequence : 0;
+
+    const poll = async () => {
+      try {
+        const next = await fetchIndexJob(pollingJobId, {
+          afterSequence: cursor,
+          eventLimit: EVENT_PAGE_SIZE,
+        });
+        if (stopped) return;
+        if (next.job_id !== pollingJobId || next.repo_id !== status.repo_id) {
+          throw new Error("Index job status escaped its repository");
+        }
+        cursor = next.next_event_sequence;
+        setJob((current) => mergeIndexJobEvents(current, next));
+        setError(null);
+        const terminal = !ACTIVE_JOB_STATES.has(next.status);
+        const pageMayContinue = next.events.length === EVENT_PAGE_SIZE;
+        if (terminal) {
+          await onRefresh();
+          return;
+        }
+        timer = window.setTimeout(poll, pageMayContinue ? 0 : 1_000);
+      } catch (failure) {
+        if (!stopped) {
+          setError(failure instanceof Error ? failure.message : String(failure));
+        }
+      }
+    };
+
+    timer = window.setTimeout(poll, job ? 750 : 0);
+    return () => {
+      stopped = true;
+      if (timer != null) window.clearTimeout(timer);
+    };
+  }, [
+    job?.job_id,
+    job?.status,
+    onRefresh,
+    pollRevision,
+    pollingJobId,
+    status.repo_id,
+  ]);
+
+  const selectedSurface =
+    status.indexes.find(
+      (surface) =>
+        surface.index_type === selected && surface.updates_enabled,
+    ) ?? null;
+
+  const submit = async () => {
+    if (!selectedSurface || busy) return;
+    const request = indexJobRequestForSurface(selectedSurface);
+    const signature = JSON.stringify({
+      repoId: status.repo_id,
+      ...request,
+    });
+    const prepared = prepareIndexJobCreate(pendingCreate.current, signature);
+    pendingCreate.current = prepared;
+    setSubmitting(true);
+    setError(null);
+    setJob(null);
+    try {
+      const created = await createIndexJob(
+        status.repo_id,
+        request,
+        { idempotencyKey: prepared.idempotencyKey },
+      );
+      if (created.repo_id !== status.repo_id) {
+        throw new Error("Created index job escaped its repository");
+      }
+      pendingCreate.current = null;
+      setJob(created);
+      setPollRevision((revision) => revision + 1);
+    } catch (failure) {
+      setError(failure instanceof Error ? failure.message : String(failure));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!enabledTypes.length) {
+    return (
+      <div className="index-job-unavailable">
+        This server has no writable index surfaces for this repository.
+      </div>
+    );
+  }
+
+  const requiresRebuild = selectedSurface?.update_mode === "rebuild";
+  return (
+    <div className="index-job-control">
+      <div className="index-job-control-head">
+        <strong>Update indexes</strong>
+        <span>Select one writable surface.</span>
+      </div>
+      <div
+        className="index-job-selection"
+        role="radiogroup"
+        aria-label="Writable index surface"
+      >
+        {status.indexes.map((surface) => (
+          <label key={surface.index_type}>
+            <input
+              type="radio"
+              name="index-job-surface"
+              checked={selected === surface.index_type}
+              disabled={!surface.updates_enabled || busy}
+              onChange={() => setSelected(surface.index_type)}
+            />
+            <span>{INDEX_LABELS[surface.index_type]}</span>
+          </label>
+        ))}
+      </div>
+      {requiresRebuild && selectedSurface && (
+        <p className="index-job-fallback-note">
+          {INDEX_LABELS[selectedSurface.index_type]} updates require a full
+          rebuild.
+        </p>
+      )}
+      <div className="index-job-actions">
+        <button
+          type="button"
+          disabled={!selectedSurface || busy}
+          onClick={() => void submit()}
+        >
+          {selectedSurface
+            ? `${requiresRebuild ? "Rebuild" : "Update"} ${
+                INDEX_LABELS[selectedSurface.index_type]
+              }`
+            : "Select an index"}
+        </button>
+      </div>
+      {submitting && <div className="index-job-submitting">Creating update…</div>}
+      {error && (
+        <div className="index-job-request-error" role="alert">
+          <span>{error}</span>
+          {pollingJobId && (
+            <button
+              type="button"
+              onClick={() => setPollRevision((revision) => revision + 1)}
+            >
+              Retry status
+            </button>
+          )}
+        </div>
+      )}
+      {job && <IndexJobProgress job={job} />}
+    </div>
+  );
+}

--- a/web/components/IndexStatusControl.test.tsx
+++ b/web/components/IndexStatusControl.test.tsx
@@ -120,6 +120,19 @@ describe("index status invariants", () => {
         ],
       }),
     ).toBe(false);
+
+    const conflicting = statusFixture();
+    conflicting.indexes[0] = {
+      ...conflicting.indexes[0],
+      state: "updating",
+      job_id: "job-1",
+    };
+    conflicting.indexes[1] = {
+      ...conflicting.indexes[1],
+      state: "updating",
+      job_id: "job-2",
+    };
+    expect(hasCanonicalIndexSurfaces(conflicting)).toBe(false);
   });
 
   it("keeps failures visible above in-progress and stale surfaces", () => {

--- a/web/components/IndexStatusControl.tsx
+++ b/web/components/IndexStatusControl.tsx
@@ -13,6 +13,7 @@ import {
   type IndexType,
   type RepoIndexStatus,
 } from "@/lib/api";
+import IndexJobControl from "./IndexJobControl";
 
 const INDEX_TYPES = ["bm25", "vector", "symbol_graph"] as const;
 
@@ -46,10 +47,18 @@ const STATE_PRIORITY: Record<IndexSurfaceState, number> = {
 };
 
 export function hasCanonicalIndexSurfaces(status: RepoIndexStatus): boolean {
+  const activeJobIds = new Set(
+    status.indexes
+      .map((surface) => surface.job_id)
+      .filter((jobId): jobId is string => Boolean(jobId)),
+  );
   return (
     status.indexes.length === INDEX_TYPES.length &&
+    activeJobIds.size <= 1 &&
     status.indexes.every(
-      (surface, index) => surface.index_type === INDEX_TYPES[index],
+      (surface, index) =>
+        surface.index_type === INDEX_TYPES[index] &&
+        (surface.state === "updating") === Boolean(surface.job_id),
     )
   );
 }
@@ -224,7 +233,14 @@ export default function IndexStatusControl({ repoId }: { repoId: string }) {
             {error}
           </div>
         ) : visibleStatus ? (
-          <IndexStatusDetails status={visibleStatus} />
+          <>
+            <IndexStatusDetails status={visibleStatus} />
+            <IndexJobControl
+              key={visibleStatus.repo_id}
+              status={visibleStatus}
+              onRefresh={load}
+            />
+          </>
         ) : (
           <div className="index-status-loading" role="status">
             Loading index status…


### PR DESCRIPTION
## Summary

Add a production-aligned repository index job control to the dynamic Web rail. The control preserves the current durable writer boundary: one advertised writable surface per job, capability-derived full or incremental mode, and no unsupported force request.

This PR is stacked on #741. Its dependency chain remains #735 -> #736 -> #737 -> #740 -> #741.

## Changes

- Add one-surface BM25, Embeddings, and Symbol graph selection with unavailable capabilities disabled.
- Resume queued or running durable jobs from repository status, poll and fully drain bounded event pages, retain a bounded deduplicated result window, and refresh status after terminal settlement.
- Follow a refreshed external active job after retaining a prior terminal result, while finishing any already-started terminal event drain first.
- Reuse a caller-owned idempotency key only for retries of the same canonical request intent.
- Abort superseded polling reads and display sanitized failures, effective update mode, public result commit, and retained incremental metrics.
- Reject conflicting active-job overlays and document the delivered #266 UI slice plus remaining vector, graph, landing, and Ask work.
- Keep the runtime-only control absent from static exports.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `cd web && npm test -- --run` (70 passed)
- `cd web && npm run build`
- `cd web && tsc --noEmit`
- Focused pre-commit hooks for all changed files
- Mocked Playwright lifecycle: BM25 full request, response polling, result rendering, and terminal status refresh

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
