### PR TITLE
feat(storage): add local reachability audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable user-facing changes are recorded here. CodeNib follows
 - A domain-local `WikiStore` harness and SQLite WAL implementation with
   versioned schema initialization, bounded canonical JSON, integrity checks,
   atomic publication, and cross-process generation guards.
+- A report-only `codenib storage audit` command that classifies SQLite catalog
+  object reachability and compares it with local CAS metadata without changing
+  storage or claiming that any bytes are reclaimable.
 
 ### Changed
 

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -4248,6 +4248,80 @@ def _compact_json_line(payload: dict[str, object]) -> str:
     )
 
 
+def _print_storage_audit(payload: dict[str, object]) -> None:
+    """Render the bounded operator summary without implying reclaimability."""
+
+    print("Local storage audit: observation only; no reclaimability decision")
+    print(f"Catalog: {payload.get('catalog_path') or '-'}")
+    print(f"CAS:     {payload.get('cas_root') or '-'}")
+    print("Limits:  writers not quiesced; stores non-atomic; hashes not verified")
+    catalog = payload.get("catalog")
+    reachability = catalog.get("reachability") if isinstance(catalog, dict) else None
+    if isinstance(reachability, dict):
+        print("Catalog objects:")
+        for category in (
+            "current_ref",
+            "historical_snapshot",
+            "generation_only",
+            "unbound_registered",
+        ):
+            summary = reachability.get(category)
+            if isinstance(summary, dict):
+                print(
+                    f"  {category:<20} "
+                    f"{summary.get('object_count', 0):>8} objects  "
+                    f"{summary.get('registered_bytes', 0):>12} bytes"
+                )
+    cas = payload.get("cas")
+    cas_observations = cas.get("observations") if isinstance(cas, dict) else None
+    if isinstance(cas_observations, dict):
+        print("CAS observations:")
+        for category in (
+            "present",
+            "missing",
+            "size_mismatch",
+            "unregistered",
+            "invalid",
+        ):
+            summary = cas_observations.get(category)
+            if isinstance(summary, dict):
+                print(f"  {category:<20} {summary.get('count', 0):>8} observations")
+
+
+def _run_storage_audit(args: argparse.Namespace) -> int:
+    """Inspect one SQLite/LocalCAS pair through a private catalog snapshot."""
+
+    from .storage._reachability_audit import _audit_local_storage_snapshot
+    from .storage.sqlite_catalog import _catalog_validation_snapshot
+
+    catalog_path = _lexical_cli_path(args.catalog, label="catalog")
+    cas_root = _lexical_cli_path(args.cas_root, label="CAS root")
+    if _paths_overlap(catalog_path, cas_root):
+        raise CLIError("catalog must not overlap the CAS root")
+    if args.sample_limit > 1_000:
+        raise CLIError("sample_limit must be between 0 and 1000")
+    try:
+        with _catalog_validation_snapshot(catalog_path) as snapshot_path:
+            payload = _audit_local_storage_snapshot(
+                snapshot_path,
+                cas_root,
+                sample_limit=args.sample_limit,
+            )
+        payload["catalog_path"] = os.fspath(catalog_path)
+        payload["cas_root"] = os.fspath(cas_root)
+        payload["catalog_source_open_mode"] = "copied-validation-snapshot"
+    except CLIError:
+        raise
+    except (OSError, RuntimeError, ValueError, sqlite3.Error) as exc:
+        raise CLIError(str(exc)) from exc
+
+    if args.json:
+        print(_compact_json_line(payload))
+    else:
+        _print_storage_audit(payload)
+    return 0
+
+
 def _run_jobs_run_once(args: argparse.Namespace) -> int:
     """Run one bounded prepare-only index worker scan."""
 
@@ -6631,6 +6705,43 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     jobs_run_parser.set_defaults(handler=_run_jobs_continuous)
+
+    storage_parser = subparsers.add_parser(
+        "storage",
+        help="inspect explicitly configured local retained storage",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    storage_subparsers = storage_parser.add_subparsers(
+        dest="storage_command",
+        required=True,
+    )
+    storage_audit_parser = storage_subparsers.add_parser(
+        "audit",
+        help="report SQLite/CAS reachability without deleting objects",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    storage_audit_parser.add_argument(
+        "--catalog",
+        required=True,
+        help="existing initialized SQLite catalog path",
+    )
+    storage_audit_parser.add_argument(
+        "--cas-root",
+        required=True,
+        help="existing local CAS root",
+    )
+    storage_audit_parser.add_argument(
+        "--sample-limit",
+        type=_argparse_nonnegative_int,
+        default=20,
+        help="maximum diagnostic samples retained per category (at most 1000)",
+    )
+    storage_audit_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit machine-readable compact JSON output",
+    )
+    storage_audit_parser.set_defaults(handler=_run_storage_audit)
 
     publish_parser = subparsers.add_parser(
         "publish",

--- a/codenib/storage/_reachability_audit.py
+++ b/codenib/storage/_reachability_audit.py
@@ -143,7 +143,7 @@ def _directory_names(descriptor: int) -> list[str]:
 def _entry_metadata(descriptor: int, name: str) -> os.stat_result | None:
     try:
         return os.stat(name, dir_fd=descriptor, follow_symlinks=False)
-    except (FileNotFoundError, PermissionError):
+    except FileNotFoundError:
         return None
 
 
@@ -224,7 +224,6 @@ def _scan_canonical_files(
     expected_layout_errors = (
         FileNotFoundError,
         NotADirectoryError,
-        PermissionError,
         StorageIntegrityError,
         StorageValidationError,
         ValueError,

--- a/codenib/storage/_reachability_audit.py
+++ b/codenib/storage/_reachability_audit.py
@@ -1,0 +1,388 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI-private, read-only diagnostics for one SQLite catalog and local CAS."""
+
+from __future__ import annotations
+
+import os
+import re
+import sqlite3
+import stat
+from pathlib import Path
+
+from .cas import _CAS_OBJECT_MODE, _open_child_directory, _open_directory_path
+from .models import StorageIntegrityError, StorageValidationError
+from .sqlite_catalog import LATEST_SCHEMA_VERSION
+
+_AUDIT_CONTRACT = "codenib.local-storage-audit.v1"
+_MAX_SAMPLE_LIMIT = 1_000
+_DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
+_SHARD_RE = re.compile(r"[0-9a-f]{2}\Z", re.ASCII)
+_OBJECT_NAME_RE = re.compile(r"[0-9a-f]{62}\Z", re.ASCII)
+_REACHABILITY = (
+    "current_ref",
+    "historical_snapshot",
+    "generation_only",
+    "unbound_registered",
+)
+_CAS_OBSERVATION_KINDS = (
+    "present",
+    "missing",
+    "size_mismatch",
+    "unregistered",
+    "invalid",
+)
+
+_REACHABILITY_SQL = """
+    WITH generation_objects(view_generation_id, digest) AS (
+        SELECT view_generation_id, object_digest
+        FROM view_generations
+        UNION
+        SELECT view_generation_id, object_digest
+        FROM view_generation_objects
+    ),
+    current_objects(digest) AS (
+        SELECT DISTINCT generation.digest
+        FROM refs AS ref
+        JOIN snapshot_views AS snapshot_view
+            ON snapshot_view.snapshot_id = ref.snapshot_id
+        JOIN generation_objects AS generation
+            ON generation.view_generation_id = snapshot_view.view_generation_id
+    ),
+    retained_snapshot_objects(digest) AS (
+        SELECT DISTINCT generation.digest
+        FROM snapshots AS snapshot
+        JOIN snapshot_views AS snapshot_view
+            ON snapshot_view.snapshot_id = snapshot.snapshot_id
+        JOIN generation_objects AS generation
+            ON generation.view_generation_id = snapshot_view.view_generation_id
+        WHERE snapshot.status = 'ready'
+    ),
+    attached_objects(digest) AS (
+        SELECT DISTINCT digest FROM generation_objects
+    )
+    SELECT
+        object.digest,
+        object.storage_key,
+        object.byte_size,
+        CASE
+            WHEN current.digest IS NOT NULL THEN 'current_ref'
+            WHEN retained.digest IS NOT NULL THEN 'historical_snapshot'
+            WHEN attached.digest IS NOT NULL THEN 'generation_only'
+            ELSE 'unbound_registered'
+        END AS reachability
+    FROM objects AS object
+    LEFT JOIN current_objects AS current
+        ON current.digest = object.digest
+    LEFT JOIN retained_snapshot_objects AS retained
+        ON retained.digest = object.digest
+    LEFT JOIN attached_objects AS attached
+        ON attached.digest = object.digest
+    ORDER BY object.digest
+"""
+
+
+class _Bucket:
+    __slots__ = ("count", "expected_bytes", "observed_bytes", "samples")
+
+    def __init__(self) -> None:
+        self.count = 0
+        self.expected_bytes = 0
+        self.observed_bytes = 0
+        self.samples: list[str] = []
+
+    def add(
+        self,
+        sample: str,
+        *,
+        sample_limit: int,
+        expected_bytes: int = 0,
+        observed_bytes: int = 0,
+    ) -> None:
+        self.count += 1
+        self.expected_bytes += expected_bytes
+        self.observed_bytes += observed_bytes
+        if len(self.samples) < sample_limit:
+            self.samples.append(sample)
+
+
+def _canonical_storage_key(digest: str) -> str:
+    return f"sha256/{digest[:2]}/{digest[2:]}"
+
+
+def _read_catalog_snapshot(
+    path: Path,
+) -> tuple[int, tuple[tuple[object, object, object, str], ...]]:
+    """Read the current schema through one caller-owned private snapshot."""
+
+    target = f"{path.as_uri()}?mode=ro"
+    connection = sqlite3.connect(target, isolation_level=None, uri=True)
+    try:
+        version_row = connection.execute("PRAGMA user_version").fetchone()
+        if version_row is None or type(version_row[0]) is not int:
+            raise ValueError("SQLite audit snapshot has no canonical schema version")
+        version = version_row[0]
+        if version != LATEST_SCHEMA_VERSION:
+            raise ValueError(
+                "storage audit requires the current SQLite catalog schema; "
+                "open it through a normal CodeNib command to migrate it first"
+            )
+        rows = connection.execute(_REACHABILITY_SQL).fetchall()
+    finally:
+        connection.close()
+    return version, tuple((row[0], row[1], row[2], row[3]) for row in rows)
+
+
+def _directory_names(descriptor: int) -> list[str]:
+    with os.scandir(descriptor) as entries:
+        return sorted(entry.name for entry in entries)
+
+
+def _entry_metadata(descriptor: int, name: str) -> os.stat_result | None:
+    try:
+        return os.stat(name, dir_fd=descriptor, follow_symlinks=False)
+    except (FileNotFoundError, PermissionError):
+        return None
+
+
+def _scan_shard(
+    descriptor: int,
+    shard_name: str,
+    registered: dict[str, tuple[int, bool]],
+    buckets: dict[str, _Bucket],
+    observed: set[str],
+    *,
+    sample_limit: int,
+) -> None:
+    for object_name in _directory_names(descriptor):
+        storage_key = f"sha256/{shard_name}/{object_name}"
+        metadata = _entry_metadata(descriptor, object_name)
+        if metadata is None:
+            buckets["invalid"].add(storage_key, sample_limit=sample_limit)
+            continue
+        if _OBJECT_NAME_RE.fullmatch(object_name) is None:
+            buckets["invalid"].add(
+                storage_key,
+                sample_limit=sample_limit,
+                observed_bytes=(
+                    metadata.st_size if stat.S_ISREG(metadata.st_mode) else 0
+                ),
+            )
+            continue
+
+        digest = f"{shard_name}{object_name}"
+        observed.add(digest)
+        record = registered.get(digest)
+        canonical_file = (
+            stat.S_ISREG(metadata.st_mode)
+            and metadata.st_nlink == 1
+            and stat.S_IMODE(metadata.st_mode) == _CAS_OBJECT_MODE
+        )
+        if not canonical_file or record is not None and not record[1]:
+            buckets["invalid"].add(
+                storage_key,
+                sample_limit=sample_limit,
+                expected_bytes=record[0] if record is not None else 0,
+                observed_bytes=(
+                    metadata.st_size if stat.S_ISREG(metadata.st_mode) else 0
+                ),
+            )
+        elif record is None:
+            buckets["unregistered"].add(
+                storage_key,
+                sample_limit=sample_limit,
+                observed_bytes=metadata.st_size,
+            )
+        elif metadata.st_size != record[0]:
+            buckets["size_mismatch"].add(
+                storage_key,
+                sample_limit=sample_limit,
+                expected_bytes=record[0],
+                observed_bytes=metadata.st_size,
+            )
+        else:
+            buckets["present"].add(
+                storage_key,
+                sample_limit=sample_limit,
+                expected_bytes=record[0],
+                observed_bytes=metadata.st_size,
+            )
+
+
+def _scan_canonical_files(
+    root: Path,
+    registered: dict[str, tuple[int, bool]],
+    buckets: dict[str, _Bucket],
+    *,
+    sample_limit: int,
+) -> set[str]:
+    """Scan below descriptor-bound directories without following replacements."""
+
+    observed: set[str] = set()
+    expected_layout_errors = (
+        FileNotFoundError,
+        NotADirectoryError,
+        PermissionError,
+        StorageIntegrityError,
+        StorageValidationError,
+        ValueError,
+    )
+    try:
+        with _open_directory_path(root, label="CAS root") as root_descriptor:
+            if root_descriptor is None:
+                raise RuntimeError(
+                    "storage audit requires descriptor-bound LocalCAS support"
+                )
+            try:
+                with _open_child_directory(
+                    root_descriptor,
+                    root,
+                    "sha256",
+                    label="CAS SHA-256 root",
+                ) as (sha256_descriptor, sha256_path):
+                    assert sha256_descriptor is not None
+                    for shard_name in _directory_names(sha256_descriptor):
+                        shard_path = f"sha256/{shard_name}"
+                        metadata = _entry_metadata(sha256_descriptor, shard_name)
+                        if (
+                            metadata is None
+                            or _SHARD_RE.fullmatch(shard_name) is None
+                            or not stat.S_ISDIR(metadata.st_mode)
+                        ):
+                            buckets["invalid"].add(
+                                shard_path,
+                                sample_limit=sample_limit,
+                            )
+                            continue
+                        try:
+                            with _open_child_directory(
+                                sha256_descriptor,
+                                sha256_path,
+                                shard_name,
+                                label="CAS digest shard",
+                            ) as (shard_descriptor, _):
+                                assert shard_descriptor is not None
+                                _scan_shard(
+                                    shard_descriptor,
+                                    shard_name,
+                                    registered,
+                                    buckets,
+                                    observed,
+                                    sample_limit=sample_limit,
+                                )
+                        except expected_layout_errors:
+                            buckets["invalid"].add(
+                                shard_path,
+                                sample_limit=sample_limit,
+                            )
+            except expected_layout_errors:
+                buckets["invalid"].add("sha256", sample_limit=sample_limit)
+    except expected_layout_errors:
+        buckets["invalid"].add(".", sample_limit=sample_limit)
+    return observed
+
+
+def _audit_local_storage_snapshot(
+    catalog_snapshot: str | Path,
+    cas_root: str | Path,
+    *,
+    sample_limit: int = 20,
+) -> dict[str, object]:
+    """Observe one private catalog snapshot and LocalCAS without mutation.
+
+    The filesystem walk is sequential and writers are not quiesced. Concurrent
+    publication can therefore appear as unregistered or invalid temporary
+    entries. No result is a deletion or reclaimability gate.
+    """
+
+    if type(sample_limit) is not int or not 0 <= sample_limit <= _MAX_SAMPLE_LIMIT:
+        raise ValueError(f"sample_limit must be between 0 and {_MAX_SAMPLE_LIMIT}")
+
+    version, rows = _read_catalog_snapshot(Path(catalog_snapshot).expanduser())
+    reachability_buckets = {name: _Bucket() for name in _REACHABILITY}
+    cas_buckets = {name: _Bucket() for name in _CAS_OBSERVATION_KINDS}
+    registered: dict[str, tuple[int, bool]] = {}
+    for digest, storage_key, byte_size, category in rows:
+        sample_digest = digest if type(digest) is str else repr(digest)
+        expected_size = byte_size if type(byte_size) is int and byte_size >= 0 else 0
+        reachability_buckets[category].add(
+            sample_digest,
+            sample_limit=sample_limit,
+            expected_bytes=expected_size,
+        )
+        valid_digest = type(digest) is str and _DIGEST_RE.fullmatch(digest) is not None
+        canonical_key = _canonical_storage_key(digest) if valid_digest else None
+        metadata_valid = (
+            valid_digest
+            and type(storage_key) is str
+            and storage_key == canonical_key
+            and type(byte_size) is int
+            and byte_size >= 0
+        )
+        if valid_digest:
+            registered[digest] = (expected_size, metadata_valid)
+        else:
+            cas_buckets["invalid"].add(
+                f"catalog:{sample_digest}",
+                sample_limit=sample_limit,
+                expected_bytes=expected_size,
+            )
+
+    observed = _scan_canonical_files(
+        Path(cas_root).expanduser(),
+        registered,
+        cas_buckets,
+        sample_limit=sample_limit,
+    )
+    for digest, (byte_size, metadata_valid) in registered.items():
+        if digest in observed:
+            continue
+        status = "missing" if metadata_valid else "invalid"
+        cas_buckets[status].add(
+            _canonical_storage_key(digest),
+            sample_limit=sample_limit,
+            expected_bytes=byte_size,
+        )
+
+    reachability = {
+        name: {
+            "object_count": reachability_buckets[name].count,
+            "registered_bytes": reachability_buckets[name].expected_bytes,
+            "sample_digests": list(reachability_buckets[name].samples),
+        }
+        for name in _REACHABILITY
+    }
+    cas_observations = {
+        name: {
+            "count": cas_buckets[name].count,
+            "expected_bytes": cas_buckets[name].expected_bytes,
+            "observed_bytes": cas_buckets[name].observed_bytes,
+            "samples": list(cas_buckets[name].samples),
+        }
+        for name in _CAS_OBSERVATION_KINDS
+    }
+    return {
+        "contract": _AUDIT_CONTRACT,
+        "mode": "metadata_only",
+        "cross_store_atomic": False,
+        "content_hashes_verified": False,
+        "writers_quiesced": False,
+        "sample_limit": sample_limit,
+        "catalog": {
+            "schema_version": version,
+            "object_count": sum(
+                bucket.count for bucket in reachability_buckets.values()
+            ),
+            "registered_bytes": sum(
+                bucket.expected_bytes for bucket in reachability_buckets.values()
+            ),
+            "reachability": reachability,
+        },
+        "cas": {"observations": cas_observations},
+        "reclamation": {
+            "assessed": False,
+            "reclaimable_bytes": None,
+        },
+    }

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -30,7 +30,7 @@ because both implementations use SQLite. Tests, this roadmap, and planned
 adapters do not count as consumers. A new generic capability must satisfy the
 evidence gates in `AGENTS.md`.
 
-The active product vertical is **Wiki Store v1**:
+The completed product vertical is **Wiki Store v1**:
 
 - keep one injectable Wiki persistence protocol next to `codenib/wiki/`;
 - implement it first as a separate SQLite WAL database with one v1 schema
@@ -52,6 +52,31 @@ implemented. Contract, Wiki, CLI, static-export, manifest, context-artifact,
 and MCP compatibility gates pass without changing the generic catalog schema.
 It is a trusted, regenerable local cache: bounds and digests detect accidental
 damage, not a hostile process that can rewrite the database.
+
+The active storage-evidence vertical is **Local Reachability Audit v1**. It is
+deliberately specific to the canonical SQLite catalog and local SHA-256 CAS:
+
+- inspect one private validation copy of the current catalog schema through a
+  read-only connection so the audit does not migrate or write the source;
+- classify registered objects as current-ref, historical-snapshot,
+  generation-only, or registered-but-unbound, including compound-generation
+  members;
+- compare those records with a metadata-only local CAS scan that rejects
+  observed symlink, special-file, and multiply-linked entries, and report
+  missing, size-mismatched, unregistered, or invalid entries;
+- keep the implementation private to `codenib storage audit` and expose only
+  bounded report output; do not add a backend-neutral enumeration API,
+  retention state, or deletion path.
+
+Status: complete. The report states that catalog and CAS observations are not
+cross-store atomic, content hashes were not verified, writers were not
+quiesced, and reclaimability was not assessed. Historical snapshots remain
+publicly addressable through explicit snapshot loading, while unbound catalog
+rows, CAS-only files, and temporary entries may be legitimate publication
+windows. The filesystem walk is sequential rather than a consistency snapshot,
+and source-catalog churn may require rerunning the validation copy. The audit
+is evidence for a later retention design, never a GC authorization.
+Tracking: [#750](https://github.com/sysevol-ai/CodeNib/issues/750).
 
 Wiki search, normalized link/citation graphs, revision browsing, PostgreSQL,
 object storage, distributed leases, remote garbage collection, and dynamic
@@ -1916,12 +1941,16 @@ publication carries forward unchanged units and applies path-aware upserts and
 deletes without resolving cross-file monikers into reusable artifacts. Tests
 cover clean/incremental convergence, profile invalidation, failed publication,
 receipt tampering, member reachability, migration, and cross-snapshot cache
-isolation.
+isolation. `codenib storage audit` now supplies a non-deleting SQLite/LocalCAS
+reachability and logical-size observation before any retention policy is
+chosen. It uses the existing primary/member relationships without changing the
+schema or generic protocols, and explicitly reports no reclaimable-byte
+decision.
 
 - Extend the current path/content identity with portable file mode and package
   identity where future non-clangd adapters require them.
-- Add snapshot leases, pins, retention policy, mark-and-sweep GC, and crash
-  recovery.
+- Use representative audit evidence to define snapshot leases, pins and a
+  retention policy before adding mark-and-sweep deletion or crash recovery.
 - Discover and ownership-validate view-bundle `.previous-*` files before
   reclaiming verified old outputs and missing-destination sentinels.
 - Generalize the clangd semantic-facts upsert/delete generation to the

--- a/test/storage/test_reachability_audit.py
+++ b/test/storage/test_reachability_audit.py
@@ -1,0 +1,301 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from codenib.storage import _reachability_audit as audit_module
+from codenib.storage._reachability_audit import _audit_local_storage_snapshot
+from codenib.storage.cas import BlobInfo, LocalCAS
+from codenib.storage.sqlite_catalog import SQLiteCatalog, _catalog_validation_snapshot
+
+
+def _audit(
+    catalog: SQLiteCatalog,
+    cas_root: Path,
+    *,
+    sample_limit: int = 20,
+) -> dict[str, object]:
+    with _catalog_validation_snapshot(Path(catalog.path)) as snapshot:
+        return _audit_local_storage_snapshot(
+            snapshot,
+            cas_root,
+            sample_limit=sample_limit,
+        )
+
+
+def _register(catalog: SQLiteCatalog, cas: LocalCAS, payload: bytes) -> BlobInfo:
+    receipt = cas.put_bytes(payload)
+    catalog.register_object(
+        receipt.digest,
+        storage_key=receipt.storage_key,
+        byte_size=receipt.byte_size,
+    )
+    return receipt
+
+
+def _stage(
+    catalog: SQLiteCatalog,
+    repository_id: str,
+    source_revision_id: str,
+    profile_id: str,
+    view_type: str,
+    primary: BlobInfo,
+    member: BlobInfo,
+) -> str:
+    return catalog.stage_view_generation(
+        repository_id,
+        source_revision_id,
+        profile_id,
+        view_type,
+        primary.digest,
+        schema_version="1",
+        member_object_digests=(member.digest,),
+    )
+
+
+def test_audit_classifies_primary_and_member_reachability(tmp_path: Path) -> None:
+    cas_root = tmp_path / "cas"
+    with (
+        SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog,
+        LocalCAS(cas_root) as cas,
+    ):
+        repository_id = catalog.create_repository("owner/repo")
+        source_revision_id = catalog.create_source_revision(
+            repository_id,
+            commit_sha="a" * 40,
+            tree_sha="b" * 64,
+        )
+        bm25_profile = catalog.create_view_profile("bm25", {})
+
+        historical = tuple(
+            _register(catalog, cas, payload)
+            for payload in (b"historical-primary", b"historical-member")
+        )
+        historical_view = _stage(
+            catalog,
+            repository_id,
+            source_revision_id,
+            bm25_profile,
+            "bm25",
+            historical[0],
+            historical[1],
+        )
+        catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            (historical_view,),
+        )
+
+        current = tuple(
+            _register(catalog, cas, payload)
+            for payload in (b"current-primary", b"current-member")
+        )
+        current_view = _stage(
+            catalog,
+            repository_id,
+            source_revision_id,
+            bm25_profile,
+            "bm25",
+            current[0],
+            current[1],
+        )
+        catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            (current_view,),
+            expected_generation=1,
+        )
+
+        symbol_profile = catalog.create_view_profile("symbols", {})
+        generation_only = tuple(
+            _register(catalog, cas, payload)
+            for payload in (b"generation-primary", b"generation-member")
+        )
+        _stage(
+            catalog,
+            repository_id,
+            source_revision_id,
+            symbol_profile,
+            "symbols",
+            generation_only[0],
+            generation_only[1],
+        )
+        unbound = _register(catalog, cas, b"unbound")
+
+        result = _audit(catalog, cas_root)
+
+    reachability = result["catalog"]["reachability"]
+    assert set(reachability["current_ref"]["sample_digests"]) == {
+        receipt.digest for receipt in current
+    }
+    assert set(reachability["historical_snapshot"]["sample_digests"]) == {
+        receipt.digest for receipt in historical
+    }
+    assert set(reachability["generation_only"]["sample_digests"]) == {
+        receipt.digest for receipt in generation_only
+    }
+    assert reachability["unbound_registered"]["sample_digests"] == [unbound.digest]
+    assert result["cas"]["observations"]["present"]["count"] == 7
+
+
+def test_audit_reports_each_canonical_file_status(tmp_path: Path) -> None:
+    cas_root = tmp_path / "cas"
+    with (
+        SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog,
+        LocalCAS(cas_root) as cas,
+    ):
+        _register(catalog, cas, b"present")
+        missing = _register(catalog, cas, b"missing")
+        mismatch = _register(catalog, cas, b"size-mismatch")
+        cas.put_bytes(b"unregistered")
+
+        (cas_root / missing.storage_key).unlink()
+        (cas_root / mismatch.storage_key).write_bytes(b"x")
+        (cas_root / "sha256" / "not-a-shard").mkdir()
+
+        result = _audit(catalog, cas_root)
+
+    files = result["cas"]["observations"]
+    assert {status: files[status]["count"] for status in files} == {
+        "present": 1,
+        "missing": 1,
+        "size_mismatch": 1,
+        "unregistered": 1,
+        "invalid": 1,
+    }
+    assert files["size_mismatch"]["expected_bytes"] == mismatch.byte_size
+    assert files["size_mismatch"]["observed_bytes"] == 1
+
+
+def test_audit_rejects_symlinked_sha256_root(tmp_path: Path) -> None:
+    cas_root = tmp_path / "cas"
+    target = tmp_path / "elsewhere"
+    cas_root.mkdir()
+    target.mkdir()
+    (cas_root / "sha256").symlink_to(target, target_is_directory=True)
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        files = _audit(catalog, cas_root)["cas"]["observations"]
+    assert files["invalid"]["count"] == 1
+    assert files["invalid"]["samples"] == ["sha256"]
+
+
+def test_audit_marks_multiply_linked_object_invalid(tmp_path: Path) -> None:
+    cas_root = tmp_path / "cas"
+    with (
+        SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog,
+        LocalCAS(cas_root) as cas,
+    ):
+        receipt = _register(catalog, cas, b"linked")
+        os.link(cas_root / receipt.storage_key, tmp_path / "second-link")
+        files = _audit(catalog, cas_root)["cas"]["observations"]
+    assert files["invalid"]["samples"] == [receipt.storage_key]
+    assert files["present"]["count"] == 0
+
+
+def test_audit_samples_are_stable_and_bounded(tmp_path: Path) -> None:
+    cas_root = tmp_path / "cas"
+    with (
+        SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog,
+        LocalCAS(cas_root) as cas,
+    ):
+        receipts = [
+            _register(catalog, cas, payload)
+            for payload in (b"delta", b"alpha", b"charlie", b"bravo")
+        ]
+        first = _audit(catalog, cas_root, sample_limit=2)
+        second = _audit(catalog, cas_root, sample_limit=2)
+
+    assert first == second
+    expected_digests = sorted(receipt.digest for receipt in receipts)[:2]
+    assert (
+        first["catalog"]["reachability"]["unbound_registered"]["sample_digests"]
+        == expected_digests
+    )
+    assert first["cas"]["observations"]["present"]["samples"] == [
+        f"sha256/{digest[:2]}/{digest[2:]}" for digest in expected_digests
+    ]
+
+
+@pytest.mark.parametrize("sample_limit", (-1, 1_001, True))
+def test_audit_rejects_invalid_sample_limit(
+    tmp_path: Path, sample_limit: object
+) -> None:
+    cas_root = tmp_path / "cas"
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog, LocalCAS(cas_root):
+        with pytest.raises(ValueError, match="sample_limit"):
+            _audit(catalog, cas_root, sample_limit=sample_limit)  # type: ignore[arg-type]
+
+
+def test_audit_missing_root_is_invalid_even_without_objects(tmp_path: Path) -> None:
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        result = _audit(catalog, tmp_path / "missing")
+    assert result["cas"]["observations"]["invalid"]["samples"] == ["."]
+    assert result["reclamation"] == {
+        "assessed": False,
+        "reclaimable_bytes": None,
+    }
+    assert result["cross_store_atomic"] is False
+    assert result["content_hashes_verified"] is False
+    assert result["writers_quiesced"] is False
+
+
+def test_audit_marks_noncanonical_object_mode_invalid(tmp_path: Path) -> None:
+    cas_root = tmp_path / "cas"
+    with (
+        SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog,
+        LocalCAS(cas_root) as cas,
+    ):
+        receipt = _register(catalog, cas, b"wrong mode")
+        (cas_root / receipt.storage_key).chmod(0o644)
+
+        files = _audit(catalog, cas_root)["cas"]["observations"]
+
+    assert files["invalid"]["samples"] == [receipt.storage_key]
+    assert files["present"]["count"] == 0
+
+
+def test_audit_does_not_follow_replaced_shard(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cas_root = tmp_path / "cas"
+    with (
+        SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog,
+        LocalCAS(cas_root) as cas,
+    ):
+        receipt = _register(catalog, cas, b"registered")
+        shard_name = receipt.digest[:2]
+        object_name = receipt.digest[2:]
+        shard = cas_root / "sha256" / shard_name
+        displaced = cas_root / "sha256" / f"{shard_name}.displaced"
+        external = tmp_path / "external"
+        external.mkdir()
+        external_object = external / object_name
+        external_object.write_bytes(b"registered")
+        external_object.chmod(0o600)
+
+        original = audit_module._entry_metadata
+        replaced = False
+
+        def replace_after_stat(descriptor: int, name: str):
+            nonlocal replaced
+            metadata = original(descriptor, name)
+            if name == shard_name and not replaced:
+                shard.rename(displaced)
+                shard.symlink_to(external, target_is_directory=True)
+                replaced = True
+            return metadata
+
+        monkeypatch.setattr(audit_module, "_entry_metadata", replace_after_stat)
+        files = _audit(catalog, cas_root)["cas"]["observations"]
+
+    assert replaced is True
+    assert files["present"]["count"] == 0
+    assert files["missing"]["count"] == 1
+    assert files["invalid"]["samples"] == [f"sha256/{shard_name}"]

--- a/test/storage/test_reachability_audit.py
+++ b/test/storage/test_reachability_audit.py
@@ -299,3 +299,22 @@ def test_audit_does_not_follow_replaced_shard(
     assert files["present"]["count"] == 0
     assert files["missing"]["count"] == 1
     assert files["invalid"]["samples"] == [f"sha256/{shard_name}"]
+
+
+def test_audit_fails_when_cas_traversal_is_denied(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cas_root = tmp_path / "cas"
+
+    def deny_traversal(descriptor: int) -> list[str]:
+        raise PermissionError("denied")
+
+    with (
+        SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog,
+        LocalCAS(cas_root),
+    ):
+        monkeypatch.setattr(audit_module, "_directory_names", deny_traversal)
+
+        with pytest.raises(PermissionError, match="denied"):
+            _audit(catalog, cas_root)

--- a/test/test_storage_audit_cli.py
+++ b/test/test_storage_audit_cli.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from codenib import cli
+from codenib.storage.cas import LocalCAS
+from codenib.storage.sqlite_catalog import LATEST_SCHEMA_VERSION, SQLiteCatalog
+
+
+def _namespace_bytes(path: Path) -> dict[str, bytes | None]:
+    return {
+        suffix: (
+            sidecar.read_bytes()
+            if (sidecar := Path(f"{path}{suffix}")).exists()
+            else None
+        )
+        for suffix in ("", "-wal", "-shm", "-journal")
+    }
+
+
+def _tree_bytes(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def test_storage_audit_parser_exposes_only_report_options() -> None:
+    args = cli.build_parser().parse_args(
+        [
+            "storage",
+            "audit",
+            "--catalog",
+            "/state/catalog.sqlite3",
+            "--cas-root",
+            "/state/cas",
+            "--sample-limit",
+            "7",
+            "--json",
+        ]
+    )
+
+    assert args.handler is cli._run_storage_audit
+    assert args.catalog == "/state/catalog.sqlite3"
+    assert args.cas_root == "/state/cas"
+    assert args.sample_limit == 7
+    assert args.json is True
+    assert not hasattr(args, "delete")
+    assert not hasattr(args, "apply")
+
+    with pytest.raises(SystemExit) as invalid:
+        cli.build_parser().parse_args(
+            [
+                "storage",
+                "audit",
+                "--catalog",
+                "/state/catalog.sqlite3",
+                "--cas-root",
+                "/state/cas",
+                "--sample-limit",
+                "-1",
+            ]
+        )
+    assert invalid.value.code == 2
+
+
+def test_storage_audit_uses_a_copy_and_does_not_change_inputs(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    catalog_path = tmp_path / "catalog.sqlite3"
+    cas_root = tmp_path / "cas"
+    with LocalCAS(cas_root) as store, SQLiteCatalog(catalog_path) as catalog:
+        receipt = store.put_bytes(b"audit object")
+        catalog.register_object(
+            receipt.digest,
+            storage_key=receipt.storage_key,
+            byte_size=receipt.byte_size,
+        )
+    catalog_before = _namespace_bytes(catalog_path)
+    cas_before = _tree_bytes(cas_root)
+
+    result = cli.run(
+        [
+            "storage",
+            "audit",
+            "--catalog",
+            str(catalog_path),
+            "--cas-root",
+            str(cas_root),
+            "--json",
+        ]
+    )
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["contract"] == "codenib.local-storage-audit.v1"
+    assert payload["catalog_source_open_mode"] == "copied-validation-snapshot"
+    assert payload["catalog"]["schema_version"] == LATEST_SCHEMA_VERSION
+    assert payload["reclamation"]["assessed"] is False
+
+    assert (
+        cli.run(
+            [
+                "storage",
+                "audit",
+                "--catalog",
+                str(catalog_path),
+                "--cas-root",
+                str(cas_root),
+            ]
+        )
+        == 0
+    )
+    human = capsys.readouterr().out
+    assert "writers not quiesced; stores non-atomic; hashes not verified" in human
+    assert catalog_before == _namespace_bytes(catalog_path)
+    assert cas_before == _tree_bytes(cas_root)
+
+
+def test_storage_audit_reports_missing_catalog_objects_without_health_exit(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    catalog_path = tmp_path / "catalog.sqlite3"
+    cas_root = tmp_path / "cas"
+    with LocalCAS(cas_root):
+        pass
+    digest = "a" * 64
+    with SQLiteCatalog(catalog_path) as catalog:
+        catalog.register_object(
+            digest,
+            storage_key=f"sha256/{digest[:2]}/{digest[2:]}",
+            byte_size=12,
+        )
+
+    result = cli.run(
+        [
+            "storage",
+            "audit",
+            "--catalog",
+            str(catalog_path),
+            "--cas-root",
+            str(cas_root),
+            "--json",
+        ]
+    )
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["cas"]["observations"]["missing"]["count"] == 1
+
+
+def test_storage_audit_rejects_old_schema_without_migrating_source(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    catalog_path = tmp_path / "catalog.sqlite3"
+    cas_root = tmp_path / "cas"
+    with LocalCAS(cas_root), SQLiteCatalog(catalog_path):
+        pass
+    connection = sqlite3.connect(catalog_path)
+    try:
+        connection.execute(f"PRAGMA user_version = {LATEST_SCHEMA_VERSION - 1}")
+        connection.commit()
+    finally:
+        connection.close()
+    before = _namespace_bytes(catalog_path)
+
+    result = cli.run(
+        [
+            "storage",
+            "audit",
+            "--catalog",
+            str(catalog_path),
+            "--cas-root",
+            str(cas_root),
+        ]
+    )
+
+    assert result == 2
+    assert "requires the current SQLite catalog schema" in capsys.readouterr().err
+    assert before == _namespace_bytes(catalog_path)


### PR DESCRIPTION
## Summary

Add one report-only local storage diagnostic that observes the canonical SQLite catalog and LocalCAS without extending generic storage contracts or deciding that any object is reclaimable.

Closes #750.

## Changes

- add `codenib storage audit --catalog ... --cas-root ...` with bounded human and JSON reports
- classify current-ref, ready historical-snapshot, generation-only, and unbound registered primary/member objects
- compare catalog records with descriptor-bound LocalCAS metadata observations for present, missing, size-mismatched, unregistered, and invalid entries
- abort incomplete traversal on permission failures instead of inferring missing objects
- read one private validation copy through SQLite read-only mode so the source catalog is neither migrated nor written
- keep the implementation CLI-private and add no schema, protocol method, registry, retention state, or deletion path
- state in both output modes that writers are not quiesced, stores are non-atomic, hashes are not verified, and reclaimability is not assessed
- update the storage roadmap and changelog with the completed narrow milestone and its remaining GC gates

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/storage/test_reachability_audit.py test/test_storage_audit_cli.py --tb=short` — 16 passed
- `pytest -q test/test_cli.py --tb=short` — 185 passed
- `pytest -q test/storage --tb=short` — 1195 passed; one pre-existing multithreaded `fork()` deprecation warning
- Black, isort, flake8, `git diff --check`, and Python 3.10 `py_compile` passed

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published