### PR TITLE
refactor(storage): detach portable artifact validation

### DIFF
--- a/codenib/_bounded_json.py
+++ b/codenib/_bounded_json.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Incremental, complexity-bounded framing for UTF-8 JSON documents."""
+"""Complexity-bounded helpers for exact JSON values and UTF-8 documents."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ import json
 import math
 import re
 from collections.abc import Iterable, Iterator
-from typing import Any, BinaryIO, Protocol
+from typing import Any, BinaryIO, NoReturn, Protocol
 
 _READ_BYTES = 1024 * 1024
 DEFAULT_MAX_ARRAY_ITEMS = 1_000_000
@@ -21,10 +21,82 @@ DEFAULT_MAX_DEPTH = 64
 DEFAULT_MAX_KEY_BYTES = 4_096
 DEFAULT_MAX_ATOM_BYTES = 1_024
 DEFAULT_MAX_STRING_BYTES = 64 * 1024 * 1024
+_DEFAULT_EXACT_JSON_MAX_DEPTH = 64
+_DEFAULT_EXACT_JSON_MAX_NODES = 250_000
+_DEFAULT_EXACT_JSON_MAX_TEXT_CHARS = 64 * 1024 * 1024
+_DEFAULT_EXACT_JSON_MAX_KEY_CHARS = 4_096
 
 
 class BinaryReader(Protocol):
     def read(self, size: int = -1) -> bytes: ...
+
+
+def snapshot_bounded_exact_json(
+    value: object,
+    *,
+    label: str,
+    max_depth: int = _DEFAULT_EXACT_JSON_MAX_DEPTH,
+    max_nodes: int = _DEFAULT_EXACT_JSON_MAX_NODES,
+    max_text_chars: int = _DEFAULT_EXACT_JSON_MAX_TEXT_CHARS,
+    max_key_chars: int = _DEFAULT_EXACT_JSON_MAX_KEY_CHARS,
+    error_type: type[Exception] = ValueError,
+) -> Any:
+    """Detach an exact built-in JSON value within aggregate resource bounds."""
+
+    nodes = 0
+    text_size = 0
+
+    def fail(message: str) -> NoReturn:
+        raise error_type(message)
+
+    def snapshot(current: object, depth: int) -> Any:
+        nonlocal nodes, text_size
+        nodes += 1
+        if nodes > max_nodes:
+            fail(f"{label} exceeds its node limit")
+        if depth > max_depth:
+            fail(f"{label} exceeds its depth limit")
+        if current is None or type(current) is bool:
+            return current
+        if type(current) is str:
+            text_size += len(current)
+            if text_size > max_text_chars or "\x00" in current:
+                fail(f"{label} contains invalid text")
+            return current
+        if type(current) is int:
+            if not -(2**63) <= current < 2**63:
+                fail(f"{label} contains an invalid integer")
+            return current
+        if type(current) is float:
+            if not math.isfinite(current):
+                fail(f"{label} contains a non-finite number")
+            return current
+        if type(current) is list:
+            if len(current) > max_nodes - nodes:
+                fail(f"{label} exceeds its node limit")
+            return [snapshot(child, depth + 1) for child in current]
+        if type(current) is dict:
+            if len(current) > max_nodes - nodes:
+                fail(f"{label} exceeds its node limit")
+            result: dict[str, Any] = {}
+            try:
+                for key, child in current.items():
+                    if type(key) is not str or not key or len(key) > max_key_chars:
+                        fail(f"{label} contains an invalid object key")
+                    text_size += len(key)
+                    if text_size > max_text_chars or "\x00" in key:
+                        fail(f"{label} contains an invalid object key")
+                    result[key] = snapshot(child, depth + 1)
+            except error_type:
+                raise
+            except Exception as exc:
+                raise error_type(f"{label} could not be snapshotted") from exc
+            if len(result) != len(current):
+                fail(f"{label} changed while snapshotted")
+            return result
+        fail(f"{label} contains a non-exact JSON value")
+
+    return snapshot(value, 1)
 
 
 def _reject_duplicate_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -785,6 +857,7 @@ __all__ = [
     "canonical_json_bytes",
     "canonical_json_value_chunks",
     "iter_bounded_json_array",
+    "snapshot_bounded_exact_json",
     "validate_bounded_json_stream",
     "validate_json_complexity",
     "write_chunks",

--- a/codenib/artifacts/portable_views.py
+++ b/codenib/artifacts/portable_views.py
@@ -38,6 +38,7 @@ from .._bounded_json import (
     DEFAULT_MAX_NODES_PER_ELEMENT,
     canonical_json_value_chunks,
     iter_bounded_json_array,
+    snapshot_bounded_exact_json,
     validate_bounded_json_stream,
     validate_json_complexity,
 )
@@ -66,8 +67,6 @@ from ..source_fingerprint import (
     RepositorySourceIdentitySnapshot,
     is_secure_source_fingerprint_v2,
 )
-from ..storage.models import StorageIntegrityError
-from ..storage.protocols import snapshot_retained_import_response
 from .security import (
     _contains_pattern,
     _interitem_cancellation,
@@ -3267,15 +3266,15 @@ def validate_portable_vector_persistence_semantics(
     """
 
     try:
-        config_value = snapshot_retained_import_response(
+        config_value = snapshot_bounded_exact_json(
             config,
             label="portable vector persistence config",
         )
-        view_config_value = snapshot_retained_import_response(
+        view_config_value = snapshot_bounded_exact_json(
             view_config,
             label="portable vector view config",
         )
-    except StorageIntegrityError as exc:
+    except ValueError as exc:
         raise ValueError(
             "portable vector persistence inputs must be bounded exact JSON objects"
         ) from exc

--- a/codenib/storage/protocols.py
+++ b/codenib/storage/protocols.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import math
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -21,6 +20,7 @@ from typing import (
     runtime_checkable,
 )
 
+from .._bounded_json import snapshot_bounded_exact_json
 from .models import (
     INDEX_JOB_EVENT_PAYLOAD_MAX_DEPTH,
     INDEX_JOB_EVENT_PAYLOAD_MAX_KEY_CHARS,
@@ -59,70 +59,15 @@ _RetainedResult = TypeVar("_RetainedResult")
 def snapshot_retained_import_response(value: object, *, label: str) -> Any:
     """Detach and enforce the public exact-JSON retained response budget."""
 
-    nodes = 0
-    text_size = 0
-
-    def snapshot(current: object, depth: int) -> Any:
-        nonlocal nodes, text_size
-        nodes += 1
-        if nodes > RETAINED_IMPORT_RESPONSE_MAX_NODES:
-            raise StorageIntegrityError(f"{label} exceeds its node limit")
-        if depth > RETAINED_IMPORT_RESPONSE_MAX_DEPTH:
-            raise StorageIntegrityError(f"{label} exceeds its depth limit")
-        if current is None or type(current) is bool:
-            return current
-        if type(current) is str:
-            text_size += len(current)
-            if text_size > RETAINED_IMPORT_RESPONSE_MAX_TEXT_CHARS or "\x00" in current:
-                raise StorageIntegrityError(f"{label} contains invalid text")
-            return current
-        if type(current) is int:
-            if not -(2**63) <= current < 2**63:
-                raise StorageIntegrityError(f"{label} contains an invalid integer")
-            return current
-        if type(current) is float:
-            if not math.isfinite(current):
-                raise StorageIntegrityError(f"{label} contains a non-finite number")
-            return current
-        if type(current) is list:
-            if len(current) > RETAINED_IMPORT_RESPONSE_MAX_NODES - nodes:
-                raise StorageIntegrityError(f"{label} exceeds its node limit")
-            return [snapshot(child, depth + 1) for child in current]
-        if type(current) is dict:
-            if len(current) > RETAINED_IMPORT_RESPONSE_MAX_NODES - nodes:
-                raise StorageIntegrityError(f"{label} exceeds its node limit")
-            result: dict[str, Any] = {}
-            try:
-                for key, child in current.items():
-                    if (
-                        type(key) is not str
-                        or not key
-                        or len(key) > RETAINED_IMPORT_RESPONSE_MAX_KEY_CHARS
-                    ):
-                        raise StorageIntegrityError(
-                            f"{label} contains an invalid object key"
-                        )
-                    text_size += len(key)
-                    if (
-                        text_size > RETAINED_IMPORT_RESPONSE_MAX_TEXT_CHARS
-                        or "\x00" in key
-                    ):
-                        raise StorageIntegrityError(
-                            f"{label} contains an invalid object key"
-                        )
-                    result[key] = snapshot(child, depth + 1)
-            except StorageIntegrityError:
-                raise
-            except Exception as exc:
-                raise StorageIntegrityError(
-                    f"{label} could not be snapshotted"
-                ) from exc
-            if len(result) != len(current):
-                raise StorageIntegrityError(f"{label} changed while snapshotted")
-            return result
-        raise StorageIntegrityError(f"{label} contains a non-exact JSON value")
-
-    return snapshot(value, 1)
+    return snapshot_bounded_exact_json(
+        value,
+        label=label,
+        max_depth=RETAINED_IMPORT_RESPONSE_MAX_DEPTH,
+        max_nodes=RETAINED_IMPORT_RESPONSE_MAX_NODES,
+        max_text_chars=RETAINED_IMPORT_RESPONSE_MAX_TEXT_CHARS,
+        max_key_chars=RETAINED_IMPORT_RESPONSE_MAX_KEY_CHARS,
+        error_type=StorageIntegrityError,
+    )
 
 
 @runtime_checkable

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -102,7 +102,7 @@ product core.
 
 ### W1: Remove the Web retained-storage route
 
-Status: complete in the current subtraction branch.
+Status: complete.
 
 - `index_storage` configuration and Web lifespan composition are gone.
 - Retained index-job read/write routes, scheduling, reconciliation, runtime
@@ -115,10 +115,10 @@ Status: in progress.
 
 - Inventory every `codenib.storage` export and CLI command against non-test
   callers.
-- Move the portable-artifact validation response and error types that Web still
-  reaches through `storage.models` and `storage.protocols` to an
-  artifact-neutral owner; this residual import opens no catalog or runtime, but
-  it keeps the package boundary wider than the target architecture.
+- Portable-artifact validation now owns its bounded exact-JSON snapshot in the
+  artifact-neutral `_bounded_json` module. The retained protocol keeps a
+  compatibility wrapper, while the default Web import path no longer reaches
+  `codenib.storage`.
 - Remove zero-consumer protocols and their intersection/conformance tests in
   focused batches.
 - Separate any genuinely required compatibility adapter from experimental

--- a/test/storage/test_contracts.py
+++ b/test/storage/test_contracts.py
@@ -9,6 +9,7 @@ import hashlib
 import pytest
 
 import codenib.storage as storage_module
+import codenib.storage.protocols as storage_protocols
 from codenib.storage import (
     RETAINED_IMPORT_CATALOG_CONTRACT,
     RETAINED_IMPORT_RESPONSE_MAX_DEPTH,
@@ -271,6 +272,38 @@ def test_retained_import_response_budgets_are_public_capability_contracts() -> N
     assert RETAINED_IMPORT_RESPONSE_MAX_KEY_CHARS == 4_096
     assert RETAINED_IMPORT_RESPONSE_MAX_NODES == 250_000
     assert RETAINED_IMPORT_RESPONSE_MAX_TEXT_CHARS == 64 * 1024 * 1024
+
+
+@pytest.mark.parametrize(
+    ("constant", "limit", "value", "message"),
+    [
+        ("RETAINED_IMPORT_RESPONSE_MAX_DEPTH", 1, [None], "depth limit"),
+        ("RETAINED_IMPORT_RESPONSE_MAX_NODES", 1, [None], "node limit"),
+        (
+            "RETAINED_IMPORT_RESPONSE_MAX_TEXT_CHARS",
+            1,
+            {"a": "b"},
+            "invalid text",
+        ),
+        (
+            "RETAINED_IMPORT_RESPONSE_MAX_KEY_CHARS",
+            1,
+            {"ab": None},
+            "invalid object key",
+        ),
+    ],
+)
+def test_retained_import_response_wrapper_reads_dynamic_public_budgets(
+    monkeypatch: pytest.MonkeyPatch,
+    constant: str,
+    limit: int,
+    value: object,
+    message: str,
+) -> None:
+    monkeypatch.setattr(storage_protocols, constant, limit)
+
+    with pytest.raises(StorageIntegrityError, match=message):
+        storage_protocols.snapshot_retained_import_response(value, label="response")
 
 
 def test_retained_import_catalog_requires_explicit_contract_opt_in() -> None:

--- a/test/storage/test_lazy_exports.py
+++ b/test/storage/test_lazy_exports.py
@@ -12,6 +12,16 @@ def test_storage_exports_stay_compatible_without_eager_runtime_imports() -> None
     script = """
 import sys
 
+import codenib.web.app
+
+loaded_storage = {
+    name
+    for name in sys.modules
+    if name == "codenib.storage" or name.startswith("codenib.storage.")
+}
+if loaded_storage:
+    raise SystemExit(f"web app imported retained storage: {loaded_storage}")
+
 import codenib.storage as storage
 
 storage_modules = {
@@ -26,21 +36,6 @@ if missing or extra:
     raise SystemExit(f"lazy export mismatch: missing={missing}, extra={extra}")
 if not set(storage.__all__) <= set(dir(storage)):
     raise SystemExit("dir(codenib.storage) omitted public lazy exports")
-
-import codenib.web.app
-
-allowed_modules = {
-    "codenib.storage.models",
-    "codenib.storage.protocols",
-}
-loaded = {
-    name for name in sys.modules if name.startswith("codenib.storage.")
-}
-unexpected = loaded - allowed_modules
-if unexpected:
-    raise SystemExit(
-        f"web app imported storage modules outside the portable allowlist: {unexpected}"
-    )
 
 for name in storage.__all__:
     getattr(storage, name)

--- a/test/test_bounded_json.py
+++ b/test/test_bounded_json.py
@@ -17,6 +17,7 @@ import pytest
 from codenib._bounded_json import (
     canonical_json_array_chunks,
     iter_bounded_json_array,
+    snapshot_bounded_exact_json,
     validate_bounded_json_stream,
 )
 
@@ -31,6 +32,79 @@ class _ChunkReader:
         block = self.payload[self.offset : self.offset + self.chunk_size]
         self.offset += len(block)
         return block
+
+
+def test_bounded_exact_json_snapshot_detaches_containers() -> None:
+    source = {"items": [{"value": "original"}], "enabled": True}
+
+    snapshot = snapshot_bounded_exact_json(source, label="response")
+
+    assert snapshot == source
+    assert snapshot is not source
+    assert snapshot["items"] is not source["items"]
+    source["items"][0]["value"] = "changed"
+    assert snapshot["items"] == [{"value": "original"}]
+
+
+class _TrapDict(dict[str, object]):
+    calls = 0
+
+    def items(self):  # type: ignore[no-untyped-def]
+        type(self).calls += 1
+        raise AssertionError("dict subclass was traversed")
+
+
+class _TrapList(list[object]):
+    calls = 0
+
+    def __iter__(self):  # type: ignore[no-untyped-def]
+        type(self).calls += 1
+        raise AssertionError("list subclass was traversed")
+
+
+def test_bounded_exact_json_snapshot_rejects_container_subclasses_without_traversal() -> (
+    None
+):
+    for value, trap_type in ((_TrapDict(), _TrapDict), (_TrapList(), _TrapList)):
+        trap_type.calls = 0
+        with pytest.raises(ValueError, match="non-exact JSON value"):
+            snapshot_bounded_exact_json(value, label="response")
+        assert trap_type.calls == 0
+
+
+@pytest.mark.parametrize(
+    ("value", "limits", "message"),
+    [
+        ([None], {"max_nodes": 1}, "node limit"),
+        ([[None]], {"max_depth": 2}, "depth limit"),
+        ({"ab": None}, {"max_key_chars": 1}, "invalid object key"),
+        ({"a": "b"}, {"max_text_chars": 1}, "invalid text"),
+        ({"": None}, {}, "invalid object key"),
+        ({"value": "nul\x00text"}, {}, "invalid text"),
+        (2**63, {}, "invalid integer"),
+        (float("nan"), {}, "non-finite number"),
+        (object(), {}, "non-exact JSON value"),
+    ],
+)
+def test_bounded_exact_json_snapshot_enforces_exact_values_and_budgets(
+    value: object,
+    limits: dict[str, int],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        snapshot_bounded_exact_json(value, label="response", **limits)
+
+
+def test_bounded_exact_json_snapshot_supports_domain_error_types() -> None:
+    class DomainIntegrityError(RuntimeError):
+        pass
+
+    with pytest.raises(DomainIntegrityError, match="non-exact JSON value"):
+        snapshot_bounded_exact_json(
+            object(),
+            label="response",
+            error_type=DomainIntegrityError,
+        )
 
 
 @pytest.mark.parametrize(
@@ -455,8 +529,7 @@ def test_canonical_array_chunks_match_the_existing_json_contract() -> None:
 
 
 def _pipeline_rss(path: Path) -> dict[str, int]:
-    script = textwrap.dedent(
-        """
+    script = textwrap.dedent("""
         import hashlib
         import json
         import os
@@ -503,8 +576,7 @@ def _pipeline_rss(path: Path) -> dict[str, int]:
                 }
             )
         )
-        """
-    )
+        """)
     result = subprocess.run(
         [sys.executable, "-c", script, str(path)],
         check=True,


### PR DESCRIPTION
## Summary
Detach portable artifact validation from the retained-storage package so the default Web import path no longer loads codenib.storage. Preserve the retained compatibility API and all existing response-budget behavior.

## Changes
- Move the bounded exact-JSON snapshot algorithm to the neutral codenib._bounded_json module.
- Keep snapshot_retained_import_response as a compatibility wrapper that reads the four public retained budgets dynamically and raises StorageIntegrityError.
- Use the neutral helper from portable vector validation and prove a fresh Web import loads zero retained-storage modules.
- Update the storage subtraction roadmap to record the completed boundary cleanup.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- 1,065 targeted tests passed across bounded JSON, portable artifacts, storage contracts and SQLite, manifest import/export, Web, lazy imports, and release-artifact guards.
- Black, isort, flake8, compileall, diff checks, and focused mypy checks passed.
- Fresh-process import check reports an empty codenib.storage module set after importing codenib.web.app.

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published