### PR TITLE
feat(wiki): add pluggable SQLite store

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,26 @@ whenever a package changes lifecycle class, an experimental surface is retired,
 an architectural dependency direction changes, or a subtraction iteration is
 completed.
 
+## Storage Scope Guard
+
+- Every storage milestone must ship an end-to-end product consumer. Do not add
+  a protocol method, table, state, or failure mode without a current consumer
+  or a prior bug that exercises it.
+- Use one public protocol, one production backend, one forward migration, and
+  at most three domain tables as the default review budget, not a hard limit.
+  Exceeding it requires a named second consumer/backend or measured need.
+- Put protocols only at real I/O boundaries. Domain stores own their models and
+  migrations; construct concrete backends in composition roots and do not add
+  domain methods to generic `IndexCatalog` or `ObjectStore` contracts.
+- Do not add registries, capability variants, dynamic plugin discovery,
+  PostgreSQL, S3, or distributed coordination before a second production
+  backend or benchmark requires them.
+- Prefer one conformance suite, one backend integration suite, and one
+  end-to-end regression. Fault tests must target observable boundaries or a
+  named prior bug, not arbitrary Python-line interruption.
+- Keep roadmap updates outcome-oriented and concise. Put implementation traces
+  in code, tests, ADRs, or the changelog instead of growing the roadmap.
+
 ## Dev Commands
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,9 +44,10 @@ completed.
 
 ## Storage Scope Guard
 
-- Every storage milestone must ship an end-to-end product consumer. Do not add
-  a protocol method, table, state, or failure mode without a current consumer
-  or a prior bug that exercises it.
+- Every storage milestone must ship one named end-to-end product vertical that
+  exercises the domain-store boundary and production backend. Do not add a
+  protocol method, table, state, or failure mode without a current consumer or
+  a prior bug that exercises it.
 - Use one public protocol, one production backend, one forward migration, and
   at most three domain tables as the default review budget, not a hard limit.
   Exceeding it requires a named second consumer/backend or measured need.
@@ -65,9 +66,10 @@ completed.
   name its invariant, linearization point, multi-lock order, and interruption
   recovery owner, and include a deterministic race test. Otherwise reuse an
   existing transaction, lease, pin, or recovery path, or simplify the design.
-- Prefer one conformance suite, one backend integration suite, and one
-  end-to-end regression. Fault tests must target observable boundaries or a
-  named prior bug, not arbitrary Python-line interruption.
+- Prefer one backend-neutral conformance harness driven by a backend
+  fixture/factory, one backend integration suite, and one product-vertical
+  regression. Fault tests must target observable boundaries or a named prior
+  bug, not arbitrary Python-line interruption.
 - Keep roadmap updates outcome-oriented and concise. Put implementation traces
   in code, tests, ADRs, or the changelog instead of growing the roadmap.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,34 +44,45 @@ completed.
 
 ## Storage Scope Guard
 
-- Every storage milestone must ship one named end-to-end product vertical that
-  exercises the domain-store boundary and production backend. Do not add a
-  protocol method, table, state, or failure mode without a current consumer or
-  a prior bug that exercises it.
-- Use one public protocol, one production backend, one forward migration, and
-  at most three domain tables as the default review budget, not a hard limit.
-  Exceeding it requires a named second consumer/backend or measured need.
+- Each PR that adds a public storage capability must name the non-test
+  production call site and end-to-end vertical that exercise it. Do not add a
+  protocol method, table, state, or failure mode unless it serves that call
+  site, a reproduced bug, or a documented data-safety, security, or
+  compatibility invariant with a deterministic regression. Tests, roadmap
+  entries, and planned adapters do not count as consumers.
+- Use one public protocol, one production backend, one schema change per PR,
+  and at most three domain tables as the default review budget, not a hard
+  limit. Preserve the complete forward path from every supported deployed
+  schema. Map each excess item to a current call site or named correctness
+  invariant and explain why it cannot be deferred.
 - Put protocols only at real I/O boundaries. Domain stores own their models and
   migrations; construct concrete backends in composition roots and do not add
-  domain methods to generic `IndexCatalog` or `ObjectStore` contracts.
-- Do not add registries, capability variants, dynamic plugin discovery,
-  PostgreSQL, S3, or distributed coordination before a second production
-  backend or benchmark requires them.
+  domain methods to generic `IndexCatalog` or `ObjectStore` contracts. Treat
+  pluggable as constructor injection plus backend-neutral conformance, not a
+  registry, capability matrix, or dynamic discovery system.
+- A non-default backend requires a documented deployment constraint that the
+  canonical backend cannot meet plus representative workload and operational
+  evidence. Registries or dynamic discovery additionally require at least two
+  supported implementations and a current runtime selection route;
+  distributed coordination requires a named multi-worker deployment invariant.
 - Define durable enqueue success at the catalog transaction boundary; treat
   worker and runtime health as availability signals. Do not add a cross-layer
   lock merely to make one health observation atomic with a recoverable enqueue
   unless the product promises synchronous execution or a reproduced data-safety
   invariant requires it.
-- A new cross-thread/process lock, retained owner, or multi-phase lifecycle must
-  name its invariant, linearization point, multi-lock order, and interruption
-  recovery owner, and include a deterministic race test. Otherwise reuse an
-  existing transaction, lease, pin, or recovery path, or simplify the design.
+- For a non-trivial cross-thread/process lock, retained owner, or multi-phase
+  lifecycle, state the invariant and linearization point in the PR or adjacent
+  docstring. Also state lock order when multiple locks exist and recovery
+  ownership when state outlives the call; add one deterministic test of the
+  invariant or reproduced race. Otherwise reuse an existing transaction,
+  lease, pin, or recovery path, or simplify the design.
 - Prefer one backend-neutral conformance harness driven by a backend
   fixture/factory, one backend integration suite, and one product-vertical
   regression. Fault tests must target observable boundaries or a named prior
   bug, not arbitrary Python-line interruption.
-- Keep roadmap updates outcome-oriented and concise. Put implementation traces
-  in code, tests, ADRs, or the changelog instead of growing the roadmap.
+- Replace a milestone's prior status with its current outcomes, open gates, and
+  PR/ADR links; do not append implementation chronology. Put implementation
+  traces in code, tests, ADRs, or the changelog.
 
 ## Dev Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,15 @@ completed.
 - Do not add registries, capability variants, dynamic plugin discovery,
   PostgreSQL, S3, or distributed coordination before a second production
   backend or benchmark requires them.
+- Define durable enqueue success at the catalog transaction boundary; treat
+  worker and runtime health as availability signals. Do not add a cross-layer
+  lock merely to make one health observation atomic with a recoverable enqueue
+  unless the product promises synchronous execution or a reproduced data-safety
+  invariant requires it.
+- A new cross-thread/process lock, retained owner, or multi-phase lifecycle must
+  name its invariant, linearization point, multi-lock order, and interruption
+  recovery owner, and include a deterministic race test. Otherwise reuse an
+  existing transaction, lease, pin, or recovery path, or simplify the design.
 - Prefer one conformance suite, one backend integration suite, and one
   end-to-end regression. Fault tests must target observable boundaries or a
   named prior bug, not arbitrary Python-line interruption.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ All notable user-facing changes are recorded here. CodeNib follows
 - Repository-bound BM25 source-attempt shards with cooperative shared writer
   and exclusive reaper leases, plus a default-off post-operation-return cleanup
   pass that retains legacy workspace cleanup as an explicit compatibility step.
+- A domain-local `WikiStore` harness and SQLite WAL implementation with
+  versioned schema initialization, bounded canonical JSON, integrity checks,
+  atomic publication, and cross-process generation guards.
+
+### Changed
+
+- AgentWiki, the web service, cache audit, prewarming, and Wiki benchmarking
+  now use `wiki_cache/wiki.sqlite3`. Eligible source-compatible JSON entries
+  remain available through read-through compatibility and are not rewritten or
+  deleted.
 
 ### Security
 

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -4497,6 +4497,7 @@ def _audit_local_wiki(local) -> dict[str, object]:
     from .web.repo_registry import RepoRegistry
     from .wiki.agent_wiki import AgentWiki
     from .wiki.quality import audit_wiki
+    from .wiki.sqlite_store import SQLiteWikiStore
 
     config = load_config(str(local.config_path))
     if local.runtime_env.get("CODENIB_DEMO_MODEL"):
@@ -4531,6 +4532,7 @@ def _audit_local_wiki(local) -> dict[str, object]:
         bundle,
         model,
         cache_dir=str(local.data_dir / "wiki_cache"),
+        store=SQLiteWikiStore(local.data_dir / "wiki_cache" / "wiki.sqlite3"),
         llm=client,
         api_base=config.wiki_generation_api_base,
         api_key=config.wiki_generation_api_key,

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -320,13 +320,10 @@ async def lifespan(app: FastAPI):
         registry.load_all()
         app.state.registry = registry
         app.state.wiki_builders = {}
-        app.state.wiki_store = (
-            SQLiteWikiStore(
-                Path(os.path.abspath(config.data_dir)) / "wiki_cache" / "wiki.sqlite3"
-            )
-            if config.wiki_agent
-            else None
-        )
+        # Wiki persistence is a regenerable, optional product surface. Open it
+        # on the first Wiki request so a damaged cache cannot block search and
+        # source APIs during application startup.
+        app.state.wiki_store = None
         app.state.edge_labelers = {}
         app.state.commit_windows = {}
         # Shared LLM narrator for DeepWiki-style prose; cached on disk, fails soft

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -21,6 +21,7 @@ import argparse
 import asyncio
 import hashlib
 import os
+import threading
 from collections.abc import Mapping
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
@@ -97,6 +98,12 @@ _WIKI_MEDIA_TYPES = {
 logger = get_logger(__name__)
 
 _MISSING_APP_STATE = object()
+# A request pins its RepoBundle before acquiring this lock. The lock then
+# linearizes the process-local Wiki store/builder cache before SQLite takes its
+# cross-process initialization lock. Store operations never re-enter this lock,
+# and a failed construction publishes no cache entry, so the next request owns
+# recovery.
+_WIKI_BUILD_LOCK = threading.Lock()
 
 
 @dataclass(slots=True)
@@ -601,7 +608,7 @@ def _prune_retired_generation_caches(registry=None) -> None:
 
 
 def _wiki(repo_id: str, bundle=None):
-    """Lazily build + cache a wiki per repo (conceptual agent wiki by default)."""
+    """Lazily build and cache one Wiki helper per pinned bundle generation."""
     if bundle is None:
         bundle = _bundle(repo_id)
     cache = app.state.wiki_builders
@@ -627,7 +634,8 @@ def _wiki(repo_id: str, bundle=None):
             )
         return WikiBuilder(bundle, narrator=getattr(app.state, "narrator", None))
 
-    return _generation_cached(cache, repo_id, repo_id, bundle, build)
+    with _WIKI_BUILD_LOCK:
+        return _generation_cached(cache, repo_id, repo_id, bundle, build)
 
 
 def _wiki_media_dir(config, repo_id: str, page_id: str) -> Path:
@@ -984,7 +992,7 @@ async def create_index_job(
 @app.get("/api/repos/{repo_id}/wiki")
 async def wiki_tree(repo_id: str, cached_only: bool = False) -> dict:
     with _pinned_bundle(repo_id) as bundle:
-        builder = _wiki(repo_id, bundle)
+        builder = await _run_pinned_thread(_wiki, repo_id, bundle)
         if cached_only:
             cached_page_tree = getattr(builder, "cached_page_tree", None)
             pages = (
@@ -1005,7 +1013,8 @@ async def wiki_page(
     materialize_media: bool = True,
 ) -> dict:
     with _pinned_bundle(repo_id) as bundle:
-        page = await _run_pinned_thread(_wiki(repo_id, bundle).page, page_id)
+        builder = await _run_pinned_thread(_wiki, repo_id, bundle)
+        page = await _run_pinned_thread(builder.page, page_id)
         if page is None:
             raise HTTPException(
                 status_code=404,
@@ -1071,7 +1080,7 @@ async def wiki_page_graph(repo_id: str, page_id: str) -> dict:
     they connect), using the same ``{nodes, edges}`` payload as ``/codemap``.
     """
     with _pinned_bundle(repo_id) as bundle:
-        builder = _wiki(repo_id, bundle)
+        builder = await _run_pinned_thread(_wiki, repo_id, bundle)
         page_citations = getattr(builder, "page_citations", None)
         if callable(page_citations):
             citations = await _run_pinned_thread(page_citations, page_id)

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -48,6 +48,7 @@ from ..wiki.media_generation import (
     redact_media_evidence_packs,
 )
 from ..wiki.narrator import Narrator
+from ..wiki.sqlite_store import SQLiteWikiStore
 from .config import load_config
 from .index_job_writes import (
     IndexJobConflictError,
@@ -319,6 +320,13 @@ async def lifespan(app: FastAPI):
         registry.load_all()
         app.state.registry = registry
         app.state.wiki_builders = {}
+        app.state.wiki_store = (
+            SQLiteWikiStore(
+                Path(os.path.abspath(config.data_dir)) / "wiki_cache" / "wiki.sqlite3"
+            )
+            if config.wiki_agent
+            else None
+        )
         app.state.edge_labelers = {}
         app.state.commit_windows = {}
         # Shared LLM narrator for DeepWiki-style prose; cached on disk, fails soft
@@ -607,10 +615,15 @@ def _wiki(repo_id: str, bundle=None):
             from ..wiki.agent_wiki import AgentWiki
 
             wiki_cache = os.path.join(os.path.abspath(config.data_dir), "wiki_cache")
+            store = getattr(app.state, "wiki_store", None)
+            if store is None:
+                store = SQLiteWikiStore(Path(wiki_cache) / "wiki.sqlite3")
+                app.state.wiki_store = store
             return AgentWiki(
                 bundle,
                 config.wiki_generation_model,
                 cache_dir=wiki_cache,
+                store=store,
                 llm=_wiki_llm(config),
                 api_base=config.wiki_generation_api_base,
                 api_key=config.wiki_generation_api_key,

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -32,7 +32,11 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence
 
 from filelock import FileLock
 
-from .._bounded_json import validate_bounded_json_stream, validate_json_complexity
+from .._bounded_json import (
+    _bounded_parse_float,
+    validate_bounded_json_stream,
+    validate_json_complexity,
+)
 from ..log_utils import get_logger
 from ..repository_summary import readme_summary
 from .builder import WikiBuilder
@@ -111,6 +115,7 @@ def _read_legacy_cache_envelope(path: str) -> dict[str, Any] | None:
             payload.decode("utf-8", errors="strict"),
             object_pairs_hook=_reject_duplicate_cache_object,
             parse_constant=_reject_nonfinite_cache_number,
+            parse_float=_bounded_parse_float,
         )
         validate_json_complexity(envelope, label="legacy Wiki cache")
     except MemoryError:

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -7,8 +7,8 @@
 Stage 1 (:mod:`outline`) proposes a conceptual page tree. This module is stage
 2: for each page it fuses the available retrieval views, builds source and
 relationship evidence, asks an LLM for a fact plan, and then writes a page
-whose citations are checked before publication. Outline + pages are disk-cached
-so generation can resume one page at a time.
+whose citations are checked before publication. Outline + pages are persisted
+through an injected Wiki store so generation can resume one page at a time.
 
 Drop-in for the demo's ``WikiBuilder``: exposes ``page_tree`` / ``page`` /
 ``source`` so ``codenib/web/app.py`` can serve it unchanged.
@@ -27,7 +27,7 @@ import tempfile
 import threading
 from contextlib import nullcontext
 from time import perf_counter, time
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Mapping, Optional, Sequence
 
 from filelock import FileLock
 
@@ -68,6 +68,7 @@ from .quality import prose_terms as _prose_terms
 from .quality import redundancy_terms as _redundancy_terms
 from .quality import section_synthesis_report as _section_synthesis_report
 from .quality import sentence_boundary_count as _sentence_boundary_count
+from .store import WikiStore, WikiStoreCorruptionError, WikiStoredEntry, WikiStoreError
 
 logger = get_logger(__name__)
 
@@ -3163,6 +3164,7 @@ class AgentWiki:
         model: str,
         cache_dir: Optional[str] = None,
         *,
+        store: Optional[WikiStore] = None,
         llm: Any = None,
         api_base: Optional[str] = None,
         api_key: Optional[str] = None,
@@ -3174,6 +3176,7 @@ class AgentWiki:
         self._api_base = api_base
         self._api_key = api_key
         self._cache_dir = cache_dir
+        self._store = store
         self._wb = WikiBuilder(bundle)  # reuse source() + symbol/citation helpers
         self._outline: Optional[Dict[str, Any]] = None
         self._pages: Dict[str, Dict[str, Any]] = {}
@@ -3209,8 +3212,8 @@ class AgentWiki:
         digest = getattr(selection, "digest", None)
         return digest if isinstance(digest, str) else ""
 
-    def _key(self, suffix: str) -> str:
-        """Return a stable cache identity for equivalent repository views."""
+    def _cache_identity(self, suffix: str) -> str:
+        """Return the unhashed identity shared by legacy and database caches."""
 
         entry = self._bundle.entry
         commit = getattr(entry, "commit_short", "") or getattr(entry, "base_commit", "")
@@ -3280,7 +3283,26 @@ class AgentWiki:
             f"{source_identity}/{source_selection_identity}/"
             f"{view_identity}/{suffix}"
         )
-        return hashlib.sha1(raw.encode()).hexdigest()[:16]
+        return raw
+
+    def _key(self, suffix: str) -> str:
+        """Return the legacy filename key for equivalent repository views."""
+
+        return hashlib.sha1(self._cache_identity(suffix).encode()).hexdigest()[:16]
+
+    def _store_entry_id(self, suffix: str) -> str:
+        """Return the collision-resistant primary key used by Wiki stores."""
+
+        return hashlib.sha256(self._cache_identity(suffix).encode()).hexdigest()
+
+    def _repository_id(self) -> str:
+        entry = self._bundle.entry
+        repository_id = str(
+            getattr(entry, "instance_id", "") or getattr(entry, "repo", "") or ""
+        )
+        if not repository_id:
+            raise ValueError("Wiki store requires a stable repository identity")
+        return repository_id
 
     def _legacy_key(self, suffix: str) -> str:
         """Return the timestamp-bound key used before stable cache identity."""
@@ -3364,6 +3386,11 @@ class AgentWiki:
         return f"page_{meta.get('id', 'page')}_{identity}"
 
     def _read_cache(self, suffix: str) -> Optional[Any]:
+        if self._store is not None:
+            stored = self._store.read(self._store_entry_id(suffix))
+            if stored is not None:
+                return self._stored_data(stored)
+
         paths = self._cache_candidate_paths(suffix)
         for index, path in enumerate(paths):
             if not os.path.isfile(path):
@@ -3375,7 +3402,20 @@ class AgentWiki:
                 continue
             if not isinstance(envelope, dict) or "data" not in envelope:
                 continue
-            if index > 0 and paths:
+            if self._store is not None:
+                try:
+                    stored = self._publish_store_cache(
+                        suffix,
+                        envelope,
+                        if_absent=True,
+                    )
+                except WikiStoreCorruptionError:
+                    raise
+                except (WikiStoreError, TypeError, ValueError) as exc:
+                    logger.warning("Could not adopt legacy Wiki cache: %s", exc)
+                else:
+                    return self._stored_data(stored)
+            elif index > 0 and paths:
                 # Adopt the current timestamp-bound entry into the stable key
                 # before a future equivalent index rebuild changes its legacy
                 # identity. Preserve the original model provenance envelope.
@@ -3389,6 +3429,11 @@ class AgentWiki:
     def _read_cache_read_only(self, suffix: str) -> Optional[Any]:
         """Read one cache entry without migrating or publishing cache data."""
 
+        if self._store is not None:
+            stored = self._store.read(self._store_entry_id(suffix))
+            if stored is not None:
+                return self._stored_data(stored)
+
         for path in self._cache_candidate_paths(suffix):
             if not os.path.isfile(path):
                 continue
@@ -3400,6 +3445,57 @@ class AgentWiki:
             if isinstance(envelope, dict) and "data" in envelope:
                 return envelope.get("data")
         return None
+
+    @staticmethod
+    def _stored_data(entry: WikiStoredEntry) -> Any:
+        envelope = entry.envelope
+        if not isinstance(envelope, Mapping) or "data" not in envelope:
+            raise WikiStoreCorruptionError(
+                f"Wiki entry {entry.entry_id!r} has no data envelope"
+            )
+        return envelope["data"]
+
+    @staticmethod
+    def _store_entry_metadata(
+        suffix: str,
+        envelope: dict[str, Any],
+    ) -> tuple[str, Optional[str]]:
+        if suffix == "outline":
+            return "outline", None
+        if suffix.startswith("evidence_page_"):
+            kind = "evidence"
+        elif suffix.startswith("page_"):
+            kind = "page"
+        else:
+            raise ValueError(f"unsupported Wiki cache suffix: {suffix!r}")
+        data = envelope.get("data")
+        page_id = str(data.get("id") or "") if isinstance(data, dict) else ""
+        if not page_id:
+            page_suffix = suffix.removeprefix("evidence_")
+            if page_suffix.startswith("page_"):
+                page_id = page_suffix[5:].rsplit("_", 1)[0]
+        if not page_id:
+            raise ValueError(f"Wiki {kind} cache entry has no page id")
+        return kind, page_id
+
+    def _publish_store_cache(
+        self,
+        suffix: str,
+        envelope: dict[str, Any],
+        *,
+        if_absent: bool = False,
+    ) -> WikiStoredEntry:
+        if self._store is None:
+            raise RuntimeError("Wiki store is not configured")
+        kind, page_id = self._store_entry_metadata(suffix, envelope)
+        return self._store.publish(
+            entry_id=self._store_entry_id(suffix),
+            repository_id=self._repository_id(),
+            kind=kind,
+            page_id=page_id,
+            envelope=envelope,
+            if_absent=if_absent,
+        )
 
     @staticmethod
     def _atomic_write_cache(
@@ -3443,6 +3539,8 @@ class AgentWiki:
                         pass
 
     def _cache_generation_lock(self, suffix: str) -> Any:
+        if self._store is not None:
+            return self._store.generation_guard(self._store_entry_id(suffix))
         path = self._cache_path(suffix)
         if not path:
             return nullcontext()
@@ -3544,21 +3642,27 @@ class AgentWiki:
         }
 
     def _write_cache(self, suffix: str, data: Any) -> None:
+        envelope = {
+            # Provenance only — none of this is part of the cache key, so a
+            # later backend swap reuses this entry.
+            "model": self._model,
+            "api_base": self._api_base or "",
+            "llm_identity": self._cache_llm_identity,
+            "data": data,
+        }
+        if self._store is not None:
+            try:
+                self._publish_store_cache(suffix, envelope)
+            except WikiStoreCorruptionError:
+                raise
+            except (WikiStoreError, TypeError, ValueError) as exc:
+                logger.warning("Could not publish Wiki cache: %s", exc)
+            return
         path = self._cache_path(suffix)
         if not path:
             return
         try:
-            self._atomic_write_cache(
-                path,
-                {
-                    # Provenance only — none of this is part of the cache key,
-                    # so a later backend swap reuses this entry.
-                    "model": self._model,
-                    "api_base": self._api_base or "",
-                    "llm_identity": self._cache_llm_identity,
-                    "data": data,
-                },
-            )
+            self._atomic_write_cache(path, envelope)
         except (OSError, TypeError):
             pass
 

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -20,6 +20,7 @@ import copy
 import dataclasses
 import hashlib
 import html
+import io
 import json
 import os
 import re
@@ -31,6 +32,7 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence
 
 from filelock import FileLock
 
+from .._bounded_json import validate_bounded_json_stream, validate_json_complexity
 from ..log_utils import get_logger
 from ..repository_summary import readme_summary
 from .builder import WikiBuilder
@@ -68,9 +70,57 @@ from .quality import prose_terms as _prose_terms
 from .quality import redundancy_terms as _redundancy_terms
 from .quality import section_synthesis_report as _section_synthesis_report
 from .quality import sentence_boundary_count as _sentence_boundary_count
-from .store import WikiStore, WikiStoreCorruptionError, WikiStoredEntry, WikiStoreError
+from .store import (
+    WIKI_ENVELOPE_MAX_BYTES,
+    WikiStore,
+    WikiStoreCorruptionError,
+    WikiStoredEntry,
+    WikiStoreError,
+)
 
 logger = get_logger(__name__)
+
+
+def _reject_duplicate_cache_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        value[key] = item
+    return value
+
+
+def _reject_nonfinite_cache_number(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _read_legacy_cache_envelope(path: str) -> dict[str, Any] | None:
+    """Read one legacy cache only after bounding its bytes and JSON shape."""
+
+    try:
+        with open(path, "rb") as handle:
+            payload = handle.read(WIKI_ENVELOPE_MAX_BYTES + 1)
+        if len(payload) > WIKI_ENVELOPE_MAX_BYTES:
+            return None
+        validate_bounded_json_stream(
+            io.BytesIO(payload),
+            label="legacy Wiki cache",
+            max_bytes=WIKI_ENVELOPE_MAX_BYTES,
+        )
+        envelope = json.loads(
+            payload.decode("utf-8", errors="strict"),
+            object_pairs_hook=_reject_duplicate_cache_object,
+            parse_constant=_reject_nonfinite_cache_number,
+        )
+        validate_json_complexity(envelope, label="legacy Wiki cache")
+    except MemoryError:
+        raise
+    except (OSError, ValueError, RecursionError):
+        return None
+    if not isinstance(envelope, dict) or "data" not in envelope:
+        return None
+    return envelope
+
 
 _EXT_LANG = {
     "py": "python",
@@ -3395,12 +3445,8 @@ class AgentWiki:
         for index, path in enumerate(paths):
             if not os.path.isfile(path):
                 continue
-            try:
-                with open(path, encoding="utf-8") as fh:
-                    envelope = json.load(fh)
-            except (OSError, json.JSONDecodeError):
-                continue
-            if not isinstance(envelope, dict) or "data" not in envelope:
+            envelope = _read_legacy_cache_envelope(path)
+            if envelope is None:
                 continue
             if self._store is not None:
                 try:
@@ -3437,12 +3483,8 @@ class AgentWiki:
         for path in self._cache_candidate_paths(suffix):
             if not os.path.isfile(path):
                 continue
-            try:
-                with open(path, encoding="utf-8") as handle:
-                    envelope = json.load(handle)
-            except (OSError, json.JSONDecodeError):
-                continue
-            if isinstance(envelope, dict) and "data" in envelope:
+            envelope = _read_legacy_cache_envelope(path)
+            if envelope is not None:
                 return envelope.get("data")
         return None
 
@@ -3455,29 +3497,6 @@ class AgentWiki:
             )
         return envelope["data"]
 
-    @staticmethod
-    def _store_entry_metadata(
-        suffix: str,
-        envelope: dict[str, Any],
-    ) -> tuple[str, Optional[str]]:
-        if suffix == "outline":
-            return "outline", None
-        if suffix.startswith("evidence_page_"):
-            kind = "evidence"
-        elif suffix.startswith("page_"):
-            kind = "page"
-        else:
-            raise ValueError(f"unsupported Wiki cache suffix: {suffix!r}")
-        data = envelope.get("data")
-        page_id = str(data.get("id") or "") if isinstance(data, dict) else ""
-        if not page_id:
-            page_suffix = suffix.removeprefix("evidence_")
-            if page_suffix.startswith("page_"):
-                page_id = page_suffix[5:].rsplit("_", 1)[0]
-        if not page_id:
-            raise ValueError(f"Wiki {kind} cache entry has no page id")
-        return kind, page_id
-
     def _publish_store_cache(
         self,
         suffix: str,
@@ -3487,12 +3506,9 @@ class AgentWiki:
     ) -> WikiStoredEntry:
         if self._store is None:
             raise RuntimeError("Wiki store is not configured")
-        kind, page_id = self._store_entry_metadata(suffix, envelope)
         return self._store.publish(
             entry_id=self._store_entry_id(suffix),
             repository_id=self._repository_id(),
-            kind=kind,
-            page_id=page_id,
             envelope=envelope,
             if_absent=if_absent,
         )

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -75,6 +75,7 @@ from .quality import redundancy_terms as _redundancy_terms
 from .quality import section_synthesis_report as _section_synthesis_report
 from .quality import sentence_boundary_count as _sentence_boundary_count
 from .store import (
+    _WIKI_CACHE_PROVENANCE_FIELD,
     WIKI_ENVELOPE_MAX_BYTES,
     WikiStore,
     WikiStoreCorruptionError,
@@ -3511,9 +3512,26 @@ class AgentWiki:
     ) -> WikiStoredEntry:
         if self._store is None:
             raise RuntimeError("Wiki store is not configured")
+        entry_id = self._store_entry_id(suffix)
+        repository_id = self._repository_id()
+        cache_files = [
+            os.path.basename(path) for path in self._cache_candidate_paths(suffix)
+        ]
+        if cache_files:
+            # Legacy files remain readable for one release. Bind their names to
+            # the canonical record so audits can ignore stale adopted copies.
+            envelope = {
+                **envelope,
+                _WIKI_CACHE_PROVENANCE_FIELD: {
+                    "schema": 1,
+                    "entry_id": entry_id,
+                    "repository_id": repository_id,
+                    "legacy_filenames": cache_files,
+                },
+            }
         return self._store.publish(
-            entry_id=self._store_entry_id(suffix),
-            repository_id=self._repository_id(),
+            entry_id=entry_id,
+            repository_id=repository_id,
             envelope=envelope,
             if_absent=if_absent,
         )

--- a/codenib/wiki/cache_audit.py
+++ b/codenib/wiki/cache_audit.py
@@ -13,7 +13,9 @@ import os
 from collections import Counter
 from typing import Any, Callable, Iterable, Optional
 
+from .._bounded_json import canonical_json_bytes
 from .agent_wiki import AgentWiki
+from .store import WikiStore, WikiStoredEntry
 
 
 def _summary(values: Iterable[float]) -> dict[str, Any]:
@@ -63,6 +65,12 @@ def _read_cache(paths: Iterable[str]) -> Optional[Any]:
     return None
 
 
+def _stored_entry_bytes(entry: WikiStoredEntry) -> int:
+    """Return the domain-canonical byte size of one stored envelope."""
+
+    return len(canonical_json_bytes(dict(entry.envelope)))
+
+
 def audit_wiki_cache(
     registry: Any,
     *,
@@ -70,6 +78,7 @@ def audit_wiki_cache(
     cache_dir: str | os.PathLike[str],
     repo_ids: Optional[Iterable[str]] = None,
     wiki_factory: Callable[..., AgentWiki] = AgentWiki,
+    store: Optional[WikiStore] = None,
 ) -> dict[str, Any]:
     """Inspect only cache entries reachable from each current Wiki outline.
 
@@ -89,6 +98,7 @@ def audit_wiki_cache(
     retry_scheduled_pages: list[dict[str, Any]] = []
     retry_exhausted_pages: list[dict[str, Any]] = []
     current_cache_paths: set[str] = set()
+    current_entry_ids: set[str] = set()
     metric_samples: dict[str, list[float]] = {
         "total_ms": [],
         "retrieval_ms": [],
@@ -114,10 +124,17 @@ def audit_wiki_cache(
         bundle = registry.get(repo_id)
         if bundle is None:
             continue
-        wiki = wiki_factory(bundle, model=model, cache_dir=cache_root)
+        wiki_kwargs: dict[str, Any] = {"model": model, "cache_dir": cache_root}
+        if store is not None:
+            wiki_kwargs["store"] = store
+        wiki = wiki_factory(bundle, **wiki_kwargs)
         outline_paths = _cache_paths(cache_root, wiki, "outline")
         current_cache_paths.update(os.path.abspath(path) for path in outline_paths)
-        outline = _read_cache(outline_paths)
+        if store is not None:
+            current_entry_ids.add(wiki._store_entry_id("outline"))
+            outline = wiki._read_cache_read_only("outline")
+        else:
+            outline = _read_cache(outline_paths)
         if not isinstance(outline, dict) or not outline.get("pages"):
             missing_outlines.append(repo_id)
             repo_reports.append(
@@ -162,9 +179,18 @@ def audit_wiki_cache(
             suffix = wiki._page_cache_suffix(meta)
             paths = _cache_paths(cache_root, wiki, suffix)
             current_cache_paths.update(os.path.abspath(path) for path in paths)
-            evidence_paths = _cache_paths(cache_root, wiki, f"evidence_{suffix}")
+            evidence_paths = _cache_paths(
+                cache_root,
+                wiki,
+                f"evidence_{suffix}",
+            )
             current_cache_paths.update(os.path.abspath(path) for path in evidence_paths)
-            page = _read_cache(paths)
+            if store is not None:
+                current_entry_ids.add(wiki._store_entry_id(suffix))
+                current_entry_ids.add(wiki._store_entry_id(f"evidence_{suffix}"))
+                page = wiki._read_cache_read_only(suffix)
+            else:
+                page = _read_cache(paths)
             if isinstance(page, dict):
                 totals["cached_pages"] += 1
                 repo_counts["cached_pages"] += 1
@@ -246,12 +272,45 @@ def audit_wiki_cache(
             for path in glob.glob(os.path.join(cache_root, "agentwiki_*.json"))
         }
     orphan_paths = all_cache_paths - current_cache_paths
-    orphan_bytes = sum(
-        os.path.getsize(path) for path in orphan_paths if os.path.isfile(path)
-    )
-    cache_bytes = sum(
+    legacy_bytes = sum(
         os.path.getsize(path) for path in all_cache_paths if os.path.isfile(path)
     )
+    orphan_legacy_bytes = sum(
+        os.path.getsize(path) for path in orphan_paths if os.path.isfile(path)
+    )
+
+    if store is not None:
+        entries = store.scan(repository_ids=selected or None)
+        orphan_entries = tuple(
+            entry for entry in entries if entry.entry_id not in current_entry_ids
+        )
+        database_bytes = sum(_stored_entry_bytes(entry) for entry in entries)
+        orphan_database_bytes = sum(
+            _stored_entry_bytes(entry) for entry in orphan_entries
+        )
+        storage_report = {
+            "backend": type(store).__name__,
+            "entries": len(entries),
+            "database_bytes": database_bytes,
+            "orphan_entries": len(orphan_entries),
+            "orphan_database_bytes": orphan_database_bytes,
+            "files": len(all_cache_paths),
+            "legacy_bytes": legacy_bytes,
+            "orphan_files": len(orphan_paths),
+            "orphan_legacy_bytes": orphan_legacy_bytes,
+            # Preserve the v1 file-counter meanings for existing report readers.
+            "bytes": legacy_bytes,
+            "orphan_bytes": orphan_legacy_bytes,
+            "total_bytes": database_bytes + legacy_bytes,
+            "total_orphan_bytes": orphan_database_bytes + orphan_legacy_bytes,
+        }
+    else:
+        storage_report = {
+            "files": len(all_cache_paths),
+            "bytes": legacy_bytes,
+            "orphan_files": len(orphan_paths),
+            "orphan_bytes": orphan_legacy_bytes,
+        }
     return {
         "schema_version": 1,
         "repositories": len(repo_reports),
@@ -296,12 +355,7 @@ def audit_wiki_cache(
             retry_exhausted_pages,
             key=lambda item: (item["repo"], item["id"]),
         ),
-        "storage": {
-            "files": len(all_cache_paths),
-            "bytes": cache_bytes,
-            "orphan_files": len(orphan_paths),
-            "orphan_bytes": orphan_bytes,
-        },
+        "storage": storage_report,
         "repos": sorted(repo_reports, key=lambda item: item["repo"]),
     }
 

--- a/codenib/wiki/cache_audit.py
+++ b/codenib/wiki/cache_audit.py
@@ -284,16 +284,16 @@ def audit_wiki_cache(
         orphan_entries = tuple(
             entry for entry in entries if entry.entry_id not in current_entry_ids
         )
-        database_bytes = sum(_stored_entry_bytes(entry) for entry in entries)
-        orphan_database_bytes = sum(
+        database_payload_bytes = sum(_stored_entry_bytes(entry) for entry in entries)
+        orphan_database_payload_bytes = sum(
             _stored_entry_bytes(entry) for entry in orphan_entries
         )
         storage_report = {
             "backend": type(store).__name__,
             "entries": len(entries),
-            "database_bytes": database_bytes,
+            "database_payload_bytes": database_payload_bytes,
             "orphan_entries": len(orphan_entries),
-            "orphan_database_bytes": orphan_database_bytes,
+            "orphan_database_payload_bytes": orphan_database_payload_bytes,
             "files": len(all_cache_paths),
             "legacy_bytes": legacy_bytes,
             "orphan_files": len(orphan_paths),
@@ -301,8 +301,6 @@ def audit_wiki_cache(
             # Preserve the v1 file-counter meanings for existing report readers.
             "bytes": legacy_bytes,
             "orphan_bytes": orphan_legacy_bytes,
-            "total_bytes": database_bytes + legacy_bytes,
-            "total_orphan_bytes": orphan_database_bytes + orphan_legacy_bytes,
         }
     else:
         storage_report = {

--- a/codenib/wiki/cache_audit.py
+++ b/codenib/wiki/cache_audit.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import glob
-import json
 import math
 import os
 from collections import Counter
@@ -51,18 +50,6 @@ def _cache_paths(cache_root: str, wiki: AgentWiki, suffix: str) -> tuple[str, ..
     if paths:
         return paths
     return (os.path.join(cache_root, f"agentwiki_{wiki._key(suffix)}.json"),)
-
-
-def _read_cache(paths: Iterable[str]) -> Optional[Any]:
-    for path in paths:
-        try:
-            with open(path, encoding="utf-8") as handle:
-                payload = json.load(handle)
-        except (OSError, json.JSONDecodeError):
-            continue
-        if isinstance(payload, dict) and "data" in payload:
-            return payload.get("data")
-    return None
 
 
 def _stored_entry_bytes(entry: WikiStoredEntry) -> int:
@@ -132,9 +119,7 @@ def audit_wiki_cache(
         current_cache_paths.update(os.path.abspath(path) for path in outline_paths)
         if store is not None:
             current_entry_ids.add(wiki._store_entry_id("outline"))
-            outline = wiki._read_cache_read_only("outline")
-        else:
-            outline = _read_cache(outline_paths)
+        outline = wiki._read_cache_read_only("outline")
         if not isinstance(outline, dict) or not outline.get("pages"):
             missing_outlines.append(repo_id)
             repo_reports.append(
@@ -188,9 +173,7 @@ def audit_wiki_cache(
             if store is not None:
                 current_entry_ids.add(wiki._store_entry_id(suffix))
                 current_entry_ids.add(wiki._store_entry_id(f"evidence_{suffix}"))
-                page = wiki._read_cache_read_only(suffix)
-            else:
-                page = _read_cache(paths)
+            page = wiki._read_cache_read_only(suffix)
             if isinstance(page, dict):
                 totals["cached_pages"] += 1
                 repo_counts["cached_pages"] += 1

--- a/codenib/wiki/quality.py
+++ b/codenib/wiki/quality.py
@@ -6,8 +6,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Iterable, List
 
@@ -22,6 +24,7 @@ from .evidence import (
     relation_endpoints_named,
     relation_matches_claim,
 )
+from .store import WikiStore
 
 _EVIDENCE_MARKER = re.compile(r"\[((?:E|R)\d+)\](?:\([^)]*\))?")
 _CATALOG_SENTENCE = re.compile(
@@ -33,6 +36,24 @@ _CATALOG_SENTENCE = re.compile(
     r"serializes?|sets?|simplifies?|supports?|utilizes?|visualizes?)\b",
     re.IGNORECASE,
 )
+
+
+def _cache_envelope_digest(envelope: Mapping[str, Any]) -> bytes | None:
+    """Identify exact database/legacy copies without conflating page IDs."""
+
+    try:
+        payload = json.dumps(
+            dict(envelope),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        return None
+    return hashlib.sha256(payload).digest()
+
+
 _RAW_EVIDENCE_ID = re.compile(r"(?<![\w`\[])\b(?:E|R)\d+\b(?![\w`])")
 _SOURCE_FILE_SUBSYSTEM = re.compile(
     r"`?[\w./-]+\.(?:py|go|rs|ts|tsx|js|jsx|c|h|cc|cpp|java|rb|php|cs|"
@@ -1101,17 +1122,43 @@ def audit_wiki(builder: Any) -> dict[str, Any]:
     }
 
 
-def audit_cache(cache_dir: str | Path) -> dict[str, Any]:
-    """Load and summarize generated page records from an AgentWiki cache."""
+def audit_cache(
+    cache_dir: str | Path,
+    *,
+    store: WikiStore | None = None,
+) -> dict[str, Any]:
+    """Load and summarize pages from the canonical database or legacy files."""
 
     pages = []
-    for path in sorted(Path(cache_dir).glob("agentwiki_*.json")):
+    stored_envelopes: set[bytes] = set()
+    cache_root = Path(cache_dir)
+    database_path = cache_root / "wiki.sqlite3"
+    if store is None and database_path.exists():
+        # This function is the compatibility composition root for the historical
+        # path-only audit API. Callers with another backend inject its WikiStore.
+        from .sqlite_store import SQLiteWikiStore
+
+        store = SQLiteWikiStore(database_path)
+    if store is not None:
+        for entry in store.scan():
+            payload = entry.envelope
+            data = payload.get("data") if isinstance(payload, Mapping) else None
+            if isinstance(data, dict) and data.get("id") and data.get("markdown"):
+                pages.append(data)
+                digest = _cache_envelope_digest(payload)
+                if digest is not None:
+                    stored_envelopes.add(digest)
+
+    for path in sorted(cache_root.glob("agentwiki_*.json")):
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             continue
         data = payload.get("data") if isinstance(payload, dict) else None
         if isinstance(data, dict) and data.get("id") and data.get("markdown"):
+            digest = _cache_envelope_digest(payload)
+            if digest is not None and digest in stored_envelopes:
+                continue
             pages.append(data)
     return summarize_page_audits(pages)
 

--- a/codenib/wiki/quality.py
+++ b/codenib/wiki/quality.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import re
 from collections.abc import Mapping
@@ -24,7 +23,7 @@ from .evidence import (
     relation_endpoints_named,
     relation_matches_claim,
 )
-from .store import WikiStore
+from .store import _WIKI_CACHE_PROVENANCE_FIELD, WikiStore
 
 _EVIDENCE_MARKER = re.compile(r"\[((?:E|R)\d+)\](?:\([^)]*\))?")
 _CATALOG_SENTENCE = re.compile(
@@ -36,22 +35,6 @@ _CATALOG_SENTENCE = re.compile(
     r"serializes?|sets?|simplifies?|supports?|utilizes?|visualizes?)\b",
     re.IGNORECASE,
 )
-
-
-def _cache_envelope_digest(envelope: Mapping[str, Any]) -> bytes | None:
-    """Identify exact database/legacy copies without conflating page IDs."""
-
-    try:
-        payload = json.dumps(
-            dict(envelope),
-            sort_keys=True,
-            separators=(",", ":"),
-            ensure_ascii=False,
-            allow_nan=False,
-        ).encode("utf-8")
-    except (TypeError, ValueError):
-        return None
-    return hashlib.sha256(payload).digest()
 
 
 _RAW_EVIDENCE_ID = re.compile(r"(?<![\w`\[])\b(?:E|R)\d+\b(?![\w`])")
@@ -1130,7 +1113,7 @@ def audit_cache(
     """Load and summarize pages from the canonical database or legacy files."""
 
     pages = []
-    stored_envelopes: set[bytes] = set()
+    stored_cache_files: set[str] = set()
     cache_root = Path(cache_dir)
     database_path = cache_root / "wiki.sqlite3"
     if store is None and database_path.exists():
@@ -1142,23 +1125,46 @@ def audit_cache(
     if store is not None:
         for entry in store.scan():
             payload = entry.envelope
+            # Only an identity-bound marker may claim a retained legacy file;
+            # page IDs such as ``overview`` routinely collide across repos.
+            provenance = (
+                payload.get(_WIKI_CACHE_PROVENANCE_FIELD)
+                if isinstance(payload, Mapping)
+                else None
+            )
+            cache_files = (
+                provenance.get("legacy_filenames")
+                if isinstance(provenance, Mapping)
+                and type(provenance.get("schema")) is int
+                and provenance.get("schema") == 1
+                and provenance.get("entry_id") == entry.entry_id
+                and provenance.get("repository_id") == entry.repository_id
+                else None
+            )
+            if isinstance(cache_files, list):
+                stored_cache_files.update(
+                    cache_file
+                    for cache_file in cache_files
+                    if type(cache_file) is str
+                    and cache_file == Path(cache_file).name
+                    and cache_file.startswith("agentwiki_")
+                    and cache_file.endswith(".json")
+                )
             data = payload.get("data") if isinstance(payload, Mapping) else None
             if isinstance(data, dict) and data.get("id") and data.get("markdown"):
                 pages.append(data)
-                digest = _cache_envelope_digest(payload)
-                if digest is not None:
-                    stored_envelopes.add(digest)
 
+    # A marker-free database row cannot prove which repository owns an
+    # identical legacy envelope, so retain both rather than cross-repo dedupe.
     for path in sorted(cache_root.glob("agentwiki_*.json")):
+        if path.name in stored_cache_files:
+            continue
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             continue
         data = payload.get("data") if isinstance(payload, dict) else None
         if isinstance(data, dict) and data.get("id") and data.get("markdown"):
-            digest = _cache_envelope_digest(payload)
-            if digest is not None and digest in stored_envelopes:
-                continue
             pages.append(data)
     return summarize_page_audits(pages)
 

--- a/codenib/wiki/sqlite_store.py
+++ b/codenib/wiki/sqlite_store.py
@@ -24,6 +24,7 @@ from typing import Any
 from filelock import FileLock
 
 from .._bounded_json import (
+    _bounded_parse_float,
     canonical_json_value_chunks,
     validate_bounded_json_stream,
     validate_json_complexity,
@@ -45,6 +46,9 @@ _MAX_IDENTIFIER_BYTES = 4_096
 _SQLITE_CORRUPT = 11
 _SQLITE_SCHEMA = 17
 _SQLITE_NOTADB = 26
+_SQLITE_CORRUPTION_MESSAGES = frozenset(
+    ("database disk image is malformed", "file is not a database")
+)
 
 _CREATE_SCHEMA_SQL = """
 CREATE TABLE wiki_entries (
@@ -81,9 +85,18 @@ def _reject_nonfinite_number(value: str) -> None:
 def _sqlite_error(operation: str, exc: sqlite3.Error) -> WikiStoreError:
     error_code = getattr(exc, "sqlite_errorcode", None)
     primary_code = error_code & 0xFF if isinstance(error_code, int) else None
-    if primary_code in {_SQLITE_CORRUPT, _SQLITE_NOTADB}:
+    message = str(exc).strip().casefold()
+    if primary_code in {_SQLITE_CORRUPT, _SQLITE_NOTADB} or (
+        primary_code is None
+        and type(exc) is sqlite3.DatabaseError
+        and message in _SQLITE_CORRUPTION_MESSAGES
+    ):
         return WikiStoreCorruptionError(f"Wiki database {operation} found corruption")
-    if primary_code == _SQLITE_SCHEMA:
+    if primary_code == _SQLITE_SCHEMA or (
+        primary_code is None
+        and not isinstance(exc, sqlite3.IntegrityError)
+        and message == "database schema has changed"
+    ):
         return WikiStoreSchemaError(f"Wiki database schema changed during {operation}")
     if isinstance(exc, sqlite3.IntegrityError):
         return WikiStoreValidationError(
@@ -150,6 +163,7 @@ def _decode_envelope(payload: object, digest: object) -> dict[str, Any]:
             payload.decode("utf-8", errors="strict"),
             object_pairs_hook=_reject_duplicate_object,
             parse_constant=_reject_nonfinite_number,
+            parse_float=_bounded_parse_float,
         )
         if not isinstance(value, dict):
             raise ValueError("Wiki envelope is not a JSON object")
@@ -174,7 +188,17 @@ class SQLiteWikiStore:
             raise WikiStoreValidationError("invalid Wiki database path") from exc
         self.path = resolved
         self._lock_directory = Path(f"{resolved}.locks")
-        self._initialize()
+        try:
+            self._lock_directory.mkdir(parents=True, exist_ok=True)
+            # Lock acquisition linearizes schema identity and the WAL transition
+            # for this database. Initialization takes no entry lock, retains no
+            # owner after return, and the OS releases the file lock on exit.
+            with FileLock(str(self._lock_directory / ".initialize.lock")):
+                self._initialize()
+        except WikiStoreError:
+            raise
+        except OSError as exc:
+            raise WikiStoreError("Wiki database initialization lock failed") from exc
 
     def _open_raw(self) -> sqlite3.Connection:
         connection = sqlite3.connect(
@@ -200,16 +224,30 @@ class SQLiteWikiStore:
         )
         return application_id, user_version, tables
 
+    @staticmethod
+    def _is_empty_database(connection: sqlite3.Connection) -> bool:
+        return (
+            connection.execute("SELECT 1 FROM sqlite_master LIMIT 1").fetchone() is None
+        )
+
     def _initialize(self) -> None:
         connection: sqlite3.Connection | None = None
         try:
             connection = self._open_raw()
-            application_id, user_version, tables = self._identity(connection)
-            if application_id == 0 and user_version == 0 and not tables:
+            application_id, user_version, _ = self._identity(connection)
+            if (
+                application_id == 0
+                and user_version == 0
+                and self._is_empty_database(connection)
+            ):
                 connection.execute("BEGIN IMMEDIATE")
                 try:
-                    application_id, user_version, tables = self._identity(connection)
-                    if application_id == 0 and user_version == 0 and not tables:
+                    application_id, user_version, _ = self._identity(connection)
+                    if (
+                        application_id == 0
+                        and user_version == 0
+                        and self._is_empty_database(connection)
+                    ):
                         schema_statements = tuple(
                             statement.strip()
                             for statement in _CREATE_SCHEMA_SQL.split(";")

--- a/codenib/wiki/sqlite_store.py
+++ b/codenib/wiki/sqlite_store.py
@@ -41,6 +41,7 @@ from .store import (
 _APPLICATION_ID = 0x434E574B  # ``CNWK``
 _SCHEMA_VERSION = 1
 _MAX_IDENTIFIER_BYTES = 4_096
+_RECORD_DIGEST_DOMAIN = b"codenib-wiki-record-v1\0"
 # Stable SQLite primary result codes. Python 3.10 does not expose the matching
 # ``sqlite3.SQLITE_*`` module constants even though exceptions carry the code.
 _SQLITE_CORRUPT = 11
@@ -51,22 +52,48 @@ _SQLITE_CORRUPTION_MESSAGES = frozenset(
 )
 _SQLITE_CORRUPTION_PREFIXES = ("malformed database schema",)
 
-_CREATE_SCHEMA_SQL = """
+_CREATE_TABLE_SQL = """
 CREATE TABLE wiki_entries (
     entry_id TEXT PRIMARY KEY NOT NULL,
     repository_id TEXT NOT NULL,
     envelope_json BLOB NOT NULL,
-    envelope_sha256 TEXT NOT NULL CHECK (length(envelope_sha256) = 64)
-);
-CREATE INDEX wiki_entries_repository_entry_idx
-    ON wiki_entries(repository_id, entry_id);
-"""
+    record_sha256 TEXT NOT NULL CHECK (length(record_sha256) = 64)
+)
+""".strip()
 
-_EXPECTED_COLUMNS = (
-    ("entry_id", "TEXT", 1, 1),
-    ("repository_id", "TEXT", 1, 0),
-    ("envelope_json", "BLOB", 1, 0),
-    ("envelope_sha256", "TEXT", 1, 0),
+_CREATE_INDEX_SQL = """
+CREATE INDEX wiki_entries_repository_entry_idx
+    ON wiki_entries(repository_id, entry_id)
+""".strip()
+
+
+def _normalize_schema_sql(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return " ".join(value.split())
+
+
+_EXPECTED_SCHEMA_OBJECTS = frozenset(
+    (
+        (
+            "table",
+            "wiki_entries",
+            "wiki_entries",
+            _normalize_schema_sql(_CREATE_TABLE_SQL),
+        ),
+        (
+            "index",
+            "sqlite_autoindex_wiki_entries_1",
+            "wiki_entries",
+            None,
+        ),
+        (
+            "index",
+            "wiki_entries_repository_entry_idx",
+            "wiki_entries",
+            _normalize_schema_sql(_CREATE_INDEX_SQL),
+        ),
+    )
 )
 
 
@@ -149,7 +176,22 @@ def _canonical_envelope(envelope: Mapping[str, Any]) -> bytes:
     return bytes(payload)
 
 
-def _decode_envelope(payload: object, digest: object) -> dict[str, Any]:
+def _record_digest(entry_id: str, repository_id: str, payload: bytes) -> str:
+    """Authenticate record identity and payload without concatenation ambiguity."""
+
+    digest = hashlib.sha256(_RECORD_DIGEST_DOMAIN)
+    for value in (entry_id.encode("utf-8"), repository_id.encode("utf-8"), payload):
+        digest.update(len(value).to_bytes(8, "big"))
+        digest.update(value)
+    return digest.hexdigest()
+
+
+def _decode_envelope(
+    entry_id: str,
+    repository_id: str,
+    payload: object,
+    digest: object,
+) -> dict[str, Any]:
     if isinstance(payload, memoryview):
         payload = payload.tobytes()
     if type(payload) is not bytes:
@@ -158,7 +200,7 @@ def _decode_envelope(payload: object, digest: object) -> dict[str, Any]:
         raise WikiStoreCorruptionError("Wiki entry payload exceeds its size limit")
     if type(digest) is not str:
         raise WikiStoreCorruptionError("Wiki entry has an invalid SHA-256 digest")
-    observed_digest = hashlib.sha256(payload).hexdigest()
+    observed_digest = _record_digest(entry_id, repository_id, payload)
     if observed_digest != digest:
         raise WikiStoreCorruptionError("Wiki entry failed its SHA-256 integrity check")
     try:
@@ -229,27 +271,39 @@ class SQLiteWikiStore:
 
     def _open_raw(self) -> sqlite3.Connection:
         connection = sqlite3.connect(
-            str(self.path),
+            f"{self.path.as_uri()}?mode=rw",
             isolation_level=None,
+            uri=True,
         )
         connection.row_factory = sqlite3.Row
         return connection
 
     @staticmethod
-    def _identity(connection: sqlite3.Connection) -> tuple[int, int, frozenset[str]]:
+    def _identity(
+        connection: sqlite3.Connection,
+    ) -> tuple[int, int, frozenset[tuple[str, str, str, str | None]]]:
         application_id = connection.execute("PRAGMA application_id").fetchone()[0]
         user_version = connection.execute("PRAGMA user_version").fetchone()[0]
-        tables = frozenset(
-            row["name"]
+        schema_objects = frozenset(
+            (
+                row["type"],
+                row["name"],
+                row["tbl_name"],
+                _normalize_schema_sql(row["sql"]),
+            )
             for row in connection.execute(
                 """
-                SELECT name
+                SELECT type, name, tbl_name, sql
                 FROM sqlite_master
-                WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+                WHERE type IN ('table', 'index', 'view', 'trigger')
+                  AND (
+                      name NOT GLOB 'sqlite_*'
+                      OR name = 'sqlite_autoindex_wiki_entries_1'
+                  )
                 """
             )
         )
-        return application_id, user_version, tables
+        return application_id, user_version, schema_objects
 
     @staticmethod
     def _is_empty_database(connection: sqlite3.Connection) -> bool:
@@ -275,12 +329,7 @@ class SQLiteWikiStore:
                         and user_version == 0
                         and self._is_empty_database(connection)
                     ):
-                        schema_statements = tuple(
-                            statement.strip()
-                            for statement in _CREATE_SCHEMA_SQL.split(";")
-                            if statement.strip()
-                        )
-                        for statement in schema_statements:
+                        for statement in (_CREATE_TABLE_SQL, _CREATE_INDEX_SQL):
                             connection.execute(statement)
                         connection.execute(
                             f"PRAGMA application_id = {_APPLICATION_ID:d}"
@@ -304,7 +353,9 @@ class SQLiteWikiStore:
 
     @staticmethod
     def _require_schema(connection: sqlite3.Connection) -> None:
-        application_id, user_version, tables = SQLiteWikiStore._identity(connection)
+        application_id, user_version, schema_objects = SQLiteWikiStore._identity(
+            connection
+        )
         if application_id != _APPLICATION_ID:
             raise WikiStoreSchemaError(
                 "file is not an initialized CodeNib Wiki database"
@@ -318,14 +369,10 @@ class SQLiteWikiStore:
             raise WikiStoreSchemaError(
                 f"unsupported Wiki database schema version: {user_version}"
             )
-        if tables != frozenset(("wiki_entries",)):
-            raise WikiStoreSchemaError("Wiki database has an unexpected table layout")
-        columns = tuple(
-            (row["name"], row["type"], row["notnull"], row["pk"])
-            for row in connection.execute("PRAGMA table_info(wiki_entries)")
-        )
-        if columns != _EXPECTED_COLUMNS:
-            raise WikiStoreSchemaError("Wiki database has an unexpected entry schema")
+        if schema_objects != _EXPECTED_SCHEMA_OBJECTS:
+            raise WikiStoreSchemaError(
+                "Wiki database has an unexpected schema object layout"
+            )
 
     @staticmethod
     def _configure_database(connection: sqlite3.Connection) -> None:
@@ -342,6 +389,7 @@ class SQLiteWikiStore:
         connection: sqlite3.Connection | None = None
         try:
             connection = self._open_raw()
+            self._require_schema(connection)
             self._configure_connection(connection)
             yield connection
         except WikiStoreError:
@@ -363,7 +411,12 @@ class SQLiteWikiStore:
             raise WikiStoreCorruptionError(
                 "Wiki entry contains invalid identity metadata"
             ) from exc
-        envelope = _decode_envelope(row["envelope_json"], row["envelope_sha256"])
+        envelope = _decode_envelope(
+            entry_id,
+            repository_id,
+            row["envelope_json"],
+            row["record_sha256"],
+        )
         return WikiStoredEntry(
             entry_id=entry_id,
             repository_id=repository_id,
@@ -391,11 +444,11 @@ class SQLiteWikiStore:
         if type(if_absent) is not bool:
             raise WikiStoreValidationError("if_absent must be a boolean")
         payload = _canonical_envelope(envelope)
-        digest = hashlib.sha256(payload).hexdigest()
+        digest = _record_digest(entry_id, repository_id, payload)
         published = WikiStoredEntry(
             entry_id=entry_id,
             repository_id=repository_id,
-            envelope=_decode_envelope(payload, digest),
+            envelope=_decode_envelope(entry_id, repository_id, payload, digest),
         )
 
         with self._connection() as connection:
@@ -405,26 +458,18 @@ class SQLiteWikiStore:
                     "SELECT * FROM wiki_entries WHERE entry_id = ?", (entry_id,)
                 ).fetchone()
                 if row is not None:
-                    try:
-                        current_repository_id = _validate_identifier(
-                            row["repository_id"], field="repository_id"
-                        )
-                    except WikiStoreValidationError as exc:
-                        raise WikiStoreCorruptionError(
-                            "Wiki entry contains invalid identity metadata"
-                        ) from exc
-                    if current_repository_id != repository_id:
+                    current = self._entry_from_row(row)
+                    if current.repository_id != repository_id:
                         raise WikiStoreValidationError(
                             "entry_id is already bound to different Wiki metadata"
                         )
                     if if_absent:
-                        current = self._entry_from_row(row)
                         connection.commit()
                         return current
                     connection.execute(
                         """
                         UPDATE wiki_entries
-                        SET envelope_json = ?, envelope_sha256 = ?
+                        SET envelope_json = ?, record_sha256 = ?
                         WHERE entry_id = ?
                         """,
                         (sqlite3.Binary(payload), digest, entry_id),
@@ -436,7 +481,7 @@ class SQLiteWikiStore:
                             entry_id,
                             repository_id,
                             envelope_json,
-                            envelope_sha256
+                            record_sha256
                         ) VALUES (?, ?, ?, ?)
                         """,
                         (

--- a/codenib/wiki/sqlite_store.py
+++ b/codenib/wiki/sqlite_store.py
@@ -197,16 +197,35 @@ class SQLiteWikiStore:
         self.path = resolved
         self._lock_directory = Path(f"{resolved}.locks")
         try:
-            self._lock_directory.mkdir(parents=True, exist_ok=True)
+            self._lock_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
             # Lock acquisition linearizes schema identity and the WAL transition
             # for this database. Initialization takes no entry lock, retains no
             # owner after return, and the OS releases the file lock on exit.
             with FileLock(str(self._lock_directory / ".initialize.lock")):
+                self._create_database_file_if_missing()
                 self._initialize()
         except WikiStoreError:
             raise
         except OSError as exc:
             raise WikiStoreError("Wiki database initialization lock failed") from exc
+
+    def _create_database_file_if_missing(self) -> None:
+        """Create a new cache privately before SQLite can create WAL sidecars."""
+
+        try:
+            descriptor = os.open(
+                self.path,
+                os.O_CREAT | os.O_EXCL | os.O_RDWR,
+                0o600,
+            )
+        except FileExistsError:
+            return
+        except OSError as exc:
+            raise WikiStoreError("Wiki database file creation failed") from exc
+        try:
+            os.close(descriptor)
+        except OSError as exc:
+            raise WikiStoreError("Wiki database file creation failed") from exc
 
     def _open_raw(self) -> sqlite3.Connection:
         connection = sqlite3.connect(
@@ -476,7 +495,7 @@ class SQLiteWikiStore:
         entry_id = _validate_identifier(entry_id, field="entry_id")
         lock_name = hashlib.sha256(entry_id.encode("utf-8")).hexdigest() + ".lock"
         try:
-            self._lock_directory.mkdir(parents=True, exist_ok=True)
+            self._lock_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
             lock = FileLock(str(self._lock_directory / lock_name))
             lock.acquire()
         except OSError as exc:

--- a/codenib/wiki/sqlite_store.py
+++ b/codenib/wiki/sqlite_store.py
@@ -40,6 +40,11 @@ from .store import (
 _APPLICATION_ID = 0x434E574B  # ``CNWK``
 _SCHEMA_VERSION = 1
 _MAX_IDENTIFIER_BYTES = 4_096
+# Stable SQLite primary result codes. Python 3.10 does not expose the matching
+# ``sqlite3.SQLITE_*`` module constants even though exceptions carry the code.
+_SQLITE_CORRUPT = 11
+_SQLITE_SCHEMA = 17
+_SQLITE_NOTADB = 26
 
 _CREATE_SCHEMA_SQL = """
 CREATE TABLE wiki_entries (
@@ -76,9 +81,9 @@ def _reject_nonfinite_number(value: str) -> None:
 def _sqlite_error(operation: str, exc: sqlite3.Error) -> WikiStoreError:
     error_code = getattr(exc, "sqlite_errorcode", None)
     primary_code = error_code & 0xFF if isinstance(error_code, int) else None
-    if primary_code in {sqlite3.SQLITE_CORRUPT, sqlite3.SQLITE_NOTADB}:
+    if primary_code in {_SQLITE_CORRUPT, _SQLITE_NOTADB}:
         return WikiStoreCorruptionError(f"Wiki database {operation} found corruption")
-    if primary_code == sqlite3.SQLITE_SCHEMA:
+    if primary_code == _SQLITE_SCHEMA:
         return WikiStoreSchemaError(f"Wiki database schema changed during {operation}")
     if isinstance(exc, sqlite3.IntegrityError):
         return WikiStoreValidationError(

--- a/codenib/wiki/sqlite_store.py
+++ b/codenib/wiki/sqlite_store.py
@@ -49,6 +49,7 @@ _SQLITE_NOTADB = 26
 _SQLITE_CORRUPTION_MESSAGES = frozenset(
     ("database disk image is malformed", "file is not a database")
 )
+_SQLITE_CORRUPTION_PREFIXES = ("malformed database schema",)
 
 _CREATE_SCHEMA_SQL = """
 CREATE TABLE wiki_entries (
@@ -89,7 +90,10 @@ def _sqlite_error(operation: str, exc: sqlite3.Error) -> WikiStoreError:
     if primary_code in {_SQLITE_CORRUPT, _SQLITE_NOTADB} or (
         primary_code is None
         and type(exc) is sqlite3.DatabaseError
-        and message in _SQLITE_CORRUPTION_MESSAGES
+        and (
+            message in _SQLITE_CORRUPTION_MESSAGES
+            or message.startswith(_SQLITE_CORRUPTION_PREFIXES)
+        )
     ):
         return WikiStoreCorruptionError(f"Wiki database {operation} found corruption")
     if primary_code == _SQLITE_SCHEMA or (
@@ -110,7 +114,11 @@ def _validate_identifier(value: object, *, field: str) -> str:
         raise WikiStoreValidationError(f"{field} must be a non-empty string")
     if "\x00" in value:
         raise WikiStoreValidationError(f"{field} must not contain NUL bytes")
-    if len(value.encode("utf-8")) > _MAX_IDENTIFIER_BYTES:
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise WikiStoreValidationError(f"{field} must contain valid Unicode") from exc
+    if len(encoded) > _MAX_IDENTIFIER_BYTES:
         raise WikiStoreValidationError(
             f"{field} exceeds its {_MAX_IDENTIFIER_BYTES}-byte limit"
         )

--- a/codenib/wiki/sqlite_store.py
+++ b/codenib/wiki/sqlite_store.py
@@ -1,0 +1,493 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""SQLite WAL implementation of the narrow Wiki store contract.
+
+This is a trusted local, regenerable cache. Bounds and digests catch malformed
+or accidentally damaged entries; they are not a security boundary against a
+process that can rewrite both the database payload and its digest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import re
+import sqlite3
+from collections.abc import Collection, Iterator, Mapping
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from filelock import FileLock
+
+from .._bounded_json import (
+    canonical_json_value_chunks,
+    validate_bounded_json_stream,
+    validate_json_complexity,
+)
+from .store import (
+    WikiEntryKind,
+    WikiStoreCorruptionError,
+    WikiStoredEntry,
+    WikiStoreError,
+    WikiStoreSchemaError,
+    WikiStoreValidationError,
+)
+
+_APPLICATION_ID = 0x434E574B  # ``CNWK``
+_SCHEMA_VERSION = 1
+_MAX_ENVELOPE_BYTES = 16 * 1024 * 1024
+_MAX_IDENTIFIER_BYTES = 4_096
+_KINDS = frozenset(("outline", "page", "evidence"))
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+_CREATE_SCHEMA_SQL = """
+CREATE TABLE wiki_entries (
+    entry_id TEXT PRIMARY KEY NOT NULL,
+    repository_id TEXT NOT NULL,
+    kind TEXT NOT NULL CHECK (kind IN ('outline', 'page', 'evidence')),
+    page_id TEXT,
+    envelope_json BLOB NOT NULL,
+    envelope_sha256 TEXT NOT NULL CHECK (length(envelope_sha256) = 64),
+    CHECK (
+        (kind = 'outline' AND page_id IS NULL)
+        OR (
+            kind IN ('page', 'evidence')
+            AND page_id IS NOT NULL
+            AND length(page_id) > 0
+        )
+    )
+);
+CREATE INDEX wiki_entries_repository_entry_idx
+    ON wiki_entries(repository_id, entry_id);
+"""
+
+_EXPECTED_COLUMNS = (
+    ("entry_id", "TEXT", 1, 1),
+    ("repository_id", "TEXT", 1, 0),
+    ("kind", "TEXT", 1, 0),
+    ("page_id", "TEXT", 0, 0),
+    ("envelope_json", "BLOB", 1, 0),
+    ("envelope_sha256", "TEXT", 1, 0),
+)
+
+
+def _reject_duplicate_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        value[key] = item
+    return value
+
+
+def _reject_nonfinite_number(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _sqlite_error(operation: str, exc: sqlite3.Error) -> WikiStoreError:
+    error_code = getattr(exc, "sqlite_errorcode", None)
+    primary_code = error_code & 0xFF if isinstance(error_code, int) else None
+    if primary_code in {sqlite3.SQLITE_CORRUPT, sqlite3.SQLITE_NOTADB}:
+        return WikiStoreCorruptionError(f"Wiki database {operation} found corruption")
+    if primary_code == sqlite3.SQLITE_SCHEMA:
+        return WikiStoreSchemaError(f"Wiki database schema changed during {operation}")
+    if isinstance(exc, sqlite3.IntegrityError):
+        return WikiStoreValidationError(
+            f"Wiki database rejected an entry during {operation}"
+        )
+    return WikiStoreError(f"Wiki database {operation} failed")
+
+
+def _validate_identifier(value: object, *, field: str) -> str:
+    if type(value) is not str or not value:
+        raise WikiStoreValidationError(f"{field} must be a non-empty string")
+    if "\x00" in value:
+        raise WikiStoreValidationError(f"{field} must not contain NUL bytes")
+    if len(value.encode("utf-8")) > _MAX_IDENTIFIER_BYTES:
+        raise WikiStoreValidationError(
+            f"{field} exceeds its {_MAX_IDENTIFIER_BYTES}-byte limit"
+        )
+    return value
+
+
+def _validate_kind(value: object) -> WikiEntryKind:
+    if type(value) is not str or value not in _KINDS:
+        raise WikiStoreValidationError(
+            "kind must be one of 'outline', 'page', or 'evidence'"
+        )
+    return value  # type: ignore[return-value]
+
+
+def _validate_kind_page(
+    kind: WikiEntryKind, page_id: object
+) -> tuple[WikiEntryKind, str | None]:
+    if kind == "outline":
+        if page_id is not None:
+            raise WikiStoreValidationError("outline entries must not have a page_id")
+        return kind, None
+    if page_id is None:
+        raise WikiStoreValidationError(f"{kind} entries require a page_id")
+    return kind, _validate_identifier(page_id, field="page_id")
+
+
+def _canonical_envelope(envelope: Mapping[str, Any]) -> bytes:
+    if not isinstance(envelope, Mapping):
+        raise WikiStoreValidationError("envelope must be a JSON object")
+    try:
+        value = dict(envelope)
+        validate_json_complexity(value, label="Wiki envelope")
+        payload = bytearray()
+        for chunk in canonical_json_value_chunks(value):
+            if len(payload) + len(chunk) > _MAX_ENVELOPE_BYTES:
+                raise WikiStoreValidationError(
+                    f"Wiki envelope exceeds its {_MAX_ENVELOPE_BYTES}-byte limit"
+                )
+            payload.extend(chunk)
+    except WikiStoreValidationError:
+        raise
+    except MemoryError:
+        raise
+    except Exception as exc:
+        raise WikiStoreValidationError(
+            "envelope must contain only bounded JSON values"
+        ) from exc
+    return bytes(payload)
+
+
+def _decode_envelope(payload: object, digest: object) -> dict[str, Any]:
+    if isinstance(payload, memoryview):
+        payload = payload.tobytes()
+    if type(payload) is not bytes:
+        raise WikiStoreCorruptionError("Wiki entry payload is not a byte string")
+    if len(payload) > _MAX_ENVELOPE_BYTES:
+        raise WikiStoreCorruptionError("Wiki entry payload exceeds its size limit")
+    if type(digest) is not str or _SHA256_RE.fullmatch(digest) is None:
+        raise WikiStoreCorruptionError("Wiki entry has an invalid SHA-256 digest")
+    observed_digest = hashlib.sha256(payload).hexdigest()
+    if observed_digest != digest:
+        raise WikiStoreCorruptionError("Wiki entry failed its SHA-256 integrity check")
+    try:
+        validate_bounded_json_stream(
+            io.BytesIO(payload),
+            label="persisted Wiki envelope",
+            max_bytes=_MAX_ENVELOPE_BYTES,
+        )
+        value = json.loads(
+            payload.decode("utf-8", errors="strict"),
+            object_pairs_hook=_reject_duplicate_object,
+            parse_constant=_reject_nonfinite_number,
+        )
+        if not isinstance(value, dict):
+            raise ValueError("Wiki envelope is not a JSON object")
+        validate_json_complexity(value, label="persisted Wiki envelope")
+    except (ValueError, WikiStoreValidationError) as exc:
+        raise WikiStoreCorruptionError("Wiki entry contains invalid JSON") from exc
+    return value
+
+
+class SQLiteWikiStore:
+    """A short-connection, transactional SQLite store for Wiki envelopes."""
+
+    def __init__(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        busy_timeout_ms: int = 5_000,
+    ) -> None:
+        if type(busy_timeout_ms) is not int or busy_timeout_ms < 0:
+            raise WikiStoreValidationError(
+                "busy_timeout_ms must be a non-negative integer"
+            )
+        if str(path) == ":memory:":
+            raise WikiStoreValidationError(
+                "short-connection Wiki stores require a filesystem path"
+            )
+        try:
+            resolved = Path(path).expanduser().resolve()
+            resolved.parent.mkdir(parents=True, exist_ok=True)
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            raise WikiStoreValidationError("invalid Wiki database path") from exc
+        self.path = resolved
+        self._busy_timeout_ms = busy_timeout_ms
+        self._lock_directory = Path(f"{resolved}.locks")
+        self._initialize()
+
+    def _open_raw(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(
+            str(self.path),
+            timeout=self._busy_timeout_ms / 1_000,
+            isolation_level=None,
+        )
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    @staticmethod
+    def _identity(connection: sqlite3.Connection) -> tuple[int, int, frozenset[str]]:
+        application_id = connection.execute("PRAGMA application_id").fetchone()[0]
+        user_version = connection.execute("PRAGMA user_version").fetchone()[0]
+        tables = frozenset(row["name"] for row in connection.execute("""
+                SELECT name
+                FROM sqlite_master
+                WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+                """))
+        return application_id, user_version, tables
+
+    def _initialize(self) -> None:
+        connection: sqlite3.Connection | None = None
+        try:
+            connection = self._open_raw()
+            application_id, user_version, tables = self._identity(connection)
+            if application_id == 0 and user_version == 0 and not tables:
+                connection.execute("BEGIN IMMEDIATE")
+                try:
+                    application_id, user_version, tables = self._identity(connection)
+                    if application_id == 0 and user_version == 0 and not tables:
+                        schema_statements = tuple(
+                            statement.strip()
+                            for statement in _CREATE_SCHEMA_SQL.split(";")
+                            if statement.strip()
+                        )
+                        for statement in schema_statements:
+                            connection.execute(statement)
+                        connection.execute(
+                            f"PRAGMA application_id = {_APPLICATION_ID:d}"
+                        )
+                        connection.execute(f"PRAGMA user_version = {_SCHEMA_VERSION:d}")
+                    connection.commit()
+                except BaseException:
+                    if connection.in_transaction:
+                        connection.rollback()
+                    raise
+            self._require_schema(connection)
+            self._configure_database(connection)
+            self._configure_connection(connection)
+        except WikiStoreError:
+            raise
+        except sqlite3.Error as exc:
+            raise _sqlite_error("initialization", exc) from exc
+        finally:
+            if connection is not None:
+                connection.close()
+
+    @staticmethod
+    def _require_schema(connection: sqlite3.Connection) -> None:
+        application_id, user_version, tables = SQLiteWikiStore._identity(connection)
+        if application_id != _APPLICATION_ID:
+            raise WikiStoreSchemaError(
+                "file is not an initialized CodeNib Wiki database"
+            )
+        if user_version > _SCHEMA_VERSION:
+            raise WikiStoreSchemaError(
+                "Wiki database schema is newer than this CodeNib version: "
+                f"{user_version} > {_SCHEMA_VERSION}"
+            )
+        if user_version != _SCHEMA_VERSION:
+            raise WikiStoreSchemaError(
+                f"unsupported Wiki database schema version: {user_version}"
+            )
+        if tables != frozenset(("wiki_entries",)):
+            raise WikiStoreSchemaError("Wiki database has an unexpected table layout")
+        columns = tuple(
+            (row["name"], row["type"], row["notnull"], row["pk"])
+            for row in connection.execute("PRAGMA table_info(wiki_entries)")
+        )
+        if columns != _EXPECTED_COLUMNS:
+            raise WikiStoreSchemaError("Wiki database has an unexpected entry schema")
+
+    @staticmethod
+    def _configure_database(connection: sqlite3.Connection) -> None:
+        journal_mode = connection.execute("PRAGMA journal_mode = WAL").fetchone()[0]
+        if str(journal_mode).lower() != "wal":
+            raise WikiStoreError("SQLite WAL mode could not be enabled")
+
+    def _configure_connection(self, connection: sqlite3.Connection) -> None:
+        connection.execute(f"PRAGMA busy_timeout = {self._busy_timeout_ms:d}")
+        connection.execute("PRAGMA synchronous = NORMAL")
+
+    @contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
+        connection: sqlite3.Connection | None = None
+        try:
+            connection = self._open_raw()
+            self._configure_connection(connection)
+            yield connection
+        except WikiStoreError:
+            raise
+        except sqlite3.Error as exc:
+            raise _sqlite_error("operation", exc) from exc
+        finally:
+            if connection is not None:
+                connection.close()
+
+    @staticmethod
+    def _entry_from_row(row: sqlite3.Row) -> WikiStoredEntry:
+        try:
+            entry_id = _validate_identifier(row["entry_id"], field="entry_id")
+            repository_id = _validate_identifier(
+                row["repository_id"], field="repository_id"
+            )
+            kind = _validate_kind(row["kind"])
+            kind, page_id = _validate_kind_page(kind, row["page_id"])
+        except WikiStoreValidationError as exc:
+            raise WikiStoreCorruptionError(
+                "Wiki entry contains invalid identity metadata"
+            ) from exc
+        envelope = _decode_envelope(row["envelope_json"], row["envelope_sha256"])
+        return WikiStoredEntry(
+            entry_id=entry_id,
+            repository_id=repository_id,
+            kind=kind,
+            page_id=page_id,
+            envelope=envelope,
+        )
+
+    def read(self, entry_id: str) -> WikiStoredEntry | None:
+        entry_id = _validate_identifier(entry_id, field="entry_id")
+        with self._connection() as connection:
+            row = connection.execute(
+                "SELECT * FROM wiki_entries WHERE entry_id = ?", (entry_id,)
+            ).fetchone()
+        return None if row is None else self._entry_from_row(row)
+
+    def publish(
+        self,
+        *,
+        entry_id: str,
+        repository_id: str,
+        kind: WikiEntryKind,
+        page_id: str | None,
+        envelope: Mapping[str, Any],
+        if_absent: bool = False,
+    ) -> WikiStoredEntry:
+        entry_id = _validate_identifier(entry_id, field="entry_id")
+        repository_id = _validate_identifier(repository_id, field="repository_id")
+        kind = _validate_kind(kind)
+        kind, page_id = _validate_kind_page(kind, page_id)
+        if type(if_absent) is not bool:
+            raise WikiStoreValidationError("if_absent must be a boolean")
+        payload = _canonical_envelope(envelope)
+        digest = hashlib.sha256(payload).hexdigest()
+
+        with self._connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            try:
+                row = connection.execute(
+                    "SELECT * FROM wiki_entries WHERE entry_id = ?", (entry_id,)
+                ).fetchone()
+                if row is not None:
+                    current = self._entry_from_row(row)
+                    if (
+                        current.repository_id != repository_id
+                        or current.kind != kind
+                        or current.page_id != page_id
+                    ):
+                        raise WikiStoreValidationError(
+                            "entry_id is already bound to different Wiki metadata"
+                        )
+                    if if_absent:
+                        connection.commit()
+                        return current
+                    connection.execute(
+                        """
+                        UPDATE wiki_entries
+                        SET envelope_json = ?, envelope_sha256 = ?
+                        WHERE entry_id = ?
+                        """,
+                        (sqlite3.Binary(payload), digest, entry_id),
+                    )
+                else:
+                    connection.execute(
+                        """
+                        INSERT INTO wiki_entries(
+                            entry_id,
+                            repository_id,
+                            kind,
+                            page_id,
+                            envelope_json,
+                            envelope_sha256
+                        ) VALUES (?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            entry_id,
+                            repository_id,
+                            kind,
+                            page_id,
+                            sqlite3.Binary(payload),
+                            digest,
+                        ),
+                    )
+                stored_row = connection.execute(
+                    "SELECT * FROM wiki_entries WHERE entry_id = ?", (entry_id,)
+                ).fetchone()
+                if stored_row is None:
+                    raise WikiStoreError("Wiki entry disappeared during publication")
+                stored = self._entry_from_row(stored_row)
+                connection.commit()
+                return stored
+            except BaseException:
+                if connection.in_transaction:
+                    connection.rollback()
+                raise
+
+    def scan(
+        self,
+        *,
+        repository_ids: Collection[str] | None = None,
+    ) -> tuple[WikiStoredEntry, ...]:
+        parameters: tuple[str, ...] = ()
+        if repository_ids is not None:
+            if isinstance(repository_ids, (str, bytes)) or not isinstance(
+                repository_ids, Collection
+            ):
+                raise WikiStoreValidationError(
+                    "repository_ids must be a collection of strings"
+                )
+            parameters = tuple(
+                sorted(
+                    {
+                        _validate_identifier(value, field="repository_id")
+                        for value in repository_ids
+                    }
+                )
+            )
+        with self._connection() as connection:
+            if repository_ids is None:
+                rows = connection.execute(
+                    "SELECT * FROM wiki_entries ORDER BY entry_id"
+                ).fetchall()
+            elif not parameters:
+                rows = []
+            else:
+                placeholders = ", ".join("?" for _ in parameters)
+                rows = connection.execute(
+                    "SELECT * FROM wiki_entries "
+                    f"WHERE repository_id IN ({placeholders}) ORDER BY entry_id",
+                    parameters,
+                ).fetchall()
+        return tuple(self._entry_from_row(row) for row in rows)
+
+    @contextmanager
+    def generation_guard(self, entry_id: str) -> Iterator[None]:
+        entry_id = _validate_identifier(entry_id, field="entry_id")
+        lock_name = hashlib.sha256(entry_id.encode("utf-8")).hexdigest() + ".lock"
+        try:
+            self._lock_directory.mkdir(parents=True, exist_ok=True)
+            lock = FileLock(str(self._lock_directory / lock_name))
+            lock.acquire()
+        except OSError as exc:
+            raise WikiStoreError("Wiki generation lock failed") from exc
+        try:
+            yield
+        finally:
+            try:
+                lock.release()
+            except OSError as exc:
+                raise WikiStoreError("Wiki generation lock release failed") from exc
+
+
+__all__ = ["SQLiteWikiStore"]

--- a/codenib/wiki/sqlite_store.py
+++ b/codenib/wiki/sqlite_store.py
@@ -30,7 +30,7 @@ from .._bounded_json import (
     validate_json_complexity,
 )
 from .store import (
-    WikiEntryKind,
+    WIKI_ENVELOPE_MAX_BYTES,
     WikiStoreCorruptionError,
     WikiStoredEntry,
     WikiStoreError,
@@ -40,27 +40,15 @@ from .store import (
 
 _APPLICATION_ID = 0x434E574B  # ``CNWK``
 _SCHEMA_VERSION = 1
-_MAX_ENVELOPE_BYTES = 16 * 1024 * 1024
 _MAX_IDENTIFIER_BYTES = 4_096
-_KINDS = frozenset(("outline", "page", "evidence"))
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 _CREATE_SCHEMA_SQL = """
 CREATE TABLE wiki_entries (
     entry_id TEXT PRIMARY KEY NOT NULL,
     repository_id TEXT NOT NULL,
-    kind TEXT NOT NULL CHECK (kind IN ('outline', 'page', 'evidence')),
-    page_id TEXT,
     envelope_json BLOB NOT NULL,
-    envelope_sha256 TEXT NOT NULL CHECK (length(envelope_sha256) = 64),
-    CHECK (
-        (kind = 'outline' AND page_id IS NULL)
-        OR (
-            kind IN ('page', 'evidence')
-            AND page_id IS NOT NULL
-            AND length(page_id) > 0
-        )
-    )
+    envelope_sha256 TEXT NOT NULL CHECK (length(envelope_sha256) = 64)
 );
 CREATE INDEX wiki_entries_repository_entry_idx
     ON wiki_entries(repository_id, entry_id);
@@ -69,8 +57,6 @@ CREATE INDEX wiki_entries_repository_entry_idx
 _EXPECTED_COLUMNS = (
     ("entry_id", "TEXT", 1, 1),
     ("repository_id", "TEXT", 1, 0),
-    ("kind", "TEXT", 1, 0),
-    ("page_id", "TEXT", 0, 0),
     ("envelope_json", "BLOB", 1, 0),
     ("envelope_sha256", "TEXT", 1, 0),
 )
@@ -115,26 +101,6 @@ def _validate_identifier(value: object, *, field: str) -> str:
     return value
 
 
-def _validate_kind(value: object) -> WikiEntryKind:
-    if type(value) is not str or value not in _KINDS:
-        raise WikiStoreValidationError(
-            "kind must be one of 'outline', 'page', or 'evidence'"
-        )
-    return value  # type: ignore[return-value]
-
-
-def _validate_kind_page(
-    kind: WikiEntryKind, page_id: object
-) -> tuple[WikiEntryKind, str | None]:
-    if kind == "outline":
-        if page_id is not None:
-            raise WikiStoreValidationError("outline entries must not have a page_id")
-        return kind, None
-    if page_id is None:
-        raise WikiStoreValidationError(f"{kind} entries require a page_id")
-    return kind, _validate_identifier(page_id, field="page_id")
-
-
 def _canonical_envelope(envelope: Mapping[str, Any]) -> bytes:
     if not isinstance(envelope, Mapping):
         raise WikiStoreValidationError("envelope must be a JSON object")
@@ -143,9 +109,9 @@ def _canonical_envelope(envelope: Mapping[str, Any]) -> bytes:
         validate_json_complexity(value, label="Wiki envelope")
         payload = bytearray()
         for chunk in canonical_json_value_chunks(value):
-            if len(payload) + len(chunk) > _MAX_ENVELOPE_BYTES:
+            if len(payload) + len(chunk) > WIKI_ENVELOPE_MAX_BYTES:
                 raise WikiStoreValidationError(
-                    f"Wiki envelope exceeds its {_MAX_ENVELOPE_BYTES}-byte limit"
+                    "Wiki envelope exceeds its " f"{WIKI_ENVELOPE_MAX_BYTES}-byte limit"
                 )
             payload.extend(chunk)
     except WikiStoreValidationError:
@@ -164,7 +130,7 @@ def _decode_envelope(payload: object, digest: object) -> dict[str, Any]:
         payload = payload.tobytes()
     if type(payload) is not bytes:
         raise WikiStoreCorruptionError("Wiki entry payload is not a byte string")
-    if len(payload) > _MAX_ENVELOPE_BYTES:
+    if len(payload) > WIKI_ENVELOPE_MAX_BYTES:
         raise WikiStoreCorruptionError("Wiki entry payload exceeds its size limit")
     if type(digest) is not str or _SHA256_RE.fullmatch(digest) is None:
         raise WikiStoreCorruptionError("Wiki entry has an invalid SHA-256 digest")
@@ -175,7 +141,7 @@ def _decode_envelope(payload: object, digest: object) -> dict[str, Any]:
         validate_bounded_json_stream(
             io.BytesIO(payload),
             label="persisted Wiki envelope",
-            max_bytes=_MAX_ENVELOPE_BYTES,
+            max_bytes=WIKI_ENVELOPE_MAX_BYTES,
         )
         value = json.loads(
             payload.decode("utf-8", errors="strict"),
@@ -336,8 +302,6 @@ class SQLiteWikiStore:
             repository_id = _validate_identifier(
                 row["repository_id"], field="repository_id"
             )
-            kind = _validate_kind(row["kind"])
-            kind, page_id = _validate_kind_page(kind, row["page_id"])
         except WikiStoreValidationError as exc:
             raise WikiStoreCorruptionError(
                 "Wiki entry contains invalid identity metadata"
@@ -346,8 +310,6 @@ class SQLiteWikiStore:
         return WikiStoredEntry(
             entry_id=entry_id,
             repository_id=repository_id,
-            kind=kind,
-            page_id=page_id,
             envelope=envelope,
         )
 
@@ -364,19 +326,20 @@ class SQLiteWikiStore:
         *,
         entry_id: str,
         repository_id: str,
-        kind: WikiEntryKind,
-        page_id: str | None,
         envelope: Mapping[str, Any],
         if_absent: bool = False,
     ) -> WikiStoredEntry:
         entry_id = _validate_identifier(entry_id, field="entry_id")
         repository_id = _validate_identifier(repository_id, field="repository_id")
-        kind = _validate_kind(kind)
-        kind, page_id = _validate_kind_page(kind, page_id)
         if type(if_absent) is not bool:
             raise WikiStoreValidationError("if_absent must be a boolean")
         payload = _canonical_envelope(envelope)
         digest = hashlib.sha256(payload).hexdigest()
+        published = WikiStoredEntry(
+            entry_id=entry_id,
+            repository_id=repository_id,
+            envelope=_decode_envelope(payload, digest),
+        )
 
         with self._connection() as connection:
             connection.execute("BEGIN IMMEDIATE")
@@ -385,16 +348,20 @@ class SQLiteWikiStore:
                     "SELECT * FROM wiki_entries WHERE entry_id = ?", (entry_id,)
                 ).fetchone()
                 if row is not None:
-                    current = self._entry_from_row(row)
-                    if (
-                        current.repository_id != repository_id
-                        or current.kind != kind
-                        or current.page_id != page_id
-                    ):
+                    try:
+                        current_repository_id = _validate_identifier(
+                            row["repository_id"], field="repository_id"
+                        )
+                    except WikiStoreValidationError as exc:
+                        raise WikiStoreCorruptionError(
+                            "Wiki entry contains invalid identity metadata"
+                        ) from exc
+                    if current_repository_id != repository_id:
                         raise WikiStoreValidationError(
                             "entry_id is already bound to different Wiki metadata"
                         )
                     if if_absent:
+                        current = self._entry_from_row(row)
                         connection.commit()
                         return current
                     connection.execute(
@@ -411,29 +378,19 @@ class SQLiteWikiStore:
                         INSERT INTO wiki_entries(
                             entry_id,
                             repository_id,
-                            kind,
-                            page_id,
                             envelope_json,
                             envelope_sha256
-                        ) VALUES (?, ?, ?, ?, ?, ?)
+                        ) VALUES (?, ?, ?, ?)
                         """,
                         (
                             entry_id,
                             repository_id,
-                            kind,
-                            page_id,
                             sqlite3.Binary(payload),
                             digest,
                         ),
                     )
-                stored_row = connection.execute(
-                    "SELECT * FROM wiki_entries WHERE entry_id = ?", (entry_id,)
-                ).fetchone()
-                if stored_row is None:
-                    raise WikiStoreError("Wiki entry disappeared during publication")
-                stored = self._entry_from_row(stored_row)
                 connection.commit()
-                return stored
+                return published
             except BaseException:
                 if connection.in_transaction:
                     connection.rollback()

--- a/codenib/wiki/sqlite_store.py
+++ b/codenib/wiki/sqlite_store.py
@@ -230,11 +230,16 @@ class SQLiteWikiStore:
     def _identity(connection: sqlite3.Connection) -> tuple[int, int, frozenset[str]]:
         application_id = connection.execute("PRAGMA application_id").fetchone()[0]
         user_version = connection.execute("PRAGMA user_version").fetchone()[0]
-        tables = frozenset(row["name"] for row in connection.execute("""
+        tables = frozenset(
+            row["name"]
+            for row in connection.execute(
+                """
                 SELECT name
                 FROM sqlite_master
                 WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
-                """))
+                """
+            )
+        )
         return application_id, user_version, tables
 
     def _initialize(self) -> None:

--- a/codenib/wiki/sqlite_store.py
+++ b/codenib/wiki/sqlite_store.py
@@ -15,7 +15,6 @@ import hashlib
 import io
 import json
 import os
-import re
 import sqlite3
 from collections.abc import Collection, Iterator, Mapping
 from contextlib import contextmanager
@@ -41,7 +40,6 @@ from .store import (
 _APPLICATION_ID = 0x434E574B  # ``CNWK``
 _SCHEMA_VERSION = 1
 _MAX_IDENTIFIER_BYTES = 4_096
-_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 _CREATE_SCHEMA_SQL = """
 CREATE TABLE wiki_entries (
@@ -132,7 +130,7 @@ def _decode_envelope(payload: object, digest: object) -> dict[str, Any]:
         raise WikiStoreCorruptionError("Wiki entry payload is not a byte string")
     if len(payload) > WIKI_ENVELOPE_MAX_BYTES:
         raise WikiStoreCorruptionError("Wiki entry payload exceeds its size limit")
-    if type(digest) is not str or _SHA256_RE.fullmatch(digest) is None:
+    if type(digest) is not str:
         raise WikiStoreCorruptionError("Wiki entry has an invalid SHA-256 digest")
     observed_digest = hashlib.sha256(payload).hexdigest()
     if observed_digest != digest:
@@ -159,16 +157,7 @@ def _decode_envelope(payload: object, digest: object) -> dict[str, Any]:
 class SQLiteWikiStore:
     """A short-connection, transactional SQLite store for Wiki envelopes."""
 
-    def __init__(
-        self,
-        path: str | os.PathLike[str],
-        *,
-        busy_timeout_ms: int = 5_000,
-    ) -> None:
-        if type(busy_timeout_ms) is not int or busy_timeout_ms < 0:
-            raise WikiStoreValidationError(
-                "busy_timeout_ms must be a non-negative integer"
-            )
+    def __init__(self, path: str | os.PathLike[str]) -> None:
         if str(path) == ":memory:":
             raise WikiStoreValidationError(
                 "short-connection Wiki stores require a filesystem path"
@@ -179,14 +168,12 @@ class SQLiteWikiStore:
         except (OSError, RuntimeError, TypeError, ValueError) as exc:
             raise WikiStoreValidationError("invalid Wiki database path") from exc
         self.path = resolved
-        self._busy_timeout_ms = busy_timeout_ms
         self._lock_directory = Path(f"{resolved}.locks")
         self._initialize()
 
     def _open_raw(self) -> sqlite3.Connection:
         connection = sqlite3.connect(
             str(self.path),
-            timeout=self._busy_timeout_ms / 1_000,
             isolation_level=None,
         )
         connection.row_factory = sqlite3.Row
@@ -276,8 +263,8 @@ class SQLiteWikiStore:
         if str(journal_mode).lower() != "wal":
             raise WikiStoreError("SQLite WAL mode could not be enabled")
 
-    def _configure_connection(self, connection: sqlite3.Connection) -> None:
-        connection.execute(f"PRAGMA busy_timeout = {self._busy_timeout_ms:d}")
+    @staticmethod
+    def _configure_connection(connection: sqlite3.Connection) -> None:
         connection.execute("PRAGMA synchronous = NORMAL")
 
     @contextmanager

--- a/codenib/wiki/store.py
+++ b/codenib/wiki/store.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 from collections.abc import Collection, Mapping
 from dataclasses import dataclass
-from typing import Any, ContextManager, Literal, Protocol
+from typing import Any, ContextManager, Protocol
 
-WikiEntryKind = Literal["outline", "page", "evidence"]
+WIKI_ENVELOPE_MAX_BYTES = 16 * 1024 * 1024
 
 
 class WikiStoreError(RuntimeError):
@@ -35,8 +35,6 @@ class WikiStoredEntry:
 
     entry_id: str
     repository_id: str
-    kind: WikiEntryKind
-    page_id: str | None
     envelope: Mapping[str, Any]
 
 
@@ -51,8 +49,6 @@ class WikiStore(Protocol):
         *,
         entry_id: str,
         repository_id: str,
-        kind: WikiEntryKind,
-        page_id: str | None,
         envelope: Mapping[str, Any],
         if_absent: bool = False,
     ) -> WikiStoredEntry:
@@ -70,7 +66,7 @@ class WikiStore(Protocol):
 
 
 __all__ = [
-    "WikiEntryKind",
+    "WIKI_ENVELOPE_MAX_BYTES",
     "WikiStore",
     "WikiStoreCorruptionError",
     "WikiStoreError",

--- a/codenib/wiki/store.py
+++ b/codenib/wiki/store.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import Any, ContextManager, Protocol
 
 WIKI_ENVELOPE_MAX_BYTES = 16 * 1024 * 1024
+_WIKI_CACHE_PROVENANCE_FIELD = "_codenib_cache_provenance"
 
 
 class WikiStoreError(RuntimeError):

--- a/codenib/wiki/store.py
+++ b/codenib/wiki/store.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Domain contract for persisted AgentWiki cache entries."""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping
+from dataclasses import dataclass
+from typing import Any, ContextManager, Literal, Protocol
+
+WikiEntryKind = Literal["outline", "page", "evidence"]
+
+
+class WikiStoreError(RuntimeError):
+    """Base error for a Wiki store operation."""
+
+
+class WikiStoreValidationError(WikiStoreError, ValueError):
+    """The caller supplied an invalid Wiki entry or query."""
+
+
+class WikiStoreSchemaError(WikiStoreError):
+    """The database does not implement the supported Wiki schema."""
+
+
+class WikiStoreCorruptionError(WikiStoreError):
+    """Persisted Wiki data failed an integrity or decoding check."""
+
+
+@dataclass(frozen=True, slots=True)
+class WikiStoredEntry:
+    """One complete Wiki cache envelope and its stable identity."""
+
+    entry_id: str
+    repository_id: str
+    kind: WikiEntryKind
+    page_id: str | None
+    envelope: Mapping[str, Any]
+
+
+class WikiStore(Protocol):
+    """Minimal persistence boundary consumed by AgentWiki."""
+
+    def read(self, entry_id: str) -> WikiStoredEntry | None:
+        """Read one entry, returning ``None`` when it is absent."""
+
+    def publish(
+        self,
+        *,
+        entry_id: str,
+        repository_id: str,
+        kind: WikiEntryKind,
+        page_id: str | None,
+        envelope: Mapping[str, Any],
+        if_absent: bool = False,
+    ) -> WikiStoredEntry:
+        """Atomically insert or replace one complete entry."""
+
+    def scan(
+        self,
+        *,
+        repository_ids: Collection[str] | None = None,
+    ) -> tuple[WikiStoredEntry, ...]:
+        """Return entries in stable ID order, optionally filtered by repository."""
+
+    def generation_guard(self, entry_id: str) -> ContextManager[None]:
+        """Serialize generation of the same entry across processes."""
+
+
+__all__ = [
+    "WikiEntryKind",
+    "WikiStore",
+    "WikiStoreCorruptionError",
+    "WikiStoreError",
+    "WikiStoreSchemaError",
+    "WikiStoredEntry",
+    "WikiStoreValidationError",
+]

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -190,8 +190,14 @@ Opens at **http://localhost:3000**.
 3. Select a page
 4. On its first request, wait while the backend generates and caches it
 
-Wiki pages are cached under `<data_dir>/wiki_cache` (by default
-`.codenib_qa/wiki_cache`) so subsequent loads avoid another model call.
+Wiki pages are stored in `<data_dir>/wiki_cache/wiki.sqlite3` (by default under
+`.codenib_qa/wiki_cache`) so subsequent loads avoid another model call. The
+database uses SQLite WAL and validates each persisted JSON envelope. Existing
+source-compatible `agentwiki_*.json` entries remain a read-through
+compatibility source and are adopted lazily; pre-selection entries are not
+eligible once a manifest records its source-selection identity. The web and
+maintenance entry points write new data only to the database.
+
 **Refresh this wiki** only re-fetches the current tree and page; it does not
 invalidate that cache or force generation. After repairing a model or index,
 prefer the bounded `wiki-cache-prewarm --retry-degraded-now` maintenance path

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -19,6 +19,34 @@ behavior over those canonical backends. Choosing the canonical backends does
 not itself promote retained compiler or runtime routes; A2, B1, and B2 remain
 separate gates.
 
+## Scope Reset: Product Verticals Before More Catalog Machinery
+
+The general catalog and object-store contracts are frozen at their currently
+exercised capabilities. New product domains must use a small domain-local
+protocol and prove it with one concrete adapter and one conformance suite;
+they do not extend `IndexCatalog` merely because both implementations use
+SQLite. A second backend, registry, distributed coordination mechanism, or
+new generic capability requires a named consumer and measured need.
+
+The active product vertical is **Wiki Store v1**:
+
+- keep one injectable Wiki persistence protocol next to `codenib/wiki/`;
+- implement it first as a separate SQLite WAL database with a single forward
+  migration and short transactions;
+- route the existing Wiki cache consumer through it while preserving current
+  API responses, static exports, `RepoManifest`, portable artifacts, and MCP
+  surfaces;
+- retain legacy JSON as a bounded read-through compatibility source for one
+  release, without making filesystem paths part of the new protocol;
+- verify protocol conformance, reopen/rollback/corruption behavior, and one
+  end-to-end Wiki cache hit before expanding the model.
+
+Wiki search, normalized link/citation graphs, revision browsing, PostgreSQL,
+object storage, distributed leases, remote garbage collection, and dynamic
+plugin discovery are deferred until a visible product route or benchmark
+requires each capability. Arbitrary Python-line interruption testing is out of
+scope; fault injection stays at declared transaction and resource boundaries.
+
 ## Architectural Boundaries
 
 The storage system has three independent layers:

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -21,12 +21,14 @@ separate gates.
 
 ## Scope Reset: Product Verticals Before More Catalog Machinery
 
-The general catalog and object-store contracts are frozen at their currently
-exercised capabilities. New product domains must use a small domain-local
-protocol and prove it with one concrete adapter and one conformance suite;
-they do not extend `IndexCatalog` merely because both implementations use
-SQLite. A second backend, registry, distributed coordination mechanism, or
-new generic capability requires a named consumer and measured need.
+The public catalog and object-store methods with named non-test production call
+sites are frozen; compatible implementation fixes remain allowed. A product
+domain introduces a small domain-local protocol only when its current consumer
+needs an injectable I/O boundary, and proves that boundary with one production
+adapter and one conformance suite. It does not extend `IndexCatalog` merely
+because both implementations use SQLite. Tests, this roadmap, and planned
+adapters do not count as consumers. A new generic capability must satisfy the
+evidence gates in `AGENTS.md`.
 
 The active product vertical is **Wiki Store v1**:
 
@@ -36,8 +38,11 @@ The active product vertical is **Wiki Store v1**:
 - route the existing Wiki cache consumer through it while preserving current
   API responses, static exports, `RepoManifest`, portable artifacts, and MCP
   surfaces;
-- retain legacy JSON as a bounded read-through compatibility source for one
-  release, without making filesystem paths part of the new protocol;
+- retain legacy JSON as a bounded read-through compatibility source through the
+  first release containing Wiki Store v1, without making filesystem paths part
+  of the new protocol; remove it through
+  [#749](https://github.com/sysevol-ai/CodeNib/issues/749) after that migration
+  window;
 - verify protocol conformance, reopen/rollback/corruption behavior, and one
   end-to-end Wiki cache hit before expanding the model.
 

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -31,8 +31,8 @@ new generic capability requires a named consumer and measured need.
 The active product vertical is **Wiki Store v1**:
 
 - keep one injectable Wiki persistence protocol next to `codenib/wiki/`;
-- implement it first as a separate SQLite WAL database with a single forward
-  migration and short transactions;
+- implement it first as a separate SQLite WAL database with one v1 schema
+  initialization, bounded legacy JSON import, and short transactions;
 - route the existing Wiki cache consumer through it while preserving current
   API responses, static exports, `RepoManifest`, portable artifacts, and MCP
   surfaces;

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -41,6 +41,13 @@ The active product vertical is **Wiki Store v1**:
 - verify protocol conformance, reopen/rollback/corruption behavior, and one
   end-to-end Wiki cache hit before expanding the model.
 
+Status: complete. The domain protocol, one-table SQLite adapter, AgentWiki
+consumer, web composition, maintenance paths, and legacy read-through are
+implemented. Contract, Wiki, CLI, static-export, manifest, context-artifact,
+and MCP compatibility gates pass without changing the generic catalog schema.
+It is a trusted, regenerable local cache: bounds and digests detect accidental
+damage, not a hostile process that can rewrite the database.
+
 Wiki search, normalized link/citation graphs, revision browsing, PostgreSQL,
 object storage, distributed leases, remote garbage collection, and dynamic
 plugin discovery are deferred until a visible product route or benchmark

--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -329,12 +329,13 @@ make wiki-cache-audit \
 ```
 
 Its JSON report separates Overview, root-page, and child-page coverage; lists
-degraded, fallback, and quality-invalid pages; and reports stale/orphaned cache
-storage. Newly generated pages also contribute retrieval, planning, model-call,
-repair-count, and total-latency summaries. Existing cache entries created before
-those metrics were introduced remain readable and are simply excluded from the
-latency sample. Add `--fail-on-fallback` and `--fail-on-quality-invalid` to use
-the report as an acceptance gate.
+degraded, fallback, and quality-invalid pages; and reports stale/orphaned Wiki
+database entries and legacy cache files separately during migration. Newly
+generated pages also contribute retrieval, planning,
+model-call, repair-count, and total-latency summaries. Existing cache entries
+created before those metrics were introduced remain readable and are simply
+excluded from the latency sample. Add `--fail-on-fallback` and
+`--fail-on-quality-invalid` to use the report as an acceptance gate.
 
 Prewarm the landing page for every registered repository with a small bounded
 worker pool after reviewing the selection in dry-run mode:

--- a/scripts/audit_wiki_cache.py
+++ b/scripts/audit_wiki_cache.py
@@ -23,6 +23,7 @@ from codenib.web.config import load_config  # noqa: E402
 from codenib.web.native_authority import authorize_local_manifest_vector  # noqa: E402
 from codenib.web.repo_registry import RepoRegistry  # noqa: E402
 from codenib.wiki.cache_audit import audit_wiki_cache  # noqa: E402
+from codenib.wiki.sqlite_store import SQLiteWikiStore  # noqa: E402
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -66,11 +67,15 @@ def main(argv: list[str] | None = None) -> int:
         allow_missing_native_index_authorization=True,
     )
     registry.load_all()
+    cache_dir = os.path.join(os.path.abspath(config.data_dir), "wiki_cache")
+    database_path = Path(cache_dir) / "wiki.sqlite3"
+    store = SQLiteWikiStore(database_path) if database_path.exists() else None
     report = audit_wiki_cache(
         registry,
         model=config.wiki_generation_model,
-        cache_dir=os.path.join(os.path.abspath(config.data_dir), "wiki_cache"),
+        cache_dir=cache_dir,
         repo_ids=args.repos,
+        store=store,
     )
     print(
         json.dumps(

--- a/scripts/benchmark_demo_wiki.py
+++ b/scripts/benchmark_demo_wiki.py
@@ -30,6 +30,7 @@ from codenib.web.config import load_config  # noqa: E402
 from codenib.web.native_authority import authorize_local_manifest_vector  # noqa: E402
 from codenib.web.repo_registry import RepoRegistry  # noqa: E402
 from codenib.wiki.agent_wiki import AgentWiki  # noqa: E402
+from codenib.wiki.sqlite_store import SQLiteWikiStore  # noqa: E402
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -138,6 +139,7 @@ def main(argv: list[str] | None = None) -> int:
     registry.load_all()
     selected = list(dict.fromkeys(args.repos or ["psf__requests"]))
     production_cache = os.path.join(os.path.abspath(config.data_dir), "wiki_cache")
+    production_store = SQLiteWikiStore(Path(production_cache) / "wiki.sqlite3")
     outlines: dict[str, dict[str, Any]] = {}
     bundles: dict[str, Any] = {}
     for repo_id in selected:
@@ -148,6 +150,7 @@ def main(argv: list[str] | None = None) -> int:
             bundle,
             model=config.wiki_generation_model,
             cache_dir=production_cache,
+            store=production_store,
         )
         outline = reference._read_cache("outline")
         if not isinstance(outline, dict) or not outline.get("pages"):
@@ -180,6 +183,7 @@ def main(argv: list[str] | None = None) -> int:
                     bundles[repo_id],
                     model=model,
                     cache_dir=run_cache,
+                    store=SQLiteWikiStore(Path(run_cache) / "wiki.sqlite3"),
                     llm=llm,
                     api_base=api_base,
                     api_key=api_key,

--- a/scripts/prewarm_wiki_cache.py
+++ b/scripts/prewarm_wiki_cache.py
@@ -25,6 +25,7 @@ from codenib.web.native_authority import authorize_local_manifest_vector  # noqa
 from codenib.web.repo_registry import RepoRegistry  # noqa: E402
 from codenib.wiki.agent_wiki import AgentWiki  # noqa: E402
 from codenib.wiki.prewarm import prewarm_wiki_cache  # noqa: E402
+from codenib.wiki.sqlite_store import SQLiteWikiStore  # noqa: E402
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -77,6 +78,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     registry.load_all()
     cache_dir = os.path.join(os.path.abspath(config.data_dir), "wiki_cache")
+    database_path = Path(cache_dir) / "wiki.sqlite3"
+    store = (
+        None
+        if args.dry_run and not database_path.exists()
+        else SQLiteWikiStore(database_path)
+    )
 
     def wiki_factory(bundle):
         llm = LiteLLMChat(
@@ -91,6 +98,7 @@ def main(argv: list[str] | None = None) -> int:
             bundle,
             model=config.wiki_generation_model,
             cache_dir=cache_dir,
+            store=store,
             llm=llm,
             api_base=config.wiki_generation_api_base,
             api_key=config.wiki_generation_api_key,

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -1383,6 +1383,41 @@ def test_wiki_llm_receives_provider_configuration(monkeypatch):
     }
 
 
+def test_agent_wiki_receives_the_shared_wiki_store(tmp_path, monkeypatch):
+    import codenib.wiki.agent_wiki as agent_wiki
+
+    store = object()
+    bundle = object()
+    captured = {}
+    config = SimpleNamespace(
+        data_dir=str(tmp_path),
+        wiki_agent=True,
+        wiki_generation_model="wiki-model",
+        wiki_generation_api_base=None,
+        wiki_generation_api_key=None,
+    )
+
+    def build(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(web_app, "load_config", lambda: config)
+    monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
+    monkeypatch.setattr(web_app, "_wiki_llm", lambda _config: "llm")
+    monkeypatch.setattr(agent_wiki, "AgentWiki", build)
+    monkeypatch.setattr(web_app.app.state, "wiki_builders", {}, raising=False)
+    monkeypatch.setattr(web_app.app.state, "wiki_store", store, raising=False)
+
+    created = web_app._wiki("repo")
+
+    assert web_app.app.state.wiki_builders["repo"] == ("repo", bundle, created)
+    assert captured["args"] == (bundle, "wiki-model")
+    assert captured["kwargs"]["store"] is store
+    assert captured["kwargs"]["cache_dir"] == str(tmp_path / "wiki_cache")
+    assert captured["kwargs"]["llm"] == "llm"
+
+
 def test_unavailable_codemap_returns_repository_setup_report(monkeypatch):
     class Window:
         available = False

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from types import SimpleNamespace
 
@@ -835,6 +836,66 @@ def test_wiki_cache_rebuilds_when_bundle_generation_changes(monkeypatch):
     assert web_app.app.state.wiki_builders["repo"] == ("repo", new, refreshed)
 
 
+def test_wiki_cache_serializes_concurrent_lazy_construction(tmp_path, monkeypatch):
+    import codenib.wiki.agent_wiki as agent_wiki
+
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    second_entered = threading.Event()
+    call_guard = threading.Lock()
+    store = object()
+    bundle = object()
+    call_count = 0
+    config = SimpleNamespace(
+        data_dir=str(tmp_path),
+        wiki_agent=True,
+        wiki_generation_model="wiki-model",
+        wiki_generation_api_base=None,
+        wiki_generation_api_key=None,
+    )
+
+    def open_store(_path):
+        nonlocal call_count
+        with call_guard:
+            call_count += 1
+            ordinal = call_count
+        if ordinal == 1:
+            first_entered.set()
+            assert release_first.wait(timeout=5)
+        else:
+            second_entered.set()
+        return store
+
+    def open_second():
+        second_started.set()
+        return web_app._wiki("repo", bundle)
+
+    monkeypatch.setattr(web_app, "_WIKI_BUILD_LOCK", threading.Lock())
+    monkeypatch.setattr(web_app, "load_config", lambda: config)
+    monkeypatch.setattr(web_app, "_wiki_llm", lambda _config: object())
+    monkeypatch.setattr(web_app, "SQLiteWikiStore", open_store)
+    monkeypatch.setattr(agent_wiki, "AgentWiki", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(web_app.app.state, "wiki_builders", {}, raising=False)
+    monkeypatch.setattr(web_app.app.state, "wiki_store", None, raising=False)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first_result = executor.submit(web_app._wiki, "repo", bundle)
+        try:
+            assert first_entered.wait(timeout=5)
+            second_result = executor.submit(open_second)
+            assert second_started.wait(timeout=5)
+            assert not second_entered.wait(timeout=0.2)
+        finally:
+            release_first.set()
+        first = first_result.result(timeout=5)
+        second = second_result.result(timeout=5)
+
+    assert call_count == 1
+    assert second is first
+    assert web_app.app.state.wiki_store is store
+
+
 def test_generation_cache_drops_helpers_bound_to_retired_bundle():
     old = SimpleNamespace(entry=SimpleNamespace(instance_id="repo"))
     new = SimpleNamespace(entry=SimpleNamespace(instance_id="repo"))
@@ -999,6 +1060,9 @@ def test_wiki_generation_runs_off_event_loop(monkeypatch):
         def page(self, page_id):
             return {"id": page_id}
 
+        def page_citations(self, _page_id):
+            return []
+
     async def fake_to_thread(func, *args, **kwargs):
         if func is web_app._capture_thread_outcome:
             observed = args[0]
@@ -1010,16 +1074,26 @@ def test_wiki_generation_runs_off_event_loop(monkeypatch):
         return func(*args, **kwargs)
 
     builder = Builder()
-    monkeypatch.setattr(web_app, "_wiki", lambda _repo_id, _bundle=None: builder)
-    monkeypatch.setattr(
-        web_app,
-        "_bundle",
-        lambda _repo_id: SimpleNamespace(entry=SimpleNamespace(repo="org/repo")),
+
+    def code_graph():
+        return None
+
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(repo="org/repo"),
+        code_graph=code_graph,
+        graph_unavailable_note=lambda: "graph unavailable",
     )
+
+    def build_wiki(_repo_id, _bundle=None):
+        return builder
+
+    monkeypatch.setattr(web_app, "_wiki", build_wiki)
+    monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
     monkeypatch.setattr(web_app.asyncio, "to_thread", fake_to_thread)
 
     tree = asyncio.run(web_app.wiki_tree("repo"))
     page = asyncio.run(web_app.wiki_page("repo", "overview"))
+    graph = asyncio.run(web_app.wiki_page_graph("repo", "overview"))
 
     assert tree == {"repo": "org/repo", "pages": [{"id": "overview"}]}
     assert page == {
@@ -1038,7 +1112,22 @@ def test_wiki_generation_runs_off_event_loop(monkeypatch):
             "relation_count": 0,
         },
     }
-    assert calls == [("page_tree", ()), ("page", ("overview",))]
+    assert graph == {
+        "available": False,
+        "nodes": [],
+        "edges": [],
+        "mermaid": "",
+        "note": "graph unavailable",
+    }
+    assert calls == [
+        ("build_wiki", ("repo", bundle)),
+        ("page_tree", ()),
+        ("build_wiki", ("repo", bundle)),
+        ("page", ("overview",)),
+        ("build_wiki", ("repo", bundle)),
+        ("page_citations", ("overview",)),
+        ("code_graph", ()),
+    ]
 
 
 def test_cached_wiki_tree_does_not_generate_a_missing_outline(monkeypatch):

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -448,6 +448,52 @@ def test_lifespan_closes_registry_when_startup_is_cancelled(monkeypatch):
     assert captured == {"closed": True}
 
 
+def test_lifespan_defers_optional_wiki_store_initialization(monkeypatch):
+    events = []
+    config = SimpleNamespace(
+        registry_path="/tmp/qa_registry.json",
+        data_dir="/tmp/data",
+        wiki_agent=True,
+        wiki_generation_model="model",
+    )
+
+    class Registry:
+        def __init__(self, _config, **_kwargs):
+            pass
+
+        def load_all(self):
+            events.append("registry-load")
+
+        def list_infos(self):
+            return []
+
+        def close(self):
+            events.append("registry-close")
+
+    monkeypatch.setattr(web_app, "load_config", lambda: config)
+    monkeypatch.setattr(web_app, "RepoRegistry", Registry)
+    monkeypatch.setattr(
+        web_app,
+        "SQLiteWikiStore",
+        lambda *_args, **_kwargs: pytest.fail("Wiki store opened during startup"),
+    )
+    monkeypatch.setattr(
+        web_app,
+        "_wiki_narrator",
+        lambda _config: SimpleNamespace(model="model", enabled=True, cache_dir=None),
+    )
+    application = SimpleNamespace(state=SimpleNamespace())
+
+    async def run_lifespan():
+        async with web_app.lifespan(application):
+            events.append("serve")
+            assert application.state.wiki_store is None
+
+    asyncio.run(run_lifespan())
+
+    assert events == ["registry-load", "serve", "registry-close"]
+
+
 def test_oversized_chat_request_is_rejected_before_runtime_lookup(monkeypatch):
     def unexpected_registry_lookup():
         raise AssertionError("invalid chat payload reached the repository runtime")

--- a/test/wiki/test_agent_wiki.py
+++ b/test/wiki/test_agent_wiki.py
@@ -6760,8 +6760,6 @@ def test_agent_wiki_persists_through_injected_store_without_json_mirror(tmp_path
     stored = store.read(original._store_entry_id("outline"))
     assert stored is not None
     assert stored.repository_id == "owner__repo-1"
-    assert stored.kind == "outline"
-    assert stored.page_id is None
     assert stored.envelope["model"] == "first-model"
 
 
@@ -6798,6 +6796,40 @@ def test_agent_wiki_lazily_adopts_json_into_store_but_read_only_does_not(tmp_pat
     adopted = store.read(entry_id)
     assert adopted is not None
     assert adopted.envelope["model"] == "old-model"
+
+
+def test_agent_wiki_rejects_unbounded_legacy_json_before_serving_or_adoption(
+    tmp_path,
+):
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=None,
+        bm25=None,
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+    )
+    cache_dir = tmp_path / "wiki-cache"
+    store = SQLiteWikiStore(cache_dir / "wiki.sqlite3")
+    wiki = AgentWiki(
+        bundle,
+        model="fake-model",
+        cache_dir=str(cache_dir),
+        store=store,
+    )
+    nested = {}
+    for _ in range(70):
+        nested = {"child": nested}
+    stable = wiki._cache_candidate_paths("outline")[0]
+    wiki._atomic_write_cache(stable, {"data": nested})
+
+    assert wiki._read_cache_read_only("outline") is None
+    assert wiki._read_cache("outline") is None
+    assert store.read(wiki._store_entry_id("outline")) is None
 
 
 def test_agent_wiki_cached_page_tree_reads_without_generating_or_migrating(

--- a/test/wiki/test_agent_wiki.py
+++ b/test/wiki/test_agent_wiki.py
@@ -10,6 +10,8 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
+import pytest
+
 from codenib.graph.code_graph import CodeGraph
 from codenib.wiki.agent_wiki import (
     AgentWiki,
@@ -39,6 +41,7 @@ from codenib.wiki.agent_wiki import (
 from codenib.wiki.builder import Symbol
 from codenib.wiki.evidence import EvidenceItem, RelationItem, candidate_key
 from codenib.wiki.quality import prose_integrity_report
+from codenib.wiki.sqlite_store import SQLiteWikiStore
 
 
 class _FakeVectorStore:
@@ -6713,6 +6716,90 @@ def test_agent_wiki_adopts_legacy_timestamp_cache_into_stable_key(tmp_path):
         assert json.load(handle)["model"] == "old-model"
 
 
+def test_agent_wiki_persists_through_injected_store_without_json_mirror(tmp_path):
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=None,
+        bm25=None,
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+    )
+    cache_dir = tmp_path / "wiki-cache"
+    store = SQLiteWikiStore(cache_dir / "wiki.sqlite3")
+    original = AgentWiki(
+        bundle,
+        model="first-model",
+        cache_dir=str(cache_dir),
+        store=store,
+    )
+    payload = {"pages": [{"id": "overview", "title": "Overview"}]}
+
+    original._write_cache("outline", payload)
+
+    assert not list(cache_dir.glob("agentwiki_*.json"))
+
+    class UnexpectedLLM:
+        cache_identity = "must-not-run"
+
+        def complete(self, *_args, **_kwargs):
+            raise AssertionError("a database hit must not invoke the model")
+
+    reloaded = AgentWiki(
+        bundle,
+        model="different-model",
+        cache_dir=str(cache_dir),
+        store=SQLiteWikiStore(cache_dir / "wiki.sqlite3"),
+        llm=UnexpectedLLM(),
+    )
+    assert reloaded.outline() == payload
+    stored = store.read(original._store_entry_id("outline"))
+    assert stored is not None
+    assert stored.repository_id == "owner__repo-1"
+    assert stored.kind == "outline"
+    assert stored.page_id is None
+    assert stored.envelope["model"] == "first-model"
+
+
+def test_agent_wiki_lazily_adopts_json_into_store_but_read_only_does_not(tmp_path):
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=None,
+        bm25=None,
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+    )
+    cache_dir = tmp_path / "wiki-cache"
+    store = SQLiteWikiStore(cache_dir / "wiki.sqlite3")
+    wiki = AgentWiki(
+        bundle,
+        model="fake-model",
+        cache_dir=str(cache_dir),
+        store=store,
+    )
+    stable = wiki._cache_candidate_paths("outline")[0]
+    payload = {"pages": [{"id": "overview", "title": "Overview"}]}
+    wiki._atomic_write_cache(stable, {"model": "old-model", "data": payload})
+    entry_id = wiki._store_entry_id("outline")
+
+    assert wiki._read_cache_read_only("outline") == payload
+    assert store.read(entry_id) is None
+
+    assert wiki._read_cache("outline") == payload
+    adopted = store.read(entry_id)
+    assert adopted is not None
+    assert adopted.envelope["model"] == "old-model"
+
+
 def test_agent_wiki_cached_page_tree_reads_without_generating_or_migrating(
     tmp_path, monkeypatch
 ):
@@ -7140,7 +7227,8 @@ def test_agent_wiki_coalesces_concurrent_page_generation(tmp_path):
     assert generation_calls == 1
 
 
-def test_agent_wiki_coalesces_generation_across_builder_instances(tmp_path):
+@pytest.mark.parametrize("use_store", [False, True])
+def test_agent_wiki_coalesces_generation_across_builder_instances(tmp_path, use_store):
     bundle = SimpleNamespace(
         entry=SimpleNamespace(
             repo="owner/repo",
@@ -7156,10 +7244,19 @@ def test_agent_wiki_coalesces_generation_across_builder_instances(tmp_path):
     meta = {"id": "runtime", "title": "Runtime", "children": []}
     outline = {"pages": [meta]}
     cache_dir = tmp_path / "wiki-cache"
-    builders = [
-        AgentWiki(bundle, model="fake-model", cache_dir=str(cache_dir))
-        for _ in range(2)
-    ]
+    builders = []
+    for _ in range(2):
+        kwargs = {}
+        if use_store:
+            kwargs["store"] = SQLiteWikiStore(cache_dir / "wiki.sqlite3")
+        builders.append(
+            AgentWiki(
+                bundle,
+                model="fake-model",
+                cache_dir=str(cache_dir),
+                **kwargs,
+            )
+        )
     for wiki in builders:
         wiki._outline = outline
     generation_started = threading.Event()

--- a/test/wiki/test_agent_wiki.py
+++ b/test/wiki/test_agent_wiki.py
@@ -6832,6 +6832,36 @@ def test_agent_wiki_rejects_unbounded_legacy_json_before_serving_or_adoption(
     assert store.read(wiki._store_entry_id("outline")) is None
 
 
+def test_agent_wiki_rejects_overflowed_legacy_json_number(tmp_path):
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=None,
+        bm25=None,
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+    )
+    cache_dir = tmp_path / "wiki-cache"
+    store = SQLiteWikiStore(cache_dir / "wiki.sqlite3")
+    wiki = AgentWiki(
+        bundle,
+        model="fake-model",
+        cache_dir=str(cache_dir),
+        store=store,
+    )
+    stable = wiki._cache_candidate_paths("outline")[0]
+    with open(stable, "w", encoding="utf-8") as handle:
+        handle.write('{"data":{"score":1e9999}}')
+
+    assert wiki._read_cache_read_only("outline") is None
+    assert wiki._read_cache("outline") is None
+    assert store.read(wiki._store_entry_id("outline")) is None
+
+
 def test_agent_wiki_cached_page_tree_reads_without_generating_or_migrating(
     tmp_path, monkeypatch
 ):

--- a/test/wiki/test_agent_wiki.py
+++ b/test/wiki/test_agent_wiki.py
@@ -42,6 +42,7 @@ from codenib.wiki.builder import Symbol
 from codenib.wiki.evidence import EvidenceItem, RelationItem, candidate_key
 from codenib.wiki.quality import prose_integrity_report
 from codenib.wiki.sqlite_store import SQLiteWikiStore
+from codenib.wiki.store import _WIKI_CACHE_PROVENANCE_FIELD
 
 
 class _FakeVectorStore:
@@ -6761,6 +6762,15 @@ def test_agent_wiki_persists_through_injected_store_without_json_mirror(tmp_path
     assert stored is not None
     assert stored.repository_id == "owner__repo-1"
     assert stored.envelope["model"] == "first-model"
+    assert stored.envelope[_WIKI_CACHE_PROVENANCE_FIELD] == {
+        "schema": 1,
+        "entry_id": original._store_entry_id("outline"),
+        "repository_id": "owner__repo-1",
+        "legacy_filenames": [
+            os.path.basename(path)
+            for path in original._cache_candidate_paths("outline")
+        ],
+    }
 
 
 def test_agent_wiki_lazily_adopts_json_into_store_but_read_only_does_not(tmp_path):
@@ -6796,6 +6806,9 @@ def test_agent_wiki_lazily_adopts_json_into_store_but_read_only_does_not(tmp_pat
     adopted = store.read(entry_id)
     assert adopted is not None
     assert adopted.envelope["model"] == "old-model"
+    assert adopted.envelope[_WIKI_CACHE_PROVENANCE_FIELD]["legacy_filenames"] == [
+        os.path.basename(path) for path in wiki._cache_candidate_paths("outline")
+    ]
 
 
 def test_agent_wiki_rejects_unbounded_legacy_json_before_serving_or_adoption(

--- a/test/wiki/test_cache_audit.py
+++ b/test/wiki/test_cache_audit.py
@@ -8,6 +8,7 @@ import pytest
 
 from codenib.wiki.agent_wiki import AgentWiki
 from codenib.wiki.cache_audit import audit_wiki_cache
+from codenib.wiki.sqlite_store import SQLiteWikiStore
 
 
 def test_cache_audit_is_read_only_and_reports_current_page_quality(tmp_path):
@@ -202,3 +203,217 @@ def test_cache_audit_subset_does_not_count_other_repo_as_orphan(tmp_path):
     assert report["repositories"] == 1
     assert report["storage"]["files"] == 1
     assert report["storage"]["orphan_files"] == 0
+
+
+def test_cache_audit_reads_store_without_publishing_and_reports_orphans(tmp_path):
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path / "repo"),
+            instance_id="owner__repo",
+            commit_short="abc123",
+            language="python",
+        ),
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+        vector_store=None,
+        bm25=None,
+    )
+    info = SimpleNamespace(id="owner__repo")
+
+    class Registry:
+        def list_infos(self):
+            return [info]
+
+        def get(self, repo_id):
+            return bundle if repo_id == info.id else None
+
+    outline = {
+        "pages": [
+            {
+                "id": "overview",
+                "title": "Overview",
+                "summary": "Repository overview",
+                "files": ["README.md"],
+                "children": [],
+            }
+        ]
+    }
+    seed_wiki = AgentWiki(bundle, model="fake-model", cache_dir=str(tmp_path))
+    overview_meta = seed_wiki._overview_page_meta(outline["pages"][0], [])
+    page_suffix = seed_wiki._page_cache_suffix(overview_meta)
+
+    def entry(
+        entry_id,
+        *,
+        repository_id="owner__repo",
+        kind="page",
+        page_id="overview",
+        data=None,
+    ):
+        return SimpleNamespace(
+            entry_id=entry_id,
+            repository_id=repository_id,
+            kind=kind,
+            page_id=page_id,
+            envelope={"model": "fake-model", "data": data or {}},
+        )
+
+    stored_entries = {
+        seed_wiki._store_entry_id("outline"): entry(
+            seed_wiki._store_entry_id("outline"),
+            kind="outline",
+            page_id=None,
+            data=outline,
+        ),
+        seed_wiki._store_entry_id(page_suffix): entry(
+            seed_wiki._store_entry_id(page_suffix),
+            data={
+                "id": "overview",
+                "title": "Overview",
+                "generation": {"mode": "generated", "metrics": {}},
+                "quality": {"valid": True},
+            },
+        ),
+        "orphan": entry("orphan", page_id="removed"),
+        "other-repository": entry(
+            "other-repository",
+            repository_id="owner__other",
+        ),
+    }
+
+    class MemoryWikiStore:
+        def __init__(self):
+            self.read_calls = []
+            self.scan_filters = []
+
+        def read(self, entry_id):
+            self.read_calls.append(entry_id)
+            return stored_entries.get(entry_id)
+
+        def publish(self, **kwargs):
+            raise AssertionError("read-only audit must not publish")
+
+        def scan(self, *, repository_ids=None):
+            self.scan_filters.append(repository_ids)
+            if repository_ids is None:
+                return tuple(stored_entries.values())
+            selected = set(repository_ids)
+            return tuple(
+                item
+                for item in stored_entries.values()
+                if item.repository_id in selected
+            )
+
+        def generation_guard(self, entry_id):
+            raise AssertionError("read-only audit must not take generation guards")
+
+    class ReadOnlyAuditWiki(AgentWiki):
+        def _read_cache(self, suffix):
+            raise AssertionError("audit must use the read-only cache path")
+
+    store = MemoryWikiStore()
+    report = audit_wiki_cache(
+        Registry(),
+        model="fake-model",
+        cache_dir=tmp_path / "missing-cache",
+        repo_ids=["owner__repo"],
+        wiki_factory=ReadOnlyAuditWiki,
+        store=store,
+    )
+
+    assert report["coverage"]["all"]["percent"] == 100.0
+    assert report["storage"]["backend"] == "MemoryWikiStore"
+    assert report["storage"]["entries"] == 3
+    assert report["storage"]["orphan_entries"] == 1
+    assert report["storage"]["files"] == 0
+    assert report["storage"]["orphan_files"] == 0
+    assert store.scan_filters == [{"owner__repo"}]
+    assert store.read_calls == [
+        seed_wiki._store_entry_id("outline"),
+        seed_wiki._store_entry_id(page_suffix),
+    ]
+    assert not (tmp_path / "missing-cache").exists()
+
+
+def test_cache_audit_reports_database_and_legacy_storage_in_mixed_state(tmp_path):
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path / "repo"),
+            instance_id="owner__repo",
+            commit_short="abc123",
+            language="python",
+        ),
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+        vector_store=None,
+        bm25=None,
+    )
+
+    class Registry:
+        def list_infos(self):
+            return [SimpleNamespace(id="owner__repo")]
+
+        def get(self, repo_id):
+            return bundle if repo_id == "owner__repo" else None
+
+    cache_dir = tmp_path / "wiki-cache"
+    legacy = AgentWiki(bundle, model="fake-model", cache_dir=str(cache_dir))
+    outline = {
+        "pages": [
+            {
+                "id": "overview",
+                "title": "Overview",
+                "summary": "Repository overview",
+                "files": ["README.md"],
+                "children": [],
+            }
+        ]
+    }
+    legacy._write_cache("outline", outline)
+    overview_meta = legacy._overview_page_meta(outline["pages"][0], [])
+    legacy._write_cache(
+        legacy._page_cache_suffix(overview_meta),
+        {
+            "id": "overview",
+            "title": "Overview",
+            "generation": {"mode": "generated", "metrics": {}},
+            "quality": {"valid": True},
+        },
+    )
+    (cache_dir / "agentwiki_orphan.json").write_text(
+        '{"data":{"id":"removed"}}',
+        encoding="utf-8",
+    )
+
+    store = SQLiteWikiStore(cache_dir / "wiki.sqlite3")
+    store.publish(
+        entry_id="orphan",
+        repository_id="owner__repo",
+        kind="page",
+        page_id="removed",
+        envelope={"data": {"id": "removed"}},
+    )
+
+    report = audit_wiki_cache(
+        Registry(),
+        model="fake-model",
+        cache_dir=cache_dir,
+        store=store,
+    )
+
+    storage = report["storage"]
+    assert report["coverage"]["all"]["percent"] == 100.0
+    assert storage["entries"] == 1
+    assert storage["orphan_entries"] == 1
+    assert storage["files"] == 3
+    assert storage["orphan_files"] == 1
+    assert storage["database_bytes"] > 0
+    assert storage["legacy_bytes"] > 0
+    assert storage["bytes"] == storage["legacy_bytes"]
+    assert storage["orphan_bytes"] == storage["orphan_legacy_bytes"]
+    assert storage["total_bytes"] == (
+        storage["database_bytes"] + storage["legacy_bytes"]
+    )
+    assert storage["total_orphan_bytes"] == (
+        storage["orphan_database_bytes"] + storage["orphan_legacy_bytes"]
+    )

--- a/test/wiki/test_cache_audit.py
+++ b/test/wiki/test_cache_audit.py
@@ -246,23 +246,17 @@ def test_cache_audit_reads_store_without_publishing_and_reports_orphans(tmp_path
         entry_id,
         *,
         repository_id="owner__repo",
-        kind="page",
-        page_id="overview",
         data=None,
     ):
         return SimpleNamespace(
             entry_id=entry_id,
             repository_id=repository_id,
-            kind=kind,
-            page_id=page_id,
             envelope={"model": "fake-model", "data": data or {}},
         )
 
     stored_entries = {
         seed_wiki._store_entry_id("outline"): entry(
             seed_wiki._store_entry_id("outline"),
-            kind="outline",
-            page_id=None,
             data=outline,
         ),
         seed_wiki._store_entry_id(page_suffix): entry(
@@ -274,7 +268,7 @@ def test_cache_audit_reads_store_without_publishing_and_reports_orphans(tmp_path
                 "quality": {"valid": True},
             },
         ),
-        "orphan": entry("orphan", page_id="removed"),
+        "orphan": entry("orphan"),
         "other-repository": entry(
             "other-repository",
             repository_id="owner__other",
@@ -389,8 +383,6 @@ def test_cache_audit_reports_database_and_legacy_storage_in_mixed_state(tmp_path
     store.publish(
         entry_id="orphan",
         repository_id="owner__repo",
-        kind="page",
-        page_id="removed",
         envelope={"data": {"id": "removed"}},
     )
 
@@ -407,13 +399,8 @@ def test_cache_audit_reports_database_and_legacy_storage_in_mixed_state(tmp_path
     assert storage["orphan_entries"] == 1
     assert storage["files"] == 3
     assert storage["orphan_files"] == 1
-    assert storage["database_bytes"] > 0
+    assert storage["database_payload_bytes"] > 0
     assert storage["legacy_bytes"] > 0
     assert storage["bytes"] == storage["legacy_bytes"]
     assert storage["orphan_bytes"] == storage["orphan_legacy_bytes"]
-    assert storage["total_bytes"] == (
-        storage["database_bytes"] + storage["legacy_bytes"]
-    )
-    assert storage["total_orphan_bytes"] == (
-        storage["orphan_database_bytes"] + storage["orphan_legacy_bytes"]
-    )
+    assert storage["orphan_database_payload_bytes"] > 0

--- a/test/wiki/test_cache_audit.py
+++ b/test/wiki/test_cache_audit.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -134,6 +135,48 @@ def test_cache_audit_does_not_create_a_missing_cache_directory(tmp_path):
 
     assert report["missing_outlines"] == ["owner__repo"]
     assert not cache_dir.exists()
+
+
+def test_cache_audit_applies_runtime_validation_to_legacy_json(tmp_path):
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path / "repo"),
+            instance_id="owner__repo",
+            commit_short="abc123",
+            language="python",
+        ),
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+        vector_store=None,
+        bm25=None,
+    )
+
+    class Registry:
+        def list_infos(self):
+            return [SimpleNamespace(id="owner__repo")]
+
+        def get(self, repo_id):
+            return bundle if repo_id == "owner__repo" else None
+
+    cache_dir = tmp_path / "wiki-cache"
+    cache_dir.mkdir()
+    wiki = AgentWiki(bundle, model="fake-model", cache_dir=str(cache_dir))
+    outline_path = wiki._cache_candidate_paths("outline")[0]
+    outline_path = Path(outline_path)
+    outline_path.write_text(
+        '{"data":{"pages":[]},"data":{"pages":['
+        '{"id":"overview","title":"Overview","children":[]}]}}',
+        encoding="utf-8",
+    )
+
+    report = audit_wiki_cache(
+        Registry(),
+        model="fake-model",
+        cache_dir=cache_dir,
+    )
+
+    assert report["missing_outlines"] == ["owner__repo"]
+    assert report["repositories"] == 1
 
 
 def test_cache_audit_rejects_unknown_repository_selectors(tmp_path):

--- a/test/wiki/test_quality.py
+++ b/test/wiki/test_quality.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from codenib.wiki.evidence import EvidenceItem, RelationItem
 from codenib.wiki.quality import (
     audit_cache,
@@ -22,6 +24,7 @@ from codenib.wiki.quality import (
     section_synthesis_report,
     summarize_page_audits,
 )
+from codenib.wiki.sqlite_store import SQLiteWikiStore
 
 
 def _page(*, repeated_prose: bool) -> dict:
@@ -1164,6 +1167,52 @@ def test_cache_audit_ignores_outline_records_and_summarizes_pages(tmp_path):
     assert report["pages"] == 2
     assert report["publishable"] == 1
     assert report["narrative_valid"] == 1
+
+
+def test_cache_audit_reads_the_canonical_sqlite_store(tmp_path):
+    page = _page(repeated_prose=False)
+    store = SQLiteWikiStore(tmp_path / "wiki.sqlite3")
+    store.publish(
+        entry_id="page:repo-a:overview",
+        repository_id="repo-a",
+        envelope={"model": "test", "data": page},
+    )
+    store.publish(
+        entry_id="outline:repo-a",
+        repository_id="repo-a",
+        envelope={"model": "test", "data": {"pages": []}},
+    )
+
+    report = audit_cache(tmp_path)
+
+    assert list(tmp_path.glob("agentwiki_*.json")) == []
+    assert report == summarize_page_audits([page])
+    assert report["pages"] == 1
+
+
+@pytest.mark.parametrize("migrate_first_page", [False, True])
+def test_cache_audit_includes_unmigrated_legacy_pages(
+    tmp_path,
+    migrate_first_page,
+):
+    pages = [_page(repeated_prose=True), _page(repeated_prose=False)]
+    pages[1] = {**pages[1], "id": "runtime", "title": "Runtime"}
+    envelopes = [{"model": "test", "data": page} for page in pages]
+    for index, envelope in enumerate(envelopes):
+        (tmp_path / f"agentwiki_page_{index}.json").write_text(json.dumps(envelope))
+
+    store = SQLiteWikiStore(tmp_path / "wiki.sqlite3")
+    if migrate_first_page:
+        store.publish(
+            entry_id="page:repo-a:overview",
+            repository_id="repo-a",
+            envelope=envelopes[0],
+        )
+
+    report = audit_cache(tmp_path)
+
+    assert report == summarize_page_audits(pages)
+    assert report["pages"] == 2
 
 
 def test_wiki_audit_generates_nested_pages_and_requires_generated_mode():

--- a/test/wiki/test_quality.py
+++ b/test/wiki/test_quality.py
@@ -25,6 +25,7 @@ from codenib.wiki.quality import (
     summarize_page_audits,
 )
 from codenib.wiki.sqlite_store import SQLiteWikiStore
+from codenib.wiki.store import _WIKI_CACHE_PROVENANCE_FIELD
 
 
 def _page(*, repeated_prose: bool) -> dict:
@@ -1196,22 +1197,60 @@ def test_cache_audit_includes_unmigrated_legacy_pages(
     migrate_first_page,
 ):
     pages = [_page(repeated_prose=True), _page(repeated_prose=False)]
-    pages[1] = {**pages[1], "id": "runtime", "title": "Runtime"}
     envelopes = [{"model": "test", "data": page} for page in pages]
-    for index, envelope in enumerate(envelopes):
-        (tmp_path / f"agentwiki_page_{index}.json").write_text(json.dumps(envelope))
+    legacy_paths = [
+        tmp_path / f"agentwiki_page_{index}.json" for index in range(len(pages))
+    ]
+    for path, envelope in zip(legacy_paths, envelopes, strict=True):
+        path.write_text(json.dumps(envelope))
 
     store = SQLiteWikiStore(tmp_path / "wiki.sqlite3")
+    expected_pages = pages
     if migrate_first_page:
+        entry_id = "page:repo-a:overview"
+        repository_id = "repo-a"
+        canonical_page = {
+            **pages[0],
+            "markdown": pages[0]["markdown"] + "\n\nCanonical refresh. [E1]",
+        }
         store.publish(
-            entry_id="page:repo-a:overview",
-            repository_id="repo-a",
-            envelope=envelopes[0],
+            entry_id=entry_id,
+            repository_id=repository_id,
+            envelope={
+                "model": "test",
+                "data": canonical_page,
+                _WIKI_CACHE_PROVENANCE_FIELD: {
+                    "schema": 1,
+                    "entry_id": entry_id,
+                    "repository_id": repository_id,
+                    "legacy_filenames": [legacy_paths[0].name],
+                },
+            },
         )
+        expected_pages = [canonical_page, pages[1]]
 
     report = audit_cache(tmp_path)
 
-    assert report == summarize_page_audits(pages)
+    assert report == summarize_page_audits(expected_pages)
+    assert report["pages"] == 2
+
+
+def test_cache_audit_does_not_dedupe_marker_free_rows_across_repositories(
+    tmp_path,
+):
+    page = _page(repeated_prose=False)
+    envelope = {"model": "test", "data": page}
+    store = SQLiteWikiStore(tmp_path / "wiki.sqlite3")
+    store.publish(
+        entry_id="page:repo-a:overview",
+        repository_id="repo-a",
+        envelope=envelope,
+    )
+    (tmp_path / "agentwiki_repo-b_overview.json").write_text(json.dumps(envelope))
+
+    report = audit_cache(tmp_path)
+
+    assert report == summarize_page_audits([page, page])
     assert report["pages"] == 2
 
 

--- a/test/wiki/test_sqlite_store.py
+++ b/test/wiki/test_sqlite_store.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import multiprocessing
 import os
 import queue
@@ -14,11 +13,18 @@ import sqlite3
 import stat
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
 
-from codenib.wiki.sqlite_store import SQLiteWikiStore, _sqlite_error
+from codenib.wiki.sqlite_store import (
+    _APPLICATION_ID,
+    _SCHEMA_VERSION,
+    SQLiteWikiStore,
+    _record_digest,
+    _sqlite_error,
+)
 from codenib.wiki.store import (
     WikiStoreCorruptionError,
     WikiStoreError,
@@ -64,6 +70,20 @@ def _probe_generation_guard_process(
         result_queue.put("entered-after-release")
 
 
+def _exercise_store_operation(store: SQLiteWikiStore, operation: str) -> object:
+    if operation == "read":
+        return store.read("page:repo-a:overview")
+    if operation == "scan":
+        return store.scan()
+    if operation == "publish":
+        return store.publish(
+            entry_id="page:repo-a:overview",
+            repository_id="repo-a",
+            envelope={"data": {"body": "replacement"}},
+        )
+    raise AssertionError(f"unexpected test operation: {operation}")
+
+
 class TestSQLiteWikiStoreContract(WikiStoreContract):
     @pytest.fixture
     def store(self, tmp_path: Path) -> SQLiteWikiStore:
@@ -86,6 +106,18 @@ def test_reopen_preserves_entries_and_uses_wal(tmp_path: Path) -> None:
         assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
         assert connection.execute("PRAGMA application_id").fetchone()[0] != 0
         assert connection.execute("PRAGMA user_version").fetchone()[0] == 1
+
+
+def test_existing_only_uri_preserves_reserved_path_characters(tmp_path: Path) -> None:
+    path = tmp_path / "wiki cache#1.sqlite3"
+    store = SQLiteWikiStore(path)
+    expected = store.publish(
+        entry_id="page:repo-a:overview",
+        repository_id="repo-a",
+        envelope={"data": {"body": "persisted"}},
+    )
+
+    assert store.read(expected.entry_id) == expected
 
 
 def test_new_database_and_wal_sidecars_are_private_under_common_umask(
@@ -253,6 +285,125 @@ def test_unidentified_view_only_database_is_not_treated_as_empty(
         )
 
 
+@pytest.mark.parametrize(
+    "schema_sql",
+    (
+        "CREATE VIEW unexpected_view AS SELECT 1 AS value",
+        "CREATE INDEX unexpected_index ON wiki_entries(entry_id)",
+        """
+        CREATE TRIGGER unexpected_trigger
+        AFTER INSERT ON wiki_entries
+        BEGIN
+            DELETE FROM wiki_entries WHERE entry_id = NEW.entry_id;
+        END
+        """,
+    ),
+)
+def test_identified_database_rejects_unexpected_schema_objects(
+    tmp_path: Path,
+    schema_sql: str,
+) -> None:
+    path = tmp_path / "wiki.sqlite3"
+    live_store = SQLiteWikiStore(path)
+    with sqlite3.connect(path) as connection:
+        assert (
+            connection.execute("PRAGMA journal_mode = DELETE").fetchone()[0] == "delete"
+        )
+        connection.execute(schema_sql)
+
+    with pytest.raises(WikiStoreSchemaError, match="schema object"):
+        SQLiteWikiStore(path)
+    with pytest.raises(WikiStoreSchemaError, match="schema object"):
+        live_store.scan()
+    with sqlite3.connect(path) as connection:
+        assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+
+
+def test_identified_database_rejects_misbound_expected_index(tmp_path: Path) -> None:
+    path = tmp_path / "wiki.sqlite3"
+    SQLiteWikiStore(path)
+    with sqlite3.connect(path) as connection:
+        connection.execute("DROP INDEX wiki_entries_repository_entry_idx")
+        connection.execute(
+            "CREATE INDEX wiki_entries_repository_entry_idx "
+            "ON wiki_entries(entry_id)"
+        )
+
+    with pytest.raises(WikiStoreSchemaError, match="schema object"):
+        SQLiteWikiStore(path)
+
+
+def test_identified_database_rejects_primary_key_collation_change(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "wiki.sqlite3"
+    with sqlite3.connect(path) as connection:
+        connection.executescript(
+            f"""
+            CREATE TABLE wiki_entries (
+                entry_id TEXT COLLATE NOCASE PRIMARY KEY NOT NULL,
+                repository_id TEXT NOT NULL,
+                envelope_json BLOB NOT NULL,
+                record_sha256 TEXT NOT NULL CHECK (length(record_sha256) = 64)
+            );
+            CREATE INDEX wiki_entries_repository_entry_idx
+                ON wiki_entries(repository_id, entry_id);
+            PRAGMA application_id = {_APPLICATION_ID};
+            PRAGMA user_version = {_SCHEMA_VERSION};
+            """
+        )
+
+    with pytest.raises(WikiStoreSchemaError, match="schema object"):
+        SQLiteWikiStore(path)
+
+
+@pytest.mark.parametrize("operation", ("read", "publish", "scan"))
+def test_operations_do_not_recreate_a_removed_database(
+    tmp_path: Path,
+    operation: str,
+) -> None:
+    path = tmp_path / "wiki.sqlite3"
+    store = SQLiteWikiStore(path)
+    path.unlink()
+
+    with pytest.raises(WikiStoreError, match="operation"):
+        _exercise_store_operation(store, operation)
+
+    assert not path.exists()
+
+
+@pytest.mark.parametrize("operation", ("read", "publish", "scan"))
+def test_operations_reject_a_foreign_replacement_database(
+    tmp_path: Path,
+    operation: str,
+) -> None:
+    path = tmp_path / "wiki.sqlite3"
+    replacement = tmp_path / "replacement.sqlite3"
+    store = SQLiteWikiStore(path)
+    with sqlite3.connect(replacement) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE wiki_entries (
+                entry_id TEXT PRIMARY KEY NOT NULL,
+                repository_id TEXT NOT NULL,
+                envelope_json BLOB NOT NULL,
+                record_sha256 TEXT NOT NULL CHECK (length(record_sha256) = 64)
+            );
+            CREATE INDEX wiki_entries_repository_entry_idx
+                ON wiki_entries(repository_id, entry_id);
+            """
+        )
+    os.replace(replacement, path)
+
+    with pytest.raises(WikiStoreSchemaError, match="not an initialized"):
+        _exercise_store_operation(store, operation)
+
+    with sqlite3.connect(path) as connection:
+        assert (
+            connection.execute("SELECT COUNT(*) FROM wiki_entries").fetchone()[0] == 0
+        )
+
+
 def test_error_mapping_supports_python_without_sqlite_result_constants(
     tmp_path: Path,
     monkeypatch,
@@ -303,6 +454,43 @@ def test_payload_digest_corruption_is_reported(tmp_path: Path) -> None:
         store.read("outline:repo-a")
 
 
+@pytest.mark.parametrize(
+    ("column", "replacement", "lookup"),
+    (
+        ("entry_id", "page:repo-b:overview", "page:repo-b:overview"),
+        ("repository_id", "repo-b", "page:repo-a:overview"),
+    ),
+)
+def test_identity_metadata_corruption_is_reported(
+    tmp_path: Path,
+    column: str,
+    replacement: str,
+    lookup: str,
+) -> None:
+    path = tmp_path / "wiki.sqlite3"
+    store = SQLiteWikiStore(path)
+    store.publish(
+        entry_id="page:repo-a:overview",
+        repository_id="repo-a",
+        envelope={"data": {"body": "persisted"}},
+    )
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            f"UPDATE wiki_entries SET {column} = ? WHERE entry_id = ?",
+            (replacement, "page:repo-a:overview"),
+        )
+
+    with pytest.raises(WikiStoreCorruptionError, match="SHA-256"):
+        store.read(lookup)
+    if column == "repository_id":
+        with pytest.raises(WikiStoreCorruptionError, match="SHA-256"):
+            store.publish(
+                entry_id="page:repo-a:overview",
+                repository_id="repo-a",
+                envelope={"data": {"body": "replacement"}},
+            )
+
+
 def test_overflowed_json_number_is_reported_as_corruption(tmp_path: Path) -> None:
     path = tmp_path / "wiki.sqlite3"
     store = SQLiteWikiStore(path)
@@ -314,14 +502,14 @@ def test_overflowed_json_number_is_reported_as_corruption(tmp_path: Path) -> Non
                 entry_id,
                 repository_id,
                 envelope_json,
-                envelope_sha256
+                record_sha256
             ) VALUES (?, ?, ?, ?)
             """,
             (
                 "page:repo-a:overview",
                 "repo-a",
                 payload,
-                hashlib.sha256(payload).hexdigest(),
+                _record_digest("page:repo-a:overview", "repo-a", payload),
             ),
         )
 
@@ -329,7 +517,10 @@ def test_overflowed_json_number_is_reported_as_corruption(tmp_path: Path) -> Non
         store.read("page:repo-a:overview")
 
 
-def test_failed_publish_rolls_back_the_previous_entry(tmp_path: Path) -> None:
+def test_failed_publish_rolls_back_the_previous_entry(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
     path = tmp_path / "wiki.sqlite3"
     store = SQLiteWikiStore(path)
     original = store.publish(
@@ -337,16 +528,23 @@ def test_failed_publish_rolls_back_the_previous_entry(tmp_path: Path) -> None:
         repository_id="repo-a",
         envelope={"data": {"body": "original"}},
     )
-    with sqlite3.connect(path) as connection:
-        connection.execute(
-            """
-            CREATE TRIGGER reject_wiki_update
-            BEFORE UPDATE ON wiki_entries
-            BEGIN
-                SELECT RAISE(ABORT, 'injected update failure');
-            END
-            """
-        )
+    original_connection = store._connection
+
+    @contextmanager
+    def connection_with_rejected_update():
+        with original_connection() as connection:
+            connection.execute(
+                """
+                CREATE TEMP TRIGGER reject_wiki_update
+                BEFORE UPDATE ON wiki_entries
+                BEGIN
+                    SELECT RAISE(ABORT, 'injected update failure');
+                END
+                """
+            )
+            yield connection
+
+    monkeypatch.setattr(store, "_connection", connection_with_rejected_update)
 
     with pytest.raises(WikiStoreError):
         store.publish(
@@ -355,8 +553,6 @@ def test_failed_publish_rolls_back_the_previous_entry(tmp_path: Path) -> None:
             envelope={"data": {"body": "replacement"}},
         )
 
-    with sqlite3.connect(path) as connection:
-        connection.execute("DROP TRIGGER reject_wiki_update")
     assert store.read(original.entry_id) == original
 
 

--- a/test/wiki/test_sqlite_store.py
+++ b/test/wiki/test_sqlite_store.py
@@ -231,7 +231,11 @@ def test_error_mapping_supports_python_without_sqlite_result_constants(
 
 @pytest.mark.parametrize(
     "message",
-    ("file is not a database", "database disk image is malformed"),
+    (
+        "file is not a database",
+        "database disk image is malformed",
+        "malformed database schema (broken) - incomplete input",
+    ),
 )
 def test_error_mapping_without_result_attributes_identifies_corruption(
     message: str,

--- a/test/wiki/test_sqlite_store.py
+++ b/test/wiki/test_sqlite_store.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 
 import hashlib
 import multiprocessing
+import os
 import queue
 import sqlite3
+import stat
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -84,6 +86,41 @@ def test_reopen_preserves_entries_and_uses_wal(tmp_path: Path) -> None:
         assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
         assert connection.execute("PRAGMA application_id").fetchone()[0] != 0
         assert connection.execute("PRAGMA user_version").fetchone()[0] == 1
+
+
+def test_new_database_and_wal_sidecars_are_private_under_common_umask(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "wiki.sqlite3"
+    previous_umask = os.umask(0o022)
+    try:
+        store = SQLiteWikiStore(path)
+        entry = store.publish(
+            entry_id="page:repo-a:overview",
+            repository_id="repo-a",
+            envelope={"data": {"body": "private"}},
+        )
+
+        with sqlite3.connect(path) as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            connection.execute(
+                "UPDATE wiki_entries SET repository_id = ? WHERE entry_id = ?",
+                ("repo-a", entry.entry_id),
+            )
+            private_files = (
+                path,
+                Path(f"{path}-wal"),
+                Path(f"{path}-shm"),
+            )
+            assert all(candidate.exists() for candidate in private_files)
+            assert all(
+                stat.S_IMODE(candidate.stat().st_mode) == 0o600
+                for candidate in private_files
+            )
+            assert stat.S_IMODE(Path(f"{path}.locks").stat().st_mode) == 0o700
+            connection.rollback()
+    finally:
+        os.umask(previous_umask)
 
 
 def test_empty_sqlite_v0_database_is_initialized(tmp_path: Path) -> None:

--- a/test/wiki/test_sqlite_store.py
+++ b/test/wiki/test_sqlite_store.py
@@ -6,6 +6,9 @@
 
 from __future__ import annotations
 
+import hashlib
+import multiprocessing
+import queue
 import sqlite3
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -13,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from codenib.wiki.sqlite_store import SQLiteWikiStore
+from codenib.wiki.sqlite_store import SQLiteWikiStore, _sqlite_error
 from codenib.wiki.store import (
     WikiStoreCorruptionError,
     WikiStoreError,
@@ -21,6 +24,42 @@ from codenib.wiki.store import (
 )
 
 from .test_store_contract import WikiStoreContract
+
+
+def _probe_generation_guard_process(
+    database_path: str,
+    entry_id: str,
+    result_queue,
+    retry_after_release,
+) -> None:
+    from filelock import Timeout
+
+    import codenib.wiki.sqlite_store as sqlite_store_module
+
+    store = sqlite_store_module.SQLiteWikiStore(database_path)
+    original_file_lock = sqlite_store_module.FileLock
+
+    class NonBlockingFileLock(original_file_lock):
+        def acquire(self, *args, **kwargs):
+            kwargs["timeout"] = 0
+            return super().acquire(*args, **kwargs)
+
+    sqlite_store_module.FileLock = NonBlockingFileLock
+    try:
+        try:
+            with store.generation_guard(entry_id):
+                result_queue.put("entered-while-held")
+        except sqlite_store_module.WikiStoreError as exc:
+            if not isinstance(exc.__cause__, Timeout):
+                raise
+            result_queue.put("blocked")
+    finally:
+        sqlite_store_module.FileLock = original_file_lock
+
+    if not retry_after_release.wait(timeout=10):
+        raise RuntimeError("parent did not release the generation guard")
+    with store.generation_guard(entry_id):
+        result_queue.put("entered-after-release")
 
 
 class TestSQLiteWikiStoreContract(WikiStoreContract):
@@ -59,6 +98,53 @@ def test_empty_sqlite_v0_database_is_initialized(tmp_path: Path) -> None:
     with sqlite3.connect(path) as connection:
         assert connection.execute("PRAGMA application_id").fetchone()[0] != 0
         assert connection.execute("PRAGMA user_version").fetchone()[0] == 1
+
+
+def test_concurrent_first_open_serializes_database_initialization(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    path = tmp_path / "wiki.sqlite3"
+    original_initialize = SQLiteWikiStore._initialize
+    call_guard = threading.Lock()
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    second_entered = threading.Event()
+    call_count = 0
+
+    def observed_initialize(store: SQLiteWikiStore) -> None:
+        nonlocal call_count
+        with call_guard:
+            call_count += 1
+            ordinal = call_count
+        if ordinal == 1:
+            first_entered.set()
+            assert release_first.wait(timeout=5)
+        else:
+            second_entered.set()
+        original_initialize(store)
+
+    def open_second() -> SQLiteWikiStore:
+        second_started.set()
+        return SQLiteWikiStore(path)
+
+    monkeypatch.setattr(SQLiteWikiStore, "_initialize", observed_initialize)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first_result = executor.submit(SQLiteWikiStore, path)
+        try:
+            assert first_entered.wait(timeout=5)
+            second_result = executor.submit(open_second)
+            assert second_started.wait(timeout=5)
+            assert not second_entered.wait(timeout=0.2)
+        finally:
+            release_first.set()
+        first_store = first_result.result(timeout=5)
+        second_store = second_result.result(timeout=5)
+
+    assert second_entered.is_set()
+    assert first_store.path == second_store.path == path
+    assert second_store.scan() == ()
 
 
 def test_future_schema_is_rejected(tmp_path: Path) -> None:
@@ -103,6 +189,33 @@ def test_unidentified_foreign_database_fails_before_wal_mutation(
         )
 
 
+def test_unidentified_view_only_database_is_not_treated_as_empty(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "foreign.sqlite3"
+    with sqlite3.connect(path) as connection:
+        connection.execute("CREATE VIEW unrelated AS SELECT 1 AS value")
+
+    with pytest.raises(WikiStoreSchemaError, match="not an initialized"):
+        SQLiteWikiStore(path)
+
+    with sqlite3.connect(path) as connection:
+        assert connection.execute("PRAGMA application_id").fetchone()[0] == 0
+        assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+        assert (
+            connection.execute(
+                "SELECT type FROM sqlite_master WHERE name = 'unrelated'"
+            ).fetchone()[0]
+            == "view"
+        )
+        assert (
+            connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE name = 'wiki_entries'"
+            ).fetchone()
+            is None
+        )
+
+
 def test_error_mapping_supports_python_without_sqlite_result_constants(
     tmp_path: Path,
     monkeypatch,
@@ -114,6 +227,21 @@ def test_error_mapping_supports_python_without_sqlite_result_constants(
 
     with pytest.raises(WikiStoreError, match="initialization"):
         SQLiteWikiStore(database_directory)
+
+
+@pytest.mark.parametrize(
+    "message",
+    ("file is not a database", "database disk image is malformed"),
+)
+def test_error_mapping_without_result_attributes_identifies_corruption(
+    message: str,
+) -> None:
+    error = sqlite3.DatabaseError(message)
+    assert not hasattr(error, "sqlite_errorcode")
+
+    mapped = _sqlite_error("read", error)
+
+    assert isinstance(mapped, WikiStoreCorruptionError)
 
 
 def test_payload_digest_corruption_is_reported(tmp_path: Path) -> None:
@@ -132,6 +260,32 @@ def test_payload_digest_corruption_is_reported(tmp_path: Path) -> None:
 
     with pytest.raises(WikiStoreCorruptionError, match="SHA-256"):
         store.read("outline:repo-a")
+
+
+def test_overflowed_json_number_is_reported_as_corruption(tmp_path: Path) -> None:
+    path = tmp_path / "wiki.sqlite3"
+    store = SQLiteWikiStore(path)
+    payload = b'{"data":{"score":1e9999}}'
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            """
+            INSERT INTO wiki_entries(
+                entry_id,
+                repository_id,
+                envelope_json,
+                envelope_sha256
+            ) VALUES (?, ?, ?, ?)
+            """,
+            (
+                "page:repo-a:overview",
+                "repo-a",
+                payload,
+                hashlib.sha256(payload).hexdigest(),
+            ),
+        )
+
+    with pytest.raises(WikiStoreCorruptionError, match="invalid JSON"):
+        store.read("page:repo-a:overview")
 
 
 def test_failed_publish_rolls_back_the_previous_entry(tmp_path: Path) -> None:
@@ -217,3 +371,33 @@ def test_generation_guard_serializes_the_same_entry(tmp_path: Path) -> None:
         second_result.result(timeout=5)
 
     assert second_entered.is_set()
+
+
+def test_generation_guard_serializes_across_processes(tmp_path: Path) -> None:
+    path = tmp_path / "wiki.sqlite3"
+    store = SQLiteWikiStore(path)
+    entry_id = "page:repo-a:overview"
+    context = multiprocessing.get_context("spawn")
+    result_queue = context.Queue()
+    retry_after_release = context.Event()
+    process = context.Process(
+        target=_probe_generation_guard_process,
+        args=(str(path), entry_id, result_queue, retry_after_release),
+    )
+
+    try:
+        with store.generation_guard(entry_id):
+            process.start()
+            assert result_queue.get(timeout=10) == "blocked"
+            retry_after_release.set()
+            with pytest.raises(queue.Empty):
+                result_queue.get(timeout=0.2)
+
+        assert result_queue.get(timeout=10) == "entered-after-release"
+        process.join(timeout=10)
+        assert process.exitcode == 0
+    finally:
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=5)
+        result_queue.close()

--- a/test/wiki/test_sqlite_store.py
+++ b/test/wiki/test_sqlite_store.py
@@ -177,13 +177,15 @@ def test_failed_publish_rolls_back_the_previous_entry(tmp_path: Path) -> None:
         envelope={"data": {"body": "original"}},
     )
     with sqlite3.connect(path) as connection:
-        connection.execute("""
+        connection.execute(
+            """
             CREATE TRIGGER reject_wiki_update
             BEFORE UPDATE ON wiki_entries
             BEGIN
                 SELECT RAISE(ABORT, 'injected update failure');
             END
-            """)
+            """
+        )
 
     with pytest.raises(WikiStoreError):
         store.publish(

--- a/test/wiki/test_sqlite_store.py
+++ b/test/wiki/test_sqlite_store.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""SQLite-specific integration tests for the Wiki store contract."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from codenib.wiki.sqlite_store import SQLiteWikiStore
+from codenib.wiki.store import (
+    WikiStoreCorruptionError,
+    WikiStoreError,
+    WikiStoreSchemaError,
+)
+
+from .test_store_contract import WikiStoreContract
+
+
+class TestSQLiteWikiStoreContract(WikiStoreContract):
+    @pytest.fixture
+    def store(self, tmp_path: Path) -> SQLiteWikiStore:
+        return SQLiteWikiStore(tmp_path / "wiki.sqlite3")
+
+
+def test_reopen_preserves_entries_and_uses_wal(tmp_path: Path) -> None:
+    path = tmp_path / "wiki.sqlite3"
+    store = SQLiteWikiStore(path, busy_timeout_ms=1_234)
+    expected = store.publish(
+        entry_id="page:repo-a:overview",
+        repository_id="repo-a",
+        kind="page",
+        page_id="overview",
+        envelope={"data": {"body": "persisted"}},
+    )
+
+    reopened = SQLiteWikiStore(path, busy_timeout_ms=1_234)
+
+    assert reopened.read(expected.entry_id) == expected
+    with sqlite3.connect(path) as connection:
+        assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+        assert connection.execute("PRAGMA application_id").fetchone()[0] != 0
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 1
+
+
+def test_empty_sqlite_v0_database_is_initialized(tmp_path: Path) -> None:
+    path = tmp_path / "wiki.sqlite3"
+    with sqlite3.connect(path) as connection:
+        connection.execute("VACUUM")
+    assert path.stat().st_size > 0
+
+    store = SQLiteWikiStore(path)
+
+    assert store.scan() == ()
+    with sqlite3.connect(path) as connection:
+        assert connection.execute("PRAGMA application_id").fetchone()[0] != 0
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 1
+
+
+def test_future_schema_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "wiki.sqlite3"
+    SQLiteWikiStore(path)
+    with sqlite3.connect(path) as connection:
+        connection.execute("PRAGMA user_version = 2")
+
+    with pytest.raises(WikiStoreSchemaError, match="newer"):
+        SQLiteWikiStore(path)
+
+
+def test_wrong_application_id_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "wiki.sqlite3"
+    SQLiteWikiStore(path)
+    with sqlite3.connect(path) as connection:
+        application_id = connection.execute("PRAGMA application_id").fetchone()[0]
+        connection.execute(f"PRAGMA application_id = {application_id + 1}")
+
+    with pytest.raises(WikiStoreSchemaError, match="not an initialized"):
+        SQLiteWikiStore(path)
+
+
+def test_unidentified_foreign_database_fails_before_wal_mutation(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "foreign.sqlite3"
+    with sqlite3.connect(path) as connection:
+        connection.execute("CREATE TABLE unrelated(value TEXT)")
+
+    with pytest.raises(WikiStoreSchemaError, match="not an initialized"):
+        SQLiteWikiStore(path)
+
+    with sqlite3.connect(path) as connection:
+        assert connection.execute("PRAGMA application_id").fetchone()[0] == 0
+        assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+        assert (
+            connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchone()[0]
+            == "unrelated"
+        )
+
+
+@pytest.mark.parametrize(
+    ("kind", "page_id"),
+    (
+        ("outline", "overview"),
+        ("page", None),
+        ("page", ""),
+        ("evidence", None),
+        ("evidence", ""),
+    ),
+)
+def test_schema_enforces_kind_page_identity(
+    tmp_path: Path, kind: str, page_id: str | None
+) -> None:
+    path = tmp_path / "wiki.sqlite3"
+    SQLiteWikiStore(path)
+    payload = b"{}"
+
+    with sqlite3.connect(path) as connection, pytest.raises(sqlite3.IntegrityError):
+        connection.execute(
+            """
+            INSERT INTO wiki_entries(
+                entry_id,
+                repository_id,
+                kind,
+                page_id,
+                envelope_json,
+                envelope_sha256
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                f"{kind}:invalid",
+                "repo-a",
+                kind,
+                page_id,
+                payload,
+                hashlib.sha256(payload).hexdigest(),
+            ),
+        )
+
+
+def test_payload_digest_corruption_is_reported(tmp_path: Path) -> None:
+    path = tmp_path / "wiki.sqlite3"
+    store = SQLiteWikiStore(path)
+    store.publish(
+        entry_id="outline:repo-a",
+        repository_id="repo-a",
+        kind="outline",
+        page_id=None,
+        envelope={"data": {"pages": []}},
+    )
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            "UPDATE wiki_entries SET envelope_json = ? WHERE entry_id = ?",
+            (b"{}", "outline:repo-a"),
+        )
+
+    with pytest.raises(WikiStoreCorruptionError, match="SHA-256"):
+        store.read("outline:repo-a")
+
+
+def test_failed_publish_rolls_back_the_previous_entry(tmp_path: Path) -> None:
+    path = tmp_path / "wiki.sqlite3"
+    store = SQLiteWikiStore(path)
+    original = store.publish(
+        entry_id="page:repo-a:overview",
+        repository_id="repo-a",
+        kind="page",
+        page_id="overview",
+        envelope={"data": {"body": "original"}},
+    )
+    with sqlite3.connect(path) as connection:
+        connection.execute("""
+            CREATE TRIGGER reject_wiki_update
+            BEFORE UPDATE ON wiki_entries
+            BEGIN
+                SELECT RAISE(ABORT, 'injected update failure');
+            END
+            """)
+
+    with pytest.raises(WikiStoreError):
+        store.publish(
+            entry_id=original.entry_id,
+            repository_id=original.repository_id,
+            kind=original.kind,
+            page_id=original.page_id,
+            envelope={"data": {"body": "replacement"}},
+        )
+
+    with sqlite3.connect(path) as connection:
+        connection.execute("DROP TRIGGER reject_wiki_update")
+    assert store.read(original.entry_id) == original
+
+
+def test_concurrent_if_absent_publishers_observe_one_winner(tmp_path: Path) -> None:
+    store = SQLiteWikiStore(tmp_path / "wiki.sqlite3")
+    workers = 8
+    start = threading.Barrier(workers)
+
+    def publish(candidate: int) -> object:
+        start.wait()
+        return store.publish(
+            entry_id="page:repo-a:overview",
+            repository_id="repo-a",
+            kind="page",
+            page_id="overview",
+            envelope={"data": {"candidate": candidate}},
+            if_absent=True,
+        ).envelope
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        observed = tuple(executor.map(publish, range(workers)))
+
+    assert len({repr(envelope) for envelope in observed}) == 1
+    persisted = store.read("page:repo-a:overview")
+    assert persisted is not None
+    assert all(envelope == persisted.envelope for envelope in observed)
+
+
+def test_generation_guard_serializes_the_same_entry(tmp_path: Path) -> None:
+    store = SQLiteWikiStore(tmp_path / "wiki.sqlite3")
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    second_entered = threading.Event()
+
+    def first() -> None:
+        with store.generation_guard("page:repo-a:overview"):
+            first_entered.set()
+            assert release_first.wait(timeout=5)
+
+    def second() -> None:
+        assert first_entered.wait(timeout=5)
+        second_started.set()
+        with store.generation_guard("page:repo-a:overview"):
+            second_entered.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first_result = executor.submit(first)
+        second_result = executor.submit(second)
+        assert first_entered.wait(timeout=5)
+        assert second_started.wait(timeout=5)
+        assert not second_entered.wait(timeout=0.2)
+        release_first.set()
+        first_result.result(timeout=5)
+        second_result.result(timeout=5)
+
+    assert second_entered.is_set()

--- a/test/wiki/test_sqlite_store.py
+++ b/test/wiki/test_sqlite_store.py
@@ -103,6 +103,19 @@ def test_unidentified_foreign_database_fails_before_wal_mutation(
         )
 
 
+def test_error_mapping_supports_python_without_sqlite_result_constants(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    for name in ("SQLITE_CORRUPT", "SQLITE_NOTADB", "SQLITE_SCHEMA"):
+        monkeypatch.delattr(sqlite3, name, raising=False)
+    database_directory = tmp_path / "wiki.sqlite3"
+    database_directory.mkdir()
+
+    with pytest.raises(WikiStoreError, match="initialization"):
+        SQLiteWikiStore(database_directory)
+
+
 def test_payload_digest_corruption_is_reported(tmp_path: Path) -> None:
     path = tmp_path / "wiki.sqlite3"
     store = SQLiteWikiStore(path)

--- a/test/wiki/test_sqlite_store.py
+++ b/test/wiki/test_sqlite_store.py
@@ -31,14 +31,14 @@ class TestSQLiteWikiStoreContract(WikiStoreContract):
 
 def test_reopen_preserves_entries_and_uses_wal(tmp_path: Path) -> None:
     path = tmp_path / "wiki.sqlite3"
-    store = SQLiteWikiStore(path, busy_timeout_ms=1_234)
+    store = SQLiteWikiStore(path)
     expected = store.publish(
         entry_id="page:repo-a:overview",
         repository_id="repo-a",
         envelope={"data": {"body": "persisted"}},
     )
 
-    reopened = SQLiteWikiStore(path, busy_timeout_ms=1_234)
+    reopened = SQLiteWikiStore(path)
 
     assert reopened.read(expected.entry_id) == expected
     with sqlite3.connect(path) as connection:

--- a/test/wiki/test_sqlite_store.py
+++ b/test/wiki/test_sqlite_store.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import sqlite3
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -36,8 +35,6 @@ def test_reopen_preserves_entries_and_uses_wal(tmp_path: Path) -> None:
     expected = store.publish(
         entry_id="page:repo-a:overview",
         repository_id="repo-a",
-        kind="page",
-        page_id="overview",
         envelope={"data": {"body": "persisted"}},
     )
 
@@ -106,54 +103,12 @@ def test_unidentified_foreign_database_fails_before_wal_mutation(
         )
 
 
-@pytest.mark.parametrize(
-    ("kind", "page_id"),
-    (
-        ("outline", "overview"),
-        ("page", None),
-        ("page", ""),
-        ("evidence", None),
-        ("evidence", ""),
-    ),
-)
-def test_schema_enforces_kind_page_identity(
-    tmp_path: Path, kind: str, page_id: str | None
-) -> None:
-    path = tmp_path / "wiki.sqlite3"
-    SQLiteWikiStore(path)
-    payload = b"{}"
-
-    with sqlite3.connect(path) as connection, pytest.raises(sqlite3.IntegrityError):
-        connection.execute(
-            """
-            INSERT INTO wiki_entries(
-                entry_id,
-                repository_id,
-                kind,
-                page_id,
-                envelope_json,
-                envelope_sha256
-            ) VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            (
-                f"{kind}:invalid",
-                "repo-a",
-                kind,
-                page_id,
-                payload,
-                hashlib.sha256(payload).hexdigest(),
-            ),
-        )
-
-
 def test_payload_digest_corruption_is_reported(tmp_path: Path) -> None:
     path = tmp_path / "wiki.sqlite3"
     store = SQLiteWikiStore(path)
     store.publish(
         entry_id="outline:repo-a",
         repository_id="repo-a",
-        kind="outline",
-        page_id=None,
         envelope={"data": {"pages": []}},
     )
     with sqlite3.connect(path) as connection:
@@ -172,8 +127,6 @@ def test_failed_publish_rolls_back_the_previous_entry(tmp_path: Path) -> None:
     original = store.publish(
         entry_id="page:repo-a:overview",
         repository_id="repo-a",
-        kind="page",
-        page_id="overview",
         envelope={"data": {"body": "original"}},
     )
     with sqlite3.connect(path) as connection:
@@ -191,8 +144,6 @@ def test_failed_publish_rolls_back_the_previous_entry(tmp_path: Path) -> None:
         store.publish(
             entry_id=original.entry_id,
             repository_id=original.repository_id,
-            kind=original.kind,
-            page_id=original.page_id,
             envelope={"data": {"body": "replacement"}},
         )
 
@@ -211,8 +162,6 @@ def test_concurrent_if_absent_publishers_observe_one_winner(tmp_path: Path) -> N
         return store.publish(
             entry_id="page:repo-a:overview",
             repository_id="repo-a",
-            kind="page",
-            page_id="overview",
             envelope={"data": {"candidate": candidate}},
             if_absent=True,
         ).envelope

--- a/test/wiki/test_store_contract.py
+++ b/test/wiki/test_store_contract.py
@@ -26,16 +26,12 @@ class WikiStoreContract:
         published = store.publish(
             entry_id="outline:repo-a",
             repository_id="repo-a",
-            kind="outline",
-            page_id=None,
             envelope=source,
         )
         source["data"]["title"] = "caller mutation"
 
         assert published.entry_id == "outline:repo-a"
         assert published.repository_id == "repo-a"
-        assert published.kind == "outline"
-        assert published.page_id is None
         assert published.envelope == {
             "data": {"title": "Overview", "sections": ["one"]}
         }
@@ -49,16 +45,12 @@ class WikiStoreContract:
         first = store.publish(
             entry_id="page:repo-a:overview",
             repository_id="repo-a",
-            kind="page",
-            page_id="overview",
             envelope={"data": {"body": "first"}},
         )
 
         second = store.publish(
             entry_id="page:repo-a:overview",
             repository_id="repo-a",
-            kind="page",
-            page_id="overview",
             envelope={"data": {"body": "second"}},
         )
 
@@ -70,16 +62,12 @@ class WikiStoreContract:
         first = store.publish(
             entry_id="evidence:repo-a:overview",
             repository_id="repo-a",
-            kind="evidence",
-            page_id="overview",
             envelope={"data": {"citations": [1]}},
         )
 
         winner = store.publish(
             entry_id="evidence:repo-a:overview",
             repository_id="repo-a",
-            kind="evidence",
-            page_id="overview",
             envelope={"data": {"citations": [2]}},
             if_absent=True,
         )
@@ -98,8 +86,6 @@ class WikiStoreContract:
             store.publish(
                 entry_id=entry_id,
                 repository_id=repository_id,
-                kind="page",
-                page_id=entry_id.removeprefix("page:"),
                 envelope={"data": {"entry_id": entry_id}},
             )
 
@@ -117,8 +103,6 @@ class WikiStoreContract:
         store.publish(
             entry_id="outline:stable",
             repository_id="repo-a",
-            kind="outline",
-            page_id=None,
             envelope={"data": {}},
         )
 
@@ -126,8 +110,6 @@ class WikiStoreContract:
             store.publish(
                 entry_id="outline:stable",
                 repository_id="repo-b",
-                kind="outline",
-                page_id=None,
                 envelope={"data": {}},
             )
 
@@ -136,8 +118,6 @@ class WikiStoreContract:
         (
             ({"entry_id": ""}, "entry_id"),
             ({"repository_id": ""}, "repository_id"),
-            ({"kind": "asset"}, "kind"),
-            ({"page_id": ""}, "page_id"),
             ({"if_absent": 1}, "if_absent"),
             ({"envelope": {"bad": float("nan")}}, "bounded JSON"),
         ),
@@ -151,8 +131,6 @@ class WikiStoreContract:
         arguments: dict[str, object] = {
             "entry_id": "page:valid",
             "repository_id": "repo-a",
-            "kind": "page",
-            "page_id": "valid",
             "envelope": {"data": {}},
         }
         arguments.update(kwargs)
@@ -160,37 +138,11 @@ class WikiStoreContract:
         with pytest.raises(WikiStoreValidationError, match=message):
             store.publish(**arguments)
 
-    @pytest.mark.parametrize(
-        ("kind", "page_id", "message"),
-        (
-            ("outline", "overview", "must not have"),
-            ("page", None, "require a page_id"),
-            ("evidence", None, "require a page_id"),
-        ),
-    )
-    def test_kind_controls_page_identity(
-        self,
-        store: WikiStore,
-        kind: str,
-        page_id: str | None,
-        message: str,
-    ) -> None:
-        with pytest.raises(WikiStoreValidationError, match=message):
-            store.publish(
-                entry_id=f"{kind}:invalid",
-                repository_id="repo-a",
-                kind=kind,
-                page_id=page_id,
-                envelope={"data": {}},
-            )
-
     def test_publish_rejects_an_oversize_envelope(self, store: WikiStore) -> None:
         with pytest.raises(WikiStoreValidationError, match="16777216-byte limit"):
             store.publish(
                 entry_id="page:oversize",
                 repository_id="repo-a",
-                kind="page",
-                page_id="oversize",
                 envelope={"data": "x" * (16 * 1024 * 1024)},
             )
 
@@ -199,8 +151,6 @@ def test_stored_entry_is_frozen() -> None:
     entry = WikiStoredEntry(
         entry_id="outline:repo-a",
         repository_id="repo-a",
-        kind="outline",
-        page_id=None,
         envelope={"data": {}},
     )
 

--- a/test/wiki/test_store_contract.py
+++ b/test/wiki/test_store_contract.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared behavioral contract for Wiki store implementations."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from codenib.wiki.store import WikiStore, WikiStoredEntry, WikiStoreValidationError
+
+
+class WikiStoreContract:
+    """Backend-neutral tests inherited by each production Wiki store."""
+
+    @pytest.fixture
+    def store(self) -> WikiStore:
+        raise NotImplementedError
+
+    def test_publish_and_read_return_isolated_envelopes(self, store: WikiStore) -> None:
+        source = {"data": {"title": "Overview", "sections": ["one"]}}
+
+        published = store.publish(
+            entry_id="outline:repo-a",
+            repository_id="repo-a",
+            kind="outline",
+            page_id=None,
+            envelope=source,
+        )
+        source["data"]["title"] = "caller mutation"
+
+        assert published.entry_id == "outline:repo-a"
+        assert published.repository_id == "repo-a"
+        assert published.kind == "outline"
+        assert published.page_id is None
+        assert published.envelope == {
+            "data": {"title": "Overview", "sections": ["one"]}
+        }
+        published.envelope["data"]["sections"].append("returned mutation")
+        loaded = store.read("outline:repo-a")
+
+        assert loaded is not None
+        assert loaded.envelope == {"data": {"title": "Overview", "sections": ["one"]}}
+
+    def test_publish_replaces_payload(self, store: WikiStore) -> None:
+        first = store.publish(
+            entry_id="page:repo-a:overview",
+            repository_id="repo-a",
+            kind="page",
+            page_id="overview",
+            envelope={"data": {"body": "first"}},
+        )
+
+        second = store.publish(
+            entry_id="page:repo-a:overview",
+            repository_id="repo-a",
+            kind="page",
+            page_id="overview",
+            envelope={"data": {"body": "second"}},
+        )
+
+        assert second.envelope == {"data": {"body": "second"}}
+        assert second.entry_id == first.entry_id
+        assert second.repository_id == first.repository_id
+
+    def test_if_absent_returns_the_persisted_winner(self, store: WikiStore) -> None:
+        first = store.publish(
+            entry_id="evidence:repo-a:overview",
+            repository_id="repo-a",
+            kind="evidence",
+            page_id="overview",
+            envelope={"data": {"citations": [1]}},
+        )
+
+        winner = store.publish(
+            entry_id="evidence:repo-a:overview",
+            repository_id="repo-a",
+            kind="evidence",
+            page_id="overview",
+            envelope={"data": {"citations": [2]}},
+            if_absent=True,
+        )
+
+        assert winner == first
+        assert store.read(first.entry_id) == first
+
+    def test_scan_is_stable_and_supports_repository_filter(
+        self, store: WikiStore
+    ) -> None:
+        for entry_id, repository_id in (
+            ("page:z", "repo-b"),
+            ("page:a", "repo-a"),
+            ("page:m", "repo-a"),
+        ):
+            store.publish(
+                entry_id=entry_id,
+                repository_id=repository_id,
+                kind="page",
+                page_id=entry_id.removeprefix("page:"),
+                envelope={"data": {"entry_id": entry_id}},
+            )
+
+        assert tuple(entry.entry_id for entry in store.scan()) == (
+            "page:a",
+            "page:m",
+            "page:z",
+        )
+        assert tuple(
+            entry.entry_id for entry in store.scan(repository_ids=["repo-a", "repo-a"])
+        ) == ("page:a", "page:m")
+        assert store.scan(repository_ids=[]) == ()
+
+    def test_entry_identity_cannot_be_rebound(self, store: WikiStore) -> None:
+        store.publish(
+            entry_id="outline:stable",
+            repository_id="repo-a",
+            kind="outline",
+            page_id=None,
+            envelope={"data": {}},
+        )
+
+        with pytest.raises(WikiStoreValidationError):
+            store.publish(
+                entry_id="outline:stable",
+                repository_id="repo-b",
+                kind="outline",
+                page_id=None,
+                envelope={"data": {}},
+            )
+
+    @pytest.mark.parametrize(
+        ("kwargs", "message"),
+        (
+            ({"entry_id": ""}, "entry_id"),
+            ({"repository_id": ""}, "repository_id"),
+            ({"kind": "asset"}, "kind"),
+            ({"page_id": ""}, "page_id"),
+            ({"if_absent": 1}, "if_absent"),
+            ({"envelope": {"bad": float("nan")}}, "bounded JSON"),
+        ),
+    )
+    def test_publish_rejects_invalid_input(
+        self,
+        store: WikiStore,
+        kwargs: dict[str, object],
+        message: str,
+    ) -> None:
+        arguments: dict[str, object] = {
+            "entry_id": "page:valid",
+            "repository_id": "repo-a",
+            "kind": "page",
+            "page_id": "valid",
+            "envelope": {"data": {}},
+        }
+        arguments.update(kwargs)
+
+        with pytest.raises(WikiStoreValidationError, match=message):
+            store.publish(**arguments)
+
+    @pytest.mark.parametrize(
+        ("kind", "page_id", "message"),
+        (
+            ("outline", "overview", "must not have"),
+            ("page", None, "require a page_id"),
+            ("evidence", None, "require a page_id"),
+        ),
+    )
+    def test_kind_controls_page_identity(
+        self,
+        store: WikiStore,
+        kind: str,
+        page_id: str | None,
+        message: str,
+    ) -> None:
+        with pytest.raises(WikiStoreValidationError, match=message):
+            store.publish(
+                entry_id=f"{kind}:invalid",
+                repository_id="repo-a",
+                kind=kind,
+                page_id=page_id,
+                envelope={"data": {}},
+            )
+
+    def test_publish_rejects_an_oversize_envelope(self, store: WikiStore) -> None:
+        with pytest.raises(WikiStoreValidationError, match="16777216-byte limit"):
+            store.publish(
+                entry_id="page:oversize",
+                repository_id="repo-a",
+                kind="page",
+                page_id="oversize",
+                envelope={"data": "x" * (16 * 1024 * 1024)},
+            )
+
+
+def test_stored_entry_is_frozen() -> None:
+    entry = WikiStoredEntry(
+        entry_id="outline:repo-a",
+        repository_id="repo-a",
+        kind="outline",
+        page_id=None,
+        envelope={"data": {}},
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        entry.entry_id = "replacement"  # type: ignore[misc]

--- a/test/wiki/test_store_contract.py
+++ b/test/wiki/test_store_contract.py
@@ -146,6 +146,32 @@ class WikiStoreContract:
                 envelope={"data": "x" * (16 * 1024 * 1024)},
             )
 
+    def test_invalid_unicode_identifiers_raise_validation_errors(
+        self,
+        store: WikiStore,
+    ) -> None:
+        invalid = "\ud800"
+
+        with pytest.raises(WikiStoreValidationError, match="valid Unicode"):
+            store.read(invalid)
+        with pytest.raises(WikiStoreValidationError, match="valid Unicode"):
+            store.publish(
+                entry_id=invalid,
+                repository_id="repo-a",
+                envelope={"data": {}},
+            )
+        with pytest.raises(WikiStoreValidationError, match="valid Unicode"):
+            store.publish(
+                entry_id="page:valid",
+                repository_id=invalid,
+                envelope={"data": {}},
+            )
+        with pytest.raises(WikiStoreValidationError, match="valid Unicode"):
+            store.scan(repository_ids=[invalid])
+        with pytest.raises(WikiStoreValidationError, match="valid Unicode"):
+            with store.generation_guard(invalid):
+                pass
+
 
 def test_stored_entry_is_frozen() -> None:
     entry = WikiStoredEntry(


### PR DESCRIPTION
## Summary
Add the first product-facing storage vertical: a narrow injectable `WikiStore` with one SQLite WAL implementation, wired through `AgentWiki` without expanding the generic index catalog or object-store contracts. Here, pluggable means constructor injection plus a backend-neutral conformance suite; it does not add a registry, dynamic discovery, or speculative remote adapters.

Existing JSON caches remain a bounded read-through source for one release, while every new Wiki entry publishes transactionally to the database. Removal is tracked by #749. The former #737 dependency is merged, and this branch is rebased directly onto `main`.

## Changes
- codify an evidence-based Storage Scope Guard: a new public storage capability needs a current production consumer, reproduced bug, or documented invariant with a deterministic regression
- set a default per-PR budget of one protocol, one production backend, one schema change, and at most three tables; this vertical uses one protocol, one backend, and one table
- add the domain-local `WikiStore` protocol with only four currently consumed operations: read, atomic publish, repository scan, and per-entry generation guard
- implement SQLite schema v1 with WAL, short connections, bounded canonical JSON, and one table
- authenticate exact table/index DDL plus application/schema identity before initialization completes and on every operational connection
- bind integrity digests to entry ID, repository ID, and envelope bytes; validate existing records before overwrite, rebind, or idempotent-return decisions
- open operational connections in existing-only mode so database removal cannot bypass initialization or private file creation
- serialize first-open schema/WAL initialization at a documented linearization point; reject foreign or altered schema objects before mutating journal mode
- create new SQLite databases before WAL activation with private POSIX permissions so the database, WAL, and SHM remain mode 0600 under a common umask
- preserve corruption classification on Python 3.10 and keep invalid identifiers inside the `WikiStoreValidationError` domain
- persist `AgentWiki` outline, page, and evidence envelopes through an injected store while preserving public API, static export, `RepoManifest`, portable artifact, and MCP behavior
- share the bounded legacy reader between runtime and cache audit, rejecting duplicate keys, excessive complexity, and non-finite or overflowed numbers before serving or adoption
- attach versioned, identity-bound legacy-file provenance to canonical entries so audits suppress stale adopted copies without cross-repository page-ID or digest guesses
- keep lazy Wiki/store construction off the FastAPI event loop and serialize process-local helper publication with one documented lock
- expose database payload and legacy-file accounting through the existing cache audit path
- track removal of the one-release legacy JSON read-through in #749
- keep PostgreSQL, object storage, Wiki search, revision history, normalized citation graphs, distributed leases, registries, dynamic discovery, and remote GC deferred until a current route, deployment constraint, or benchmark requires them

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/storage test/web test/wiki -n auto --tb=short`: 2401 passed, 1 existing interpreter-dependent opcode-trace test skipped
- focused SQLite store, backend-neutral contract, quality-audit, AgentWiki, and Web runtime regressions: 301 passed
- Black, isort, flake8, Python 3.10 bytecode compilation, Python 3.10 exact-schema/reopen/removal/cross-repository probes, and diff checks pass on all changed Python files

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published