### PR TITLE
fix(web): stabilize local index topology checks

### DIFF
--- a/codenib/web/local_index_service.py
+++ b/codenib/web/local_index_service.py
@@ -38,6 +38,7 @@ from .config import LocalIndexStorageConfig
 _MAX_BUSY_TIMEOUT_MS = 86_400_000
 _MAX_MOUNTINFO_ENTRIES = 65_536
 _MAX_MOUNTINFO_LINE_BYTES = 64 * 1024
+_MAX_OPTIONAL_CATALOG_OBSERVATION_ATTEMPTS = 8
 _MAX_RETAINED_TOPOLOGY_RESOURCES = 16_384
 _TOPOLOGY_TRANSIENT_RESOURCE_RESERVE = 64
 _CATALOG_SIDECARS = (
@@ -60,6 +61,26 @@ class LocalIndexServiceError(StorageError):
     """The explicitly configured local index service is unavailable."""
 
 
+def _catalog_file_identity(metadata: os.stat_result) -> tuple[int, int, int]:
+    identity = (
+        int(metadata.st_dev),
+        int(metadata.st_ino),
+        int(metadata.st_nlink),
+    )
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or identity[0] < 1
+        or identity[1] < 1
+        or identity[2] != 1
+        or getattr(metadata, "st_file_attributes", 0) & _WINDOWS_REPARSE_POINT_ATTRIBUTE
+    ):
+        raise LocalIndexServiceError(
+            "local index catalog must be one real single-linked file"
+        )
+    return identity
+
+
 def _canonical_catalog_path(value: Path) -> Path:
     if type(value) is not type(Path()):
         raise TypeError("local index catalog path must be an exact Path")
@@ -79,49 +100,45 @@ def _observe_catalog_identity_maybe_missing(
     *,
     missing_ok: bool,
 ) -> tuple[int, int, int] | None:
-    try:
-        resolved_before = path.resolve(strict=True)
-        metadata = path.lstat()
-        resolved_after = path.resolve(strict=True)
-    except FileNotFoundError as exc:
-        if missing_ok:
-            # WAL/SHM files are SQLite-owned and may disappear between any two
-            # observations. Accept only a second exact missing observation;
-            # a broken link or immediate replacement remains unsafe.
+    for attempt in range(_MAX_OPTIONAL_CATALOG_OBSERVATION_ATTEMPTS):
+        try:
+            resolved_before = path.resolve(strict=True)
+            metadata = path.lstat()
+            resolved_after = path.resolve(strict=True)
+        except FileNotFoundError as exc:
+            if not missing_ok:
+                raise LocalIndexServiceError(
+                    "local index catalog cannot be inspected safely"
+                ) from exc
+            # WAL/SHM files are SQLite-owned and may disappear or reappear
+            # between observations. Accept a confirmed absence, retry a safe
+            # reappearance, and reject an unsafe replacement immediately.
             try:
-                path.lstat()
+                replacement = path.lstat()
             except FileNotFoundError:
                 return None
             except OSError as retry_exc:
                 raise LocalIndexServiceError(
                     "local index catalog cannot be inspected safely"
                 ) from retry_exc
-        raise LocalIndexServiceError(
-            "local index catalog cannot be inspected safely"
-        ) from exc
-    except (OSError, RuntimeError, ValueError) as exc:
-        raise LocalIndexServiceError(
-            "local index catalog cannot be inspected safely"
-        ) from exc
-    identity = (
-        int(metadata.st_dev),
-        int(metadata.st_ino),
-        int(metadata.st_nlink),
-    )
-    if (
-        resolved_before != path
-        or resolved_after != path
-        or not stat.S_ISREG(metadata.st_mode)
-        or stat.S_ISLNK(metadata.st_mode)
-        or identity[0] < 1
-        or identity[1] < 1
-        or identity[2] != 1
-        or getattr(metadata, "st_file_attributes", 0) & _WINDOWS_REPARSE_POINT_ATTRIBUTE
-    ):
-        raise LocalIndexServiceError(
-            "local index catalog must be one real single-linked file"
-        )
-    return identity
+            _catalog_file_identity(replacement)
+            if attempt + 1 < _MAX_OPTIONAL_CATALOG_OBSERVATION_ATTEMPTS:
+                continue
+            raise LocalIndexServiceError(
+                "local index catalog cannot be inspected safely"
+            ) from exc
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise LocalIndexServiceError(
+                "local index catalog cannot be inspected safely"
+            ) from exc
+        identity = _catalog_file_identity(metadata)
+        if resolved_before != path or resolved_after != path:
+            raise LocalIndexServiceError(
+                "local index catalog must be one real single-linked file"
+            )
+        return identity
+    else:  # pragma: no cover - every loop branch returns or raises
+        raise LocalIndexServiceError("local index catalog cannot be inspected safely")
 
 
 def _observe_catalog_identity(path: Path) -> tuple[int, int, int]:

--- a/test/web/test_local_index_service.py
+++ b/test/web/test_local_index_service.py
@@ -259,32 +259,18 @@ def test_local_index_topology_owner_retains_return_boundary_interruption(
     config, repositories = _topology_config(tmp_path)
     owner = LocalIndexStorageTopologyOwner()
     interruption = KeyboardInterrupt("topology return interrupted")
-    acquire = LocalIndexStorageTopology.acquire
-    implementation = acquire.__func__
-    instructions = tuple(dis.get_instructions(implementation))
-    return_offsets = {
-        instruction.offset
-        for index, instruction in enumerate(instructions)
-        if instruction.opname == "RETURN_VALUE"
-        and any(
-            candidate.opname == "LOAD_FAST" and candidate.argval == "topology"
-            for candidate in instructions[max(0, index - 15) : index]
-        )
-    }
-    assert len(return_offsets) == 1
+    implementation = LocalIndexStorageTopology.acquire.__func__
     injected = False
     previous_trace = sys.gettrace()
 
-    def trace(frame, event: str, _arg: object):
+    def trace(frame, event: str, value: object):
         nonlocal injected
-        if event == "call" and frame.f_code is implementation.__code__:
-            frame.f_trace_opcodes = True
-            return trace
         if (
             not injected
             and frame.f_code is implementation.__code__
-            and event == "opcode"
-            and frame.f_lasti in return_offsets
+            and event == "return"
+            and value is not None
+            and value is frame.f_locals.get("topology")
         ):
             injected = True
             sys.settrace(None)
@@ -294,7 +280,7 @@ def test_local_index_topology_owner_retains_return_boundary_interruption(
     sys.settrace(trace)
     try:
         with pytest.raises(KeyboardInterrupt) as raised:
-            acquire(config, repositories, owner=owner)
+            LocalIndexStorageTopology.acquire(config, repositories, owner=owner)
     finally:
         sys.settrace(previous_trace)
 

--- a/test/web/test_local_index_service.py
+++ b/test/web/test_local_index_service.py
@@ -502,6 +502,102 @@ def test_optional_catalog_sidecar_accepts_confirmed_disappearance(
     assert observations == 2
 
 
+def test_optional_catalog_sidecar_retries_safe_reappearance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sidecar = tmp_path / "catalog.sqlite3-wal"
+    real_resolve = Path.resolve
+    observations = 0
+
+    def reappear(path: Path, strict: bool = False):
+        nonlocal observations
+        if path == sidecar:
+            observations += 1
+            if observations == 1:
+                try:
+                    return real_resolve(path, strict=strict)
+                finally:
+                    sidecar.write_bytes(b"replacement WAL")
+        return real_resolve(path, strict=strict)
+
+    monkeypatch.setattr(Path, "resolve", reappear)
+
+    assert not sidecar.exists()
+    identity = local_index_service._observe_optional_catalog_sidecar(
+        sidecar,
+        label="WAL sidecar",
+    )
+
+    assert identity is not None
+    assert identity == (
+        sidecar.stat().st_dev,
+        sidecar.stat().st_ino,
+        sidecar.stat().st_nlink,
+    )
+    assert observations == 3
+
+
+def test_optional_catalog_sidecar_rejects_unsafe_reappearance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sidecar = tmp_path / "catalog.sqlite3-wal"
+    missing_target = tmp_path / "missing-target"
+    real_resolve = Path.resolve
+    observations = 0
+
+    def reappear_as_broken_link(path: Path, strict: bool = False):
+        nonlocal observations
+        if path == sidecar:
+            observations += 1
+            if observations == 1:
+                try:
+                    return real_resolve(path, strict=strict)
+                finally:
+                    sidecar.symlink_to(missing_target)
+        return real_resolve(path, strict=strict)
+
+    monkeypatch.setattr(Path, "resolve", reappear_as_broken_link)
+
+    with pytest.raises(LocalIndexServiceError, match="must be one real"):
+        local_index_service._observe_optional_catalog_sidecar(
+            sidecar,
+            label="WAL sidecar",
+        )
+
+    assert observations == 1
+
+
+def test_optional_catalog_sidecar_bounds_continuous_reappearance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sidecar = tmp_path / "catalog.sqlite3-wal"
+    sidecar.write_bytes(b"churning WAL")
+    real_resolve = Path.resolve
+    observations = 0
+
+    def keep_reappearing(path: Path, strict: bool = False):
+        nonlocal observations
+        if path == sidecar:
+            observations += 1
+            raise FileNotFoundError(path)
+        return real_resolve(path, strict=strict)
+
+    monkeypatch.setattr(Path, "resolve", keep_reappearing)
+
+    with pytest.raises(LocalIndexServiceError, match="must be one real"):
+        local_index_service._observe_optional_catalog_sidecar(
+            sidecar,
+            label="WAL sidecar",
+        )
+
+    assert (
+        observations == local_index_service._MAX_OPTIONAL_CATALOG_OBSERVATION_ATTEMPTS
+    )
+
+
 def test_local_index_topology_rejects_retained_resource_overcommit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Restore the scheduled Full CI unit tier by removing an interpreter-order dependency from the topology handoff test and by tolerating safe SQLite WAL/SHM sidecar reappearance during concurrent local runtimes.

## Changes

- inject the ownership-handoff interruption through Python's documented return trace event instead of CPython bytecode offsets
- retry a bounded number of observations when an optional SQLite sidecar safely reappears
- continue to reject symlinks, non-regular files, hard links, reparse points, and sidecars that never stabilize
- add deterministic coverage for safe, unsafe, and continuously changing sidecar observations

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- 20 repeated topology handoff checks
- 20 repeated cooperating-worker checks
- `pytest -q test/web/test_local_index_service.py -k 'optional_catalog_sidecar or unconfigured_unsafe_catalog_sidecar' --tb=short`
- `pytest test/web -n auto -q --tb=short` — 658 passed, 1 skipped
- Black, isort, flake8, Python 3.10 compile, and diff checks

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

PR #737 already contains the sidecar commit and should drop that duplicate when rebased after this PR. It remains independently held for its unresolved runtime-admission review threads.