### PR TITLE
feat(web): guard Ask with index freshness

### DIFF
--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1596,8 +1596,7 @@ lifespan now owns that composition
 and verifies a real first-build job through strict materialization and RCU
 replacement. The dynamic repository rail now exposes the three canonical index
 surfaces, durable job progress, and one capability-bound update action. MCP,
-Ask freshness controls, vector/graph adapters, and default storage routing
-remain absent.
+vector/graph adapters, and default storage routing remain absent.
 
 - The backend-neutral worker now owns advisory scan/claim, per-attempt task
   authority, independent heartbeat sessions, cancellation precedence, bounded
@@ -1693,8 +1692,8 @@ remain absent.
   and advertising updates when either owned loop faults, reports unbound
   repositories as unavailable, and rejects a retained BM25 replacement whose
   source-selection policy or normalized language sequence differs from the
-  active Web generation. The remaining #266 work includes Ask freshness choices,
-  production vector/graph update adapters, and their default routing.
+  active Web generation. The remaining #266 work includes production
+  vector/graph update adapters and their default routing.
 - The first #266 read slice exposes one pinned, detached status snapshot for
   exactly BM25, vector, and symbol-graph surfaces. It reports manifest/current
   commit drift and retained incremental metrics without exposing mutable bundle
@@ -1826,6 +1825,17 @@ remain absent.
   rejects a cross-repository or noncanonical response, and degrades without
   hiding the repository when status is unavailable. Static exports issue no
   status request and render no runtime-only badge placeholder.
+- The Ask route now performs one abortable, two-second-bounded strict status read
+  before dispatching a first question. A stale, updating, or failed BM25/vector
+  retrieval surface holds that question and offers an explicit current-snapshot
+  choice or a retrieval-only update control; unavailable status fails open to
+  the already loaded runtime. A successful guarded refresh that makes the
+  retrieval snapshot current automatically dispatches the held question, while
+  choosing the incumbent never cancels an update already running in the
+  background. Missing unavailable vector and all symbol-graph state are not
+  misrepresented as Ask retrieval freshness. React StrictMode replay and route
+  changes cannot duplicate the first question, and static exports make no
+  runtime status request.
 - Keep read-only/prebuilt paths safe through copy-on-write or explicit refusal.
 
 ### M4: Cross-file reference de-materialization

--- a/web/app/[repoId]/ask/page.tsx
+++ b/web/app/[repoId]/ask/page.tsx
@@ -4,22 +4,30 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Header from "@/components/Header";
 import Markdown from "@/components/Markdown";
 import AskBar from "@/components/AskBar";
+import AskIndexFreshness, {
+  askIndexAttention,
+} from "@/components/AskIndexFreshness";
 import CodePanel from "@/components/CodePanel";
 import {
   askQuestion,
+  fetchIndexStatus,
   fetchRepos,
   fetchWikiTree,
   type ChatMessage,
   type ChatResponse,
   type RepoInfo,
+  type RepoIndexStatus,
   type WikiPageRef,
 } from "@/lib/api";
 import { codeRefs } from "@/lib/citations";
+import { hasCanonicalIndexSurfaces } from "@/lib/indexStatus";
 import { relatedWikiPages } from "@/lib/relatedWiki";
 import { AppLink } from "@/lib/router";
+import { isStaticRuntime } from "@/lib/runtime";
 
 // DeepWiki clamps the question to ~200 chars before "Show full text".
 const Q_TRUNCATE = 200;
+const INDEX_STATUS_GATE_TIMEOUT_MS = 2_000;
 
 // One question + its (eventual) answer in the conversation thread.
 interface Turn {
@@ -28,17 +36,86 @@ interface Turn {
   err: string | null;
 }
 
+interface QueuedQuestion {
+  id: number;
+  query: string;
+}
+
 function AskAnswer({ repoId, query }: { repoId: string; query: string }) {
   const q = query.trim();
+  const staticRuntime = isStaticRuntime();
 
   const [repo, setRepo] = useState<RepoInfo | null>(null);
   const [wikiPages, setWikiPages] = useState<WikiPageRef[]>([]);
   const [turns, setTurns] = useState<Turn[]>([]);
   const [loading, setLoading] = useState(false);
   const [loadingSeconds, setLoadingSeconds] = useState(0);
+  const [indexStatus, setIndexStatus] = useState<RepoIndexStatus | null>(null);
+  const [indexStatusResolved, setIndexStatusResolved] = useState(false);
+  const [pendingQuestion, setPendingQuestion] =
+    useState<QueuedQuestion | null>(null);
+  const [showIndexUpdate, setShowIndexUpdate] = useState(false);
   // Bumped whenever the thread resets so in-flight answers from a previous
   // conversation can't land in the new one.
   const genRef = useRef(0);
+  const indexStatusRequest = useRef<AbortController | null>(null);
+  const indexStatusRequestId = useRef(0);
+  const questionId = useRef(0);
+  const conversationKey = `${repoId}\u0000${q}`;
+  const conversationKeyRef = useRef(conversationKey);
+  const dispatchedQuestionId = useRef(0);
+  const consumedPendingId = useRef(0);
+  const [queuedQuestion, setQueuedQuestion] =
+    useState<QueuedQuestion | null>(() =>
+      q ? { id: ++questionId.current, query: q } : null,
+    );
+
+  const loadIndexStatus = useCallback(async () => {
+    indexStatusRequest.current?.abort();
+    const controller = new AbortController();
+    indexStatusRequest.current = controller;
+    const requestId = ++indexStatusRequestId.current;
+    setIndexStatusResolved(false);
+    if (staticRuntime) {
+      indexStatusRequest.current = null;
+      setIndexStatus(null);
+      setIndexStatusResolved(true);
+      return;
+    }
+
+    const timeout = window.setTimeout(
+      () => controller.abort(),
+      INDEX_STATUS_GATE_TIMEOUT_MS,
+    );
+    try {
+      const next = await fetchIndexStatus(repoId, {
+        signal: controller.signal,
+      });
+      if (next.repo_id !== repoId || !hasCanonicalIndexSurfaces(next)) {
+        throw new Error("Index status response is incomplete");
+      }
+      if (indexStatusRequestId.current === requestId) setIndexStatus(next);
+    } catch {
+      // Index awareness must not make an otherwise usable Ask route fail. A
+      // bounded unavailable read falls back to the currently loaded runtime.
+    } finally {
+      window.clearTimeout(timeout);
+      if (indexStatusRequestId.current === requestId) {
+        indexStatusRequest.current = null;
+        setIndexStatusResolved(true);
+      }
+    }
+  }, [repoId, staticRuntime]);
+
+  useEffect(() => {
+    setIndexStatus(null);
+    void loadIndexStatus();
+    return () => {
+      indexStatusRequestId.current += 1;
+      indexStatusRequest.current?.abort();
+      indexStatusRequest.current = null;
+    };
+  }, [loadIndexStatus]);
 
   useEffect(() => {
     let cancelled = false;
@@ -107,15 +184,47 @@ function AskAnswer({ repoId, query }: { repoId: string; query: string }) {
     [repoId]
   );
 
-  // A new URL question (arriving from a wiki page's ask bar) starts a fresh
-  // conversation; follow-ups submitted on this page append in place instead.
+  // A new URL question starts one fresh conversation. The key ref also avoids
+  // issuing a duplicate initial request when React StrictMode replays effects.
   useEffect(() => {
+    if (conversationKeyRef.current === conversationKey) return;
+    conversationKeyRef.current = conversationKey;
     genRef.current += 1;
     setTurns([]);
     setLoading(false);
     setQExpanded(new Set());
-    if (q) runAsk(q, []);
-  }, [repoId, q, runAsk]);
+    setPendingQuestion(null);
+    setShowIndexUpdate(false);
+    consumedPendingId.current = 0;
+    setQueuedQuestion(
+      q ? { id: ++questionId.current, query: q } : null,
+    );
+  }, [conversationKey, q]);
+
+  const indexAttention = useMemo(
+    () => (indexStatus ? askIndexAttention(indexStatus) : null),
+    [indexStatus],
+  );
+
+  // A first question waits only for the bounded status read. Missing or failed
+  // status awareness fails open to the already loaded retrieval snapshot.
+  useEffect(() => {
+    if (!queuedQuestion || !indexStatusResolved) return;
+    if (dispatchedQuestionId.current === queuedQuestion.id) return;
+    dispatchedQuestionId.current = queuedQuestion.id;
+    setQueuedQuestion(null);
+    if (indexStatus && indexAttention?.needsAttention) {
+      setPendingQuestion(queuedQuestion);
+      return;
+    }
+    runAsk(queuedQuestion.query, []);
+  }, [
+    indexAttention,
+    indexStatus,
+    indexStatusResolved,
+    queuedQuestion,
+    runAsk,
+  ]);
 
   function followUp(query: string) {
     if (loading) return;
@@ -128,7 +237,50 @@ function AskAnswer({ repoId, query }: { repoId: string; query: string }) {
     runAsk(query, history);
   }
 
+  function submitQuestion(query: string) {
+    if (loading) return;
+    if (turns.length > 0) {
+      followUp(query);
+      return;
+    }
+    setQueuedQuestion({ id: ++questionId.current, query });
+  }
+
+  const askPendingQuestion = useCallback(() => {
+    if (!pendingQuestion || consumedPendingId.current === pendingQuestion.id) {
+      return;
+    }
+    consumedPendingId.current = pendingQuestion.id;
+    const next = pendingQuestion.query;
+    setPendingQuestion(null);
+    setShowIndexUpdate(false);
+    runAsk(next, []);
+  }, [pendingQuestion, runAsk]);
+
+  // Once the guarded runtime refresh reports a current retrieval snapshot,
+  // continue the held question without asking the user to submit it again.
+  useEffect(() => {
+    if (
+      !showIndexUpdate ||
+      !pendingQuestion ||
+      !indexStatusResolved ||
+      !indexStatus ||
+      indexAttention?.needsAttention
+    ) {
+      return;
+    }
+    askPendingQuestion();
+  }, [
+    askPendingQuestion,
+    indexAttention,
+    indexStatus,
+    indexStatusResolved,
+    pendingQuestion,
+    showIndexUpdate,
+  ]);
+
   const repoName = repo ? repo.repo : repoId;
+  const waitingQuestion = pendingQuestion ?? queuedQuestion;
   // Per-turn citation lists so a chip's index lines up with the code pane.
   const turnRefs = useMemo(
     () => turns.map((t) => codeRefs(t.resp?.citations ?? [])),
@@ -208,14 +360,33 @@ function AskAnswer({ repoId, query }: { repoId: string; query: string }) {
 
           {turns.length === 0 && (
             <>
-              <h1 className="ask-q">Ask about {repoName}</h1>
-              <AskBar
-                repoId={repoId}
-                repo={repoName}
-                onSubmit={followUp}
-                disabled={loading}
-                inline
-              />
+              <h1 className="ask-q">
+                {waitingQuestion?.query ?? `Ask about ${repoName}`}
+              </h1>
+              {queuedQuestion && !indexStatusResolved && (
+                <div className="ask-index-checking" role="status">
+                  Checking retrieval index freshness…
+                </div>
+              )}
+              {indexStatus && indexAttention?.needsAttention && (
+                <AskIndexFreshness
+                  status={indexStatus}
+                  hasPendingQuestion={Boolean(pendingQuestion)}
+                  showUpdateControl={showIndexUpdate}
+                  onShowUpdate={() => setShowIndexUpdate(true)}
+                  onAskCurrent={askPendingQuestion}
+                  onRefresh={loadIndexStatus}
+                />
+              )}
+              {!waitingQuestion && (
+                <AskBar
+                  repoId={repoId}
+                  repo={repoName}
+                  onSubmit={submitQuestion}
+                  disabled={loading}
+                  inline
+                />
+              )}
             </>
           )}
 
@@ -312,7 +483,12 @@ function AskAnswer({ repoId, query }: { repoId: string; query: string }) {
       </div>
 
       {turns.length > 0 && (
-        <AskBar repoId={repoId} repo={repoName} onSubmit={followUp} disabled={loading} />
+        <AskBar
+          repoId={repoId}
+          repo={repoName}
+          onSubmit={submitQuestion}
+          disabled={loading}
+        />
       )}
     </div>
   );

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3662,6 +3662,86 @@ a.evidence-row:hover {
   line-height: 1.35;
   margin: 10px 0 18px;
 }
+
+.ask-index-checking,
+.ask-index-freshness {
+  margin: 4px 0 20px;
+  padding: 13px 14px;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: var(--bg-surface);
+}
+
+.ask-index-checking {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.ask-index-freshness.stale,
+.ask-index-freshness.updating {
+  border-color: rgba(217, 119, 6, 0.35);
+  background: rgba(217, 119, 6, 0.05);
+}
+
+.ask-index-freshness.failed {
+  border-color: rgba(220, 38, 38, 0.35);
+  background: rgba(220, 38, 38, 0.05);
+}
+
+.ask-index-freshness-head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.ask-index-freshness-head strong {
+  color: var(--text);
+  font-size: 13px;
+}
+
+.ask-index-freshness p {
+  margin: 7px 0 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.ask-index-commits {
+  margin-top: 6px;
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.ask-index-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 11px;
+}
+
+.ask-index-actions button {
+  min-height: 32px;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--bg);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.ask-index-actions button:first-child {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.ask-index-freshness .index-job-control {
+  margin-top: 12px;
+}
+
 .askbar-inline {
   position: static;
   width: 100%;

--- a/web/components/AskIndexFreshness.test.tsx
+++ b/web/components/AskIndexFreshness.test.tsx
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { RepoIndexStatus } from "@/lib/api";
+import AskIndexFreshness, { askIndexAttention } from "./AskIndexFreshness";
+
+function statusFixture(): RepoIndexStatus {
+  return {
+    repo_id: "demo",
+    last_indexed_commit: "1234567890abcdef",
+    current_head: "fedcba0987654321",
+    stale: true,
+    indexes: [
+      {
+        index_type: "bm25",
+        state: "stale",
+        stale: true,
+        indexed_commit: "1234567890abcdef",
+        built_at: "2026-08-28T00:00:00Z",
+        update_mode: "rebuild",
+        updates_enabled: true,
+        update_reason: "",
+        job_id: null,
+        metrics: null,
+      },
+      {
+        index_type: "vector",
+        state: "missing",
+        stale: false,
+        indexed_commit: null,
+        built_at: null,
+        update_mode: "unavailable",
+        updates_enabled: false,
+        update_reason: "No vector writer is configured.",
+        job_id: null,
+        metrics: null,
+      },
+      {
+        index_type: "symbol_graph",
+        state: "failed",
+        stale: false,
+        indexed_commit: null,
+        built_at: null,
+        update_mode: "patch",
+        updates_enabled: true,
+        update_reason: "",
+        job_id: null,
+        metrics: null,
+      },
+    ],
+  };
+}
+
+describe("askIndexAttention", () => {
+  it("tracks Ask retrieval surfaces without treating graph state as retrieval", () => {
+    const attention = askIndexAttention(statusFixture());
+
+    expect(attention).toEqual({
+      needsAttention: true,
+      state: "stale",
+      indexes: ["bm25"],
+      writable: true,
+    });
+  });
+
+  it("prioritizes failed and updating retrieval states", () => {
+    const failed = statusFixture();
+    failed.indexes[0] = { ...failed.indexes[0], state: "failed" };
+    expect(askIndexAttention(failed).state).toBe("failed");
+
+    const updating = statusFixture();
+    updating.indexes[0] = {
+      ...updating.indexes[0],
+      state: "updating",
+      job_id: "job-1",
+    };
+    expect(askIndexAttention(updating).state).toBe("updating");
+  });
+
+  it("accepts a current built retrieval snapshot", () => {
+    const current = statusFixture();
+    current.stale = false;
+    current.current_head = current.last_indexed_commit;
+    current.indexes[0] = {
+      ...current.indexes[0],
+      state: "built",
+      stale: false,
+    };
+
+    expect(askIndexAttention(current).needsAttention).toBe(false);
+  });
+});
+
+describe("AskIndexFreshness", () => {
+  it("offers an explicit update-or-current choice for a pending question", () => {
+    const html = renderToStaticMarkup(
+      <AskIndexFreshness
+        status={statusFixture()}
+        hasPendingQuestion
+        showUpdateControl={false}
+        onShowUpdate={vi.fn()}
+        onAskCurrent={vi.fn()}
+        onRefresh={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain("Newer source changes are available");
+    expect(html).toContain("BM25 may not match the repository HEAD");
+    expect(html).toContain("Update indexes first");
+    expect(html).toContain("Ask with current index");
+    expect(html).toContain("12345678");
+    expect(html).toContain("fedcba09");
+  });
+
+  it("limits the embedded update control to retrieval surfaces", () => {
+    const html = renderToStaticMarkup(
+      <AskIndexFreshness
+        status={statusFixture()}
+        hasPendingQuestion
+        showUpdateControl
+        onShowUpdate={vi.fn()}
+        onAskCurrent={vi.fn()}
+        onRefresh={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain("Rebuild BM25");
+    expect(html).toContain(">Symbol graph<");
+    expect(html.match(/type="radio"[^>]*disabled/g)).toHaveLength(2);
+    expect(html).toContain("Ask with current index");
+  });
+});

--- a/web/components/AskIndexFreshness.tsx
+++ b/web/components/AskIndexFreshness.tsx
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import type { IndexType, RepoIndexStatus } from "@/lib/api";
+import IndexJobControl from "./IndexJobControl";
+
+const RETRIEVAL_INDEXES = new Set<IndexType>(["bm25", "vector"]);
+const INDEX_LABELS: Record<IndexType, string> = {
+  bm25: "BM25",
+  vector: "Embeddings",
+  symbol_graph: "Symbol graph",
+};
+
+export interface AskIndexAttention {
+  needsAttention: boolean;
+  state: "fresh" | "stale" | "updating" | "failed";
+  indexes: IndexType[];
+  writable: boolean;
+}
+
+export function askIndexAttention(status: RepoIndexStatus): AskIndexAttention {
+  const relevant = status.indexes.filter(
+    (surface) =>
+      surface.index_type === "bm25" ||
+      (surface.index_type === "vector" &&
+        (surface.state !== "missing" || surface.updates_enabled)),
+  );
+  const unsettled = relevant.filter((surface) => surface.state !== "built");
+  const needsAttention = status.stale || unsettled.length > 0;
+  let state: AskIndexAttention["state"] = "fresh";
+  if (needsAttention) {
+    state = unsettled.some((surface) => surface.state === "failed")
+      ? "failed"
+      : unsettled.some((surface) => surface.state === "updating")
+        ? "updating"
+        : "stale";
+  }
+  return {
+    needsAttention,
+    state,
+    indexes: (unsettled.length ? unsettled : relevant).map(
+      (surface) => surface.index_type,
+    ),
+    writable: relevant.some((surface) => surface.updates_enabled),
+  };
+}
+
+function retrievalOnlyStatus(status: RepoIndexStatus): RepoIndexStatus {
+  return {
+    ...status,
+    indexes: status.indexes.map((surface) =>
+      RETRIEVAL_INDEXES.has(surface.index_type)
+        ? surface
+        : {
+            ...surface,
+            update_mode: "unavailable",
+            updates_enabled: false,
+            update_reason: "Symbol graph updates do not change Ask retrieval.",
+          },
+    ),
+  };
+}
+
+const TITLES: Record<AskIndexAttention["state"], string> = {
+  fresh: "Retrieval indexes are current",
+  stale: "Newer source changes are available",
+  updating: "Retrieval indexes are updating",
+  failed: "A retrieval index needs attention",
+};
+
+export default function AskIndexFreshness({
+  status,
+  hasPendingQuestion,
+  showUpdateControl,
+  onShowUpdate,
+  onAskCurrent,
+  onRefresh,
+}: {
+  status: RepoIndexStatus;
+  hasPendingQuestion: boolean;
+  showUpdateControl: boolean;
+  onShowUpdate: () => void;
+  onAskCurrent: () => void;
+  onRefresh: () => Promise<void>;
+}) {
+  const attention = askIndexAttention(status);
+  if (!attention.needsAttention) return null;
+  const labels = attention.indexes.map((indexType) => INDEX_LABELS[indexType]);
+  const subject = labels.length ? labels.join(" and ") : "retrieval indexes";
+  const tracking = attention.state === "updating";
+
+  return (
+    <section
+      className={`ask-index-freshness ${attention.state}`}
+      aria-label="Ask index freshness"
+    >
+      <div className="ask-index-freshness-head">
+        <span className={`index-state ${attention.state}`}>
+          {attention.state}
+        </span>
+        <strong>{TITLES[attention.state]}</strong>
+      </div>
+      <p>
+        {subject} may not match the repository HEAD. You can use the current
+        indexed snapshot or update before asking.
+      </p>
+      {status.last_indexed_commit && status.current_head && (
+        <div className="ask-index-commits mono">
+          Indexed {status.last_indexed_commit.slice(0, 8)} · HEAD{" "}
+          {status.current_head.slice(0, 8)}
+        </div>
+      )}
+      <div className="ask-index-actions">
+        {attention.writable && !showUpdateControl && (
+          <button type="button" onClick={onShowUpdate}>
+            {tracking ? "Track update first" : "Update indexes first"}
+          </button>
+        )}
+        {hasPendingQuestion && (
+          <button type="button" onClick={onAskCurrent}>
+            Ask with current index
+          </button>
+        )}
+      </div>
+      {showUpdateControl && (
+        <IndexJobControl
+          status={retrievalOnlyStatus(status)}
+          onRefresh={onRefresh}
+        />
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Make Ask explicitly index-aware before dispatching a first question. A bounded strict status read holds questions when BM25 or Embeddings are stale, updating, or failed, then offers a current-snapshot choice or the existing durable update workflow.

This PR is stacked on #743. The remaining dependency chain is #736 -> #737 -> #740 -> #741 -> #742 -> #743.

## Changes

- Perform one abortable, two-second-bounded strict status read before a first Ask request.
- Hold URL and inline first questions when relevant retrieval surfaces need attention.
- Offer `Update indexes first` and `Ask with current index` without treating graph-only state as Ask retrieval freshness.
- Reuse the durable job control with symbol-graph writes disabled in the Ask context.
- Automatically dispatch the held question after a successful guarded refresh reports a current retrieval snapshot.
- Keep an already-running update alive when the user chooses the incumbent snapshot.
- Fail open to the loaded runtime when status awareness is unavailable or times out.
- Prevent StrictMode replay and route changes from duplicating the first chat request.
- Keep static exports free of runtime status reads and update the #266 roadmap state.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `cd web && npm test -- --run` (78 passed)
- `cd web && npm run build`
- `cd web && tsc --noEmit`
- Focused pre-commit hooks for every changed file
- Mocked Playwright current-snapshot flow: stale gate sends zero chats before choice and exactly one after
- Mocked Playwright update-first flow: one full BM25 job, two polls, automatic refresh, and exactly one chat
- Mocked Playwright unavailable-status flow: bounded timeout followed by exactly one incumbent chat
- Visual check of the stale question gate at 1100x850

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
