### PR TITLE
test: defer optional ML runtime probes

### DIFF
--- a/test/agent/test_embedding_search_e2e.py
+++ b/test/agent/test_embedding_search_e2e.py
@@ -30,28 +30,30 @@ import pytest
 from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
 from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 
-
-def _cuda_available() -> bool:
-    try:
-        import torch
-    except Exception:
-        return False
-    return bool(torch.cuda.is_available())
-
-
-pytestmark = [
-    pytest.mark.slow,
-    pytest.mark.skipif(
-        not _cuda_available(),
-        reason="embedding_search e2e requires a CUDA-capable torch install",
-    ),
-]
+pytestmark = pytest.mark.slow
 
 DEFAULT_EMBEDDING_MODEL = "nomic-ai/CodeRankEmbed"
 DEFAULT_EMBEDDING_DIM = 768
 DEFAULT_EMBEDDING_PROVIDER = "huggingface"
 
 EMBEDDING_INDEX_PATH = "/tmp/embedding_e2e_index"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _require_embedding_runtime():
+    """Probe optional ML dependencies only when this slow module is selected."""
+
+    torch = pytest.importorskip(
+        "torch",
+        reason="embedding_search e2e requires torch",
+    )
+    cuda = getattr(torch, "cuda", None)
+    try:
+        cuda_available = cuda is not None and bool(cuda.is_available())
+    except Exception:
+        cuda_available = False
+    if not cuda_available:
+        pytest.skip("embedding_search e2e requires a CUDA-capable torch install")
 
 
 def _load_test_owned_vector(store, path):

--- a/test/serving/test_hf_engine.py
+++ b/test/serving/test_hf_engine.py
@@ -16,9 +16,6 @@ from typing import List, Tuple
 
 import pytest
 
-torch = pytest.importorskip("torch")
-pytest.importorskip("transformers")
-
 # Needs the model runtime from the ``serving`` extra, so it is not part of the
 # default unit tier.
 pytestmark = pytest.mark.slow
@@ -39,6 +36,8 @@ def _tiny_model():
     Built from config (no download). Eager attention is required so a custom 4D
     attention mask is honored rather than ignored by a fused kernel.
     """
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("transformers")
     from transformers import LlamaConfig, LlamaForCausalLM
 
     torch.manual_seed(0)
@@ -71,6 +70,8 @@ def _branches(tree: DraftTree) -> List[Tuple[DraftNode, List[int]]]:
 
 def _flat_argmax_after(model, seq: List[int]) -> int:
     """Greedy next-token id the model predicts after the flat sequence ``seq``."""
+    import torch
+
     with torch.no_grad():
         logits = model(torch.tensor([seq], dtype=torch.long)).logits[0]
     return int(logits[len(seq) - 1].argmax())

--- a/test/test_lazy_imports.py
+++ b/test/test_lazy_imports.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -23,6 +24,8 @@ forbidden = {
     "litellm",
     "matplotlib",
     "sentence_transformers",
+    "torch",
+    "transformers",
 }
 loaded = sorted(forbidden.intersection(sys.modules))
 if loaded:
@@ -36,6 +39,64 @@ if loaded:
         text=True,
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_non_slow_collection_does_not_probe_ml_runtimes() -> None:
+    root = Path(__file__).resolve().parents[1]
+    script = """
+import importlib.abc
+import sys
+
+import pytest
+
+watched = {"sentence_transformers", "torch", "transformers"}
+attempts = set()
+
+class RuntimeProbe(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path, target=None):
+        if fullname.partition(".")[0] in watched:
+            attempts.add(fullname)
+            raise ModuleNotFoundError(
+                f"blocked ML runtime probe: {fullname}",
+                name=fullname,
+            )
+        return None
+
+probe = RuntimeProbe()
+sys.meta_path.insert(0, probe)
+try:
+    exit_code = pytest.main(
+        [
+            "--collect-only",
+            "-q",
+            "-m",
+            "not slow",
+            "test/agent/test_embedding_search_e2e.py",
+            "test/serving/test_hf_engine.py",
+        ]
+    )
+finally:
+    sys.meta_path.remove(probe)
+
+allowed_exit_codes = {pytest.ExitCode.OK, pytest.ExitCode.NO_TESTS_COLLECTED}
+if exit_code not in allowed_exit_codes:
+    raise SystemExit(f"pytest collection failed with exit code {exit_code}")
+if attempts:
+    raise SystemExit(f"ML runtimes probed during collection: {sorted(attempts)}")
+"""
+
+    env = dict(os.environ)
+    env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+    env.pop("PYTEST_ADDOPTS", None)
+    env.pop("PYTEST_PLUGINS", None)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_sparse_ask_runtime_does_not_require_semantic_or_graph_extras() -> None:


### PR DESCRIPTION
## Summary
Stop deselected slow tests from importing Torch, Transformers, and SentenceTransformers during pytest collection. This isolates the ML test runtime from the default non-slow tier and confirms that the behavior is unrelated to storage or Web startup.

## Changes
- Move the embedding CUDA and optional-runtime checks from module import into the selected slow-test fixture.
- Load Torch and Transformers inside the HF test model helpers instead of at module collection time.
- Extend the Web lazy-import guard to forbid Torch and Transformers.
- Add a subprocess regression that records any ML runtime import attempted while collecting the two deselected slow modules.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- Full ML runtime: 13 selected slow tests passed and 5 lazy-import tests passed.
- Limited runtime: 13 selected slow tests skipped and the two relevant lazy/collection guards passed.
- Black, isort, flake8, compileall, and diff checks passed.

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published