### PR TITLE
feat(web): show repository index badges

### DIFF
--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1596,8 +1596,8 @@ lifespan now owns that composition
 and verifies a real first-build job through strict materialization and RCU
 replacement. The dynamic repository rail now exposes the three canonical index
 surfaces, durable job progress, and one capability-bound update action. MCP,
-landing/Ask freshness controls, vector/graph adapters, and default storage
-routing remain absent.
+Ask freshness controls, vector/graph adapters, and default storage routing
+remain absent.
 
 - The backend-neutral worker now owns advisory scan/claim, per-attempt task
   authority, independent heartbeat sessions, cancellation precedence, bounded
@@ -1693,9 +1693,8 @@ routing remain absent.
   and advertising updates when either owned loop faults, reports unbound
   repositories as unavailable, and rejects a retained BM25 replacement whose
   source-selection policy or normalized language sequence differs from the
-  active Web generation. The remaining #266 work includes landing-page badges,
-  Ask freshness choices, production vector/graph update adapters, and their
-  default routing.
+  active Web generation. The remaining #266 work includes Ask freshness choices,
+  production vector/graph update adapters, and their default routing.
 - The first #266 read slice exposes one pinned, detached status snapshot for
   exactly BM25, vector, and symbol-graph surfaces. It reports manifest/current
   commit drift and retained incremental metrics without exposing mutable bundle
@@ -1821,6 +1820,12 @@ routing remain absent.
   the repository status after terminal settlement. Static exports omit the
   runtime-only control. The production local service currently advertises only
   retained-source BM25 rebuilds; vector and graph writes remain unavailable.
+- Dynamic landing-page repository cards now fetch the same strict three-surface
+  status and show compact text-plus-color BM25, Embeddings, and Graph badges
+  together with repository freshness. Each card aborts an obsolete request,
+  rejects a cross-repository or noncanonical response, and degrades without
+  hiding the repository when status is unavailable. Static exports issue no
+  status request and render no runtime-only badge placeholder.
 - Keep read-only/prebuilt paths safe through copy-on-write or explicit refusal.
 
 ### M4: Cross-file reference de-materialization

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -354,6 +354,64 @@ pre {
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
+
+.repo-index-summary {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 5px 8px;
+  min-height: 25px;
+  margin-top: 10px;
+  padding-top: 9px;
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.repo-index-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.repo-index-badge {
+  padding: 3px 6px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-muted);
+  font-size: 9px;
+}
+
+.repo-index-freshness {
+  color: #b45309;
+  font-weight: 650;
+  white-space: nowrap;
+}
+
+.repo-index-summary.loading {
+  animation: repo-index-pulse 1.4s ease-in-out infinite;
+}
+
+.repo-index-summary.unavailable {
+  color: var(--text-secondary);
+}
+
+[data-theme="dark"] .repo-index-freshness {
+  color: #fbbf24;
+}
+
+@keyframes repo-index-pulse {
+  50% {
+    opacity: 0.55;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .repo-index-summary.loading {
+    animation: none;
+  }
+}
+
 .repo-card .repo-card-footer {
   margin-top: auto;
   padding-top: 12px;

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Header from "@/components/Header";
+import RepoIndexBadges from "@/components/RepoIndexBadges";
 import { fetchRepos, type RepoInfo } from "@/lib/api";
 import { AppLink, navigate } from "@/lib/router";
 import { isStaticRuntime } from "@/lib/runtime";
@@ -24,12 +25,19 @@ function incrementalNote(r: RepoInfo): string | null {
   return `${commits} · ${s.speedup}× warm-patch speedup`;
 }
 
-function RepoCard({ r }: { r: RepoInfo }) {
+function RepoCard({
+  r,
+  showIndexStatus,
+}: {
+  r: RepoInfo;
+  showIndexStatus: boolean;
+}) {
   const incremental = incrementalNote(r);
   return (
     <AppLink className="repo-card" href={`/${r.id}`} aria-label={`Open ${r.repo} wiki`}>
       <div className="repo-card-title">{r.repo}</div>
       <div className="repo-card-desc">{repoDescription(r)}</div>
+      {showIndexStatus && <RepoIndexBadges repoId={r.id} />}
       <div className="repo-card-footer">
         <span className={`lang lang-${(r.language || "").toLowerCase().split("/")[0]}`}>
           {r.language || "code"}
@@ -189,7 +197,7 @@ export default function Landing() {
         {!error && loading && repos.length === 0 && <div className="empty">Loading repositories…</div>}
         {!error && !loading && repos.length === 0 && <div className="empty">No repositories found.</div>}
         {filtered.map((r) => (
-          <RepoCard key={r.id} r={r} />
+          <RepoCard key={r.id} r={r} showIndexStatus={!staticRuntime} />
         ))}
       </div>
     </div>

--- a/web/components/IndexStatusControl.tsx
+++ b/web/components/IndexStatusControl.tsx
@@ -13,9 +13,13 @@ import {
   type IndexType,
   type RepoIndexStatus,
 } from "@/lib/api";
+import {
+  aggregateIndexState,
+  hasCanonicalIndexSurfaces,
+} from "@/lib/indexStatus";
 import IndexJobControl from "./IndexJobControl";
 
-const INDEX_TYPES = ["bm25", "vector", "symbol_graph"] as const;
+export { aggregateIndexState, hasCanonicalIndexSurfaces } from "@/lib/indexStatus";
 
 const INDEX_LABELS: Record<IndexType, string> = {
   bm25: "BM25",
@@ -37,41 +41,6 @@ const MODE_LABELS: Record<IndexSurfaceStatus["update_mode"], string> = {
   rebuild: "Rebuild on update",
   unavailable: "Updates unavailable",
 };
-
-const STATE_PRIORITY: Record<IndexSurfaceState, number> = {
-  built: 0,
-  missing: 1,
-  stale: 2,
-  updating: 3,
-  failed: 4,
-};
-
-export function hasCanonicalIndexSurfaces(status: RepoIndexStatus): boolean {
-  const activeJobIds = new Set(
-    status.indexes
-      .map((surface) => surface.job_id)
-      .filter((jobId): jobId is string => Boolean(jobId)),
-  );
-  return (
-    status.indexes.length === INDEX_TYPES.length &&
-    activeJobIds.size <= 1 &&
-    status.indexes.every(
-      (surface, index) =>
-        surface.index_type === INDEX_TYPES[index] &&
-        (surface.state === "updating") === Boolean(surface.job_id),
-    )
-  );
-}
-
-export function aggregateIndexState(status: RepoIndexStatus): IndexSurfaceState {
-  return status.indexes.reduce<IndexSurfaceState>(
-    (current, surface) =>
-      STATE_PRIORITY[surface.state] > STATE_PRIORITY[current]
-        ? surface.state
-        : current,
-    status.stale ? "stale" : "built",
-  );
-}
 
 function shortCommit(commit: string | null): string {
   return commit ? commit.slice(0, 8) : "—";

--- a/web/components/RepoIndexBadges.test.tsx
+++ b/web/components/RepoIndexBadges.test.tsx
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { RepoIndexStatus } from "@/lib/api";
+import RepoIndexBadges, { RepoIndexBadgeList } from "./RepoIndexBadges";
+
+function statusFixture(): RepoIndexStatus {
+  return {
+    repo_id: "demo",
+    last_indexed_commit: "1234567890abcdef",
+    current_head: "fedcba0987654321",
+    stale: true,
+    indexes: [
+      {
+        index_type: "bm25",
+        state: "stale",
+        stale: true,
+        indexed_commit: "1234567890abcdef",
+        built_at: "2026-08-28T00:00:00Z",
+        update_mode: "rebuild",
+        updates_enabled: true,
+        update_reason: "",
+        job_id: null,
+        metrics: null,
+      },
+      {
+        index_type: "vector",
+        state: "built",
+        stale: false,
+        indexed_commit: "fedcba0987654321",
+        built_at: "2026-08-28T00:01:00Z",
+        update_mode: "incremental",
+        updates_enabled: true,
+        update_reason: "",
+        job_id: null,
+        metrics: null,
+      },
+      {
+        index_type: "symbol_graph",
+        state: "missing",
+        stale: false,
+        indexed_commit: null,
+        built_at: null,
+        update_mode: "unavailable",
+        updates_enabled: false,
+        update_reason: "No graph updater is configured.",
+        job_id: null,
+        metrics: null,
+      },
+    ],
+  };
+}
+
+describe("RepoIndexBadgeList", () => {
+  it("shows exactly the three canonical surfaces and repository freshness", () => {
+    const html = renderToStaticMarkup(
+      <RepoIndexBadgeList status={statusFixture()} />,
+    );
+
+    expect(html.match(/class="repo-index-badge index-state/g)).toHaveLength(3);
+    expect(html).toContain("BM25 · Stale");
+    expect(html).toContain("Embeddings · Built");
+    expect(html).toContain("Graph · Missing");
+    expect(html).toContain("Update available");
+  });
+
+  it("keeps update mode, commit, and disabled reason in each badge title", () => {
+    const html = renderToStaticMarkup(
+      <RepoIndexBadgeList status={statusFixture()} />,
+    );
+
+    expect(html).toContain("rebuild on update · indexed 12345678");
+    expect(html).toContain("incremental update · indexed fedcba09");
+    expect(html).toContain(
+      "updates unavailable · No graph updater is configured.",
+    );
+  });
+
+  it("reserves a visible loading state before the runtime response", () => {
+    const html = renderToStaticMarkup(<RepoIndexBadges repoId="demo" />);
+
+    expect(html).toContain("Checking indexes…");
+    expect(html).toContain('class="repo-index-summary loading"');
+  });
+});

--- a/web/components/RepoIndexBadges.tsx
+++ b/web/components/RepoIndexBadges.tsx
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  fetchIndexStatus,
+  type IndexSurfaceState,
+  type IndexSurfaceStatus,
+  type IndexType,
+  type RepoIndexStatus,
+} from "@/lib/api";
+import { hasCanonicalIndexSurfaces } from "@/lib/indexStatus";
+
+const INDEX_LABELS: Record<IndexType, string> = {
+  bm25: "BM25",
+  vector: "Embeddings",
+  symbol_graph: "Graph",
+};
+
+const STATE_LABELS: Record<IndexSurfaceState, string> = {
+  built: "Built",
+  missing: "Missing",
+  stale: "Stale",
+  updating: "Updating",
+  failed: "Failed",
+};
+
+const MODE_LABELS: Record<IndexSurfaceStatus["update_mode"], string> = {
+  incremental: "incremental update",
+  patch: "patch update",
+  rebuild: "rebuild on update",
+  unavailable: "updates unavailable",
+};
+
+function badgeTitle(surface: IndexSurfaceStatus): string {
+  const details = [
+    `${INDEX_LABELS[surface.index_type]}: ${STATE_LABELS[surface.state]}`,
+    MODE_LABELS[surface.update_mode],
+  ];
+  if (surface.indexed_commit) {
+    details.push(`indexed ${surface.indexed_commit.slice(0, 8)}`);
+  }
+  if (!surface.updates_enabled && surface.update_reason) {
+    details.push(surface.update_reason);
+  }
+  return details.join(" · ");
+}
+
+export function RepoIndexBadgeList({ status }: { status: RepoIndexStatus }) {
+  return (
+    <div className="repo-index-summary" aria-label="Repository index status">
+      <div className="repo-index-badges">
+        {status.indexes.map((surface) => (
+          <span
+            className={`repo-index-badge index-state ${surface.state}`}
+            title={badgeTitle(surface)}
+            key={surface.index_type}
+          >
+            {INDEX_LABELS[surface.index_type]} · {STATE_LABELS[surface.state]}
+          </span>
+        ))}
+      </div>
+      {status.stale && (
+        <span className="repo-index-freshness">Update available</span>
+      )}
+    </div>
+  );
+}
+
+export default function RepoIndexBadges({ repoId }: { repoId: string }) {
+  const [status, setStatus] = useState<RepoIndexStatus | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let active = true;
+    setStatus(null);
+    setUnavailable(false);
+
+    void fetchIndexStatus(repoId, { signal: controller.signal })
+      .then((next) => {
+        if (!active) return;
+        if (next.repo_id !== repoId || !hasCanonicalIndexSurfaces(next)) {
+          throw new Error("Index status response is incomplete");
+        }
+        setStatus(next);
+      })
+      .catch(() => {
+        if (active && !controller.signal.aborted) setUnavailable(true);
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [repoId]);
+
+  if (status) return <RepoIndexBadgeList status={status} />;
+  return (
+    <div
+      className={`repo-index-summary ${
+        unavailable ? "unavailable" : "loading"
+      }`}
+    >
+      {unavailable ? "Index status unavailable" : "Checking indexes…"}
+    </div>
+  );
+}

--- a/web/lib/indexStatus.ts
+++ b/web/lib/indexStatus.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { IndexSurfaceState, RepoIndexStatus } from "./api";
+
+const INDEX_TYPES = ["bm25", "vector", "symbol_graph"] as const;
+
+const STATE_PRIORITY: Record<IndexSurfaceState, number> = {
+  built: 0,
+  missing: 1,
+  stale: 2,
+  updating: 3,
+  failed: 4,
+};
+
+export function hasCanonicalIndexSurfaces(status: RepoIndexStatus): boolean {
+  const activeJobIds = new Set(
+    status.indexes
+      .map((surface) => surface.job_id)
+      .filter((jobId): jobId is string => Boolean(jobId)),
+  );
+  return (
+    status.indexes.length === INDEX_TYPES.length &&
+    activeJobIds.size <= 1 &&
+    status.indexes.every(
+      (surface, index) =>
+        surface.index_type === INDEX_TYPES[index] &&
+        (surface.state === "updating") === Boolean(surface.job_id),
+    )
+  );
+}
+
+export function aggregateIndexState(
+  status: RepoIndexStatus,
+): IndexSurfaceState {
+  return status.indexes.reduce<IndexSurfaceState>(
+    (current, surface) =>
+      STATE_PRIORITY[surface.state] > STATE_PRIORITY[current]
+        ? surface.state
+        : current,
+    status.stale ? "stale" : "built",
+  );
+}


### PR DESCRIPTION
## Summary

Show the strict three-surface index status directly on each dynamic landing-page repository card. Cards remain usable when status is unavailable, while static exports make no runtime status request and render no badge placeholder.

This PR is stacked on #742. The remaining dependency chain is #736 -> #737 -> #740 -> #741 -> #742.

## Changes

- Add compact text-plus-color BM25, Embeddings, and Graph badges with explicit built, missing, stale, updating, and failed states.
- Show repository-level update availability and retain update mode, indexed commit, and disabled reason in badge details.
- Abort obsolete per-card reads and reject cross-repository or noncanonical three-surface responses.
- Degrade to a quiet unavailable state without hiding or disabling the repository card.
- Extract canonical status validation and aggregation into a lightweight shared module for detail, landing, and future Ask consumers.
- Keep static exports free of runtime index-status requests and record the #266 landing milestone in the storage roadmap.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `cd web && npm test -- --run` (73 passed)
- `cd web && npm run build`
- `cd web && tsc --noEmit`
- Focused pre-commit hooks for every changed file
- Mocked Playwright dynamic landing check: six badges across two cards and no horizontal overflow
- Mocked Playwright static export check: zero badge placeholders, add-repo cards, or index-status requests

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
