### PR TITLE
chore(release): prepare v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable user-facing changes are recorded here. CodeNib follows
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-09-03
+
 ### Added
 
 - A Wiki-only `codenib.storage` facade exposing the domain-local `WikiStore`
@@ -249,7 +251,8 @@ All notable user-facing changes are recorded here. CodeNib follows
 - Prepared secretless PyPI publishing through a dedicated GitHub Actions OIDC
   workflow.
 
-[Unreleased]: https://github.com/sysevol-ai/CodeNib/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/sysevol-ai/CodeNib/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/sysevol-ai/CodeNib/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/sysevol-ai/CodeNib/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/sysevol-ai/CodeNib/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/sysevol-ai/CodeNib/compare/v0.1.0...v0.2.0

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -243,7 +243,7 @@ reasoning loop while replacing its repository data plane with
 localization baselines:
 
 ```bash
-python -m pip install "codenib[agent,graph]==0.2.2"
+python -m pip install "codenib[agent,graph]==0.2.3"
 codenib toolchain install /path/to/repository --scope graph
 ```
 

--- a/docs/codegraph.md
+++ b/docs/codegraph.md
@@ -14,10 +14,10 @@ bounded source reads.
 
 ## One-command setup
 
-Install CodeNib 0.2.2 with the graph runtime and official MCP SDK:
+Install CodeNib 0.2.3 with the graph runtime and official MCP SDK:
 
 ```bash
-python -m pip install "codenib[graph,mcp]==0.2.2"
+python -m pip install "codenib[graph,mcp]==0.2.3"
 codenib codegraph init /absolute/path/to/repository
 ```
 

--- a/docs/github_pages.md
+++ b/docs/github_pages.md
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.2
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.3
 ```
 
 The version tag keeps the compiler, frontend, Action, and artifact schema on
@@ -54,7 +54,7 @@ than natural-language retrieval quality:
 ```yaml
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.2
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.3
     with:
       preset: fast
 ```
@@ -71,7 +71,7 @@ artifact or Pages workflow:
 ```yaml
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.2
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.3
     with:
       preset: semantic
       embedding-provider: openai
@@ -141,7 +141,7 @@ The composite Action can be used directly when another static host or artifact
 store owns deployment:
 
 ```yaml
-- uses: sysevol-ai/CodeNib/.github/actions/publish@v0.2.2
+- uses: sysevol-ai/CodeNib/.github/actions/publish@v0.2.3
   id: codenib
   with:
     preset: fast

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,11 +34,11 @@ core decoder parity.
 
 ## Quick Start
 
-CodeNib 0.2.2 can prepare a local, model-free CodeGraph and register it with
+CodeNib 0.2.3 can prepare a local, model-free CodeGraph and register it with
 installed Codex and Claude Code clients in one command:
 
 ```bash
-python -m pip install "codenib[graph,mcp]==0.2.2"
+python -m pip install "codenib[graph,mcp]==0.2.3"
 codenib codegraph init /path/to/repository
 ```
 
@@ -49,7 +49,7 @@ the clients' own CLIs. The target checkout remains unchanged. Read the
 tool examples.
 
 ```bash
-python -m pip install "codenib[semantic]==0.2.2"
+python -m pip install "codenib[semantic]==0.2.3"
 codenib wiki /path/to/repository
 ```
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -13,11 +13,11 @@ then reuse that manifest across agent sessions.
 
 ## Install And Index
 
-For Codex or Claude Code, the recommended 0.2.2 path prepares the graph index
+For Codex or Claude Code, the recommended 0.2.3 path prepares the graph index
 and native client configuration together:
 
 ```bash
-python -m pip install "codenib[graph,mcp]==0.2.2"
+python -m pip install "codenib[graph,mcp]==0.2.3"
 codenib codegraph init /path/to/repository
 ```
 
@@ -31,14 +31,14 @@ For a custom MCP client or a retrieval-only setup, build and launch the server
 manually. The smaller no-model fallback is:
 
 ```bash
-python -m pip install "codenib[mcp]==0.2.2"
+python -m pip install "codenib[mcp]==0.2.3"
 codenib index /path/to/repository --preset fast
 ```
 
 Add static navigation and dependency tools without an embedding download:
 
 ```bash
-python -m pip install "codenib[graph,mcp]==0.2.2"
+python -m pip install "codenib[graph,mcp]==0.2.3"
 codenib toolchain install /path/to/repository --scope graph
 codenib index /path/to/repository --preset graph
 ```
@@ -120,8 +120,8 @@ absolute path to a repository previously indexed with `codenib index`. The
 declared launch is equivalent to:
 
 ```bash
-uvx --with "codenib[mcp]==0.2.2" \
-  "codenib==0.2.2" mcp /absolute/path/to/repository
+uvx --with "codenib[mcp]==0.2.3" \
+  "codenib==0.2.3" mcp /absolute/path/to/repository
 ```
 
 The Registry path is intentionally query-only and model-free. It can always
@@ -211,7 +211,7 @@ Parameter and return schemas live in
 The `full` preset requests BM25, vectors, a symbol graph, and Zoekt:
 
 ```bash
-python -m pip install "codenib[full]==0.2.2"
+python -m pip install "codenib[full]==0.2.3"
 codenib toolchain install /path/to/repository --scope graph
 codenib index /path/to/repository --preset full
 ```

--- a/docs/news.md
+++ b/docs/news.md
@@ -11,6 +11,15 @@ the complete version history, see
 [GitHub Releases](https://github.com/sysevol-ai/CodeNib/releases) and the
 [changelog](https://github.com/sysevol-ai/CodeNib/blob/main/CHANGELOG.md).
 
+## 2026-09-03 — Wiki-only storage boundary
+
+CodeNib 0.2.3 makes `codenib.storage` a single-file Wiki-only facade for
+`WikiStore` and `SQLiteWikiStore`. Repository indexes remain manifest-bound
+file artifacts, while the former generic catalog, CAS, and retained-storage
+CLI commands are removed.
+
+[Read the 0.2.3 release notes](releases/0.2.3.md)
+
 ## 2026-08-21 — Repository source authority
 
 CodeNib 0.2.2 admits absolute symlinks through authenticated indexing only

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,11 +18,11 @@ uses BM25 plus static symbol relationships and needs no model or API key.
 Install the exact release with its graph and MCP dependencies from PyPI:
 
 ```bash
-python -m pip install "codenib[graph,mcp]==0.2.2"
+python -m pip install "codenib[graph,mcp]==0.2.3"
 codenib --version
 ```
 
-The version command must report `codenib 0.2.2`. Exact version pins keep the
+The version command must report `codenib 0.2.3`. Exact version pins keep the
 environment reproducible.
 
 ## Connect A CodeGraph To Your Agent
@@ -96,7 +96,7 @@ Install the semantic extra when the browser Wiki should use local dense
 retrieval in addition to BM25:
 
 ```bash
-python -m pip install "codenib[semantic]==0.2.2"
+python -m pip install "codenib[semantic]==0.2.3"
 ```
 
 ```bash
@@ -230,7 +230,7 @@ To keep embeddings out of the local process, use a BYO OpenAI-compatible
 embedding service:
 
 ```bash
-python -m pip install "codenib[semantic-remote]==0.2.2"
+python -m pip install "codenib[semantic-remote]==0.2.3"
 export EMBEDDING_API_KEY=...
 codenib doctor --require semantic \
   --embedding-provider openai \
@@ -300,7 +300,7 @@ clangd, and live LSP providers are language-specific executables, so CodeNib
 plans them from the detected repository rather than installing every language:
 
 ```bash
-python -m pip install "codenib[graph]==0.2.2"
+python -m pip install "codenib[graph]==0.2.3"
 codenib toolchain status /path/to/repository --scope graph
 codenib toolchain install /path/to/repository --scope graph
 codenib doctor /path/to/repository --require graph
@@ -347,7 +347,7 @@ Static Wiki pages are the default. To generate conceptual page narratives
 through a LiteLLM-supported provider:
 
 ```bash
-python -m pip install "codenib[agent,semantic]==0.2.2"
+python -m pip install "codenib[agent,semantic]==0.2.3"
 export OPENAI_API_KEY=...
 codenib doctor --require agent \
   --model openai/gpt-4o-mini --api-key-env OPENAI_API_KEY --probe-model
@@ -378,7 +378,7 @@ codenib wiki . --generate --model anthropic/claude-sonnet-4-5
 Vertex AI additionally requires CodeNib's `vertex` extra:
 
 ```bash
-python -m pip install "codenib[agent,semantic,vertex]==0.2.2"
+python -m pip install "codenib[agent,semantic,vertex]==0.2.3"
 gcloud auth application-default login
 codenib wiki . --generate \
   --model vertex_ai/gemini-2.5-flash \
@@ -433,7 +433,7 @@ continues to work.
 ## Serve The Index Over MCP
 
 ```bash
-python -m pip install "codenib[mcp,semantic]==0.2.2"
+python -m pip install "codenib[mcp,semantic]==0.2.3"
 codenib index /path/to/repository
 codenib mcp /path/to/repository
 ```

--- a/docs/releases/0.2.3.md
+++ b/docs/releases/0.2.3.md
@@ -1,0 +1,74 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# CodeNib 0.2.3
+
+CodeNib 0.2.3 narrows the product database boundary to the Wiki domain. The
+public `codenib.storage` name is now a single-file, lazily loaded facade for
+`WikiStore`, its `SQLiteWikiStore` implementation, and their Wiki-specific
+types and errors. It no longer provides a generic repository catalog, content
+addressed store, job system, or backend registry.
+
+```bash
+python -m pip install --upgrade "codenib[graph,mcp]==0.2.3"
+codenib --version
+```
+
+## Wiki-only storage
+
+Applications that need to inject or open the supported Wiki store can import
+the complete public boundary from one module:
+
+```python
+from codenib.storage import SQLiteWikiStore, WikiStore
+```
+
+`WikiStore` owns complete Wiki cache envelopes and only the operations used by
+the Wiki consumer: reading, atomic publication, maintenance scans, and
+generation serialization. `SQLiteWikiStore` stores those envelopes in
+`wiki_cache/wiki.sqlite3` with a versioned one-table schema, SQLite WAL,
+bounded canonical JSON, record digests, short transactions, and cross-process
+generation guards.
+
+AgentWiki, the Web service, cache audit, prewarming, and Wiki benchmarks now
+share that database boundary. Eligible entries from the earlier JSON cache
+remain available through read-through compatibility; CodeNib does not rewrite
+or delete those source files during a read.
+
+## Repository indexes remain artifacts
+
+`RepoManifest`, BM25, FAISS, igraph, and portable context payloads remain
+manifest-bound file artifacts. Existing compiler caches can be packaged with
+`codenib artifact pack`; portable artifacts remain supported by `codenib
+artifact verify` and `codenib mcp --artifact`.
+
+No catalog data is migrated into `WikiStore`. Wiki cache entries and repository
+artifacts have separate ownership and lifecycle contracts, and sharing SQLite
+does not make them one storage abstraction.
+
+## Removed generic storage surface
+
+The v0.2.2 generic `codenib.storage` package, including `SQLiteCatalog`,
+`LocalCAS`, storage protocols, schema state, and backend discovery, is removed.
+The `artifact import-cache`, `artifact materialize`, `storage audit`, and
+retained index-publication commands are also absent from 0.2.3. Unreleased Web
+index jobs, retained BM25 activation, durable storage workers, catalog-backed
+clangd FactBatch reuse, and their configuration surfaces are removed without
+changing the normal index, Wiki, publish, portable-artifact, or MCP routes.
+
+## Upgrade from 0.2.2
+
+- A v0.2.2 SQLite catalog cannot be opened by 0.2.3. Before upgrading, use a
+  pinned CodeNib 0.2.2 environment and its `artifact materialize` command to
+  produce a portable context artifact. Upgrade only after
+  `codenib artifact verify` succeeds for that artifact.
+- Do not migrate catalog rows into `WikiStore`; it accepts Wiki cache envelopes,
+  not repository refs, snapshots, CAS objects, jobs, or leases.
+- Existing compiler cache directories do not need a catalog migration. Use
+  `codenib artifact pack` when a portable copy is required.
+- The 0.2.2 source-selection and manifest compatibility rules remain in force;
+  normal repositories can be re-indexed or reused through their existing
+  manifest-bound routes.

--- a/docs/scip_index.md
+++ b/docs/scip_index.md
@@ -23,7 +23,7 @@ Install the graph dependencies, check the target repository, and then select
 the graph preset:
 
 ```bash
-python -m pip install "codenib[graph]==0.2.2"
+python -m pip install "codenib[graph]==0.2.3"
 codenib toolchain install /path/to/repository --scope graph
 codenib doctor /path/to/repository --require graph
 codenib index /path/to/repository --preset graph

--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -10,7 +10,7 @@ For one local repository, use the packaged two-command path in the
 [Quickstart](quickstart.md):
 
 ```bash
-python -m pip install "codenib[semantic]==0.2.2"
+python -m pip install "codenib[semantic]==0.2.3"
 codenib wiki /path/to/repository
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -170,6 +170,7 @@ nav:
       - get-started/index.md
       - Quickstart: quickstart.md
       - Agent-ready CodeGraph: codegraph.md
+      - Release 0.2.3: releases/0.2.3.md
       - Release 0.2.2: releases/0.2.2.md
       - Release 0.2.1: releases/0.2.1.md
       - Release 0.2.0: releases/0.2.0.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codenib"
-version = "0.2.2"
+version = "0.2.3"
 description = "A multi-view data system for serving repository context to coding agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -8,19 +8,19 @@
     "url": "https://github.com/sysevol-ai/CodeNib",
     "source": "github"
   },
-  "version": "0.2.2",
+  "version": "0.2.3",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "codenib",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "runtimeHint": "uvx",
       "runtimeArguments": [
         {
           "type": "named",
           "name": "--with",
-          "value": "codenib[graph,mcp]==0.2.2",
+          "value": "codenib[graph,mcp]==0.2.3",
           "description": "Install the version-matched CodeNib CodeGraph and MCP runtime."
         }
       ],

--- a/test/test_mcp_registry.py
+++ b/test/test_mcp_registry.py
@@ -18,11 +18,11 @@ def test_registry_metadata_matches_package_and_uvx_contract() -> None:
 
     version, server = registry.validate_registry_metadata(root)
 
-    assert version == "0.2.2"
+    assert version == "0.2.3"
     assert server["name"] == "ai.codenib/codenib"
     package = server["packages"][0]
     assert package["identifier"] == "codenib"
-    assert package["runtimeArguments"][0]["value"] == ("codenib[graph,mcp]==0.2.2")
+    assert package["runtimeArguments"][0]["value"] == ("codenib[graph,mcp]==0.2.3")
     assert package["packageArguments"][1]["format"] == "filepath"
 
 

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -192,8 +192,8 @@ def test_project_identity_and_tag_match_release_metadata() -> None:
     name, version = project_identity(root / "pyproject.toml")
 
     assert name == "codenib"
-    assert expected_tag(version) == "v0.2.2"
-    validate_tag("v0.2.2", version)
+    assert expected_tag(version) == "v0.2.3"
+    validate_tag("v0.2.3", version)
 
 
 def test_release_tag_must_match_project_version() -> None:
@@ -378,16 +378,20 @@ def test_select_compatible_wheel_rejects_unsupported_platform(tmp_path: Path) ->
         select_compatible_wheel(dist, system="linux", machine="ppc64le")
 
 
-def test_stable_release_notes_describe_the_repository_source_contract() -> None:
+def test_stable_release_notes_describe_the_wiki_storage_boundary() -> None:
     root = Path(__file__).resolve().parents[1]
-    notes = (root / "docs" / "releases" / "0.2.2.md").read_text(encoding="utf-8")
+    notes = (root / "docs" / "releases" / "0.2.3.md").read_text(encoding="utf-8")
 
-    assert '"codenib[graph,mcp]==0.2.2"' in notes
-    assert "codenib codegraph init" in notes
-    assert "--exclude-dir" in notes
-    assert "contained absolute symlinks" in notes.lower()
-    assert "Manifest 1.2" in notes
-    assert "Zoekt" in notes
+    assert '"codenib[graph,mcp]==0.2.3"' in notes
+    assert "single-file" in notes
+    assert "`codenib.storage`" in notes
+    assert "`WikiStore`" in notes
+    assert "`SQLiteWikiStore`" in notes
+    assert "manifest-bound file artifacts" in notes
+    assert "`artifact materialize`" in notes
+    assert "pinned CodeNib 0.2.2" in notes
+    assert "`SQLiteCatalog`" in notes
+    assert "`LocalCAS`" in notes
     assert "test-files.pythonhosted.org" not in notes
     assert "--extra-index-url" not in notes
     assert "--index-url" not in notes
@@ -431,7 +435,7 @@ def test_public_install_commands_select_the_current_stable_release(
 
     assert install_lines
     assert "CODENIB_ALPHA_WHEEL=" not in text
-    assert all("==0.2.2" in line for line in install_lines)
+    assert all("==0.2.3" in line for line in install_lines)
 
 
 def test_readme_install_commands_remain_unpinned() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -572,7 +572,7 @@ wheels = [
 
 [[package]]
 name = "codenib"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Prepare CodeNib 0.2.3 as the release of the simplified Wiki-only storage boundary merged in #762 and #763. This keeps `codenib.storage` as a narrow `WikiStore` facade while the former generic catalog/CAS surface remains retired.

## Changes

- Bump package, lockfile, MCP Registry, and runtime package metadata from 0.2.2 to 0.2.3.
- Move the current changelog batch into a dated 0.2.3 section and add dedicated release notes.
- Update stable public installation pins, GitHub Pages reusable refs, News, and MkDocs navigation.
- Update release and MCP metadata assertions for 0.2.3.
- Preserve 0.2.2 wherever it is the real catalog-migration baseline, historical version, or dependency lower bound; keep README install examples intentionally unpinned.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- 118 release metadata, MCP registry, artifact, upgrade-helper, public-doc, storage facade, and SQLite WikiStore tests passed in an isolated 0.2.3 environment.
- `uv lock --check` passed and changed only the editable CodeNib package version.
- MCP Registry metadata validation passed as `ai.codenib/codenib 0.2.3`.
- Strict MkDocs build and public-doc boundary validation passed.
- The 0.2.3 source distribution built successfully and contains the Wiki-only `codenib/storage.py` layout.
- Black, isort, flake8, JSON parsing, and `git diff --check` passed for the changed surface.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
