### PR TITLE
feat(storage): add bounded BM25 persistence experiment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,10 +31,10 @@ For the current multi-language SCIP cold-start and acceleration program, use
 whenever a backend is promoted, a C++ acceleration gate changes, or a related
 issue/PR is closed.
 
-For storage scope and subtraction, use `docs/storage_backend_roadmap.md` as the
-durable objective record. Update it whenever the Wiki database boundary
-changes, a retained compatibility surface is removed, or a proposal attempts
-to reopen the generic backend program.
+For the storage boundary and the time-bounded hybrid-index experiment, use
+`docs/storage_backend_roadmap.md` as the durable objective record. Update it
+whenever the Wiki database boundary changes, an experiment gate changes, or a
+related issue or PR is reconciled.
 
 For the cognitive-debt reduction program, use
 `docs/cognitive_debt_roadmap.md` as the durable objective record. Update it
@@ -56,12 +56,26 @@ completed.
   facade and the retained-storage CLI commands were removed. Do not turn that
   module back into a package or reintroduce a generic catalog, CAS, schema
   state, storage protocol, backend registry, or product route.
-- PostgreSQL, S3-compatible storage, generic garbage collection, shared ANN,
-  distributed coordination, and backend discovery are closed plans. Reopening
-  one requires a current non-test product route, a deployment constraint the
-  existing Wiki/artifact model cannot meet, representative measurements, and
-  an explicit scope decision. Tests, roadmap entries, and planned adapters do
-  not count as consumers.
+- One exception is authorized through 2026-10-04: the source-checkout-only H1
+  experiment under `scripts/experimental/hybrid_index/`, its developer script,
+  and focused tests. H1 accepts exactly one verified BM25-only portable
+  artifact, stores its immutable archive in one local SHA-256 CAS, and records
+  generation, snapshot, and ref identity in one private four-table SQLite WAL
+  catalog. It must not be installed under `codenib`, shipped in a wheel,
+  imported by product code, exposed by the official CLI, or wired into Web,
+  MCP, configuration, or a default route.
+- The H1 owner is the index/artifact maintainers. By 2026-10-04 they must either
+  promote it through an explicit scope decision backed by a current non-test
+  consumer, a representative benchmark, portable-artifact compatibility, and
+  the recorded safety gates, or delete its implementation, executable script,
+  and dedicated tests while retaining the decision record. Default-off or
+  source-only status is not permission to keep an unevaluated experiment.
+- H2-H7 are demand-gated hypotheses, not implementation authorization. Do not
+  add FAISS/igraph persistence, jobs, leases, hot switching, per-file CAS,
+  xref de-materialization, GC, overlays, PostgreSQL, object storage, shared ANN,
+  distributed coordination, or backend discovery before the preceding gate
+  and a current product need are recorded in the roadmap. Tests, roadmap
+  entries, and planned adapters do not count as consumers.
 - Put any future persistence protocol at a real domain I/O boundary. Name the
   current production call site, use one domain protocol and one implementation
   first, and remove the old path in the same program. Sharing SQLite does not

--- a/docs/cognitive_debt_roadmap.md
+++ b/docs/cognitive_debt_roadmap.md
@@ -88,13 +88,15 @@ source and manifest contracts
 
 Wiki consumer -> WikiStore -> SQLiteWikiStore
 manifest-bound views -> BM25 / FAISS / igraph / portable file artifacts
+source-only H1 experiment -> published artifact contracts
 labs and experiments -> published contracts only
 ```
 
 `web` must not own Wiki domain behavior, MCP must not own the reusable
 repository runtime, and `compiler` and `artifacts` must not import each other.
 Generic catalog, snapshot, job, lease, and object-store machinery is not on a
-protected product path.
+protected product path. The bounded H1 experiment is evidence-gathering outside
+the installed package, not another product runtime.
 
 ## Workstreams
 
@@ -154,6 +156,29 @@ Status: in progress.
 
 Exit condition: protected product journeys use only the Wiki database facade
 and manifest-bound artifacts; no generic storage surface remains.
+
+### S1E: Time-bounded hybrid-index evidence
+
+Status: experimental through 2026-10-04.
+
+Owner: index/artifact maintainers.
+
+- Keep the candidate under `scripts/experimental/hybrid_index/`, outside the
+  installed `codenib` namespace and every default product import.
+- Accept exactly one verified BM25-only portable artifact and use exactly one
+  SQLite WAL catalog plus local SHA-256 CAS implementation.
+- Add no stable export, official CLI/configuration, Web/MCP route, backend
+  registry, additional view, job, lease, GC, overlay, or remote adapter.
+- Treat a real non-test consumer, a representative benchmark, portable
+  round-trip compatibility, and the recorded failure matrix as promotion
+  prerequisites rather than follow-up work.
+- By 2026-10-04, make an explicit promotion decision or delete the
+  implementation, executable script, and dedicated tests while retaining the
+  evidence record.
+
+Exit condition: H1 is either promoted by a new scope decision that names the
+old path it replaces, or fully removed. Source-only and default-off code does
+not receive an indefinite exception.
 
 ### S2: Stable versus labs packaging
 
@@ -236,6 +261,7 @@ Status: pending.
 | 2026-09-01 | Make WikiStore the only product database and stop the generic backend program | Storage audit counts, protected-journey consumer tracing, and the one-table Wiki conformance results are summarized in `storage_backend_roadmap.md` | Remove the Web retained-storage vertical; freeze generic storage/CLI compatibility code and delete it by proven consumer; close PostgreSQL, S3, generic GC, and dynamic-registry plans |
 | 2026-09-02 | Use the next release as the generic-storage removal boundary | The consumer audit found only the two retained artifact bridges and one catalog-backed FactBatch profile; ordinary product routes were independent | Delete the complete generic package and callers; keep v0.2.2 only as the pre-upgrade materialization tool |
 | 2026-09-03 | Publish the subtraction as v0.2.3 and reserve `codenib.storage` for the Wiki database | `WikiStore` is the only product database contract, while the old package name remains the clearest public entry point | Add one lazy Wiki-only module with an exact export list; keep all generic submodules, protocols, catalogs, and CAS implementations retired |
+| 2026-09-03 | Authorize one source-only BM25 H1 evidence experiment without reopening the stable storage boundary | `docs/experiments/hybrid_index_h1.md` records its schema, linearization points, verified failure matrix, commands, and diagnostic benchmark | Keep it outside the wheel and product routes; promote through an explicit demand-backed decision or delete code, script, and tests by 2026-10-04 |
 
 ## Completion Gate
 

--- a/docs/experiments/hybrid_index_h1.md
+++ b/docs/experiments/hybrid_index_h1.md
@@ -1,0 +1,197 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# H1 Hybrid-index Persistence Experiment
+
+## Lifecycle
+
+| Field | Value |
+| --- | --- |
+| Class | `experimental` |
+| Owner | index/artifact maintainers |
+| Decision date | 2026-09-03 |
+| Promote-or-delete deadline | 2026-10-04 |
+| Tracker | #765 |
+| Stable API or CLI | none |
+| Current non-test consumer | none; promotion blocker |
+| Package location | none; source checkout only |
+
+H1 asks one narrow question: does a local SQLite WAL control plane plus a local
+content-addressed archive improve a real BM25 workflow enough to justify a
+maintained persistence boundary? It does not reopen the stable storage API.
+
+The candidate lives only in:
+
+- `scripts/experimental/hybrid_index/`;
+- `scripts/experimental/index_persistence.py`;
+- `test/scripts/hybrid_index/`;
+- `test/scripts/test_experimental_index_persistence.py`.
+
+It accepts exactly one verified portable context artifact whose only view is
+BM25. FAISS, igraph, jobs, leases, hot switching, xref changes, per-file units,
+GC, overlays, PostgreSQL, and object storage are later gated hypotheses.
+
+The complexity budget is one concrete backend composition, one repository
+harness, three operations, four tables, two developer commands, no dependency,
+no public export, and no product route.
+
+## Store and Schema
+
+The selected root contains `catalog.sqlite3` and
+`objects/sha256/<first-two-hex>/<remaining-hex>`. The object name is the SHA-256
+of one deterministic `ZIP_STORED` archive of the already verified portable
+artifact. The catalog uses application id `CNIX`, schema version 1, WAL mode,
+foreign keys, and `synchronous=FULL`.
+
+The H1 CAS requires same-filesystem hard-link publication. It has no fallback
+backend and intentionally omits generic byte reads, arbitrary materialization,
+deletion, discovery, and adapter APIs.
+
+The schema has exactly four tables:
+
+| Table | Identity and role |
+| --- | --- |
+| `generations` | Immutable `generation_id` row binding repository, commit, source fingerprint, `view_type=bm25`, metadata digest, archive digest/size, and artifact counts |
+| `snapshots` | Immutable `snapshot_id` row binding one repository, commit, and source fingerprint |
+| `snapshot_generations` | Immutable membership; primary key `(snapshot_id, view_type)` and foreign keys to the snapshot and generation |
+| `refs` | The only mutable state; primary key `(repository, ref_name)`, pointing to a same-repository snapshot with a positive revision |
+
+H1 snapshots contain exactly one BM25 generation. `generation_id` is derived
+from the portable context metadata digest; `snapshot_id` is derived from the
+repository/source identity and generation membership. Opening an existing
+catalog requires the exact application id, schema version, and canonical schema
+signature. This is a trusted local cache, not an authorization or tenancy
+boundary.
+
+## Publication and Read Linearization
+
+Publication proceeds in this order:
+
+1. Verify the input with the ordinary portable-artifact verifier and reject any
+   view set other than exactly `("bm25",)`.
+2. Re-read the authenticated artifact tree into a deterministic archive. Store
+   it under its SHA-256, flush its bytes, publish or verify the exact immutable
+   winner, and flush the containing directory.
+3. Extract and verify that CAS archive in a private preflight directory against
+   repository, commit, source fingerprint, view, and metadata identity.
+4. Start SQLite `BEGIN IMMEDIATE`; insert or validate the immutable generation,
+   snapshot, and membership; compare the expected ref revision; then insert or
+   update the ref and commit.
+
+The ref insert or guarded update chooses the logical winner inside the write
+transaction; the containing commit is the external visibility point. A reader
+pins the ref and its complete snapshot closure in one SQLite read transaction.
+Object bytes are durable before catalog publication begins, so a failure may
+leave an unreachable CAS object but cannot publish a ref to an incomplete
+transaction. H1 deliberately has no deletion or orphan-reclamation path.
+
+For a new ref, `expected_revision=0` creates revision 1. A different snapshot
+requires the exact current revision and advances it by one. Retrying the exact
+already-published snapshot is idempotent and does not advance the revision.
+
+## Required Failure Matrix
+
+No row is considered verified until its focused test and the final combined H1
+command pass at the same revision.
+
+| Boundary | Required observable result | Status |
+| --- | --- | --- |
+| Unrelated, identified, or drifted SQLite file | Fail closed without adopting or rewriting it | Verified at `247b1dc5` |
+| Concurrent first catalog open | One canonical four-table CNIX/WAL database | Verified at `247b1dc5` |
+| Invalid or non-BM25 portable input | No ref or catalog publication | Verified at `247b1dc5` |
+| Artifact changes while archived | Publication fails; no ref becomes visible | Verified at `247b1dc5` |
+| CAS temporary write or publish failure | No corrupt canonical object; temporary state is cleaned | Verified at `247b1dc5` |
+| Concurrent identical CAS puts | All callers receive the same verified digest without false mutation errors | Verified at `247b1dc5`; 20 repeated eight-writer runs |
+| Failure after durable CAS and before SQLite commit | At most an unreachable object; old ref remains readable | Verified at `247b1dc5` |
+| Injected failure immediately before ref mutation | Generation, snapshot, membership, and ref transaction rolls back | Verified at `247b1dc5` |
+| Two publishers use the same expected revision | Exactly one different snapshot wins; loser reports conflict | Verified at `247b1dc5`; 20 repeated runs |
+| Exact publication retry | Same snapshot and revision are returned | Verified at `247b1dc5` |
+| Reader overlaps a publisher | Reader observes one complete old or new snapshot closure | Verified at `247b1dc5` |
+| Missing, replaced, or corrupt CAS object on export | Fail before a verified destination is published | Verified at `0bf6e752` |
+| Symlinked destination ancestor or interrupted extraction | No path escape, foreign write, or leaked stage | Verified at `247b1dc5`, including the existing archive stage-swap test |
+| Store is removed after successful export | Exported artifact still verifies and serves through ordinary BM25/MCP | Verified at `247b1dc5` |
+| Wheel and stable command inspection | No `codenib` experimental module, export, command, or default import | Verified at `247b1dc5` |
+
+The catalog's `_before_ref_update` hook exists only for the named transaction
+failure test. New arbitrary line-by-line fault seams require a reproduced bug.
+
+## Developer Commands
+
+These commands require a source checkout. The two experimental subcommands are
+not part of the `codenib` CLI contract.
+
+```bash
+codenib artifact pack /path/to/repo \
+  --output /tmp/codenib-bm25-artifact \
+  --repository owner/repository \
+  --view bm25
+
+python scripts/experimental/index_persistence.py publish-bm25 \
+  /tmp/codenib-bm25-artifact \
+  --store /tmp/codenib-h1-store \
+  --ref main \
+  --expected-revision 0
+
+python scripts/experimental/index_persistence.py export-ref \
+  owner/repository \
+  /tmp/codenib-bm25-export \
+  --store /tmp/codenib-h1-store \
+  --ref main
+
+codenib artifact verify /tmp/codenib-bm25-export
+codenib mcp --artifact /tmp/codenib-bm25-export \
+  --repository owner/repository
+```
+
+The focused H1 command passed at `0bf6e752`: **36 passed**. The repository unit
+tier additionally reached **6,919 passed, 34 skipped**; its only unavailable
+cases were two pre-existing tests that resolve `/usr/bin/docker`, which is not
+installed on the benchmark host. The other 38 Docker tests passed when those
+two environment-bound cases were deselected.
+
+```bash
+.venv/bin/pytest -q \
+  test/scripts/hybrid_index \
+  test/scripts/test_experimental_index_persistence.py
+```
+
+## Benchmark Receipt
+
+The first diagnostic receipt uses thresholds fixed before its run: exact
+top-20 BM25 projection parity; ten identical republishes add no CAS object,
+object bytes, generation, snapshot, membership, or ref revision; warm ref
+resolve p95 is at most 25 ms; republish p95 is at most 5 seconds; export p95 is
+at most 2 seconds for an artifact no larger than 50 MiB; and retained store
+bytes are at most archive bytes plus 1 MiB. Passing these diagnostics cannot
+replace the missing real-consumer gate.
+
+| Field | Required value | Current value |
+| --- | --- | --- |
+| Repository and immutable commit | Representative real BM25 workload | CodeNib `247b1dc5f495d444ed65280b60e28921c933b845`; 573 Python files, 8,682 chunks |
+| Host/filesystem/Python/CodeNib revision | Reproducible environment | Linux 6.17 aarch64, Lustre, Python 3.14.6, CodeNib `247b1dc5` |
+| Repetitions and cold/warm policy | 1 cold operation followed by 10 warm repetitions | Fixed as stated above |
+| Baseline | Direct verified portable artifact load and query | Verify p50/p95 559.4/562.6 ms; load 1,308.9 ms; query p50/p95 5.40/8.29 ms |
+| Candidate | Publish, resolve/export, then the same ordinary load and query | Initial publish 1,810.4 ms; republish p50/p95 1,788.8/1,799.0 ms; resolve 0.47/0.59 ms; export 1,182.4/1,194.6 ms; load 1,301.1 ms; query 5.63/7.93 ms |
+| Correctness | Exact manifest identity and deterministic query-result parity | Exact top-20 parity; source fingerprint `sha256-v2:44c8bd30...e280957` |
+| Latency | Publish, resolve, export, cold query, and warm-query p50/p95 | All diagnostic limits passed |
+| Resources | Peak RSS and retained bytes, including SQLite WAL and CAS | Peak process RSS 167,744 KiB; 10,943,912-byte archive; 10,993,064-byte store |
+| Concurrency | Same-ref conflict and same-digest dedup workload | Unit gates passed; 20 repeated runs each |
+| Promotion thresholds | Numeric latency/storage limits agreed before run | All diagnostic limits passed; real-consumer threshold remains TBD |
+
+Ten identical republishes kept exactly one object, one row in each table, ref
+revision 1, and zero retained-byte growth. The archive held three files and
+10,941,994 uncompressed bytes; store overhead was 49,152 bytes. The benchmark
+query returned 20 identical projected results before and after persistence.
+
+## Decision
+
+Promotion requires every failure row, package boundary, portable round trip,
+real consumer, and benchmark threshold to pass. Promotion must also identify
+the old product path it replaces; it does not automatically authorize H2.
+
+If those conditions are not recorded by 2026-10-04, remove the implementation,
+developer script, and dedicated tests. Keep this document with the negative or
+inconclusive receipt and mark H1 retired in the storage roadmap.

--- a/docs/experiments/hybrid_index_h1.md
+++ b/docs/experiments/hybrid_index_h1.md
@@ -88,6 +88,8 @@ pins the ref and its complete snapshot closure in one SQLite read transaction.
 Object bytes are durable before catalog publication begins, so a failure may
 leave an unreachable CAS object but cannot publish a ref to an incomplete
 transaction. H1 deliberately has no deletion or orphan-reclamation path.
+Export verifies the CAS digest, size, metadata digest, payload file count, and
+payload byte count before the ordinary extractor prepares its destination.
 
 For a new ref, `expected_revision=0` creates revision 1. A different snapshot
 requires the exact current revision and advances it by one. Retrying the exact
@@ -101,7 +103,7 @@ command pass at the same revision.
 | Boundary | Required observable result | Status |
 | --- | --- | --- |
 | Unrelated, identified, or drifted SQLite file | Fail closed without adopting or rewriting it | Verified at `247b1dc5` |
-| Concurrent first catalog open | One canonical four-table CNIX/WAL database | Verified at `247b1dc5` |
+| Concurrent first catalog open | One canonical four-table CNIX/WAL database | Verified at `178c3a35`; 100 repeated 16-thread and 30 repeated eight-process review runs |
 | Invalid or non-BM25 portable input | No ref or catalog publication | Verified at `247b1dc5` |
 | Artifact changes while archived | Publication fails; no ref becomes visible | Verified at `247b1dc5` |
 | CAS temporary write or publish failure | No corrupt canonical object; temporary state is cleaned | Verified at `247b1dc5` |
@@ -112,9 +114,12 @@ command pass at the same revision.
 | Exact publication retry | Same snapshot and revision are returned | Verified at `247b1dc5` |
 | Reader overlaps a publisher | Reader observes one complete old or new snapshot closure | Verified at `247b1dc5` |
 | Missing, replaced, or corrupt CAS object on export | Fail before a verified destination is published | Verified at `0bf6e752` |
+| Catalog generation counts or archive identity drift | Fail before creating the export destination or an extraction stage | Verified at `178c3a35` |
+| Symlinked store root or catalog file | Fail without writing through the final symlink | Verified at `178c3a35` |
 | Symlinked destination ancestor or interrupted extraction | No path escape, foreign write, or leaked stage | Verified at `247b1dc5`, including the existing archive stage-swap test |
 | Store is removed after successful export | Exported artifact still verifies and serves through ordinary BM25/MCP | Verified at `247b1dc5` |
-| Wheel and stable command inspection | No `codenib` experimental module, export, command, or default import | Verified at `247b1dc5` |
+| SQLite failure through the developer command | Exit 1 with one concise error and no traceback | Verified at `178c3a35` |
+| Wheel and stable command inspection | No `codenib` experimental module, export, command, or default import | Verified at `86fbe2cb`, including the actual source-only script paths |
 
 The catalog's `_before_ref_update` hook exists only for the named transaction
 failure test. New arbitrary line-by-line fault seams require a reproduced bug.
@@ -147,7 +152,7 @@ codenib mcp --artifact /tmp/codenib-bm25-export \
   --repository owner/repository
 ```
 
-The focused H1 command passed at `0bf6e752`: **36 passed**. The repository unit
+The focused H1 command passed at `178c3a35`: **40 passed**. The repository unit
 tier additionally reached **6,919 passed, 34 skipped**; its only unavailable
 cases were two pre-existing tests that resolve `/usr/bin/docker`, which is not
 installed on the benchmark host. The other 38 Docker tests passed when those
@@ -186,6 +191,15 @@ Ten identical republishes kept exactly one object, one row in each table, ref
 revision 1, and zero retained-byte growth. The archive held three files and
 10,941,994 uncompressed bytes; store overhead was 49,152 bytes. The benchmark
 query returned 20 identical projected results before and after persistence.
+
+The export-integrity fix was rechecked from clean `86fbe2cb` on the same host
+and workload class: 573 Python files and 8,684 chunks. Initial publish was
+1,788.1 ms; ten exact republishes had p50/p95 1,782.1/1,788.4 ms; 20 ref
+resolves had p50/p95 0.417/0.476 ms; and ten exports had p50/p95
+1,175.9/1,180.4 ms. The 10,947,167-byte archive digest was
+`38154aef6212bdd89a82ecc66b0d2275046349fd3648f2d867b12ebcf4d54b4a`.
+The changed export path therefore remains below the pre-fixed 2-second p95
+threshold without a second extraction pass.
 
 ## Decision
 

--- a/docs/experiments/hybrid_index_h1.md
+++ b/docs/experiments/hybrid_index_h1.md
@@ -15,6 +15,7 @@ SPDX-License-Identifier: Apache-2.0
 | Decision date | 2026-09-03 |
 | Promote-or-delete deadline | 2026-10-04 |
 | Tracker | #765 |
+| Implementation PR | #766 |
 | Stable API or CLI | none |
 | Current non-test consumer | none; promotion blocker |
 | Package location | none; source checkout only |

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -4,176 +4,189 @@ SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Storage Scope and Subtraction Roadmap
+# Hybrid Index Storage Roadmap
 
-## Current Decision
+## Stable Product Boundary
 
 CodeNib has one public product database boundary: `codenib.storage.WikiStore`.
-The single-file facade points to the domain-local contract and its supported
-`SQLiteWikiStore` implementation, which uses SQLite WAL and a deliberately
-small schema. Constructor injection and the Wiki store conformance suite are
-the pluggable harness; a backend registry or generic catalog is not part of the
-product design.
+The single-file facade points to the Wiki-owned contract and its supported
+`SQLiteWikiStore` implementation. Constructor injection plus the Wiki
+conformance suite is the complete stable pluggability boundary; there is no
+stable storage registry, catalog, CAS, or remote backend API.
 
-Repository search state remains in the formats that already serve it:
+Repository search state keeps its existing portable contract:
 
 - `RepoManifest` records source identity and available views;
 - BM25, FAISS, igraph, and portable context payloads remain file artifacts;
-- product readers load those artifacts through their existing manifest-bound
-  routes rather than copying their lifecycle into a database.
+  those files stay bound to `RepoManifest` identity;
+- ordinary compiler, artifact, and MCP readers remain authoritative.
 
-The optional Web `index_storage` vertical, including retained index jobs and
-runtime activation, has been removed. It was not required by the protected
-CodeGraph, Wiki, MCP, or `RepositoryContextExplorer` journeys.
+The source-only experiment described below does not change those statements.
+In particular, it must not turn `codenib.storage` back into a package or make
+a database necessary to query a portable artifact.
 
-At the v0.2.3 boundary, the generic `codenib.storage` package is replaced by a
-single Wiki-only `codenib.storage` module and its retained-storage CLI commands
-are removed. No generic catalog, CAS, or database compatibility layer remains
-in the product. A v0.2.2 catalog must be materialized with a pinned v0.2.2
-environment before upgrading; the resulting portable context artifact remains
-supported by the ordinary artifact and MCP routes.
+## H0: v0.2.3 Subtraction Baseline
 
-## Product Boundary
+Status: complete and released on 2026-09-03.
 
-```python
-from codenib.storage import SQLiteWikiStore, WikiStore
-```
+The v0.2.3 boundary is the baseline, not an implementation to undo:
 
-`WikiStore` owns only complete Wiki cache envelopes and the minimum operations
-the Wiki consumer uses:
+- #748 added the narrow Wiki store.
+- #753 through #762 removed the zero-consumer retained-storage product routes,
+  workers, benchmark, generic catalog/CAS package, and catalog-backed FactBatch
+  experiment.
+- #763 reserved the public `codenib.storage` name for the Wiki-only facade.
+- #764 released that boundary as v0.2.3.
 
-- read one entry;
-- atomically publish one entry;
-- scan entries for Wiki maintenance;
-- serialize generation of the same entry.
+The earlier storage RFC #199 is closed historical evidence. Existing v0.2.2
+catalogs must be materialized with a pinned v0.2.2 environment before upgrading;
+the resulting portable artifact remains supported. No catalog rows migrate
+into `WikiStore`.
 
-`SQLiteWikiStore` remains a trusted, regenerable local cache. Its one-table
-schema, bounded canonical JSON, record digest, short transactions, WAL mode,
-and cross-process generation guard cover the current product need. It is not a
-general repository catalog, object store, job scheduler, lease service, or
-authorization database.
-
-The following are explicitly outside this database boundary:
-
-- repository refs, snapshots, view generations, build jobs, and worker leases;
-- BM25 documents, vector indexes, graph payloads, and context bundles;
-- distributed coordination, tenancy, or remote artifact publication;
-- plugin discovery and backend capability negotiation.
-
-If another product domain eventually needs persistence, it introduces a small
-domain-local protocol only after a current non-test consumer needs an injectable
-I/O boundary. Sharing SQLite does not make two domains one storage abstraction.
-
-## Evidence for the Reset
-
-The 2026-09-01 audit of `origin/main` at
-`6eba4a39bc790e525c3a2e50ba9535b57b75f666` found:
-
-| Observation | Consequence |
-| --- | --- |
-| `codenib/storage` contained about 25,996 production lines and its tests about 31,679 lines. | The maintenance and verification surface was larger than the Wiki database need. |
-| `sqlite_catalog.py` alone contained about 10,572 lines and 86 methods; the resulting schema had 23 tables, 11 indexes, and 86 triggers. | Generic publication, scheduling, and retention invariants dominated a local Wiki product. |
-| Several public streaming and job protocols had no non-test production call site; the remaining generic catalog consumer was outside the protected product journeys. | Public abstraction breadth was not evidence of product demand. |
-| A `SQLiteCatalog(create=False)` open copied and validated the catalog, ran migration setup, and validated retained history. Web reconciliation could repeat that work several times per repository per poll. | A nominal read path amplified into full-history work and writer coordination. |
-| Catalog and local-CAS history had no supported retention path, while validation imposed a 1 GiB bound. | The design could grow into its own availability failure instead of solving a current product problem. |
-| Wiki storage already used one domain protocol and one SQLite WAL table, with contract, corruption, rollback, reopen, CLI, Web, manifest, export, and MCP coverage. | The smaller boundary was already sufficient for the protected Wiki journey. |
-
-The earlier catalog/CAS implementation remains useful evidence about atomic
-publication and validation, but that evidence does not justify keeping every
-experiment on a product route. Historical implementation chronology was
-removed from this roadmap; Git history and focused tests retain it where still
-needed.
-
-## Release Boundary for Retired Generic Storage
-
-The v0.2.3 release decision closes the temporary v0.2.2 compatibility period:
-
-1. Existing compiler caches use `artifact pack`; no database import is needed.
-2. Existing v0.2.2 catalogs are converted before upgrade with the v0.2.2
-   `artifact materialize` command.
-3. New releases continue to verify and serve the resulting portable artifacts,
-   but do not open the old catalog or carry a compatibility shim.
-
-No catalog data is migrated into `WikiStore`. Wiki entries and repository
-artifacts have different ownership and lifecycle contracts.
-
-## Active Work
-
-### W1: Remove the Web retained-storage route
-
-Status: complete.
-
-- `index_storage` configuration and Web lifespan composition are gone.
-- Retained index-job read/write routes, scheduling, reconciliation, runtime
-  activation, and their route-specific tests are gone.
-- Manifest-backed repository status and all protected journeys remain.
-
-### W2: Shrink the compatibility surface by consumer
-
-Status: complete.
-
-Outcome:
-
-- Default Web and portable-artifact validation no longer import
-  `codenib.storage`; bounded exact-JSON validation lives in the
-  artifact-neutral `_bounded_json` module.
-- The unreleased reachability audit, catalog-selected MCP cold start, and
-  `index --publish-retained` routes, retained benchmark, durable jobs stack, and
-  schema-v5-v8 expansion are gone. The two private retained BM25 generation
-  plan/replay helpers orphaned by the jobs removal are gone as well. Ordinary
-  `index`, `publish`, and `mcp --artifact [--repo]` behavior is unchanged.
-- The release decision removes `artifact import-cache`, `artifact materialize`,
-  all retained compiler import/export/materialization modules, the complete
-  schema-v4 catalog/CAS package, and their dedicated tests.
-- The catalog-backed clangd FactBatch generation experiment is removed with its
-  profiler. Provider-neutral facts and promoted native query paths remain.
-- The release upgrade gate starts from v0.2.2, proves compatible BM25 and
-  portable-artifact reuse, and verifies that the Wiki-only facade is present
-  while the generic package exports, submodules, and two retired commands are
-  absent.
-
-### W3: Close the small Wiki operational gaps
-
-Status: pending.
-
-- Bound generation-lock acquisition so a stuck generator cannot wait forever
-  without an actionable error.
-- Add only the Wiki-specific lifecycle operation justified by measured cache
-  growth; do not introduce generic CAS garbage collection.
-- Make maintenance inspection physically read-only and document regeneration
-  as the corruption-recovery path.
-
-These items must keep the `WikiStore` protocol small. A maintenance need is not
-permission to recreate snapshot, ref, job, or object-store machinery.
+No generic catalog, CAS, or database compatibility layer remains in the
+v0.2.3 product.
 
 ## Closed Plans
 
-CodeNib no longer plans PostgreSQL, S3-compatible object storage, generic local
-or remote garbage collection, a dynamic backend registry, distributed leases,
-or a shared ANN database as part of this program. DuckDB and graph databases
-are likewise not product persistence targets.
+CodeNib no longer plans PostgreSQL, S3-compatible object storage, generic GC,
+distributed leases, a shared ANN database, or backend discovery as approved
+product work. H2-H7 are only gates for reconsidering a narrowly evidenced need;
+their presence in this roadmap is not approval to implement them.
 
-Reopening one of these options requires all of the following:
+## Promotion Rule
 
-- a current product route that the Wiki SQLite or existing artifact model
-  cannot serve;
-- a documented deployment constraint and representative workload;
-- measured operational evidence;
-- an explicit scope decision that identifies the old path it replaces.
+Each later milestone is demand-gated. A design document, test fixture, or
+default-off implementation is not a product consumer. Before a milestone moves
+from `gated` to `in progress`, the roadmap must name:
 
-## Completion Gate
+1. the current non-test consumer and user-visible problem;
+2. the deployment or workload constraint the existing artifact path cannot
+   meet;
+3. a representative baseline and a success threshold fixed before measurement;
+4. the old path that promotion replaces or the new path's deletion date.
 
-Status: complete for generic-storage subtraction. Wiki-specific operational
-hardening remains tracked separately in W3.
+Stable promotion additionally requires RepoManifest, direct portable-artifact,
+and ordinary MCP compatibility. Failed experiments keep aggregate evidence but
+delete implementation, scripts, switches, and dedicated tests.
 
-The completed boundary has these properties:
+## Milestones
 
-- the default CodeGraph, Wiki, Web, MCP, and repository-context paths do not
-  import or configure `codenib.storage`;
-- Wiki persistence passes its domain contract and protected product journeys
-  with SQLite WAL as the supported implementation;
-- manifest-bound BM25, FAISS, igraph, and context artifacts remain compatible;
-- no generic storage package, protocol, catalog, CAS, or product route remains;
-  the single `codenib.storage` module exposes only the Wiki database boundary;
-- documentation and the changelog describe the current boundary rather than a
-  speculative backend program.
+| Milestone | Status | Authorized result |
+| --- | --- | --- |
+| H1: BM25 publication proof | Experimental through 2026-10-04 | One source-only SQLite WAL + local CAS round trip |
+| H2: Portable multi-view snapshot | Gated on H1 promotion and a second real view consumer | Immutable BM25/FAISS/igraph generations without changing their query formats |
+| H3: Jobs and hot switch | Gated on continuous-update product demand | Bounded jobs and validated request-pinned activation |
+| H4: Cross-file xref de-materialization | Gated on measured graph-update cost and parity plan | Unresolved monikers plus bounded query-time resolution |
+| H5: Per-file content addressing | Gated on H4 parity and reuse evidence | Context-bound reusable file units and version manifests |
+| H6: GC and overlays | Gated on retained-byte and dirty-workspace evidence | Audited reachability, safe reclamation, and path-aware overlays |
+| H7: Server adapters | Gated on a deployment that exceeds the embedded backend | PostgreSQL control-plane and object-store adapters for a proven contract |
+
+### H1: BM25 Publication Proof
+
+Status: in progress as an `experimental` source-checkout surface.
+
+Owner: index/artifact maintainers. Decision deadline: 2026-10-04.
+
+Allowed surface:
+
+- `scripts/experimental/hybrid_index/`;
+- `scripts/experimental/index_persistence.py`;
+- focused tests under `test/scripts/hybrid_index/` and the developer-script
+  command test;
+- the evidence record in `docs/experiments/hybrid_index_h1.md`.
+
+H1 accepts exactly one verified BM25-only portable context artifact. It stores
+one deterministic archive in a local SHA-256 CAS and records one immutable
+generation, one single-generation snapshot, and a compare-and-swap ref in a
+private four-table SQLite WAL catalog. It can export the pinned snapshot back
+to the ordinary portable format.
+
+H1 has no stable API, package export, official CLI command, configuration,
+Web/MCP route, jobs, leases, GC, overlay, remote adapter, or backend registry.
+The experiment uses constructor composition with exactly one implementation.
+
+Open gates:
+
+- [ ] name a current non-test consumer;
+- [x] record representative direct-artifact versus persisted-round-trip
+      latency, RSS, and retained-byte results;
+- [x] pass the failure and concurrency matrix in the H1 evidence record;
+- [x] prove the exported artifact passes the existing verifier and ordinary
+      BM25/MCP query path without the store;
+- [x] prove wheels and stable imports contain no experimental module or command;
+- [ ] make an explicit promote-or-delete decision by 2026-10-04.
+
+If any promotion gate remains open at the deadline, delete the H1
+implementation, executable script, and dedicated tests. H2 must not start from
+an unpromoted H1.
+
+### H2: Portable Multi-view Snapshot
+
+Status: gated; not started.
+
+Demand gate: at least two current view consumers must need the same immutable
+publication lifecycle. Promotion must keep BM25 and FAISS in their existing
+portable query formats and prove direct-artifact parity. Because igraph is not
+currently portable, graph support would first need a separately verified
+non-pickle artifact contract. Do not add a generic view protocol merely because
+formats share a directory.
+
+### H3: Jobs and Hot Switch
+
+Status: gated; not started.
+
+Demand gate: a product route must require asynchronous repeated builds rather
+than an ordinary explicit `index` or `artifact pack` operation. Only then
+define the minimum persisted job states. Activation must validate the complete
+new artifact before one request-pinned pointer swap; failures keep the previous
+snapshot active. Coordinate any Web work with open issue #266.
+
+### H4: Cross-file Xref De-materialization
+
+Status: gated; not started.
+
+Demand gate: representative repositories must show that eager cross-file edge
+reconnection blocks incremental indexing goals. Retain unresolved SCIP/LSP
+monikers per immutable unit, resolve only within a pinned snapshot, and require
+graph-query parity before changing the legacy materialized graph authority.
+
+### H5: Per-file Content Addressing
+
+Status: gated; not started.
+
+Demand gate: H4 parity plus measured reuse must justify the extra identity
+surface. A file unit identity must include path, mode, source/package context,
+build flags and dependencies, analyzer/toolchain version, and profile where
+they affect facts; raw content hash alone is insufficient.
+
+### H6: GC and Overlays
+
+Status: gated; not started.
+
+Demand gate: first measure retained bytes and identify a real dirty-workspace
+consumer. GC begins with a non-deleting reachability report and explicit pins,
+grace periods, quiescence, and recovery ownership. Overlays use path-aware
+upserts and delete tombstones over a pinned base; they are not set union.
+
+### H7: Server Adapters
+
+Status: gated; not started.
+
+Demand gate: document a multi-process or remote deployment that SQLite WAL and
+the local filesystem cannot serve, with concurrency, durability, latency, and
+cost evidence. PostgreSQL and object storage may then implement the proven
+domain contract. They do not justify a dynamic registry, shared ANN database,
+or speculative authorization system.
+
+## Tracking
+
+Issue #765 owns the bounded H1 evidence and its 2026-10-04
+promote-or-delete decision. It references historical #199, foundation #535,
+and subtraction #753-#762; it does not reopen those scopes. Record the H1 PR
+here when opened. Do not use the stale `feat/storage-catalog-foundation` branch
+as a base.
+
+The detailed H1 schema, linearization points, failure matrix, commands, and
+benchmark receipt live in
+`docs/experiments/hybrid_index_h1.md`. Replace milestone status with current
+evidence; keep implementation chronology in Git history and PRs.

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -181,10 +181,10 @@ or speculative authorization system.
 ## Tracking
 
 Issue #765 owns the bounded H1 evidence and its 2026-10-04
-promote-or-delete decision. It references historical #199, foundation #535,
-and subtraction #753-#762; it does not reopen those scopes. Record the H1 PR
-here when opened. Do not use the stale `feat/storage-catalog-foundation` branch
-as a base.
+promote-or-delete decision; PR #766 carries the source-only implementation and
+evidence. The tracker references historical #199, foundation #535, and
+subtraction #753-#762 without reopening those scopes. Do not use the stale
+`feat/storage-catalog-foundation` branch as a base.
 
 The detailed H1 schema, linearization points, failure matrix, commands, and
 benchmark receipt live in

--- a/scripts/experimental/hybrid_index/__init__.py
+++ b/scripts/experimental/hybrid_index/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Source-checkout-only hybrid index persistence experiment.
+
+Nothing in this package is part of the installed :mod:`codenib` API.  The
+stable :mod:`codenib.storage` namespace remains the Wiki-only database facade.
+"""
+
+from .repository import IndexRepository, PublicationResult
+
+__all__ = ["IndexRepository", "PublicationResult"]

--- a/scripts/experimental/hybrid_index/cas.py
+++ b/scripts/experimental/hybrid_index/cas.py
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimal local content-addressed object store for the H1 experiment."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import stat
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO
+
+from .contracts import StorageIntegrityError, StorageValidationError
+
+_DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
+_COPY_BYTES = 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class BlobInfo:
+    digest: str
+    byte_size: int
+
+
+def _real_directory(path: Path, *, create: bool, label: str) -> Path:
+    if create:
+        path.mkdir(parents=True, exist_ok=True)
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise StorageValidationError(f"{label} is unavailable: {path}") from exc
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise StorageValidationError(f"{label} is not a real directory: {path}")
+    return path
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    descriptor = os.open(path, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _validate_digest(value: object) -> str:
+    if type(value) is not str or _DIGEST_RE.fullmatch(value) is None:
+        raise StorageValidationError(
+            "digest must be 64 lowercase hexadecimal characters"
+        )
+    return value
+
+
+def _file_signature(handle: BinaryIO) -> tuple[int, int, int, int, int, int]:
+    metadata = os.fstat(handle.fileno())
+    if not stat.S_ISREG(metadata.st_mode):
+        raise StorageValidationError("CAS source must be a regular file")
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        stat.S_IFMT(metadata.st_mode),
+    )
+
+
+def _object_signature(handle: BinaryIO) -> tuple[int, int, int, int, int]:
+    metadata = os.fstat(handle.fileno())
+    if not stat.S_ISREG(metadata.st_mode):
+        raise StorageIntegrityError("CAS object is not a regular file")
+    # A concurrent deduplicated publisher may unlink another hard link, which
+    # changes ctime/link-count without changing the immutable object bytes.
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        stat.S_IFMT(metadata.st_mode),
+    )
+
+
+class LocalCAS:
+    """Store immutable files by SHA-256 on one trusted local filesystem.
+
+    H1 intentionally supports only the operations used by ``IndexRepository``.
+    It is not a generic storage API and does not defend against a hostile process
+    running as the same user.
+    """
+
+    def __init__(self, root: str | os.PathLike[str]) -> None:
+        requested = Path(root).expanduser()
+        if requested.exists() or requested.is_symlink():
+            _real_directory(requested, create=False, label="CAS root")
+        self.root = requested.resolve(strict=False)
+        _real_directory(self.root, create=True, label="CAS root")
+        self._objects = _real_directory(
+            self.root / "sha256",
+            create=True,
+            label="CAS object root",
+        )
+        self._temporary = _real_directory(
+            self.root / "tmp",
+            create=True,
+            label="CAS temporary root",
+        )
+        _fsync_directory(self.root)
+
+    def _object_path(self, digest: str) -> Path:
+        digest = _validate_digest(digest)
+        return self._objects / digest[:2] / digest[2:]
+
+    def _ensure_shard(self, digest: str) -> Path:
+        shard = self._objects / digest[:2]
+        created = False
+        try:
+            shard.mkdir()
+            created = True
+        except FileExistsError:
+            pass
+        _real_directory(shard, create=False, label="CAS digest shard")
+        if created:
+            _fsync_directory(self._objects)
+        return shard
+
+    def put_file(self, source: str | os.PathLike[str]) -> BlobInfo:
+        """Copy one stable regular file and publish it without replacement."""
+
+        source_path = Path(source)
+        try:
+            source_metadata = source_path.lstat()
+        except OSError as exc:
+            raise StorageValidationError("CAS source is unavailable") from exc
+        if not stat.S_ISREG(source_metadata.st_mode):
+            raise StorageValidationError("CAS source must be a regular file")
+
+        source_handle = source_path.open("rb")
+        try:
+            descriptor, temporary_name = tempfile.mkstemp(
+                prefix="put-",
+                suffix=".tmp",
+                dir=self._temporary,
+            )
+        except BaseException:
+            source_handle.close()
+            raise
+        temporary = Path(temporary_name)
+        digest = hashlib.sha256()
+        byte_size = 0
+        try:
+            with source_handle, os.fdopen(descriptor, "wb") as target:
+                before = _file_signature(source_handle)
+                while True:
+                    block = source_handle.read(_COPY_BYTES)
+                    if not block:
+                        break
+                    target.write(block)
+                    digest.update(block)
+                    byte_size += len(block)
+                after = _file_signature(source_handle)
+                target.flush()
+                os.fsync(target.fileno())
+            if before != after or byte_size != before[2]:
+                raise OSError(f"CAS source changed while being copied: {source_path}")
+
+            info = BlobInfo(digest=digest.hexdigest(), byte_size=byte_size)
+            shard = self._ensure_shard(info.digest)
+            destination = self._object_path(info.digest)
+            try:
+                os.link(temporary, destination)
+            except FileExistsError:
+                self.verify(info.digest, expected_size=info.byte_size)
+                _fsync_directory(shard)
+            else:
+                _fsync_directory(shard)
+            return info
+        finally:
+            temporary.unlink(missing_ok=True)
+            _fsync_directory(self._temporary)
+
+    def verify(self, digest: str, *, expected_size: int | None = None) -> BlobInfo:
+        """Read and hash the complete object before returning its receipt."""
+
+        digest = _validate_digest(digest)
+        if expected_size is not None and (
+            type(expected_size) is not int or expected_size < 0
+        ):
+            raise StorageValidationError("expected object size must be non-negative")
+        shard = self._objects / digest[:2]
+        _real_directory(shard, create=False, label="CAS digest shard")
+        path = self._object_path(digest)
+        try:
+            metadata = path.lstat()
+        except FileNotFoundError:
+            raise
+        except OSError as exc:
+            raise StorageIntegrityError(f"CAS object is unavailable: {digest}") from exc
+        if not stat.S_ISREG(metadata.st_mode):
+            raise StorageIntegrityError(f"CAS object is not a regular file: {digest}")
+
+        observed = hashlib.sha256()
+        byte_size = 0
+        flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(path, flags)
+            with os.fdopen(descriptor, "rb") as handle:
+                before = _object_signature(handle)
+                while True:
+                    block = handle.read(_COPY_BYTES)
+                    if not block:
+                        break
+                    observed.update(block)
+                    byte_size += len(block)
+                after = _object_signature(handle)
+        except OSError as exc:
+            raise StorageIntegrityError(f"CAS object cannot be read: {digest}") from exc
+        if before != after or byte_size != before[2]:
+            raise StorageIntegrityError(f"CAS object changed while reading: {digest}")
+        if observed.hexdigest() != digest:
+            raise StorageIntegrityError(f"CAS object digest mismatch: {digest}")
+        if expected_size is not None and byte_size != expected_size:
+            raise StorageIntegrityError(f"CAS object size mismatch: {digest}")
+        return BlobInfo(digest=digest, byte_size=byte_size)
+
+    def verified_path(self, digest: str, *, expected_size: int | None = None) -> Path:
+        self.verify(digest, expected_size=expected_size)
+        return self._object_path(digest)
+
+
+__all__ = ["BlobInfo", "LocalCAS"]

--- a/scripts/experimental/hybrid_index/catalog.py
+++ b/scripts/experimental/hybrid_index/catalog.py
@@ -1,0 +1,616 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Four-table SQLite WAL control plane for the H1 experiment."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import stat
+import time
+from functools import lru_cache
+from pathlib import Path
+
+from .contracts import (
+    Generation,
+    PublishConflict,
+    RefHead,
+    ResolvedSnapshot,
+    Snapshot,
+    StorageIntegrityError,
+    StorageNotFound,
+    StorageValidationError,
+    required_text,
+)
+
+_APPLICATION_ID = 0x434E4958  # ``CNIX``
+_SCHEMA_VERSION = 1
+
+_SCHEMA = (
+    """
+    CREATE TABLE generations (
+        generation_id TEXT PRIMARY KEY,
+        repository TEXT NOT NULL,
+        commit_sha TEXT NOT NULL,
+        source_fingerprint TEXT NOT NULL,
+        view_type TEXT NOT NULL,
+        metadata_digest TEXT NOT NULL CHECK (length(metadata_digest) = 64),
+        archive_digest TEXT NOT NULL CHECK (length(archive_digest) = 64),
+        archive_size INTEGER NOT NULL CHECK (archive_size >= 0),
+        file_count INTEGER NOT NULL CHECK (file_count >= 0),
+        byte_count INTEGER NOT NULL CHECK (byte_count >= 0),
+        created_at REAL NOT NULL,
+        UNIQUE (generation_id, view_type)
+    )
+    """,
+    """
+    CREATE TABLE snapshots (
+        snapshot_id TEXT PRIMARY KEY,
+        repository TEXT NOT NULL,
+        commit_sha TEXT NOT NULL,
+        source_fingerprint TEXT NOT NULL,
+        created_at REAL NOT NULL,
+        UNIQUE (snapshot_id, repository)
+    )
+    """,
+    """
+    CREATE TABLE snapshot_generations (
+        snapshot_id TEXT NOT NULL,
+        view_type TEXT NOT NULL,
+        generation_id TEXT NOT NULL,
+        PRIMARY KEY (snapshot_id, view_type),
+        UNIQUE (snapshot_id, generation_id),
+        FOREIGN KEY (snapshot_id) REFERENCES snapshots(snapshot_id)
+            ON DELETE RESTRICT,
+        FOREIGN KEY (generation_id, view_type)
+            REFERENCES generations(generation_id, view_type)
+            ON DELETE RESTRICT
+    )
+    """,
+    """
+    CREATE TABLE refs (
+        repository TEXT NOT NULL,
+        ref_name TEXT NOT NULL,
+        snapshot_id TEXT NOT NULL,
+        revision INTEGER NOT NULL CHECK (revision > 0),
+        updated_at REAL NOT NULL,
+        PRIMARY KEY (repository, ref_name),
+        FOREIGN KEY (snapshot_id, repository)
+            REFERENCES snapshots(snapshot_id, repository)
+            ON DELETE RESTRICT
+    )
+    """,
+)
+
+
+def _normalize_sql(value: object) -> str | None:
+    if value is None:
+        return None
+    return " ".join(str(value).split())
+
+
+def _schema_objects(connection: sqlite3.Connection) -> tuple[tuple[object, ...], ...]:
+    return tuple(
+        (
+            row["type"],
+            row["name"],
+            row["tbl_name"],
+            _normalize_sql(row["sql"]),
+        )
+        for row in connection.execute("""
+            SELECT type, name, tbl_name, sql
+              FROM sqlite_schema
+             WHERE name NOT LIKE 'sqlite_%'
+             ORDER BY type, name
+            """)
+    )
+
+
+def _create_schema(connection: sqlite3.Connection) -> None:
+    for statement in _SCHEMA:
+        connection.execute(statement)
+
+
+@lru_cache(maxsize=1)
+def _expected_schema() -> tuple[tuple[object, ...], ...]:
+    connection = sqlite3.connect(":memory:")
+    connection.row_factory = sqlite3.Row
+    try:
+        connection.execute("PRAGMA foreign_keys = ON")
+        _create_schema(connection)
+        return _schema_objects(connection)
+    finally:
+        connection.close()
+
+
+def _database_identity(path: Path) -> tuple[int, int, int]:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise StorageIntegrityError("catalog database path is unavailable") from exc
+    if not stat.S_ISREG(metadata.st_mode) or not metadata.st_dev or not metadata.st_ino:
+        raise StorageIntegrityError("catalog database is not a stable regular file")
+    return (metadata.st_dev, metadata.st_ino, stat.S_IFMT(metadata.st_mode))
+
+
+def _generation_fields(generation: Generation) -> tuple[object, ...]:
+    return (
+        generation.repository,
+        generation.commit,
+        generation.source_fingerprint,
+        generation.view_type,
+        generation.metadata_digest,
+        generation.archive_digest,
+        generation.archive_size,
+        generation.file_count,
+        generation.byte_count,
+    )
+
+
+def _snapshot_fields(snapshot: Snapshot) -> tuple[object, ...]:
+    return (
+        snapshot.repository,
+        snapshot.commit,
+        snapshot.source_fingerprint,
+    )
+
+
+class SQLiteCatalog:
+    """Short-connection catalog whose only mutable rows are named refs.
+
+    Object bytes are made durable before :meth:`publish_snapshot` starts.
+    The ref INSERT/UPDATE inside ``BEGIN IMMEDIATE`` is the publication
+    linearization point.  A failed transaction may leave an unreachable CAS
+    object, but cannot expose an incomplete snapshot.
+    """
+
+    def __init__(self, path: str | os.PathLike[str], *, timeout: float = 30.0) -> None:
+        if type(timeout) not in {int, float} or timeout <= 0:
+            raise StorageValidationError("catalog timeout must be positive")
+        if str(path) == ":memory:":
+            raise StorageValidationError("H1 catalog requires a filesystem path")
+        try:
+            candidate = Path(path).expanduser().resolve(strict=False)
+            candidate.parent.mkdir(parents=True, exist_ok=True)
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            raise StorageValidationError("invalid catalog database path") from exc
+        self.path = candidate
+        self.timeout = float(timeout)
+        self._identity: tuple[int, int, int] | None = None
+        self._initialize()
+        self._identity = _database_identity(self.path)
+
+    def _open_raw(self, *, create: bool) -> sqlite3.Connection:
+        if not create and self._identity is not None:
+            if _database_identity(self.path) != self._identity:
+                raise StorageIntegrityError("catalog database path identity changed")
+        target = self.path
+        if create:
+            connection = sqlite3.connect(
+                target,
+                timeout=self.timeout,
+                isolation_level=None,
+            )
+        else:
+            connection = sqlite3.connect(
+                f"{target.as_uri()}?mode=rw",
+                timeout=self.timeout,
+                isolation_level=None,
+                uri=True,
+            )
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute("PRAGMA synchronous = FULL")
+        connection.execute(f"PRAGMA busy_timeout = {int(self.timeout * 1000)}")
+        if not create and self._identity is not None:
+            if _database_identity(self.path) != self._identity:
+                connection.close()
+                raise StorageIntegrityError("catalog database path identity changed")
+        return connection
+
+    @staticmethod
+    def _header(connection: sqlite3.Connection) -> tuple[int, int]:
+        return (
+            int(connection.execute("PRAGMA application_id").fetchone()[0]),
+            int(connection.execute("PRAGMA user_version").fetchone()[0]),
+        )
+
+    @classmethod
+    def _require_schema(cls, connection: sqlite3.Connection) -> None:
+        application_id, user_version = cls._header(connection)
+        if application_id != _APPLICATION_ID:
+            raise StorageIntegrityError(
+                "SQLite file is not a CodeNib index experiment catalog"
+            )
+        if user_version != _SCHEMA_VERSION:
+            raise StorageIntegrityError(
+                f"unsupported index experiment schema: {user_version}"
+            )
+        if _schema_objects(connection) != _expected_schema():
+            raise StorageIntegrityError("index experiment schema is not canonical")
+
+    def _initialize(self) -> None:
+        connection = self._open_raw(create=True)
+        try:
+            if _schema_objects(connection):
+                self._require_schema(connection)
+            else:
+                connection.execute("BEGIN IMMEDIATE")
+                try:
+                    if _schema_objects(connection):
+                        self._require_schema(connection)
+                    else:
+                        application_id, user_version = self._header(connection)
+                        if application_id != 0 or user_version != 0:
+                            raise StorageIntegrityError(
+                                "refusing to initialize an identified SQLite file"
+                            )
+                        _create_schema(connection)
+                        connection.execute(f"PRAGMA application_id = {_APPLICATION_ID}")
+                        connection.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
+                        self._require_schema(connection)
+                    connection.commit()
+                except BaseException:
+                    if connection.in_transaction:
+                        connection.rollback()
+                    raise
+            mode = str(
+                connection.execute("PRAGMA journal_mode = WAL").fetchone()[0]
+            ).lower()
+            if mode != "wal":
+                raise StorageIntegrityError("index experiment catalog requires WAL")
+        finally:
+            connection.close()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = self._open_raw(create=False)
+        try:
+            self._require_schema(connection)
+            mode = str(connection.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+            if mode != "wal":
+                raise StorageIntegrityError("index experiment catalog left WAL mode")
+            return connection
+        except BaseException:
+            connection.close()
+            raise
+
+    @property
+    def journal_mode(self) -> str:
+        connection = self._connect()
+        try:
+            return str(connection.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+        finally:
+            connection.close()
+
+    @staticmethod
+    def _insert_generation(
+        connection: sqlite3.Connection,
+        generation: Generation,
+        *,
+        now: float,
+    ) -> None:
+        row = connection.execute(
+            """
+            SELECT repository, commit_sha, source_fingerprint, view_type,
+                   metadata_digest, archive_digest, archive_size,
+                   file_count, byte_count
+              FROM generations
+             WHERE generation_id = ?
+            """,
+            (generation.generation_id,),
+        ).fetchone()
+        if row is None:
+            connection.execute(
+                """
+                INSERT INTO generations(
+                    generation_id, repository, commit_sha, source_fingerprint,
+                    view_type, metadata_digest, archive_digest, archive_size,
+                    file_count, byte_count, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (generation.generation_id, *_generation_fields(generation), now),
+            )
+        elif tuple(row) != _generation_fields(generation):
+            raise StorageIntegrityError(
+                f"generation {generation.generation_id} is not immutable"
+            )
+
+    @staticmethod
+    def _insert_snapshot(
+        connection: sqlite3.Connection,
+        snapshot: Snapshot,
+        *,
+        now: float,
+    ) -> None:
+        row = connection.execute(
+            """
+            SELECT repository, commit_sha, source_fingerprint
+              FROM snapshots
+             WHERE snapshot_id = ?
+            """,
+            (snapshot.snapshot_id,),
+        ).fetchone()
+        expected_members = tuple(
+            (generation.view_type, generation.generation_id)
+            for generation in snapshot.generations
+        )
+        if row is None:
+            connection.execute(
+                """
+                INSERT INTO snapshots(
+                    snapshot_id, repository, commit_sha,
+                    source_fingerprint, created_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (snapshot.snapshot_id, *_snapshot_fields(snapshot), now),
+            )
+            connection.executemany(
+                """
+                INSERT INTO snapshot_generations(
+                    snapshot_id, view_type, generation_id
+                ) VALUES (?, ?, ?)
+                """,
+                (
+                    (snapshot.snapshot_id, view_type, generation_id)
+                    for view_type, generation_id in expected_members
+                ),
+            )
+            return
+        observed_members = tuple(
+            tuple(member)
+            for member in connection.execute(
+                """
+                SELECT view_type, generation_id
+                  FROM snapshot_generations
+                 WHERE snapshot_id = ?
+                 ORDER BY view_type
+                """,
+                (snapshot.snapshot_id,),
+            )
+        )
+        if tuple(row) != _snapshot_fields(snapshot) or observed_members != (
+            expected_members
+        ):
+            raise StorageIntegrityError(
+                f"snapshot {snapshot.snapshot_id} is not immutable"
+            )
+
+    def _before_ref_update(self) -> None:
+        """Fault-injection seam immediately before the mutable operation."""
+
+    @staticmethod
+    def _advance_ref(
+        connection: sqlite3.Connection,
+        snapshot: Snapshot,
+        *,
+        ref_name: str,
+        expected_revision: int,
+        now: float,
+    ) -> RefHead:
+        row = connection.execute(
+            """
+            SELECT snapshot_id, revision
+              FROM refs
+             WHERE repository = ? AND ref_name = ?
+            """,
+            (snapshot.repository, ref_name),
+        ).fetchone()
+        if row is None:
+            if expected_revision != 0:
+                raise PublishConflict(
+                    f"ref {snapshot.repository}:{ref_name} does not exist"
+                )
+            revision = 1
+            connection.execute(
+                """
+                INSERT INTO refs(
+                    repository, ref_name, snapshot_id, revision, updated_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    snapshot.repository,
+                    ref_name,
+                    snapshot.snapshot_id,
+                    revision,
+                    now,
+                ),
+            )
+        else:
+            current_snapshot = str(row["snapshot_id"])
+            current_revision = int(row["revision"])
+            if current_snapshot == snapshot.snapshot_id and expected_revision in {
+                current_revision,
+                current_revision - 1,
+            }:
+                return RefHead(
+                    repository=snapshot.repository,
+                    ref_name=ref_name,
+                    snapshot_id=current_snapshot,
+                    revision=current_revision,
+                )
+            if current_revision != expected_revision:
+                raise PublishConflict(
+                    f"ref {snapshot.repository}:{ref_name} is at revision "
+                    f"{current_revision}, not {expected_revision}"
+                )
+            revision = current_revision + 1
+            connection.execute(
+                """
+                UPDATE refs
+                   SET snapshot_id = ?, revision = ?, updated_at = ?
+                 WHERE repository = ? AND ref_name = ? AND revision = ?
+                """,
+                (
+                    snapshot.snapshot_id,
+                    revision,
+                    now,
+                    snapshot.repository,
+                    ref_name,
+                    expected_revision,
+                ),
+            )
+            if int(connection.execute("SELECT changes()").fetchone()[0]) != 1:
+                raise PublishConflict(
+                    f"ref {snapshot.repository}:{ref_name} changed concurrently"
+                )
+        return RefHead(
+            repository=snapshot.repository,
+            ref_name=ref_name,
+            snapshot_id=snapshot.snapshot_id,
+            revision=revision,
+        )
+
+    def publish_snapshot(
+        self,
+        snapshot: Snapshot,
+        *,
+        ref_name: str = "main",
+        expected_revision: int = 0,
+    ) -> RefHead:
+        if type(snapshot) is not Snapshot:
+            raise TypeError("catalog publication requires an exact Snapshot")
+        ref_name = required_text(ref_name, label="ref name")
+        if type(expected_revision) is not int or expected_revision < 0:
+            raise StorageValidationError(
+                "expected ref revision must be a non-negative integer"
+            )
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            now = time.time()
+            for generation in snapshot.generations:
+                self._insert_generation(connection, generation, now=now)
+            self._insert_snapshot(connection, snapshot, now=now)
+            self._before_ref_update()
+            head = self._advance_ref(
+                connection,
+                snapshot,
+                ref_name=ref_name,
+                expected_revision=expected_revision,
+                now=now,
+            )
+            connection.commit()
+            return head
+        except BaseException:
+            if connection.in_transaction:
+                connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    @staticmethod
+    def _load_snapshot(
+        connection: sqlite3.Connection,
+        snapshot_id: str,
+    ) -> Snapshot:
+        row = connection.execute(
+            """
+            SELECT repository, commit_sha, source_fingerprint
+              FROM snapshots
+             WHERE snapshot_id = ?
+            """,
+            (snapshot_id,),
+        ).fetchone()
+        if row is None:
+            raise StorageNotFound(f"snapshot does not exist: {snapshot_id}")
+        generation_rows = tuple(
+            connection.execute(
+                """
+                SELECT g.generation_id, g.repository, g.commit_sha,
+                       g.source_fingerprint, g.view_type, g.metadata_digest,
+                       g.archive_digest, g.archive_size, g.file_count, g.byte_count
+                  FROM snapshot_generations AS sg
+                  JOIN generations AS g
+                    ON g.generation_id = sg.generation_id
+                   AND g.view_type = sg.view_type
+                 WHERE sg.snapshot_id = ?
+                 ORDER BY sg.view_type
+                """,
+                (snapshot_id,),
+            )
+        )
+        try:
+            generations = tuple(
+                Generation(
+                    generation_id=generation["generation_id"],
+                    repository=generation["repository"],
+                    commit=generation["commit_sha"],
+                    source_fingerprint=generation["source_fingerprint"],
+                    view_type=generation["view_type"],
+                    metadata_digest=generation["metadata_digest"],
+                    archive_digest=generation["archive_digest"],
+                    archive_size=generation["archive_size"],
+                    file_count=generation["file_count"],
+                    byte_count=generation["byte_count"],
+                )
+                for generation in generation_rows
+            )
+            return Snapshot(
+                snapshot_id=snapshot_id,
+                repository=row["repository"],
+                commit=row["commit_sha"],
+                source_fingerprint=row["source_fingerprint"],
+                generations=generations,
+            )
+        except (TypeError, ValueError) as exc:
+            raise StorageIntegrityError(
+                f"snapshot {snapshot_id} contains invalid metadata"
+            ) from exc
+
+    def get_snapshot(self, snapshot_id: str) -> ResolvedSnapshot:
+        snapshot_id = required_text(snapshot_id, label="snapshot ID")
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN")
+            snapshot = self._load_snapshot(connection, snapshot_id)
+            connection.commit()
+            return ResolvedSnapshot(snapshot=snapshot)
+        except BaseException:
+            if connection.in_transaction:
+                connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def resolve_ref(
+        self,
+        repository: str,
+        ref_name: str = "main",
+    ) -> ResolvedSnapshot:
+        repository = required_text(repository, label="repository")
+        ref_name = required_text(ref_name, label="ref name")
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN")
+            row = connection.execute(
+                """
+                SELECT snapshot_id, revision
+                  FROM refs
+                 WHERE repository = ? AND ref_name = ?
+                """,
+                (repository, ref_name),
+            ).fetchone()
+            if row is None:
+                raise StorageNotFound(f"ref does not exist: {repository}:{ref_name}")
+            head = RefHead(
+                repository=repository,
+                ref_name=ref_name,
+                snapshot_id=row["snapshot_id"],
+                revision=row["revision"],
+            )
+            snapshot = self._load_snapshot(connection, head.snapshot_id)
+            if snapshot.repository != repository:
+                raise StorageIntegrityError("ref crosses repository identity")
+            connection.commit()
+            return ResolvedSnapshot(snapshot=snapshot, ref=head)
+        except BaseException:
+            if connection.in_transaction:
+                connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+
+__all__ = ["SQLiteCatalog"]

--- a/scripts/experimental/hybrid_index/catalog.py
+++ b/scripts/experimental/hybrid_index/catalog.py
@@ -27,6 +27,8 @@ from .contracts import (
 
 _APPLICATION_ID = 0x434E4958  # ``CNIX``
 _SCHEMA_VERSION = 1
+_SQLITE_BUSY = 5
+_SQLITE_LOCKED = 6
 
 _SCHEMA = (
     """
@@ -157,13 +159,24 @@ def _snapshot_fields(snapshot: Snapshot) -> tuple[object, ...]:
     )
 
 
+def _is_sqlite_busy_or_locked(exc: sqlite3.OperationalError) -> bool:
+    code = getattr(exc, "sqlite_errorcode", None)
+    if type(code) is int:
+        return code & 0xFF in {_SQLITE_BUSY, _SQLITE_LOCKED}
+    message = str(exc).casefold()
+    return message.startswith(
+        ("database is locked", "database table is locked", "database schema is locked")
+    )
+
+
 class SQLiteCatalog:
     """Short-connection catalog whose only mutable rows are named refs.
 
     Object bytes are made durable before :meth:`publish_snapshot` starts.
-    The ref INSERT/UPDATE inside ``BEGIN IMMEDIATE`` is the publication
-    linearization point.  A failed transaction may leave an unreachable CAS
-    object, but cannot expose an incomplete snapshot.
+    The ref INSERT/UPDATE inside ``BEGIN IMMEDIATE`` decides the winning value;
+    ``COMMIT`` is the publication linearization point visible to readers. A
+    failed transaction may leave an unreachable CAS object, but cannot expose
+    an incomplete snapshot.
     """
 
     def __init__(self, path: str | os.PathLike[str], *, timeout: float = 30.0) -> None:
@@ -256,9 +269,18 @@ class SQLiteCatalog:
                     if connection.in_transaction:
                         connection.rollback()
                     raise
-            mode = str(
-                connection.execute("PRAGMA journal_mode = WAL").fetchone()[0]
-            ).lower()
+            deadline = time.monotonic() + self.timeout
+            while True:
+                try:
+                    mode = str(
+                        connection.execute("PRAGMA journal_mode = WAL").fetchone()[0]
+                    ).lower()
+                    break
+                except sqlite3.OperationalError as exc:
+                    remaining = deadline - time.monotonic()
+                    if not _is_sqlite_busy_or_locked(exc) or remaining <= 0:
+                        raise
+                    time.sleep(min(0.01, remaining))
             if mode != "wal":
                 raise StorageIntegrityError("index experiment catalog requires WAL")
         finally:

--- a/scripts/experimental/hybrid_index/contracts.py
+++ b/scripts/experimental/hybrid_index/contracts.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small immutable identities used by the H1 persistence experiment."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+_DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
+_COMMIT_RE = re.compile(r"[0-9a-f]{40}\Z", re.ASCII)
+_MAX_TEXT_BYTES = 4096
+_MAX_IDENTITY_JSON_BYTES = 1024 * 1024
+
+
+class StorageError(RuntimeError):
+    """Base class for experimental persistence failures."""
+
+
+class StorageIntegrityError(StorageError):
+    """Persisted bytes or metadata differ from their immutable identity."""
+
+
+class StorageNotFound(StorageError):
+    """A requested artifact, snapshot, or ref does not exist."""
+
+
+class PublishConflict(StorageError):
+    """A ref compare-and-swap precondition no longer holds."""
+
+
+class StorageValidationError(StorageError, ValueError):
+    """Input cannot form a valid persistence identity."""
+
+
+def required_text(value: object, *, label: str) -> str:
+    if type(value) is not str or not value or "\x00" in value:
+        raise StorageValidationError(f"{label} must be non-empty text")
+    try:
+        encoded = value.encode("utf-8", errors="strict")
+    except UnicodeError as exc:
+        raise StorageValidationError(f"{label} must be valid Unicode") from exc
+    if len(encoded) > _MAX_TEXT_BYTES:
+        raise StorageValidationError(
+            f"{label} exceeds its {_MAX_TEXT_BYTES}-byte limit"
+        )
+    return value
+
+
+def normalize_digest(value: object, *, label: str = "digest") -> str:
+    normalized = required_text(value, label=label).lower()
+    if normalized.startswith("sha256:"):
+        normalized = normalized[7:]
+    if _DIGEST_RE.fullmatch(normalized) is None:
+        raise StorageValidationError(
+            f"{label} must be 64 lowercase hexadecimal characters"
+        )
+    return normalized
+
+
+def canonical_json(value: Mapping[str, Any]) -> str:
+    if not isinstance(value, Mapping):
+        raise StorageValidationError("identity payload must be a JSON object")
+    try:
+        encoded = json.dumps(
+            dict(value),
+            allow_nan=False,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("ascii")
+    except (TypeError, ValueError) as exc:
+        raise StorageValidationError("identity payload is not canonical JSON") from exc
+    if len(encoded) > _MAX_IDENTITY_JSON_BYTES:
+        raise StorageValidationError("identity payload exceeds its byte limit")
+    return encoded.decode("ascii")
+
+
+def content_id(prefix: str, value: Mapping[str, Any]) -> str:
+    prefix = required_text(prefix, label="content ID prefix")
+    digest = hashlib.sha256(canonical_json(value).encode("ascii")).hexdigest()
+    return f"{prefix}_{digest}"
+
+
+def _nonnegative_int(value: object, *, label: str) -> int:
+    if type(value) is not int or value < 0:
+        raise StorageValidationError(f"{label} must be a non-negative integer")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class Generation:
+    """One immutable portable BM25 artifact generation."""
+
+    generation_id: str
+    repository: str
+    commit: str
+    source_fingerprint: str
+    view_type: str
+    metadata_digest: str
+    archive_digest: str
+    archive_size: int
+    file_count: int
+    byte_count: int
+
+    def __post_init__(self) -> None:
+        repository = required_text(self.repository, label="repository")
+        commit = required_text(self.commit, label="commit").lower()
+        if _COMMIT_RE.fullmatch(commit) is None:
+            raise StorageValidationError("commit must be a full lowercase Git SHA")
+        source_fingerprint = required_text(
+            self.source_fingerprint,
+            label="source fingerprint",
+        )
+        if self.view_type != "bm25":
+            raise StorageValidationError("H1 supports exactly the BM25 view")
+        metadata_digest = normalize_digest(
+            self.metadata_digest,
+            label="context metadata digest",
+        )
+        archive_digest = normalize_digest(
+            self.archive_digest,
+            label="archive digest",
+        )
+        archive_size = _nonnegative_int(self.archive_size, label="archive size")
+        file_count = _nonnegative_int(self.file_count, label="artifact file count")
+        byte_count = _nonnegative_int(self.byte_count, label="artifact byte count")
+        expected_id = f"gen_{metadata_digest}"
+        if self.generation_id != expected_id:
+            raise StorageValidationError(
+                "generation ID does not match context metadata content"
+            )
+        object.__setattr__(self, "repository", repository)
+        object.__setattr__(self, "commit", commit)
+        object.__setattr__(self, "source_fingerprint", source_fingerprint)
+        object.__setattr__(self, "metadata_digest", metadata_digest)
+        object.__setattr__(self, "archive_digest", archive_digest)
+        object.__setattr__(self, "archive_size", archive_size)
+        object.__setattr__(self, "file_count", file_count)
+        object.__setattr__(self, "byte_count", byte_count)
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        repository: str,
+        commit: str,
+        source_fingerprint: str,
+        metadata_digest: str,
+        archive_digest: str,
+        archive_size: int,
+        file_count: int,
+        byte_count: int,
+    ) -> "Generation":
+        metadata_digest = normalize_digest(
+            metadata_digest,
+            label="context metadata digest",
+        )
+        return cls(
+            generation_id=f"gen_{metadata_digest}",
+            repository=repository,
+            commit=commit,
+            source_fingerprint=source_fingerprint,
+            view_type="bm25",
+            metadata_digest=metadata_digest,
+            archive_digest=archive_digest,
+            archive_size=archive_size,
+            file_count=file_count,
+            byte_count=byte_count,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Snapshot:
+    """An immutable compatible set of generations for one source identity."""
+
+    snapshot_id: str
+    repository: str
+    commit: str
+    source_fingerprint: str
+    generations: tuple[Generation, ...]
+
+    def __post_init__(self) -> None:
+        repository = required_text(self.repository, label="repository")
+        commit = required_text(self.commit, label="commit").lower()
+        source_fingerprint = required_text(
+            self.source_fingerprint,
+            label="source fingerprint",
+        )
+        generations = tuple(self.generations)
+        if len(generations) != 1 or generations[0].view_type != "bm25":
+            raise StorageValidationError(
+                "H1 snapshots contain exactly one BM25 generation"
+            )
+        generation = generations[0]
+        if (
+            generation.repository,
+            generation.commit,
+            generation.source_fingerprint,
+        ) != (repository, commit, source_fingerprint):
+            raise StorageValidationError(
+                "snapshot and generation source identities differ"
+            )
+        expected_id = content_id(
+            "snap",
+            {
+                "repository": repository,
+                "commit": commit,
+                "source_fingerprint": source_fingerprint,
+                "generations": {generation.view_type: generation.generation_id},
+            },
+        )
+        if self.snapshot_id != expected_id:
+            raise StorageValidationError(
+                "snapshot ID does not match its generation set"
+            )
+        object.__setattr__(self, "repository", repository)
+        object.__setattr__(self, "commit", commit)
+        object.__setattr__(self, "source_fingerprint", source_fingerprint)
+        object.__setattr__(self, "generations", generations)
+
+    @classmethod
+    def create(cls, generation: Generation) -> "Snapshot":
+        snapshot_id = content_id(
+            "snap",
+            {
+                "repository": generation.repository,
+                "commit": generation.commit,
+                "source_fingerprint": generation.source_fingerprint,
+                "generations": {generation.view_type: generation.generation_id},
+            },
+        )
+        return cls(
+            snapshot_id=snapshot_id,
+            repository=generation.repository,
+            commit=generation.commit,
+            source_fingerprint=generation.source_fingerprint,
+            generations=(generation,),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RefHead:
+    repository: str
+    ref_name: str
+    snapshot_id: str
+    revision: int
+
+    def __post_init__(self) -> None:
+        required_text(self.repository, label="repository")
+        required_text(self.ref_name, label="ref name")
+        required_text(self.snapshot_id, label="snapshot ID")
+        if type(self.revision) is not int or self.revision <= 0:
+            raise StorageValidationError("ref revision must be a positive integer")
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedSnapshot:
+    snapshot: Snapshot
+    ref: RefHead | None = None
+
+
+__all__ = [
+    "Generation",
+    "PublishConflict",
+    "RefHead",
+    "ResolvedSnapshot",
+    "Snapshot",
+    "StorageError",
+    "StorageIntegrityError",
+    "StorageNotFound",
+    "StorageValidationError",
+    "canonical_json",
+    "content_id",
+    "normalize_digest",
+    "required_text",
+]

--- a/scripts/experimental/hybrid_index/repository.py
+++ b/scripts/experimental/hybrid_index/repository.py
@@ -1,0 +1,289 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""One BM25 portable-artifact publication harness for H1."""
+
+from __future__ import annotations
+
+import os
+import stat
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+from codenib._atomic_directory import (
+    PublicationDirectoryReader,
+    directory_ownership_file_records,
+    lexical_directory_path,
+    reopen_authenticated_directory,
+)
+from codenib.artifacts.archive import (
+    DEFAULT_MAX_ARCHIVE_BYTES,
+    extract_context_artifact_archive,
+)
+from codenib.artifacts.context import CONTEXT_ARTIFACT_MANIFEST
+from codenib.artifacts.runtime import VerifiedContextArtifact, verify_context_artifact
+
+from .cas import BlobInfo, LocalCAS
+from .catalog import SQLiteCatalog
+from .contracts import Generation, ResolvedSnapshot, Snapshot, StorageIntegrityError
+
+_COPY_BYTES = 1024 * 1024
+_ZIP_TIME = (1980, 1, 1, 0, 0, 0)
+
+
+@dataclass(frozen=True, slots=True)
+class PublicationResult:
+    repository: str
+    ref_name: str
+    ref_revision: int
+    snapshot_id: str
+    generation_id: str
+    archive_digest: str
+    archive_size: int
+
+
+def _records(artifact: VerifiedContextArtifact) -> tuple[object, ...]:
+    return directory_ownership_file_records(artifact.ownership)  # type: ignore[arg-type]
+
+
+def _metadata_digest(artifact: VerifiedContextArtifact) -> str:
+    for record in _records(artifact):
+        if record.path == CONTEXT_ARTIFACT_MANIFEST:
+            return record.sha256
+    raise StorageIntegrityError("portable artifact metadata record is missing")
+
+
+def _zip_info(path: str, *, size: int) -> zipfile.ZipInfo:
+    info = zipfile.ZipInfo(path, date_time=_ZIP_TIME)
+    info.create_system = 3
+    info.compress_type = zipfile.ZIP_STORED
+    info.external_attr = (stat.S_IFREG | 0o644) << 16
+    info.file_size = size
+    return info
+
+
+def _write_deterministic_archive(
+    artifact: VerifiedContextArtifact,
+    destination: Path,
+) -> None:
+    """Write the exact verified tree as a deterministic ZIP_STORED file."""
+
+    records = _records(artifact)
+    if not records:
+        raise StorageIntegrityError("portable artifact contains no files")
+    total_size = sum(record.size for record in records)
+    if total_size > DEFAULT_MAX_ARCHIVE_BYTES:
+        raise ValueError(
+            "H1 portable artifact exceeds its "
+            f"{DEFAULT_MAX_ARCHIVE_BYTES}-byte archive limit"
+        )
+
+    with destination.open("w+b") as raw_archive:
+        with zipfile.ZipFile(
+            raw_archive,
+            mode="w",
+            compression=zipfile.ZIP_STORED,
+            allowZip64=True,
+            strict_timestamps=True,
+        ) as archive:
+            archive.comment = b""
+
+            def write(publication: PublicationDirectoryReader) -> None:
+                for record in records:
+                    relative = PurePosixPath(record.path)
+                    with publication.open_authenticated_file(
+                        relative,
+                        max_bytes=record.size,
+                    ) as source:
+                        with archive.open(
+                            _zip_info(record.path, size=record.size),
+                            mode="w",
+                            force_zip64=record.size >= zipfile.ZIP64_LIMIT,
+                        ) as target:
+                            written = 0
+                            for block in source.iter_bytes(chunk_size=_COPY_BYTES):
+                                target.write(block)
+                                written += len(block)
+                    if written != record.size or source.record != record:
+                        raise StorageIntegrityError(
+                            f"portable artifact changed while packing: {record.path}"
+                        )
+                if publication.capture_ownership() != artifact.ownership:
+                    raise StorageIntegrityError(
+                        "portable artifact changed while packing its archive"
+                    )
+
+            reopen_authenticated_directory(
+                artifact.root,
+                artifact.ownership,  # type: ignore[arg-type]
+                write,
+            )
+        raw_archive.flush()
+        os.fsync(raw_archive.fileno())
+    if destination.stat().st_size > DEFAULT_MAX_ARCHIVE_BYTES:
+        raise ValueError(
+            "H1 portable artifact archive exceeds its "
+            f"{DEFAULT_MAX_ARCHIVE_BYTES}-byte limit"
+        )
+
+
+def _paths_overlap(first: Path, second: Path) -> bool:
+    return first == second or first in second.parents or second in first.parents
+
+
+class IndexRepository:
+    """Compose the one H1 SQLite catalog and local CAS implementation.
+
+    Constructor composition is the experimental harness seam; H1 deliberately
+    has no backend registry or public protocol hierarchy.
+    """
+
+    def __init__(
+        self,
+        *,
+        root: Path,
+        catalog: SQLiteCatalog,
+        objects: LocalCAS,
+    ) -> None:
+        self.root = root
+        self.catalog = catalog
+        self.objects = objects
+
+    @classmethod
+    def open(cls, root: str | os.PathLike[str]) -> "IndexRepository":
+        candidate = Path(root).expanduser().resolve(strict=False)
+        candidate.mkdir(parents=True, exist_ok=True)
+        if not candidate.is_dir():
+            raise ValueError("H1 repository root must be a directory")
+        # Validate/provision the data plane before creating catalog state.
+        objects = LocalCAS(candidate / "objects")
+        catalog = SQLiteCatalog(candidate / "catalog.sqlite3")
+        return cls(root=candidate, catalog=catalog, objects=objects)
+
+    def _preflight_archive(
+        self,
+        blob: BlobInfo,
+        artifact: VerifiedContextArtifact,
+    ) -> None:
+        archive = self.objects.verified_path(
+            blob.digest,
+            expected_size=blob.byte_size,
+        )
+        with tempfile.TemporaryDirectory(prefix="codenib-h1-preflight-") as temporary:
+            extracted = extract_context_artifact_archive(
+                archive,
+                Path(temporary) / "artifact",
+                expected_repository=artifact.repository,
+                expected_commit=artifact.commit,
+                max_archive_bytes=DEFAULT_MAX_ARCHIVE_BYTES,
+            )
+            if (
+                extracted.source_fingerprint != artifact.source_fingerprint
+                or extracted.views != artifact.views
+                or _metadata_digest(extracted) != _metadata_digest(artifact)
+            ):
+                raise StorageIntegrityError(
+                    "CAS archive preflight differs from the portable artifact"
+                )
+
+    def publish_bm25(
+        self,
+        artifact_root: str | os.PathLike[str],
+        *,
+        ref_name: str = "main",
+        expected_revision: int = 0,
+    ) -> PublicationResult:
+        """Store one verified BM25 artifact, then atomically move its ref."""
+
+        artifact = verify_context_artifact(artifact_root)
+        if artifact.views != ("bm25",):
+            raise ValueError("H1 accepts exactly one portable BM25 view")
+        with tempfile.TemporaryDirectory(prefix="codenib-h1-pack-") as temporary:
+            archive = Path(temporary) / "context.zip"
+            _write_deterministic_archive(artifact, archive)
+            blob = self.objects.put_file(archive)
+        self._preflight_archive(blob, artifact)
+
+        generation = Generation.create(
+            repository=artifact.repository,
+            commit=artifact.commit,
+            source_fingerprint=artifact.source_fingerprint,
+            metadata_digest=_metadata_digest(artifact),
+            archive_digest=blob.digest,
+            archive_size=blob.byte_size,
+            file_count=artifact.file_count,
+            byte_count=artifact.byte_count,
+        )
+        snapshot = Snapshot.create(generation)
+        head = self.catalog.publish_snapshot(
+            snapshot,
+            ref_name=ref_name,
+            expected_revision=expected_revision,
+        )
+        return PublicationResult(
+            repository=head.repository,
+            ref_name=head.ref_name,
+            ref_revision=head.revision,
+            snapshot_id=head.snapshot_id,
+            generation_id=generation.generation_id,
+            archive_digest=blob.digest,
+            archive_size=blob.byte_size,
+        )
+
+    def resolve_ref(
+        self,
+        repository: str,
+        ref_name: str = "main",
+    ) -> ResolvedSnapshot:
+        """Resolve catalog metadata once; materialization verifies CAS closure."""
+
+        return self.catalog.resolve_ref(repository, ref_name)
+
+    def materialize_snapshot(
+        self,
+        snapshot_id: str,
+        destination: str | os.PathLike[str],
+    ) -> VerifiedContextArtifact:
+        """Export a pinned snapshot as an ordinary portable context artifact."""
+
+        closure = self.catalog.get_snapshot(snapshot_id)
+        generation = closure.snapshot.generations[0]
+        output = lexical_directory_path(Path(destination))
+        if _paths_overlap(self.root, output):
+            raise ValueError("materialized artifact must be outside the H1 store")
+        if output.exists() or output.is_symlink():
+            raise FileExistsError(
+                f"snapshot materialization destination already exists: {output}"
+            )
+        archive = self.objects.verified_path(
+            generation.archive_digest,
+            expected_size=generation.archive_size,
+        )
+        artifact = extract_context_artifact_archive(
+            archive,
+            output,
+            expected_repository=closure.snapshot.repository,
+            expected_commit=closure.snapshot.commit,
+            max_archive_bytes=DEFAULT_MAX_ARCHIVE_BYTES,
+        )
+        if (
+            artifact.source_fingerprint != closure.snapshot.source_fingerprint
+            or artifact.views != (generation.view_type,)
+            or _metadata_digest(artifact) != generation.metadata_digest
+            or artifact.file_count != generation.file_count
+            or artifact.byte_count != generation.byte_count
+        ):
+            raise StorageIntegrityError(
+                "materialized artifact differs from its generation identity"
+            )
+        return artifact
+
+
+__all__ = [
+    "IndexRepository",
+    "PublicationResult",
+    "_write_deterministic_archive",
+]

--- a/scripts/experimental/hybrid_index/repository.py
+++ b/scripts/experimental/hybrid_index/repository.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 import stat
 import tempfile
@@ -28,7 +29,13 @@ from codenib.artifacts.runtime import VerifiedContextArtifact, verify_context_ar
 
 from .cas import BlobInfo, LocalCAS
 from .catalog import SQLiteCatalog
-from .contracts import Generation, ResolvedSnapshot, Snapshot, StorageIntegrityError
+from .contracts import (
+    Generation,
+    ResolvedSnapshot,
+    Snapshot,
+    StorageIntegrityError,
+    StorageValidationError,
+)
 
 _COPY_BYTES = 1024 * 1024
 _ZIP_TIME = (1980, 1, 1, 0, 0, 0)
@@ -130,6 +137,41 @@ def _write_deterministic_archive(
         )
 
 
+def _archive_identity(path: Path) -> tuple[str, int, int]:
+    """Read the identity fields committed by one H1 deterministic archive."""
+
+    try:
+        with zipfile.ZipFile(path) as archive:
+            members = archive.infolist()
+            metadata = [
+                member
+                for member in members
+                if member.filename == CONTEXT_ARTIFACT_MANIFEST and not member.is_dir()
+            ]
+            if len(metadata) != 1 or any(member.is_dir() for member in members):
+                raise StorageIntegrityError(
+                    "CAS archive does not have the deterministic H1 shape"
+                )
+            digest = hashlib.sha256()
+            observed_size = 0
+            with archive.open(metadata[0], "r") as source:
+                while block := source.read(_COPY_BYTES):
+                    digest.update(block)
+                    observed_size += len(block)
+            if observed_size != metadata[0].file_size:
+                raise StorageIntegrityError("CAS archive metadata size changed")
+            payload = [member for member in members if member is not metadata[0]]
+            return (
+                digest.hexdigest(),
+                len(payload),
+                sum(member.file_size for member in payload),
+            )
+    except StorageIntegrityError:
+        raise
+    except (OSError, RuntimeError, zipfile.BadZipFile) as exc:
+        raise StorageIntegrityError("CAS archive identity cannot be read") from exc
+
+
 def _paths_overlap(first: Path, second: Path) -> bool:
     return first == second or first in second.parents or second in first.parents
 
@@ -154,13 +196,21 @@ class IndexRepository:
 
     @classmethod
     def open(cls, root: str | os.PathLike[str]) -> "IndexRepository":
-        candidate = Path(root).expanduser().resolve(strict=False)
+        requested = Path(root).expanduser()
+        if requested.exists() or requested.is_symlink():
+            metadata = requested.lstat()
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise StorageValidationError(
+                    f"H1 repository root is not a real directory: {requested}"
+                )
+        candidate = requested.resolve(strict=False)
         candidate.mkdir(parents=True, exist_ok=True)
-        if not candidate.is_dir():
-            raise ValueError("H1 repository root must be a directory")
+        catalog_path = candidate / "catalog.sqlite3"
+        if catalog_path.is_symlink():
+            raise StorageValidationError("catalog database path is not a regular file")
         # Validate/provision the data plane before creating catalog state.
         objects = LocalCAS(candidate / "objects")
-        catalog = SQLiteCatalog(candidate / "catalog.sqlite3")
+        catalog = SQLiteCatalog(catalog_path)
         return cls(root=candidate, catalog=catalog, objects=objects)
 
     def _preflight_archive(
@@ -262,24 +312,21 @@ class IndexRepository:
             generation.archive_digest,
             expected_size=generation.archive_size,
         )
-        artifact = extract_context_artifact_archive(
+        if _archive_identity(archive) != (
+            generation.metadata_digest,
+            generation.file_count,
+            generation.byte_count,
+        ):
+            raise StorageIntegrityError(
+                "CAS archive differs from its generation identity"
+            )
+        return extract_context_artifact_archive(
             archive,
             output,
             expected_repository=closure.snapshot.repository,
             expected_commit=closure.snapshot.commit,
             max_archive_bytes=DEFAULT_MAX_ARCHIVE_BYTES,
         )
-        if (
-            artifact.source_fingerprint != closure.snapshot.source_fingerprint
-            or artifact.views != (generation.view_type,)
-            or _metadata_digest(artifact) != generation.metadata_digest
-            or artifact.file_count != generation.file_count
-            or artifact.byte_count != generation.byte_count
-        ):
-            raise StorageIntegrityError(
-                "materialized artifact differs from its generation identity"
-            )
-        return artifact
 
 
 __all__ = [

--- a/scripts/experimental/index_persistence.py
+++ b/scripts/experimental/index_persistence.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import argparse
+import sqlite3
 import sys
 from pathlib import Path
 from typing import Sequence
@@ -90,7 +91,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     try:
         return int(args.handler(args))
-    except (OSError, RuntimeError, ValueError) as exc:
+    except (OSError, RuntimeError, ValueError, sqlite3.Error) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 

--- a/scripts/experimental/index_persistence.py
+++ b/scripts/experimental/index_persistence.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Developer-only entry point for the H1 hybrid-index experiment."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Sequence
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.experimental.hybrid_index import IndexRepository  # noqa: E402
+
+
+def _nonnegative_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a non-negative integer") from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative integer")
+    return parsed
+
+
+def _publish(args: argparse.Namespace) -> int:
+    result = IndexRepository.open(args.store).publish_bm25(
+        args.artifact,
+        ref_name=args.ref,
+        expected_revision=args.expected_revision,
+    )
+    print(
+        f"published {result.repository}:{result.ref_name}@{result.ref_revision} "
+        f"{result.snapshot_id}"
+    )
+    return 0
+
+
+def _export(args: argparse.Namespace) -> int:
+    repository = IndexRepository.open(args.store)
+    closure = repository.resolve_ref(args.repository, args.ref)
+    artifact = repository.materialize_snapshot(
+        closure.snapshot.snapshot_id,
+        args.output,
+    )
+    print(f"exported {closure.snapshot.snapshot_id} to {artifact.root}")
+    return 0
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="source-checkout-only hybrid index persistence experiment"
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    publish = commands.add_parser(
+        "publish-bm25",
+        help="publish one verified portable BM25 artifact",
+    )
+    publish.add_argument("artifact")
+    publish.add_argument("--store", required=True)
+    publish.add_argument("--ref", default="main")
+    publish.add_argument(
+        "--expected-revision",
+        type=_nonnegative_int,
+        default=0,
+    )
+    publish.set_defaults(handler=_publish)
+
+    export = commands.add_parser(
+        "export-ref",
+        help="materialize one ref as a portable context artifact",
+    )
+    export.add_argument("repository")
+    export.add_argument("output")
+    export.add_argument("--store", required=True)
+    export.add_argument("--ref", default="main")
+    export.set_defaults(handler=_export)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        return int(args.handler(args))
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/smoke_release_upgrade.py
+++ b/scripts/smoke_release_upgrade.py
@@ -143,6 +143,7 @@ def _assert_storage_surface(
             "-c",
             (
                 "import argparse\n"
+                "import importlib.util\n"
                 "import json\n"
                 "from pathlib import Path\n"
                 "import tempfile\n"
@@ -179,6 +180,8 @@ def _assert_storage_surface(
                 "('LocalCAS', 'SQLiteCatalog', 'StorageError') "
                 "if hasattr(storage, name)),\n"
                 "    'artifact_commands': sorted(commands.choices),\n"
+                "    'index_persistence_importable': "
+                "importlib.util.find_spec('codenib.index.persistence') is not None,\n"
                 "}))\n"
             ),
         ],
@@ -202,6 +205,7 @@ def _assert_storage_surface(
         ],
         "retired_exports": [],
         "artifact_commands": ["fetch", "mcp-config", "pack", "verify"],
+        "index_persistence_importable": False,
     }:
         raise RuntimeError(f"unexpected candidate storage surface: {surface!r}")
 

--- a/scripts/verify_release_artifacts.py
+++ b/scripts/verify_release_artifacts.py
@@ -67,6 +67,8 @@ _RETIRED_RUNTIME_MEMBERS = frozenset(
         "codenib/facts/storage.py",
     }
 )
+_SOURCE_ONLY_WHEEL_PREFIXES = ("scripts/experimental/hybrid_index/",)
+_SOURCE_ONLY_WHEEL_MEMBERS = frozenset({"scripts/experimental/index_persistence.py"})
 
 
 def validate_readme_citation(readme: str) -> None:
@@ -231,6 +233,17 @@ def _validate_wheel(wheel: Path, name: str, version: str) -> None:
             raise ReleaseValidationError(
                 f"{wheel.name} contains retired storage runtime files: "
                 + ", ".join(retired)
+            )
+        source_only = sorted(
+            member
+            for member in members
+            if member in _SOURCE_ONLY_WHEEL_MEMBERS
+            or any(member.startswith(prefix) for prefix in _SOURCE_ONLY_WHEEL_PREFIXES)
+        )
+        if source_only:
+            raise ReleaseValidationError(
+                f"{wheel.name} contains source-only experimental files: "
+                + ", ".join(source_only)
             )
         if not any(
             member.startswith("codenib/web/frontend/assets/") and member.endswith(".js")

--- a/scripts/verify_release_artifacts.py
+++ b/scripts/verify_release_artifacts.py
@@ -49,7 +49,10 @@ _COMPILED_BINARY_SUFFIXES = (
     ".pyd",
     ".so",
 )
-_RETIRED_RUNTIME_PREFIXES = ("codenib/storage/",)
+_RETIRED_RUNTIME_PREFIXES = (
+    "codenib/index/persistence/",
+    "codenib/storage/",
+)
 _RETIRED_RUNTIME_MEMBERS = frozenset(
     {
         "codenib/compiler/cache_import.py",

--- a/test/scripts/hybrid_index/test_cas.py
+++ b/test/scripts/hybrid_index/test_cas.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import threading
+from pathlib import Path
+
+import pytest
+
+from scripts.experimental.hybrid_index import cas as cas_module
+from scripts.experimental.hybrid_index.cas import LocalCAS
+from scripts.experimental.hybrid_index.contracts import (
+    StorageIntegrityError,
+    StorageValidationError,
+)
+
+
+def _source(tmp_path: Path, payload: bytes = b"immutable archive") -> Path:
+    source = tmp_path / "source.zip"
+    source.write_bytes(payload)
+    return source
+
+
+def test_put_file_uses_sha256_key_and_deduplicates(tmp_path: Path) -> None:
+    source = _source(tmp_path)
+    store = LocalCAS(tmp_path / "objects")
+    expected = hashlib.sha256(source.read_bytes()).hexdigest()
+
+    first = store.put_file(source)
+    stored = store._object_path(first.digest)
+    inode = stored.stat().st_ino
+    second = store.put_file(source)
+
+    assert first == second
+    assert first.digest == expected
+    assert stored.stat().st_ino == inode
+    assert stored.read_bytes() == source.read_bytes()
+    assert store.verified_path(first.digest, expected_size=first.byte_size) == stored
+
+
+def test_concurrent_put_of_same_file_publishes_one_object(tmp_path: Path) -> None:
+    source = _source(tmp_path, b"concurrent archive" * 100)
+    store = LocalCAS(tmp_path / "objects")
+    start = threading.Barrier(8)
+    results = []
+    errors: list[BaseException] = []
+
+    def put() -> None:
+        try:
+            start.wait(timeout=10)
+            results.append(store.put_file(source))
+        except Exception as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=put) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert errors == []
+    assert len(set(results)) == 1
+    assert len(tuple((store.root / "sha256").glob("*/*"))) == 1
+
+
+def test_corrupt_existing_object_is_never_replaced(tmp_path: Path) -> None:
+    source = _source(tmp_path)
+    store = LocalCAS(tmp_path / "objects")
+    info = store.put_file(source)
+    stored = store._object_path(info.digest)
+    inode = stored.stat().st_ino
+    stored.write_bytes(b"corrupt")
+
+    with pytest.raises(StorageIntegrityError, match="digest mismatch"):
+        store.verify(info.digest)
+    with pytest.raises(StorageIntegrityError, match="digest mismatch"):
+        store.put_file(source)
+
+    assert stored.stat().st_ino == inode
+    assert stored.read_bytes() == b"corrupt"
+
+
+def test_put_failure_removes_temporary_and_does_not_publish(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source(tmp_path)
+    store = LocalCAS(tmp_path / "objects")
+    digest = hashlib.sha256(source.read_bytes()).hexdigest()
+
+    def fail_link(_source: Path, _destination: Path) -> None:
+        raise OSError("injected publication failure")
+
+    monkeypatch.setattr(cas_module.os, "link", fail_link)
+
+    with pytest.raises(OSError, match="injected publication failure"):
+        store.put_file(source)
+
+    assert not store._object_path(digest).exists()
+    assert tuple((store.root / "tmp").iterdir()) == ()
+
+
+def test_constructor_and_put_reject_symlinks(tmp_path: Path) -> None:
+    actual_root = tmp_path / "actual"
+    actual_root.mkdir()
+    linked_root = tmp_path / "linked"
+    linked_root.symlink_to(actual_root, target_is_directory=True)
+    actual_source = _source(tmp_path)
+    linked_source = tmp_path / "linked.zip"
+    linked_source.symlink_to(actual_source)
+
+    with pytest.raises(StorageValidationError, match="real directory"):
+        LocalCAS(linked_root)
+
+    store = LocalCAS(tmp_path / "objects")
+    with pytest.raises(StorageValidationError, match="regular file"):
+        store.put_file(linked_source)
+
+
+@pytest.mark.parametrize("digest", ["", "A" * 64, "0" * 63, "g" * 64])
+def test_verify_rejects_noncanonical_digest(tmp_path: Path, digest: str) -> None:
+    store = LocalCAS(tmp_path / "objects")
+
+    with pytest.raises(StorageValidationError, match="64 lowercase"):
+        store.verify(digest)
+
+
+def test_new_object_fsyncs_its_shard(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source(tmp_path)
+    store = LocalCAS(tmp_path / "objects")
+    fsynced: list[Path] = []
+    monkeypatch.setattr(cas_module, "_fsync_directory", fsynced.append)
+
+    info = store.put_file(source)
+
+    assert store._object_path(info.digest).parent in fsynced

--- a/test/scripts/hybrid_index/test_catalog.py
+++ b/test/scripts/hybrid_index/test_catalog.py
@@ -1,0 +1,469 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from scripts.experimental.hybrid_index.catalog import SQLiteCatalog
+from scripts.experimental.hybrid_index.contracts import (
+    Generation,
+    PublishConflict,
+    Snapshot,
+    StorageIntegrityError,
+)
+
+_TABLES = (
+    "generations",
+    "refs",
+    "snapshot_generations",
+    "snapshots",
+)
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _generation(
+    seed: str,
+    *,
+    repository: str = "owner/repository",
+) -> Generation:
+    payload = f"archive:{seed}".encode("utf-8")
+    return Generation.create(
+        repository=repository,
+        commit=_digest(f"commit:{seed}")[:40],
+        source_fingerprint=f"source-v2:{_digest(f'source:{seed}')}",
+        metadata_digest=_digest(f"metadata:{seed}"),
+        archive_digest=hashlib.sha256(payload).hexdigest(),
+        archive_size=len(payload),
+        file_count=3,
+        byte_count=len(payload) + 128,
+    )
+
+
+def _snapshot(
+    seed: str,
+    *,
+    repository: str = "owner/repository",
+) -> Snapshot:
+    return Snapshot.create(_generation(seed, repository=repository))
+
+
+def _table_counts(path: Path) -> dict[str, int]:
+    connection = sqlite3.connect(path)
+    try:
+        return {
+            table: int(
+                connection.execute(f"SELECT count(*) FROM {table}").fetchone()[0]
+            )
+            for table in _TABLES
+        }
+    finally:
+        connection.close()
+
+
+def test_catalog_creates_exact_four_table_cnix_wal_schema(tmp_path: Path) -> None:
+    path = tmp_path / "catalog.sqlite3"
+    catalog = SQLiteCatalog(path)
+
+    connection = sqlite3.connect(path)
+    connection.row_factory = sqlite3.Row
+    try:
+        objects = tuple(tuple(row) for row in connection.execute("""
+                SELECT type, name, tbl_name
+                  FROM sqlite_schema
+                 WHERE name NOT LIKE 'sqlite_%'
+                 ORDER BY type, name
+                """))
+        columns = {
+            table: tuple(
+                str(row["name"])
+                for row in connection.execute(f"PRAGMA table_info({table})")
+            )
+            for table in _TABLES
+        }
+        snapshot_foreign_keys = {
+            (row["table"], row["from"], row["to"], row["on_delete"])
+            for row in connection.execute(
+                "PRAGMA foreign_key_list(snapshot_generations)"
+            )
+        }
+        ref_foreign_keys = {
+            (row["table"], row["from"], row["to"], row["on_delete"])
+            for row in connection.execute("PRAGMA foreign_key_list(refs)")
+        }
+
+        assert int(connection.execute("PRAGMA application_id").fetchone()[0]) == (
+            0x434E4958
+        )
+        assert int(connection.execute("PRAGMA user_version").fetchone()[0]) == 1
+        assert str(connection.execute("PRAGMA journal_mode").fetchone()[0]).lower() == (
+            "wal"
+        )
+    finally:
+        connection.close()
+
+    assert catalog.path == path.resolve()
+    assert catalog.journal_mode == "wal"
+    assert objects == tuple(("table", table, table) for table in _TABLES)
+    assert columns == {
+        "generations": (
+            "generation_id",
+            "repository",
+            "commit_sha",
+            "source_fingerprint",
+            "view_type",
+            "metadata_digest",
+            "archive_digest",
+            "archive_size",
+            "file_count",
+            "byte_count",
+            "created_at",
+        ),
+        "refs": (
+            "repository",
+            "ref_name",
+            "snapshot_id",
+            "revision",
+            "updated_at",
+        ),
+        "snapshot_generations": (
+            "snapshot_id",
+            "view_type",
+            "generation_id",
+        ),
+        "snapshots": (
+            "snapshot_id",
+            "repository",
+            "commit_sha",
+            "source_fingerprint",
+            "created_at",
+        ),
+    }
+    assert snapshot_foreign_keys == {
+        ("generations", "generation_id", "generation_id", "RESTRICT"),
+        ("generations", "view_type", "view_type", "RESTRICT"),
+        ("snapshots", "snapshot_id", "snapshot_id", "RESTRICT"),
+    }
+    assert ref_foreign_keys == {
+        ("snapshots", "repository", "repository", "RESTRICT"),
+        ("snapshots", "snapshot_id", "snapshot_id", "RESTRICT"),
+    }
+
+
+def test_concurrent_first_open_initializes_one_catalog(tmp_path: Path) -> None:
+    path = tmp_path / "catalog.sqlite3"
+    worker_count = 8
+    start = threading.Barrier(worker_count)
+
+    def open_catalog() -> SQLiteCatalog:
+        start.wait(timeout=10)
+        return SQLiteCatalog(path, timeout=10)
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        catalogs = tuple(
+            executor.map(lambda _index: open_catalog(), range(worker_count))
+        )
+
+    assert {catalog.path for catalog in catalogs} == {path.resolve()}
+    assert {catalog.journal_mode for catalog in catalogs} == {"wal"}
+    assert _table_counts(path) == {table: 0 for table in _TABLES}
+
+
+def test_unrelated_sqlite_database_fails_closed_without_mutation(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "unrelated.sqlite3"
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute("CREATE TABLE unrelated(value TEXT NOT NULL)")
+        connection.execute("INSERT INTO unrelated(value) VALUES ('keep')")
+        connection.commit()
+    finally:
+        connection.close()
+    before = path.read_bytes()
+
+    with pytest.raises(StorageIntegrityError, match="not a CodeNib index"):
+        SQLiteCatalog(path)
+
+    assert path.read_bytes() == before
+    assert not Path(f"{path}-wal").exists()
+    assert not Path(f"{path}-shm").exists()
+    connection = sqlite3.connect(path)
+    try:
+        assert connection.execute("SELECT value FROM unrelated").fetchone() == ("keep",)
+        assert connection.execute("PRAGMA application_id").fetchone() == (0,)
+        assert connection.execute("PRAGMA user_version").fetchone() == (0,)
+        assert str(connection.execute("PRAGMA journal_mode").fetchone()[0]).lower() == (
+            "delete"
+        )
+    finally:
+        connection.close()
+
+
+@pytest.mark.parametrize("tamper", ["application_id", "schema", "user_version"])
+def test_live_catalog_rejects_identity_or_schema_tampering(
+    tmp_path: Path,
+    tamper: str,
+) -> None:
+    path = tmp_path / f"{tamper}.sqlite3"
+    catalog = SQLiteCatalog(path)
+    connection = sqlite3.connect(path)
+    try:
+        if tamper == "application_id":
+            connection.execute("PRAGMA application_id = 305419896")
+        elif tamper == "schema":
+            connection.execute("CREATE TABLE injected(value TEXT)")
+        else:
+            connection.execute("PRAGMA user_version = 2")
+        connection.commit()
+    finally:
+        connection.close()
+
+    with pytest.raises(StorageIntegrityError):
+        catalog.resolve_ref("owner/repository")
+
+
+def test_live_catalog_rejects_database_path_replacement(tmp_path: Path) -> None:
+    path = tmp_path / "catalog.sqlite3"
+    stale_catalog = SQLiteCatalog(path)
+    displaced = tmp_path / "displaced.sqlite3"
+    os.replace(path, displaced)
+    replacement_catalog = SQLiteCatalog(path)
+
+    assert replacement_catalog.journal_mode == "wal"
+    with pytest.raises(StorageIntegrityError, match="path identity changed"):
+        stale_catalog.resolve_ref("owner/repository")
+
+
+def test_publish_is_idempotent_and_keeps_historical_snapshots(
+    tmp_path: Path,
+) -> None:
+    catalog = SQLiteCatalog(tmp_path / "catalog.sqlite3")
+    first = _snapshot("first")
+    second = _snapshot("second")
+
+    first_head = catalog.publish_snapshot(first, expected_revision=0)
+    retry_from_original_precondition = catalog.publish_snapshot(
+        first,
+        expected_revision=0,
+    )
+    retry_from_current_precondition = catalog.publish_snapshot(
+        first,
+        expected_revision=1,
+    )
+    second_head = catalog.publish_snapshot(second, expected_revision=1)
+
+    assert first_head.revision == 1
+    assert retry_from_original_precondition == first_head
+    assert retry_from_current_precondition == first_head
+    assert second_head.revision == 2
+    assert catalog.resolve_ref(first.repository).snapshot == second
+    assert catalog.resolve_ref(first.repository).ref == second_head
+    assert catalog.get_snapshot(first.snapshot_id).snapshot == first
+    assert catalog.get_snapshot(second.snapshot_id).snapshot == second
+    assert _table_counts(catalog.path) == {
+        "generations": 2,
+        "refs": 1,
+        "snapshot_generations": 2,
+        "snapshots": 2,
+    }
+
+
+def test_concurrent_compare_and_swap_advances_ref_once(tmp_path: Path) -> None:
+    path = tmp_path / "catalog.sqlite3"
+    catalog = SQLiteCatalog(path)
+    initial = _snapshot("initial")
+    candidates = (_snapshot("candidate-a"), _snapshot("candidate-b"))
+    catalog.publish_snapshot(initial, expected_revision=0)
+
+    first_connection = SQLiteCatalog(path, timeout=10)
+    second_connection = SQLiteCatalog(path, timeout=10)
+    start = threading.Barrier(2)
+
+    def publish(candidate: Snapshot, publisher: SQLiteCatalog) -> object:
+        start.wait(timeout=10)
+        try:
+            return publisher.publish_snapshot(candidate, expected_revision=1)
+        except PublishConflict as exc:
+            return exc
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = tuple(
+            executor.map(
+                lambda item: publish(*item),
+                zip(
+                    candidates,
+                    (first_connection, second_connection),
+                    strict=True,
+                ),
+            )
+        )
+
+    winners = [result for result in results if not isinstance(result, PublishConflict)]
+    conflicts = [result for result in results if isinstance(result, PublishConflict)]
+    assert len(winners) == 1
+    assert len(conflicts) == 1
+    winner = winners[0]
+    assert winner.revision == 2
+    assert winner.snapshot_id in {candidate.snapshot_id for candidate in candidates}
+    resolved = catalog.resolve_ref(initial.repository)
+    assert resolved.ref == winner
+    assert resolved.snapshot.snapshot_id == winner.snapshot_id
+    assert catalog.get_snapshot(initial.snapshot_id).snapshot == initial
+    assert _table_counts(path) == {
+        "generations": 2,
+        "refs": 1,
+        "snapshot_generations": 2,
+        "snapshots": 2,
+    }
+
+
+def test_reader_overlapping_publication_observes_complete_snapshots(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "catalog.sqlite3"
+    reader = SQLiteCatalog(path)
+    publisher = SQLiteCatalog(path)
+    initial = _snapshot("initial")
+    candidate = _snapshot("candidate")
+    initial_head = publisher.publish_snapshot(initial, expected_revision=0)
+    before_ref = threading.Event()
+    release = threading.Event()
+    errors: list[BaseException] = []
+
+    def pause_before_ref_update() -> None:
+        before_ref.set()
+        if not release.wait(timeout=10):
+            raise TimeoutError("reader did not release publisher")
+
+    monkeypatch.setattr(publisher, "_before_ref_update", pause_before_ref_update)
+
+    def publish() -> None:
+        try:
+            publisher.publish_snapshot(candidate, expected_revision=1)
+        except Exception as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    thread = threading.Thread(target=publish)
+    thread.start()
+    assert before_ref.wait(timeout=10)
+    overlapping = reader.resolve_ref(initial.repository)
+    release.set()
+    thread.join(timeout=10)
+
+    assert not thread.is_alive()
+    assert errors == []
+    assert overlapping.ref == initial_head
+    assert overlapping.snapshot == initial
+    published = reader.resolve_ref(initial.repository)
+    assert published.ref is not None
+    assert published.ref.revision == 2
+    assert published.snapshot == candidate
+
+
+def test_failure_before_ref_update_rolls_back_all_catalog_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog = SQLiteCatalog(tmp_path / "catalog.sqlite3")
+    current = _snapshot("current")
+    candidate = _snapshot("candidate")
+    current_head = catalog.publish_snapshot(current, expected_revision=0)
+    before = _table_counts(catalog.path)
+
+    def fail_before_ref_update() -> None:
+        raise RuntimeError("injected transaction failure")
+
+    monkeypatch.setattr(catalog, "_before_ref_update", fail_before_ref_update)
+
+    with pytest.raises(RuntimeError, match="injected transaction failure"):
+        catalog.publish_snapshot(candidate, expected_revision=1)
+
+    assert _table_counts(catalog.path) == before
+    resolved = catalog.resolve_ref(current.repository)
+    assert resolved.ref == current_head
+    assert resolved.snapshot == current
+
+
+def test_generation_identity_collision_is_rejected_without_ref_change(
+    tmp_path: Path,
+) -> None:
+    catalog = SQLiteCatalog(tmp_path / "catalog.sqlite3")
+    original = _generation("original")
+    first = Snapshot.create(original)
+    first_head = catalog.publish_snapshot(first, expected_revision=0)
+    conflicting_archive = b"different immutable archive"
+    conflicting = Generation(
+        generation_id=original.generation_id,
+        repository=original.repository,
+        commit=original.commit,
+        source_fingerprint=original.source_fingerprint,
+        view_type=original.view_type,
+        metadata_digest=original.metadata_digest,
+        archive_digest=hashlib.sha256(conflicting_archive).hexdigest(),
+        archive_size=len(conflicting_archive),
+        file_count=original.file_count,
+        byte_count=original.byte_count,
+    )
+    collision = Snapshot.create(conflicting)
+
+    with pytest.raises(StorageIntegrityError, match="generation .* is not immutable"):
+        catalog.publish_snapshot(collision, expected_revision=1)
+
+    assert catalog.resolve_ref(original.repository).ref == first_head
+    assert catalog.resolve_ref(original.repository).snapshot == first
+    assert _table_counts(catalog.path) == {
+        "generations": 1,
+        "refs": 1,
+        "snapshot_generations": 1,
+        "snapshots": 1,
+    }
+
+
+def test_snapshot_identity_collision_rolls_back_new_generation_and_ref(
+    tmp_path: Path,
+) -> None:
+    catalog = SQLiteCatalog(tmp_path / "catalog.sqlite3")
+    candidate = _snapshot("candidate")
+    connection = sqlite3.connect(catalog.path)
+    try:
+        connection.execute(
+            """
+            INSERT INTO snapshots(
+                snapshot_id, repository, commit_sha,
+                source_fingerprint, created_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                candidate.snapshot_id,
+                "different/repository",
+                candidate.commit,
+                candidate.source_fingerprint,
+                0.0,
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    with pytest.raises(StorageIntegrityError, match="snapshot .* is not immutable"):
+        catalog.publish_snapshot(candidate, expected_revision=0)
+
+    assert _table_counts(catalog.path) == {
+        "generations": 0,
+        "refs": 0,
+        "snapshot_generations": 0,
+        "snapshots": 1,
+    }

--- a/test/scripts/hybrid_index/test_catalog.py
+++ b/test/scripts/hybrid_index/test_catalog.py
@@ -162,22 +162,26 @@ def test_catalog_creates_exact_four_table_cnix_wal_schema(tmp_path: Path) -> Non
 
 
 def test_concurrent_first_open_initializes_one_catalog(tmp_path: Path) -> None:
-    path = tmp_path / "catalog.sqlite3"
-    worker_count = 8
-    start = threading.Barrier(worker_count)
+    worker_count = 16
 
-    def open_catalog() -> SQLiteCatalog:
-        start.wait(timeout=10)
-        return SQLiteCatalog(path, timeout=10)
+    def open_concurrently(path: Path) -> tuple[SQLiteCatalog, ...]:
+        start = threading.Barrier(worker_count)
 
-    with ThreadPoolExecutor(max_workers=worker_count) as executor:
-        catalogs = tuple(
-            executor.map(lambda _index: open_catalog(), range(worker_count))
-        )
+        def open_catalog() -> SQLiteCatalog:
+            start.wait(timeout=10)
+            return SQLiteCatalog(path, timeout=10)
 
-    assert {catalog.path for catalog in catalogs} == {path.resolve()}
-    assert {catalog.journal_mode for catalog in catalogs} == {"wal"}
-    assert _table_counts(path) == {table: 0 for table in _TABLES}
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            return tuple(
+                executor.map(lambda _index: open_catalog(), range(worker_count))
+            )
+
+    for iteration in range(25):
+        path = tmp_path / f"catalog-{iteration}.sqlite3"
+        catalogs = open_concurrently(path)
+        assert {catalog.path for catalog in catalogs} == {path.resolve()}
+        assert {catalog.journal_mode for catalog in catalogs} == {"wal"}
+        assert _table_counts(path) == {table: 0 for table in _TABLES}
 
 
 def test_unrelated_sqlite_database_fails_closed_without_mutation(

--- a/test/scripts/hybrid_index/test_repository.py
+++ b/test/scripts/hybrid_index/test_repository.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import sqlite3
 import stat
 import subprocess
 import zipfile
@@ -29,6 +30,7 @@ from scripts.experimental.hybrid_index.contracts import (
     PublishConflict,
     StorageIntegrityError,
     StorageNotFound,
+    StorageValidationError,
 )
 from scripts.experimental.hybrid_index.repository import (
     IndexRepository,
@@ -404,6 +406,52 @@ def test_corrupt_cas_archive_cannot_materialize_a_published_snapshot(
     with pytest.raises(StorageIntegrityError, match="not a regular file"):
         store.materialize_snapshot(publication.snapshot_id, replaced_destination)
     assert not replaced_destination.exists()
+
+
+def test_catalog_identity_mismatch_does_not_publish_materialization(
+    tmp_path: Path,
+) -> None:
+    repository = _initialize_repository(tmp_path, _initial_source())
+    built = _build_portable_bm25(
+        tmp_path,
+        repository,
+        generation="catalog-mismatch",
+    )
+    store = IndexRepository.open(tmp_path / "h1-store")
+    publication = store.publish_bm25(built.root)
+    with sqlite3.connect(store.catalog.path) as connection:
+        connection.execute("UPDATE generations SET file_count = file_count + 1")
+    destination = tmp_path / "must-not-publish-catalog-mismatch"
+
+    with pytest.raises(StorageIntegrityError, match="generation identity"):
+        store.materialize_snapshot(publication.snapshot_id, destination)
+
+    assert not destination.exists()
+    assert not list(tmp_path.glob(f".{destination.name}*"))
+
+
+def test_repository_open_rejects_a_symlinked_root(tmp_path: Path) -> None:
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    final_alias = tmp_path / "store-alias"
+    final_alias.symlink_to(victim, target_is_directory=True)
+
+    with pytest.raises(StorageValidationError, match="real directory"):
+        IndexRepository.open(final_alias)
+
+    assert tuple(victim.iterdir()) == ()
+
+
+def test_repository_open_rejects_a_symlinked_catalog(tmp_path: Path) -> None:
+    store_root = tmp_path / "h1-store"
+    store_root.mkdir()
+    outside = tmp_path / "outside.sqlite3"
+    (store_root / "catalog.sqlite3").symlink_to(outside)
+
+    with pytest.raises(StorageValidationError, match="regular file"):
+        IndexRepository.open(store_root)
+
+    assert not outside.exists()
 
 
 def test_materialize_rejects_a_symlinked_destination_ancestor(

--- a/test/scripts/hybrid_index/test_repository.py
+++ b/test/scripts/hybrid_index/test_repository.py
@@ -393,6 +393,18 @@ def test_corrupt_cas_archive_cannot_materialize_a_published_snapshot(
     )
     assert (built.root / CONTEXT_ARTIFACT_MANIFEST).is_file()
 
+    archive.unlink()
+    missing_destination = tmp_path / "missing-must-not-publish"
+    with pytest.raises(FileNotFoundError):
+        store.materialize_snapshot(publication.snapshot_id, missing_destination)
+    assert not missing_destination.exists()
+
+    archive.symlink_to(built.root / CONTEXT_ARTIFACT_MANIFEST)
+    replaced_destination = tmp_path / "replaced-must-not-publish"
+    with pytest.raises(StorageIntegrityError, match="not a regular file"):
+        store.materialize_snapshot(publication.snapshot_id, replaced_destination)
+    assert not replaced_destination.exists()
+
 
 def test_materialize_rejects_a_symlinked_destination_ancestor(
     tmp_path: Path,

--- a/test/scripts/hybrid_index/test_repository.py
+++ b/test/scripts/hybrid_index/test_repository.py
@@ -1,0 +1,424 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import stat
+import subprocess
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+import codenib.mcp.server as server_module
+import scripts.experimental.hybrid_index.repository as repository_module
+from codenib.artifacts import (
+    CONTEXT_ARTIFACT_MANIFEST,
+    query_context_artifact,
+    stage_context_artifact,
+    verify_context_artifact,
+)
+from codenib.compiler.index_builders import BM25IndexBuilder, IndexBuilderRegistry
+from codenib.compiler.index_compiler import IndexCompiler, IndexCompilerConfig
+from codenib.compiler.manifest import MANIFEST_FILENAME
+from scripts.experimental.hybrid_index.contracts import (
+    PublishConflict,
+    StorageIntegrityError,
+    StorageNotFound,
+)
+from scripts.experimental.hybrid_index.repository import (
+    IndexRepository,
+    _write_deterministic_archive,
+)
+
+_REPOSITORY = "example/h1-bm25"
+
+
+@dataclass(frozen=True, slots=True)
+class _BuiltArtifact:
+    root: Path
+    commit: str
+    cache: Path
+
+
+def _git(repository: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repository), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _initialize_repository(root: Path, source: str) -> Path:
+    repository = root / "checkout"
+    repository.mkdir()
+    (repository / "billing.py").write_text(source, encoding="utf-8")
+    _git(repository, "init", "--quiet")
+    _git(repository, "config", "user.name", "CodeNib Test")
+    _git(repository, "config", "user.email", "codenib@example.invalid")
+    _git(repository, "add", "billing.py")
+    _git(repository, "commit", "--quiet", "-m", "initial fixture")
+    return repository
+
+
+def _commit_source(repository: Path, source: str, message: str) -> str:
+    (repository / "billing.py").write_text(source, encoding="utf-8")
+    _git(repository, "add", "billing.py")
+    _git(repository, "commit", "--quiet", "-m", message)
+    return _git(repository, "rev-parse", "HEAD")
+
+
+def _build_portable_bm25(
+    root: Path,
+    repository: Path,
+    *,
+    generation: str,
+) -> _BuiltArtifact:
+    registry = IndexBuilderRegistry()
+    registry.register("bm25", BM25IndexBuilder(languages=["python"]))
+    compiler = IndexCompiler(
+        registry,
+        IndexCompilerConfig(index_types=["bm25"], languages=["python"]),
+    )
+    cache = root / f"compiler-{generation}"
+    manifest = compiler.compile_repo(str(repository), cache_dir=str(cache))
+    assert manifest.indexes["bm25"].status == "fresh"
+
+    artifact = root / f"artifact-{generation}"
+    stage_context_artifact(
+        repository,
+        cache / MANIFEST_FILENAME,
+        artifact,
+        repository=_REPOSITORY,
+        views=["bm25"],
+    )
+    verified = verify_context_artifact(
+        artifact,
+        expected_repository=_REPOSITORY,
+        expected_commit=manifest.commit,
+    )
+    assert verified.views == ("bm25",)
+    return _BuiltArtifact(root=artifact, commit=manifest.commit, cache=cache)
+
+
+def _initial_source(token: str = "rare_invoice_token") -> str:
+    return (
+        "def calculate_tax(invoice_total):\n"
+        f'    """Apply the {token} formula."""\n'
+        "    return invoice_total * 0.07\n"
+    )
+
+
+def test_real_bm25_round_trip_reaches_the_mcp_query(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _initialize_repository(tmp_path, _initial_source())
+    built = _build_portable_bm25(
+        tmp_path,
+        repository,
+        generation="first",
+    )
+    store = IndexRepository.open(tmp_path / "h1-store")
+
+    publication = store.publish_bm25(built.root)
+    resolved = store.resolve_ref(_REPOSITORY)
+    materialized = tmp_path / "materialized"
+    artifact = store.materialize_snapshot(publication.snapshot_id, materialized)
+
+    assert resolved.ref is not None
+    assert resolved.ref.snapshot_id == publication.snapshot_id
+    assert resolved.ref.revision == 1
+    assert artifact.commit == built.commit
+    assert artifact.views == ("bm25",)
+
+    built.cache.rename(tmp_path / "compiler-cache-offline")
+    repository.rename(tmp_path / "checkout-offline")
+    store.root.rename(tmp_path / "h1-store-offline")
+    assert not built.cache.exists()
+    assert not repository.exists()
+    assert not store.root.exists()
+
+    monkeypatch.setattr(server_module, "_ctx", None)
+    binding = query_context_artifact(
+        materialized,
+        expected_repository=_REPOSITORY,
+        expected_commit=built.commit,
+    )
+    context = None
+    try:
+        server_module.init_server(
+            binding.manifest,
+            artifact={
+                "verified": True,
+                "schema": artifact.metadata["schema"],
+                "repository": artifact.repository,
+                "commit": artifact.commit,
+                "views": list(artifact.views),
+            },
+            artifact_binding=binding,
+        )
+        binding.close()
+        context = server_module.get_context()
+
+        results = asyncio.run(
+            server_module.search_bm25(
+                query="rare_invoice_token calculate_tax",
+                top_k=10,
+            )
+        )
+
+        assert context.loaded_views == frozenset({"bm25"})
+        assert not context.source_verified
+        assert any(result["file"] == "billing.py" for result in results)
+        assert any(
+            "calculate_tax" in result["node_name"] for result in results
+        ), results
+        assert all(result.get("content") is None for result in results)
+    finally:
+        if context is not None:
+            context.close()
+        binding.close()
+        server_module._ctx = None
+
+
+def test_archive_bytes_and_zip_metadata_are_deterministic(tmp_path: Path) -> None:
+    repository = _initialize_repository(tmp_path, _initial_source())
+    built = _build_portable_bm25(
+        tmp_path,
+        repository,
+        generation="deterministic",
+    )
+    artifact = verify_context_artifact(built.root)
+    first = tmp_path / "first.zip"
+    second = tmp_path / "second.zip"
+
+    _write_deterministic_archive(artifact, first)
+    _write_deterministic_archive(artifact, second)
+
+    first_bytes = first.read_bytes()
+    assert first_bytes == second.read_bytes()
+    assert (
+        hashlib.sha256(first_bytes).hexdigest()
+        == hashlib.sha256(second.read_bytes()).hexdigest()
+    )
+    with zipfile.ZipFile(first) as archive:
+        members = archive.infolist()
+    assert [member.filename for member in members] == sorted(
+        member.filename for member in members
+    )
+    assert all(not member.is_dir() for member in members)
+    assert all(member.date_time == (1980, 1, 1, 0, 0, 0) for member in members)
+    assert all(member.compress_type == zipfile.ZIP_STORED for member in members)
+    assert all(member.create_system == 3 for member in members)
+    assert all(stat.S_IMODE(member.external_attr >> 16) == 0o644 for member in members)
+
+
+def test_exact_publication_retry_reuses_one_archive_and_revision(
+    tmp_path: Path,
+) -> None:
+    repository = _initialize_repository(tmp_path, _initial_source())
+    built = _build_portable_bm25(tmp_path, repository, generation="retry")
+    store = IndexRepository.open(tmp_path / "h1-store")
+
+    first = store.publish_bm25(built.root, expected_revision=0)
+    object_paths = tuple((store.root / "objects/sha256").glob("*/*"))
+    first_bytes = sum(path.stat().st_size for path in object_paths)
+    second = store.publish_bm25(built.root, expected_revision=0)
+    retried_paths = tuple((store.root / "objects/sha256").glob("*/*"))
+
+    assert second == first
+    assert retried_paths == object_paths
+    assert sum(path.stat().st_size for path in retried_paths) == first_bytes
+
+
+def test_invalid_artifact_does_not_publish_catalog_or_object_state(
+    tmp_path: Path,
+) -> None:
+    invalid = tmp_path / "invalid-artifact"
+    invalid.mkdir()
+    (invalid / "not-context.txt").write_text("invalid", encoding="utf-8")
+    store = IndexRepository.open(tmp_path / "h1-store")
+
+    with pytest.raises(ValueError):
+        store.publish_bm25(invalid)
+
+    with pytest.raises(StorageNotFound):
+        store.resolve_ref(_REPOSITORY)
+    assert tuple((store.root / "objects/sha256").glob("*/*")) == ()
+
+
+def test_artifact_change_during_pack_does_not_publish(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _initialize_repository(tmp_path, _initial_source())
+    built = _build_portable_bm25(tmp_path, repository, generation="mutation")
+    store = IndexRepository.open(tmp_path / "h1-store")
+    real_reopen = repository_module.reopen_authenticated_directory
+    changed = False
+
+    def mutate_then_reopen(path, ownership, callback):
+        nonlocal changed
+        if not changed:
+            changed = True
+            documents = path / "views/bm25/documents.json"
+            documents.write_bytes(documents.read_bytes() + b" ")
+        return real_reopen(path, ownership, callback)
+
+    monkeypatch.setattr(
+        repository_module,
+        "reopen_authenticated_directory",
+        mutate_then_reopen,
+    )
+
+    with pytest.raises((RuntimeError, ValueError), match="changed|ownership"):
+        store.publish_bm25(built.root)
+
+    with pytest.raises(StorageNotFound):
+        store.resolve_ref(_REPOSITORY)
+    assert tuple((store.root / "objects/sha256").glob("*/*")) == ()
+
+
+def test_catalog_failure_after_cas_leaves_only_an_unreachable_object(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _initialize_repository(tmp_path, _initial_source())
+    built = _build_portable_bm25(tmp_path, repository, generation="db-failure")
+    store = IndexRepository.open(tmp_path / "h1-store")
+
+    def fail_before_ref_update() -> None:
+        raise RuntimeError("injected catalog failure")
+
+    monkeypatch.setattr(store.catalog, "_before_ref_update", fail_before_ref_update)
+
+    with pytest.raises(RuntimeError, match="injected catalog failure"):
+        store.publish_bm25(built.root)
+
+    objects = tuple((store.root / "objects/sha256").glob("*/*"))
+    assert len(objects) == 1
+    assert store.objects.verify(objects[0].parent.name + objects[0].name)
+    with pytest.raises(StorageNotFound):
+        store.resolve_ref(_REPOSITORY)
+
+
+def test_ref_advance_preserves_history_and_rejects_a_stale_writer(
+    tmp_path: Path,
+) -> None:
+    repository = _initialize_repository(tmp_path, _initial_source("first_token"))
+    first_artifact = _build_portable_bm25(
+        tmp_path,
+        repository,
+        generation="first",
+    )
+    store = IndexRepository.open(tmp_path / "h1-store")
+    first = store.publish_bm25(first_artifact.root)
+
+    second_commit = _commit_source(
+        repository,
+        _initial_source("second_token"),
+        "change formula token",
+    )
+    second_artifact = _build_portable_bm25(
+        tmp_path,
+        repository,
+        generation="second",
+    )
+    second = store.publish_bm25(
+        second_artifact.root,
+        expected_revision=first.ref_revision,
+    )
+
+    current = store.resolve_ref(_REPOSITORY)
+    assert current.ref is not None
+    assert current.ref.snapshot_id == second.snapshot_id
+    assert current.ref.revision == 2
+    assert current.snapshot.commit == second_commit
+    assert first.snapshot_id != second.snapshot_id
+
+    old_destination = tmp_path / "materialized-first"
+    historical = store.materialize_snapshot(first.snapshot_id, old_destination)
+    assert historical.commit == first_artifact.commit
+    assert historical.commit != second_commit
+    assert (
+        store.catalog.get_snapshot(first.snapshot_id).snapshot.snapshot_id
+        == first.snapshot_id
+    )
+
+    with pytest.raises(PublishConflict, match="is at revision 2, not 1"):
+        store.publish_bm25(
+            first_artifact.root,
+            expected_revision=first.ref_revision,
+        )
+
+    unchanged = store.resolve_ref(_REPOSITORY)
+    assert unchanged.ref == current.ref
+    assert unchanged.snapshot == current.snapshot
+
+
+def test_corrupt_cas_archive_cannot_materialize_a_published_snapshot(
+    tmp_path: Path,
+) -> None:
+    repository = _initialize_repository(tmp_path, _initial_source())
+    built = _build_portable_bm25(
+        tmp_path,
+        repository,
+        generation="corruption",
+    )
+    store = IndexRepository.open(tmp_path / "h1-store")
+    publication = store.publish_bm25(built.root)
+    closure = store.catalog.get_snapshot(publication.snapshot_id)
+    generation = closure.snapshot.generations[0]
+    archive = store.objects.verified_path(
+        generation.archive_digest,
+        expected_size=generation.archive_size,
+    )
+    corrupted = bytearray(archive.read_bytes())
+    corrupted[0] ^= 0xFF
+    archive.write_bytes(corrupted)
+    destination = tmp_path / "must-not-publish"
+
+    with pytest.raises(StorageIntegrityError, match="digest mismatch"):
+        store.materialize_snapshot(publication.snapshot_id, destination)
+
+    assert not destination.exists()
+    assert store.resolve_ref(_REPOSITORY).snapshot.snapshot_id == (
+        publication.snapshot_id
+    )
+    assert (built.root / CONTEXT_ARTIFACT_MANIFEST).is_file()
+
+
+def test_materialize_rejects_a_symlinked_destination_ancestor(
+    tmp_path: Path,
+) -> None:
+    repository = _initialize_repository(tmp_path, _initial_source())
+    built = _build_portable_bm25(
+        tmp_path,
+        repository,
+        generation="symlink-ancestor",
+    )
+    store = IndexRepository.open(tmp_path / "h1-store")
+    publication = store.publish_bm25(built.root)
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    marker = victim / "valuable.txt"
+    marker.write_text("preserve", encoding="utf-8")
+    alias = tmp_path / "destination-alias"
+    alias.symlink_to(victim, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="real directory"):
+        store.materialize_snapshot(
+            publication.snapshot_id,
+            alias / "published",
+        )
+
+    assert alias.is_symlink()
+    assert marker.read_text(encoding="utf-8") == "preserve"
+    assert tuple(victim.iterdir()) == (marker,)
+    assert not list(victim.glob(".*.normalize-*"))

--- a/test/scripts/test_experimental_index_persistence.py
+++ b/test/scripts/test_experimental_index_persistence.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts.experimental import index_persistence
+
+
+def test_experiment_exposes_only_two_source_checkout_commands() -> None:
+    parser = index_persistence._parser()
+    commands = next(
+        action
+        for action in parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+    )
+
+    assert set(commands.choices) == {"publish-bm25", "export-ref"}
+
+
+def test_publish_command_forwards_the_ref_revision(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    calls: list[tuple[object, ...]] = []
+
+    class Repository:
+        def publish_bm25(self, artifact, *, ref_name, expected_revision):
+            calls.append((artifact, ref_name, expected_revision))
+            return SimpleNamespace(
+                repository="example/project",
+                ref_name=ref_name,
+                ref_revision=expected_revision + 1,
+                snapshot_id="snap_123",
+            )
+
+    monkeypatch.setattr(
+        index_persistence.IndexRepository,
+        "open",
+        lambda root: calls.append(("open", root)) or Repository(),
+    )
+
+    assert (
+        index_persistence.main(
+            [
+                "publish-bm25",
+                str(tmp_path / "artifact"),
+                "--store",
+                str(tmp_path / "store"),
+                "--ref",
+                "stable",
+                "--expected-revision",
+                "4",
+            ]
+        )
+        == 0
+    )
+    assert calls == [
+        ("open", str(tmp_path / "store")),
+        (str(tmp_path / "artifact"), "stable", 4),
+    ]
+    assert "example/project:stable@5 snap_123" in capsys.readouterr().out
+
+
+def test_export_command_resolves_then_materializes(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls: list[tuple[object, ...]] = []
+    output = tmp_path / "artifact"
+
+    class Repository:
+        def resolve_ref(self, repository, ref_name):
+            calls.append(("resolve", repository, ref_name))
+            return SimpleNamespace(snapshot=SimpleNamespace(snapshot_id="snap_123"))
+
+        def materialize_snapshot(self, snapshot_id, destination):
+            calls.append(("materialize", snapshot_id, destination))
+            return SimpleNamespace(root=output)
+
+    monkeypatch.setattr(
+        index_persistence.IndexRepository,
+        "open",
+        lambda root: calls.append(("open", root)) or Repository(),
+    )
+
+    assert (
+        index_persistence.main(
+            [
+                "export-ref",
+                "example/project",
+                str(output),
+                "--store",
+                str(tmp_path / "store"),
+                "--ref",
+                "stable",
+            ]
+        )
+        == 0
+    )
+    assert calls == [
+        ("open", str(tmp_path / "store")),
+        ("resolve", "example/project", "stable"),
+        ("materialize", "snap_123", str(output)),
+    ]
+
+
+def test_command_reports_repository_failures(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    def fail(_root):
+        raise RuntimeError("catalog is unavailable")
+
+    monkeypatch.setattr(index_persistence.IndexRepository, "open", fail)
+
+    assert (
+        index_persistence.main(
+            [
+                "publish-bm25",
+                str(tmp_path / "artifact"),
+                "--store",
+                str(tmp_path / "store"),
+            ]
+        )
+        == 1
+    )
+    assert "error: catalog is unavailable" in capsys.readouterr().err

--- a/test/scripts/test_experimental_index_persistence.py
+++ b/test/scripts/test_experimental_index_persistence.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+import sqlite3
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -132,3 +133,29 @@ def test_command_reports_repository_failures(
         == 1
     )
     assert "error: catalog is unavailable" in capsys.readouterr().err
+
+
+def test_command_reports_sqlite_failures_without_a_traceback(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    def fail(_root):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(index_persistence.IndexRepository, "open", fail)
+
+    assert (
+        index_persistence.main(
+            [
+                "publish-bm25",
+                str(tmp_path / "artifact"),
+                "--store",
+                str(tmp_path / "store"),
+            ]
+        )
+        == 1
+    )
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "error: database is locked\n"

--- a/test/scripts/test_smoke_release_upgrade.py
+++ b/test/scripts/test_smoke_release_upgrade.py
@@ -87,6 +87,7 @@ def test_upgrade_smoke_accepts_wiki_only_storage_surface(monkeypatch):
         ],
         "retired_exports": [],
         "artifact_commands": ["fetch", "mcp-config", "pack", "verify"],
+        "index_persistence_importable": False,
     }
     monkeypatch.setattr(
         upgrade_smoke,

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -332,6 +332,23 @@ def test_release_wheel_rejects_experimental_index_persistence(
         validate_release(dist, project_file=project)
 
 
+def test_release_wheel_rejects_source_only_h1_experiment(tmp_path: Path) -> None:
+    project, dist = _write_test_release(tmp_path)
+    wheel = dist / "codenib-0.2.1-cp310-abi3-manylinux_2_28_x86_64.whl"
+    with zipfile.ZipFile(wheel, mode="a") as archive:
+        archive.writestr(
+            "scripts/experimental/hybrid_index/catalog.py",
+            "source only",
+        )
+        archive.writestr(
+            "scripts/experimental/index_persistence.py",
+            "source only",
+        )
+
+    with pytest.raises(ReleaseValidationError, match="source-only experimental"):
+        validate_release(dist, project_file=project)
+
+
 def test_release_sdist_rejects_retired_compiler_bridge(tmp_path: Path) -> None:
     project, dist = _write_test_release(
         tmp_path,

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -320,6 +320,18 @@ def test_release_wheel_rejects_retired_storage_runtime(tmp_path: Path) -> None:
         validate_release(dist, project_file=project)
 
 
+def test_release_wheel_rejects_experimental_index_persistence(
+    tmp_path: Path,
+) -> None:
+    project, dist = _write_test_release(tmp_path)
+    wheel = dist / "codenib-0.2.1-cp310-abi3-manylinux_2_28_x86_64.whl"
+    with zipfile.ZipFile(wheel, mode="a") as archive:
+        archive.writestr("codenib/index/persistence/catalog.py", "experimental")
+
+    with pytest.raises(ReleaseValidationError, match="retired storage runtime"):
+        validate_release(dist, project_file=project)
+
+
 def test_release_sdist_rejects_retired_compiler_bridge(tmp_path: Path) -> None:
     project, dist = _write_test_release(
         tmp_path,
@@ -1083,3 +1095,7 @@ def test_product_storage_scope_and_removal_policy_are_documented() -> None:
     provider_prose = " ".join(provider.split())
     assert "a filesystem publication boundary, not a database" in provider_prose
     assert "v0.2.2 environment before upgrading" in roadmap_prose
+    project = (root / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'include = ["codenib*"]' in project
+    assert (root / "scripts/experimental/hybrid_index").is_dir()
+    assert not (root / "codenib/index/persistence").exists()


### PR DESCRIPTION
## Summary

Add the time-bounded H1 evidence experiment tracked by #765 without reopening the stable storage API. codenib.storage remains the Wiki-only single-file facade, and the project version and v0.2.3 release artifacts are unchanged.

## Changes
- Add one source-checkout-only IndexRepository harness for verified BM25 portable artifacts.
- Store one deterministic ZIP object in a minimal local SHA-256 CAS and generation, snapshot, membership, and ref rows in a four-table CNIX SQLite WAL catalog.
- Expose only publish-bm25 and export-ref developer-script commands; add no codenib export, official CLI command, config, Web route, MCP route, or dependency.
- Add failure, concurrency, corruption, historical snapshot, offline MCP, deterministic archive, WAL initialization, and clean CLI failure tests.
- Add wheel gates for the actual source-only H1 paths and retain the prohibition on a future installed codenib.index.persistence surface.
- Record the diagnostic benchmark and the 2026-10-04 promote-or-delete gate; keep H2-H7 demand-gated.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- 40 focused H1 tests and 35 release-artifact tests passed.
- 6,919 unit tests passed and 34 skipped. Two pre-existing Docker tests require /usr/bin/docker on this host; the other 38 tests in that file passed with those two deselected.
- Same-digest and same-ref concurrency cases each passed 20 repeated runs.
- Concurrent first-open WAL initialization passed 100 runs with 16 threads and 30 runs with eight processes.
- Post-fix CodeNib self-benchmark: 573 Python files and 8,684 chunks; republish p95 1.788 s, resolve p95 0.476 ms, and export p95 1.180 s for a 10.95 MB archive. The earlier complete run retained exact top-20 BM25 parity and zero byte growth across ten republishes.

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published