### PR TITLE
refactor(wiki): retire legacy JSON cache

### DIFF
--- a/.claude/guides/frontend-loop.md
+++ b/.claude/guides/frontend-loop.md
@@ -57,9 +57,9 @@ npm run dev            # = `next dev`; binds :3000 (no port flag anywhere)
 
 ## Performance & caching (why a page can feel slow)
 
-- **Wiki prose is LLM-generated and disk-cached** under `<data_dir>/wiki_cache/`
-  (i.e. `.codenib_qa/wiki_cache/agentwiki_<sha1(instance@commit/suffix)[:16]>.json`)
-  — NOT under `${CODENIB_PREBUILT_DIR}` (that holds the prebuilt graph + vectors).
+- **Wiki prose is LLM-generated and stored** in
+  `<data_dir>/wiki_cache/wiki.sqlite3` — NOT under `${CODENIB_PREBUILT_DIR}`
+  (that holds the prebuilt graph + vectors).
   The **first** visit to an un-narrated page runs the model (~8–20s); after that
   it's ~2ms. The codemap / wiki-page subgraph is computed **dynamically** per
   request but is fast (~50–115ms), so it isn't cached.
@@ -75,8 +75,9 @@ npm run dev            # = `next dev`; binds :3000 (no port flag anywhere)
     for p in $(ids "$r"); do curl -s -o /dev/null --max-time 120 "$B/api/repos/$r/wiki/$p"; done
   done
   ```
-  To force re-narration after a prompt change, delete the matching
-  `agentwiki_*.json` (outline key = `sha1("<instance>@<commit_short>/outline")[:16]`).
+  Prompt or index identity changes select a fresh entry automatically. To
+  retry degraded entries without discarding healthy pages, use
+  `wiki-cache-prewarm --retry-degraded-now`.
 - **Frontend weight**: Mermaid (~1MB) and the Cytoscape graph are `next/dynamic`
   lazy-loaded, so the narrative paints first. Remember `next dev` is unminified —
   a production `next build && next start` is markedly faster than the dev server.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,10 @@ completed.
   facade and the retained-storage CLI commands were removed. Do not turn that
   module back into a package or reintroduce a generic catalog, CAS, schema
   state, storage protocol, backend registry, or product route.
+- The v0.2.3 release was the complete migration window for legacy
+  `agentwiki_*.json` caches. Do not restore JSON discovery, read-through,
+  adoption, writes, file locking, provenance markers, or audit accounting;
+  Wiki persistence requires an injected `WikiStore`.
 - One exception is authorized through 2026-10-04: the source-checkout-only H1
   experiment under `scripts/experimental/hybrid_index/`, its developer script,
   and focused tests. H1 accepts exactly one verified BM25-only portable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ All notable user-facing changes are recorded here. CodeNib follows
 
 ## [Unreleased]
 
+### Removed
+
+- Retired the one-release `agentwiki_*.json` compatibility path tracked by
+  #749. AgentWiki no longer discovers, reads, writes, adopts, locks, or audits
+  JSON cache files; persistence requires an injected `WikiStore`, while
+  store-less callers remain in memory. Existing `wiki.sqlite3` entries and
+  legacy files are not deleted. The Wiki cache audit report is now schema v2
+  and reports only database entry and payload-byte accounting.
+
 ## [0.2.3] - 2026-09-03
 
 ### Added

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -1225,7 +1225,6 @@ def _audit_local_wiki(local) -> dict[str, object]:
     builder = AgentWiki(
         bundle,
         model,
-        cache_dir=str(local.data_dir / "wiki_cache"),
         store=SQLiteWikiStore(local.data_dir / "wiki_cache" / "wiki.sqlite3"),
         llm=client,
         api_base=config.wiki_generation_api_base,

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -385,7 +385,6 @@ def _wiki(repo_id: str, bundle=None):
             return AgentWiki(
                 bundle,
                 config.wiki_generation_model,
-                cache_dir=wiki_cache,
                 store=store,
                 llm=_wiki_llm(config),
                 api_base=config.wiki_generation_api_base,

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -20,23 +20,14 @@ import copy
 import dataclasses
 import hashlib
 import html
-import io
 import json
 import os
 import re
-import tempfile
 import threading
 from contextlib import nullcontext
 from time import perf_counter, time
 from typing import Any, Dict, List, Mapping, Optional, Sequence
 
-from filelock import FileLock
-
-from .._bounded_json import (
-    _bounded_parse_float,
-    validate_bounded_json_stream,
-    validate_json_complexity,
-)
 from ..log_utils import get_logger
 from ..repository_summary import readme_summary
 from .builder import WikiBuilder
@@ -74,59 +65,9 @@ from .quality import prose_terms as _prose_terms
 from .quality import redundancy_terms as _redundancy_terms
 from .quality import section_synthesis_report as _section_synthesis_report
 from .quality import sentence_boundary_count as _sentence_boundary_count
-from .store import (
-    _WIKI_CACHE_PROVENANCE_FIELD,
-    WIKI_ENVELOPE_MAX_BYTES,
-    WikiStore,
-    WikiStoreCorruptionError,
-    WikiStoredEntry,
-    WikiStoreError,
-)
+from .store import WikiStore, WikiStoreCorruptionError, WikiStoredEntry, WikiStoreError
 
 logger = get_logger(__name__)
-
-
-def _reject_duplicate_cache_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
-    value: dict[str, Any] = {}
-    for key, item in pairs:
-        if key in value:
-            raise ValueError(f"duplicate JSON object key: {key}")
-        value[key] = item
-    return value
-
-
-def _reject_nonfinite_cache_number(value: str) -> None:
-    raise ValueError(f"non-finite JSON number: {value}")
-
-
-def _read_legacy_cache_envelope(path: str) -> dict[str, Any] | None:
-    """Read one legacy cache only after bounding its bytes and JSON shape."""
-
-    try:
-        with open(path, "rb") as handle:
-            payload = handle.read(WIKI_ENVELOPE_MAX_BYTES + 1)
-        if len(payload) > WIKI_ENVELOPE_MAX_BYTES:
-            return None
-        validate_bounded_json_stream(
-            io.BytesIO(payload),
-            label="legacy Wiki cache",
-            max_bytes=WIKI_ENVELOPE_MAX_BYTES,
-        )
-        envelope = json.loads(
-            payload.decode("utf-8", errors="strict"),
-            object_pairs_hook=_reject_duplicate_cache_object,
-            parse_constant=_reject_nonfinite_cache_number,
-            parse_float=_bounded_parse_float,
-        )
-        validate_json_complexity(envelope, label="legacy Wiki cache")
-    except MemoryError:
-        raise
-    except (OSError, ValueError, RecursionError):
-        return None
-    if not isinstance(envelope, dict) or "data" not in envelope:
-        return None
-    return envelope
-
 
 _EXT_LANG = {
     "py": "python",
@@ -3218,7 +3159,6 @@ class AgentWiki:
         self,
         bundle: Any,
         model: str,
-        cache_dir: Optional[str] = None,
         *,
         store: Optional[WikiStore] = None,
         llm: Any = None,
@@ -3231,7 +3171,6 @@ class AgentWiki:
         self._cache_llm_identity = getattr(llm, "cache_identity", "")
         self._api_base = api_base
         self._api_key = api_key
-        self._cache_dir = cache_dir
         self._store = store
         self._wb = WikiBuilder(bundle)  # reuse source() + symbol/citation helpers
         self._outline: Optional[Dict[str, Any]] = None
@@ -3269,7 +3208,7 @@ class AgentWiki:
         return digest if isinstance(digest, str) else ""
 
     def _cache_identity(self, suffix: str) -> str:
-        """Return the unhashed identity shared by legacy and database caches."""
+        """Return the unhashed identity used by the Wiki store."""
 
         entry = self._bundle.entry
         commit = getattr(entry, "commit_short", "") or getattr(entry, "base_commit", "")
@@ -3341,11 +3280,6 @@ class AgentWiki:
         )
         return raw
 
-    def _key(self, suffix: str) -> str:
-        """Return the legacy filename key for equivalent repository views."""
-
-        return hashlib.sha1(self._cache_identity(suffix).encode()).hexdigest()[:16]
-
     def _store_entry_id(self, suffix: str) -> str:
         """Return the collision-resistant primary key used by Wiki stores."""
 
@@ -3360,38 +3294,6 @@ class AgentWiki:
             raise ValueError("Wiki store requires a stable repository identity")
         return repository_id
 
-    def _legacy_key(self, suffix: str) -> str:
-        """Return the timestamp-bound key used before stable cache identity."""
-
-        entry = self._bundle.entry
-        commit = getattr(entry, "commit_short", "") or getattr(entry, "base_commit", "")
-        indexes = getattr(getattr(self._bundle, "manifest", None), "indexes", {})
-        view_parts = []
-        for name, view in sorted(indexes.items()):
-            config = getattr(view, "config", {}) or {}
-            config_hash = hashlib.sha1(
-                json.dumps(
-                    config,
-                    sort_keys=True,
-                    separators=(",", ":"),
-                    default=str,
-                ).encode("utf-8")
-            ).hexdigest()[:10]
-            view_parts.append(
-                f"{name}:{getattr(view, 'status', '')}:"
-                f"{getattr(view, 'commit', '')}:"
-                f"{getattr(view, 'source_fingerprint', '')}:"
-                f"{getattr(view, 'built_at_epoch', '')}:{config_hash}"
-            )
-        prompt_version = (
-            _OUTLINE_PROMPT_VERSION if suffix == "outline" else _PAGE_PROMPT_VERSION
-        )
-        raw = (
-            f"{prompt_version}/{getattr(entry, 'instance_id', 'repo')}@{commit}/"
-            f"{','.join(view_parts)}/{suffix}"
-        )
-        return hashlib.sha1(raw.encode()).hexdigest()[:16]
-
     def _client(self):
         if self._llm is None:
             from ..llm.litellm_chat import LiteLLMChat
@@ -3404,28 +3306,6 @@ class AgentWiki:
                 api_key=self._api_key,
             )
         return self._llm
-
-    def _cache_path(self, suffix: str) -> Optional[str]:
-        if not self._cache_dir:
-            return None
-        os.makedirs(self._cache_dir, exist_ok=True)
-        return self._cache_candidate_paths(suffix)[0]
-
-    def _cache_candidate_paths(self, suffix: str) -> tuple[str, ...]:
-        """Return stable then legacy cache paths without touching the disk."""
-
-        if not self._cache_dir:
-            return ()
-        keys = [self._key(suffix)]
-        # Pre-selection caches cannot prove which source inventory produced
-        # their prompts. Keep migration only for legacy manifests that have no
-        # persisted selection identity at all.
-        if not self._source_selection_identity():
-            keys.append(self._legacy_key(suffix))
-        return tuple(
-            os.path.join(self._cache_dir, f"agentwiki_{key}.json")
-            for key in dict.fromkeys(keys)
-        )
 
     @staticmethod
     def _page_cache_suffix(meta: Dict[str, Any]) -> str:
@@ -3442,57 +3322,10 @@ class AgentWiki:
         return f"page_{meta.get('id', 'page')}_{identity}"
 
     def _read_cache(self, suffix: str) -> Optional[Any]:
-        if self._store is not None:
-            stored = self._store.read(self._store_entry_id(suffix))
-            if stored is not None:
-                return self._stored_data(stored)
-
-        paths = self._cache_candidate_paths(suffix)
-        for index, path in enumerate(paths):
-            if not os.path.isfile(path):
-                continue
-            envelope = _read_legacy_cache_envelope(path)
-            if envelope is None:
-                continue
-            if self._store is not None:
-                try:
-                    stored = self._publish_store_cache(
-                        suffix,
-                        envelope,
-                        if_absent=True,
-                    )
-                except WikiStoreCorruptionError:
-                    raise
-                except (WikiStoreError, TypeError, ValueError) as exc:
-                    logger.warning("Could not adopt legacy Wiki cache: %s", exc)
-                else:
-                    return self._stored_data(stored)
-            elif index > 0 and paths:
-                # Adopt the current timestamp-bound entry into the stable key
-                # before a future equivalent index rebuild changes its legacy
-                # identity. Preserve the original model provenance envelope.
-                try:
-                    self._atomic_write_cache(paths[0], envelope, if_absent=True)
-                except (OSError, TypeError):
-                    pass
-            return envelope.get("data")
-        return None
-
-    def _read_cache_read_only(self, suffix: str) -> Optional[Any]:
-        """Read one cache entry without migrating or publishing cache data."""
-
-        if self._store is not None:
-            stored = self._store.read(self._store_entry_id(suffix))
-            if stored is not None:
-                return self._stored_data(stored)
-
-        for path in self._cache_candidate_paths(suffix):
-            if not os.path.isfile(path):
-                continue
-            envelope = _read_legacy_cache_envelope(path)
-            if envelope is not None:
-                return envelope.get("data")
-        return None
+        if self._store is None:
+            return None
+        stored = self._store.read(self._store_entry_id(suffix))
+        return self._stored_data(stored) if stored is not None else None
 
     @staticmethod
     def _stored_data(entry: WikiStoredEntry) -> Any:
@@ -3503,87 +3336,10 @@ class AgentWiki:
             )
         return envelope["data"]
 
-    def _publish_store_cache(
-        self,
-        suffix: str,
-        envelope: dict[str, Any],
-        *,
-        if_absent: bool = False,
-    ) -> WikiStoredEntry:
-        if self._store is None:
-            raise RuntimeError("Wiki store is not configured")
-        entry_id = self._store_entry_id(suffix)
-        repository_id = self._repository_id()
-        cache_files = [
-            os.path.basename(path) for path in self._cache_candidate_paths(suffix)
-        ]
-        if cache_files:
-            # Legacy files remain readable for one release. Bind their names to
-            # the canonical record so audits can ignore stale adopted copies.
-            envelope = {
-                **envelope,
-                _WIKI_CACHE_PROVENANCE_FIELD: {
-                    "schema": 1,
-                    "entry_id": entry_id,
-                    "repository_id": repository_id,
-                    "legacy_filenames": cache_files,
-                },
-            }
-        return self._store.publish(
-            entry_id=entry_id,
-            repository_id=repository_id,
-            envelope=envelope,
-            if_absent=if_absent,
-        )
-
-    @staticmethod
-    def _atomic_write_cache(
-        path: str,
-        envelope: dict[str, Any],
-        *,
-        if_absent: bool = False,
-    ) -> None:
-        """Publish one complete JSON envelope under an inter-process lock."""
-
-        parent = os.path.dirname(path)
-        os.makedirs(parent, exist_ok=True)
-        with FileLock(f"{path}.lock"):
-            if if_absent and os.path.isfile(path):
-                return
-            descriptor, temporary_path = tempfile.mkstemp(
-                prefix=f".{os.path.basename(path)}.",
-                suffix=".tmp",
-                dir=parent,
-            )
-            try:
-                with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
-                    json.dump(envelope, handle)
-                    handle.flush()
-                    os.fsync(handle.fileno())
-                os.replace(temporary_path, path)
-                temporary_path = ""
-                try:
-                    directory_descriptor = os.open(parent, os.O_RDONLY)
-                    try:
-                        os.fsync(directory_descriptor)
-                    finally:
-                        os.close(directory_descriptor)
-                except OSError:
-                    pass
-            finally:
-                if temporary_path:
-                    try:
-                        os.unlink(temporary_path)
-                    except OSError:
-                        pass
-
     def _cache_generation_lock(self, suffix: str) -> Any:
         if self._store is not None:
             return self._store.generation_guard(self._store_entry_id(suffix))
-        path = self._cache_path(suffix)
-        if not path:
-            return nullcontext()
-        return FileLock(f"{path}.generate.lock")
+        return nullcontext()
 
     @staticmethod
     def _cached_page_is_degraded(page: Any) -> bool:
@@ -3689,21 +3445,18 @@ class AgentWiki:
             "llm_identity": self._cache_llm_identity,
             "data": data,
         }
-        if self._store is not None:
-            try:
-                self._publish_store_cache(suffix, envelope)
-            except WikiStoreCorruptionError:
-                raise
-            except (WikiStoreError, TypeError, ValueError) as exc:
-                logger.warning("Could not publish Wiki cache: %s", exc)
-            return
-        path = self._cache_path(suffix)
-        if not path:
+        if self._store is None:
             return
         try:
-            self._atomic_write_cache(path, envelope)
-        except (OSError, TypeError):
-            pass
+            self._store.publish(
+                entry_id=self._store_entry_id(suffix),
+                repository_id=self._repository_id(),
+                envelope=envelope,
+            )
+        except WikiStoreCorruptionError:
+            raise
+        except (WikiStoreError, TypeError, ValueError) as exc:
+            logger.warning("Could not publish Wiki cache: %s", exc)
 
     # -- outline + nav -----------------------------------------------------
 
@@ -3742,8 +3495,6 @@ class AgentWiki:
     def _page_tree_refs(
         self,
         outline_pages: List[Dict[str, Any]],
-        *,
-        read_only: bool = False,
     ) -> List[dict]:
         def refs(pages: List[Dict[str, Any]], *, top_level: bool = False) -> List[dict]:
             return [
@@ -3755,8 +3506,7 @@ class AgentWiki:
                             self._overview_page_meta(p, outline_pages[1:])
                             if top_level and p.get("id") == "overview"
                             else p
-                        ),
-                        read_only=read_only,
+                        )
                     ),
                     "children": refs(p.get("children", []) or []),
                 }
@@ -3774,24 +3524,18 @@ class AgentWiki:
 
         outline = self._outline
         if outline is None:
-            outline = self._read_cache_read_only("outline")
+            outline = self._read_cache("outline")
         if not isinstance(outline, dict) or not isinstance(outline.get("pages"), list):
             return None
-        return self._page_tree_refs(outline["pages"], read_only=True)
+        return self._page_tree_refs(outline["pages"])
 
-    def _page_cache_state(
-        self,
-        meta: Dict[str, Any],
-        *,
-        read_only: bool = False,
-    ) -> str:
+    def _page_cache_state(self, meta: Dict[str, Any]) -> str:
         """Return a reader-facing cache state without generating the page."""
 
         page_id = str(meta.get("id") or "")
         page = self._pages.get(page_id)
         if page is None:
-            reader = self._read_cache_read_only if read_only else self._read_cache
-            page = reader(self._page_cache_suffix(meta))
+            page = self._read_cache(self._page_cache_suffix(meta))
         if not isinstance(page, dict):
             return "cold"
         invalid = self._cached_page_is_degraded(page)

--- a/codenib/wiki/cache_audit.py
+++ b/codenib/wiki/cache_audit.py
@@ -6,9 +6,7 @@
 
 from __future__ import annotations
 
-import glob
 import math
-import os
 from collections import Counter
 from typing import Any, Callable, Iterable, Optional
 
@@ -43,15 +41,6 @@ def _coverage(cached: int, total: int) -> dict[str, Any]:
     }
 
 
-def _cache_paths(cache_root: str, wiki: AgentWiki, suffix: str) -> tuple[str, ...]:
-    """Resolve stable and legacy cache files without creating a directory."""
-
-    paths = wiki._cache_candidate_paths(suffix)
-    if paths:
-        return paths
-    return (os.path.join(cache_root, f"agentwiki_{wiki._key(suffix)}.json"),)
-
-
 def _stored_entry_bytes(entry: WikiStoredEntry) -> int:
     """Return the domain-canonical byte size of one stored envelope."""
 
@@ -62,7 +51,6 @@ def audit_wiki_cache(
     registry: Any,
     *,
     model: str,
-    cache_dir: str | os.PathLike[str],
     repo_ids: Optional[Iterable[str]] = None,
     wiki_factory: Callable[..., AgentWiki] = AgentWiki,
     store: Optional[WikiStore] = None,
@@ -73,7 +61,6 @@ def audit_wiki_cache(
     invokes a model. Missing outlines are reported instead of generated.
     """
 
-    cache_root = os.path.abspath(os.fspath(cache_dir))
     selected = {str(repo_id) for repo_id in repo_ids or ()}
     totals = Counter()
     modes = Counter()
@@ -84,7 +71,6 @@ def audit_wiki_cache(
     fallback_pages: list[dict[str, Any]] = []
     retry_scheduled_pages: list[dict[str, Any]] = []
     retry_exhausted_pages: list[dict[str, Any]] = []
-    current_cache_paths: set[str] = set()
     current_entry_ids: set[str] = set()
     metric_samples: dict[str, list[float]] = {
         "total_ms": [],
@@ -111,15 +97,12 @@ def audit_wiki_cache(
         bundle = registry.get(repo_id)
         if bundle is None:
             continue
-        wiki_kwargs: dict[str, Any] = {"model": model, "cache_dir": cache_root}
+        wiki_kwargs: dict[str, Any] = {"model": model}
         if store is not None:
             wiki_kwargs["store"] = store
         wiki = wiki_factory(bundle, **wiki_kwargs)
-        outline_paths = _cache_paths(cache_root, wiki, "outline")
-        current_cache_paths.update(os.path.abspath(path) for path in outline_paths)
-        if store is not None:
-            current_entry_ids.add(wiki._store_entry_id("outline"))
-        outline = wiki._read_cache_read_only("outline")
+        current_entry_ids.add(wiki._store_entry_id("outline"))
+        outline = wiki._read_cache("outline")
         if not isinstance(outline, dict) or not outline.get("pages"):
             missing_outlines.append(repo_id)
             repo_reports.append(
@@ -162,18 +145,9 @@ def audit_wiki_cache(
                 meta = raw_meta
 
             suffix = wiki._page_cache_suffix(meta)
-            paths = _cache_paths(cache_root, wiki, suffix)
-            current_cache_paths.update(os.path.abspath(path) for path in paths)
-            evidence_paths = _cache_paths(
-                cache_root,
-                wiki,
-                f"evidence_{suffix}",
-            )
-            current_cache_paths.update(os.path.abspath(path) for path in evidence_paths)
-            if store is not None:
-                current_entry_ids.add(wiki._store_entry_id(suffix))
-                current_entry_ids.add(wiki._store_entry_id(f"evidence_{suffix}"))
-            page = wiki._read_cache_read_only(suffix)
+            current_entry_ids.add(wiki._store_entry_id(suffix))
+            current_entry_ids.add(wiki._store_entry_id(f"evidence_{suffix}"))
+            page = wiki._read_cache(suffix)
             if isinstance(page, dict):
                 totals["cached_pages"] += 1
                 repo_counts["cached_pages"] += 1
@@ -243,25 +217,6 @@ def audit_wiki_cache(
             }
         )
 
-    if selected:
-        # Cache keys are hashed, so an arbitrary file cannot be attributed to a
-        # selected repository without resolving that repository's outline.
-        # Keep subset accounting scoped to the selected repositories instead
-        # of calling every unselected repository's valid cache orphaned.
-        all_cache_paths = {path for path in current_cache_paths if os.path.isfile(path)}
-    else:
-        all_cache_paths = {
-            os.path.abspath(path)
-            for path in glob.glob(os.path.join(cache_root, "agentwiki_*.json"))
-        }
-    orphan_paths = all_cache_paths - current_cache_paths
-    legacy_bytes = sum(
-        os.path.getsize(path) for path in all_cache_paths if os.path.isfile(path)
-    )
-    orphan_legacy_bytes = sum(
-        os.path.getsize(path) for path in orphan_paths if os.path.isfile(path)
-    )
-
     if store is not None:
         entries = store.scan(repository_ids=selected or None)
         orphan_entries = tuple(
@@ -277,23 +232,17 @@ def audit_wiki_cache(
             "database_payload_bytes": database_payload_bytes,
             "orphan_entries": len(orphan_entries),
             "orphan_database_payload_bytes": orphan_database_payload_bytes,
-            "files": len(all_cache_paths),
-            "legacy_bytes": legacy_bytes,
-            "orphan_files": len(orphan_paths),
-            "orphan_legacy_bytes": orphan_legacy_bytes,
-            # Preserve the v1 file-counter meanings for existing report readers.
-            "bytes": legacy_bytes,
-            "orphan_bytes": orphan_legacy_bytes,
         }
     else:
         storage_report = {
-            "files": len(all_cache_paths),
-            "bytes": legacy_bytes,
-            "orphan_files": len(orphan_paths),
-            "orphan_bytes": orphan_legacy_bytes,
+            "backend": None,
+            "entries": 0,
+            "database_payload_bytes": 0,
+            "orphan_entries": 0,
+            "orphan_database_payload_bytes": 0,
         }
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "repositories": len(repo_reports),
         "coverage": {
             "all": _coverage(totals["cached_pages"], totals["pages"]),

--- a/codenib/wiki/narrator.py
+++ b/codenib/wiki/narrator.py
@@ -93,7 +93,7 @@ class Narrator:
     def _cache_file(self, key: str) -> Optional[str]:
         if not self.cache_dir:
             return None
-        # Model-independent by design (same rationale as AgentWiki._key): the
+        # Model-independent by design (same rationale as AgentWiki): the
         # prose is keyed by prompt version + call key, so pointing the narrator
         # at a different backend reuses what was already generated. The
         # producing model is recorded in the entry by ``_write_cache``.

--- a/codenib/wiki/quality.py
+++ b/codenib/wiki/quality.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import json
 import re
 from collections.abc import Mapping
 from pathlib import Path
@@ -23,7 +22,7 @@ from .evidence import (
     relation_endpoints_named,
     relation_matches_claim,
 )
-from .store import _WIKI_CACHE_PROVENANCE_FIELD, WikiStore
+from .store import WikiStore
 
 _EVIDENCE_MARKER = re.compile(r"\[((?:E|R)\d+)\](?:\([^)]*\))?")
 _CATALOG_SENTENCE = re.compile(
@@ -1110,10 +1109,9 @@ def audit_cache(
     *,
     store: WikiStore | None = None,
 ) -> dict[str, Any]:
-    """Load and summarize pages from the canonical database or legacy files."""
+    """Load and summarize pages from the canonical Wiki store."""
 
     pages = []
-    stored_cache_files: set[str] = set()
     cache_root = Path(cache_dir)
     database_path = cache_root / "wiki.sqlite3"
     if store is None and database_path.exists():
@@ -1125,47 +1123,9 @@ def audit_cache(
     if store is not None:
         for entry in store.scan():
             payload = entry.envelope
-            # Only an identity-bound marker may claim a retained legacy file;
-            # page IDs such as ``overview`` routinely collide across repos.
-            provenance = (
-                payload.get(_WIKI_CACHE_PROVENANCE_FIELD)
-                if isinstance(payload, Mapping)
-                else None
-            )
-            cache_files = (
-                provenance.get("legacy_filenames")
-                if isinstance(provenance, Mapping)
-                and type(provenance.get("schema")) is int
-                and provenance.get("schema") == 1
-                and provenance.get("entry_id") == entry.entry_id
-                and provenance.get("repository_id") == entry.repository_id
-                else None
-            )
-            if isinstance(cache_files, list):
-                stored_cache_files.update(
-                    cache_file
-                    for cache_file in cache_files
-                    if type(cache_file) is str
-                    and cache_file == Path(cache_file).name
-                    and cache_file.startswith("agentwiki_")
-                    and cache_file.endswith(".json")
-                )
             data = payload.get("data") if isinstance(payload, Mapping) else None
             if isinstance(data, dict) and data.get("id") and data.get("markdown"):
                 pages.append(data)
-
-    # A marker-free database row cannot prove which repository owns an
-    # identical legacy envelope, so retain both rather than cross-repo dedupe.
-    for path in sorted(cache_root.glob("agentwiki_*.json")):
-        if path.name in stored_cache_files:
-            continue
-        try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            continue
-        data = payload.get("data") if isinstance(payload, dict) else None
-        if isinstance(data, dict) and data.get("id") and data.get("markdown"):
-            pages.append(data)
     return summarize_page_audits(pages)
 
 

--- a/codenib/wiki/store.py
+++ b/codenib/wiki/store.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass
 from typing import Any, ContextManager, Protocol
 
 WIKI_ENVELOPE_MAX_BYTES = 16 * 1024 * 1024
-_WIKI_CACHE_PROVENANCE_FIELD = "_codenib_cache_provenance"
 
 
 class WikiStoreError(RuntimeError):

--- a/docs/cognitive_debt_roadmap.md
+++ b/docs/cognitive_debt_roadmap.md
@@ -151,6 +151,12 @@ Status: in progress.
 - [x] Move portable-artifact validation contracts into the artifact-neutral
       `_bounded_json` module so default Web imports no longer cross a generic
       storage namespace.
+- [x] End the v0.2.3 Wiki JSON migration window by removing legacy cache
+      lookup, parsing, writes, adoption, file locks, provenance bookkeeping,
+      and file-based audit accounting. Keep existing SQLite rows readable and
+      make a missing `WikiStore` explicitly memory-only. The closure removes
+      354 net production lines and 256 net test lines while deleting zero
+      scripts and zero public entry points.
 - [ ] Bound Wiki generation-lock waiting and make maintenance inspection
       physically read-only without broadening the Wiki protocol.
 
@@ -262,6 +268,7 @@ Status: pending.
 | 2026-09-02 | Use the next release as the generic-storage removal boundary | The consumer audit found only the two retained artifact bridges and one catalog-backed FactBatch profile; ordinary product routes were independent | Delete the complete generic package and callers; keep v0.2.2 only as the pre-upgrade materialization tool |
 | 2026-09-03 | Publish the subtraction as v0.2.3 and reserve `codenib.storage` for the Wiki database | `WikiStore` is the only product database contract, while the old package name remains the clearest public entry point | Add one lazy Wiki-only module with an exact export list; keep all generic submodules, protocols, catalogs, and CAS implementations retired |
 | 2026-09-03 | Authorize one source-only BM25 H1 evidence experiment without reopening the stable storage boundary | `docs/experiments/hybrid_index_h1.md` records its schema, linearization points, verified failure matrix, commands, and diagnostic benchmark | Keep it outside the wheel and product routes; promote through an explicit demand-backed decision or delete code, script, and tests by 2026-10-04 |
+| 2026-09-05 | End the one-release Wiki JSON compatibility window | The v0.2.3 release notes and #749 record the migration window; production compositions already inject the Wiki store | Delete the legacy implementation and compatibility tests; preserve SQLite data and the `WikiStore` API |
 
 ## Completion Gate
 

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -192,11 +192,10 @@ Opens at **http://localhost:3000**.
 
 Wiki pages are stored in `<data_dir>/wiki_cache/wiki.sqlite3` (by default under
 `.codenib_qa/wiki_cache`) so subsequent loads avoid another model call. The
-database uses SQLite WAL and validates each persisted JSON envelope. Existing
-source-compatible `agentwiki_*.json` entries remain a read-through
-compatibility source and are adopted lazily; pre-selection entries are not
-eligible once a manifest records its source-selection identity. The web and
-maintenance entry points write new data only to the database.
+database uses SQLite WAL and validates each persisted JSON envelope. It is the
+only persistent Wiki cache; legacy `agentwiki_*.json` files are left untouched
+but ignored. The web and maintenance entry points use the database through the
+WikiStore boundary.
 
 **Refresh this wiki** only re-fetches the current tree and page; it does not
 invalidate that cache or force generation. After repairing a model or index,

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -46,6 +46,13 @@ into `WikiStore`.
 No generic catalog, CAS, or database compatibility layer remains in the
 v0.2.3 product.
 
+The v0.2.3 release was the sole read-through migration window for legacy
+`agentwiki_*.json` caches. After #749, AgentWiki no longer discovers, reads,
+writes, adopts, locks, or audits those files. Without an injected `WikiStore`,
+an AgentWiki instance is memory-only. Existing JSON files are left untouched
+but ignored; existing `wiki.sqlite3` data, its schema, and the
+`codenib.storage` API remain unchanged.
+
 ## Closed Plans
 
 CodeNib no longer plans PostgreSQL, S3-compatible object storage, generic GC,
@@ -185,6 +192,10 @@ promote-or-delete decision; PR #766 carries the source-only implementation and
 evidence. The tracker references historical #199, foundation #535, and
 subtraction #753-#762 without reopening those scopes. Do not use the stale
 `feat/storage-catalog-foundation` branch as a base.
+
+Issue #749 owns the post-v0.2.3 retirement of the legacy Wiki JSON cache path;
+PR #767 carries that subtraction. It does not authorize changes to H1 or any
+H2-H7 work.
 
 The detailed H1 schema, linearization points, failure matrix, commands, and
 benchmark receipt live in

--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -330,8 +330,8 @@ make wiki-cache-audit \
 
 Its JSON report separates Overview, root-page, and child-page coverage; lists
 degraded, fallback, and quality-invalid pages; and reports stale/orphaned Wiki
-database entries and legacy cache files separately during migration. Newly
-generated pages also contribute retrieval, planning,
+database entries and payload bytes. Newly generated pages also contribute
+retrieval, planning,
 model-call, repair-count, and total-latency summaries. Existing cache entries
 created before those metrics were introduced remain readable and are simply
 excluded from the latency sample. Add `--fail-on-fallback` and

--- a/scripts/audit_wiki_cache.py
+++ b/scripts/audit_wiki_cache.py
@@ -73,7 +73,6 @@ def main(argv: list[str] | None = None) -> int:
     report = audit_wiki_cache(
         registry,
         model=config.wiki_generation_model,
-        cache_dir=cache_dir,
         repo_ids=args.repos,
         store=store,
     )

--- a/scripts/benchmark_demo_wiki.py
+++ b/scripts/benchmark_demo_wiki.py
@@ -149,7 +149,6 @@ def main(argv: list[str] | None = None) -> int:
         reference = AgentWiki(
             bundle,
             model=config.wiki_generation_model,
-            cache_dir=production_cache,
             store=production_store,
         )
         outline = reference._read_cache("outline")
@@ -182,7 +181,6 @@ def main(argv: list[str] | None = None) -> int:
                 wiki = AgentWiki(
                     bundles[repo_id],
                     model=model,
-                    cache_dir=run_cache,
                     store=SQLiteWikiStore(Path(run_cache) / "wiki.sqlite3"),
                     llm=llm,
                     api_base=api_base,

--- a/scripts/prewarm_wiki_cache.py
+++ b/scripts/prewarm_wiki_cache.py
@@ -97,7 +97,6 @@ def main(argv: list[str] | None = None) -> int:
         return AgentWiki(
             bundle,
             model=config.wiki_generation_model,
-            cache_dir=cache_dir,
             store=store,
             llm=llm,
             api_base=config.wiki_generation_api_base,

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -1227,7 +1227,7 @@ def test_agent_wiki_receives_the_shared_wiki_store(tmp_path, monkeypatch):
     assert web_app.app.state.wiki_builders["repo"] == ("repo", bundle, created)
     assert captured["args"] == (bundle, "wiki-model")
     assert captured["kwargs"]["store"] is store
-    assert captured["kwargs"]["cache_dir"] == str(tmp_path / "wiki_cache")
+    assert "cache_dir" not in captured["kwargs"]
     assert captured["kwargs"]["llm"] == "llm"
 
 

--- a/test/wiki/test_agent_wiki.py
+++ b/test/wiki/test_agent_wiki.py
@@ -10,8 +10,6 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
-import pytest
-
 from codenib.graph.code_graph import CodeGraph
 from codenib.wiki.agent_wiki import (
     AgentWiki,
@@ -42,7 +40,6 @@ from codenib.wiki.builder import Symbol
 from codenib.wiki.evidence import EvidenceItem, RelationItem, candidate_key
 from codenib.wiki.quality import prose_integrity_report
 from codenib.wiki.sqlite_store import SQLiteWikiStore
-from codenib.wiki.store import _WIKI_CACHE_PROVENANCE_FIELD
 
 
 class _FakeVectorStore:
@@ -6507,7 +6504,7 @@ def test_page_reports_model_unavailable_when_fact_planning_falls_back(tmp_path):
     assert llm.calls == 1
 
 
-def test_agent_wiki_cache_key_tracks_view_rebuild_identity(tmp_path):
+def test_agent_wiki_store_entry_id_tracks_view_rebuild_identity(tmp_path):
     view = SimpleNamespace(
         status="fresh",
         commit="abc123",
@@ -6527,14 +6524,14 @@ def test_agent_wiki_cache_key_tracks_view_rebuild_identity(tmp_path):
         manifest=SimpleNamespace(languages=["python"], indexes={"bm25": view}),
     )
     wiki = AgentWiki(bundle, model="fake-model")
-    before = wiki._key("outline")
+    before = wiki._store_entry_id("outline")
     view.built_at_epoch = 2.0
     view.config = {"builder_schema": 2}
 
-    assert wiki._key("outline") != before
+    assert wiki._store_entry_id("outline") != before
 
 
-def test_agent_wiki_cache_key_ignores_equivalent_rebuild_timestamp(tmp_path):
+def test_agent_wiki_store_entry_id_ignores_equivalent_rebuild_timestamp(tmp_path):
     view = SimpleNamespace(
         status="fresh",
         commit="abc123",
@@ -6560,14 +6557,14 @@ def test_agent_wiki_cache_key_ignores_equivalent_rebuild_timestamp(tmp_path):
         ),
     )
     wiki = AgentWiki(bundle, model="fake-model")
-    before = wiki._key("outline")
+    before = wiki._store_entry_id("outline")
 
     view.built_at_epoch = 2.0
 
-    assert wiki._key("outline") == before
+    assert wiki._store_entry_id("outline") == before
 
 
-def test_agent_wiki_cache_key_tracks_artifact_receipt(tmp_path):
+def test_agent_wiki_store_entry_id_tracks_artifact_receipt(tmp_path):
     view = SimpleNamespace(
         status="fresh",
         commit="abc123",
@@ -6593,14 +6590,14 @@ def test_agent_wiki_cache_key_tracks_artifact_receipt(tmp_path):
         ),
     )
     wiki = AgentWiki(bundle, model="fake-model")
-    before = wiki._key("outline")
+    before = wiki._store_entry_id("outline")
 
     view.metadata["artifact_digest"] = "sha256:second"
 
-    assert wiki._key("outline") != before
+    assert wiki._store_entry_id("outline") != before
 
 
-def test_agent_wiki_cache_key_tracks_view_source_identity(tmp_path):
+def test_agent_wiki_store_entry_id_tracks_view_source_identity(tmp_path):
     view = SimpleNamespace(
         status="fresh",
         commit="abc123",
@@ -6621,13 +6618,13 @@ def test_agent_wiki_cache_key_tracks_view_source_identity(tmp_path):
         manifest=SimpleNamespace(languages=["python"], indexes={"bm25": view}),
     )
     wiki = AgentWiki(bundle, model="fake-model")
-    before = wiki._key("outline")
+    before = wiki._store_entry_id("outline")
     view.source_fingerprint = "sha256:second"
 
-    assert wiki._key("outline") != before
+    assert wiki._store_entry_id("outline") != before
 
 
-def test_agent_wiki_cache_key_tracks_source_selection_identity(tmp_path):
+def test_agent_wiki_store_entry_id_tracks_source_selection_identity(tmp_path):
     manifest = SimpleNamespace(
         languages=["python"],
         indexes={},
@@ -6646,21 +6643,15 @@ def test_agent_wiki_cache_key_tracks_source_selection_identity(tmp_path):
         bm25=None,
         manifest=manifest,
     )
-    wiki = AgentWiki(
-        bundle,
-        model="fake-model",
-        cache_dir=str(tmp_path / "wiki-cache"),
-    )
-    before = wiki._key("outline")
+    wiki = AgentWiki(bundle, model="fake-model")
+    before = wiki._store_entry_id("outline")
 
-    assert len(wiki._cache_candidate_paths("outline")) == 1
     manifest.source_selection_digest = "sha256:second-selection"
 
-    assert wiki._key("outline") != before
-    assert len(wiki._cache_candidate_paths("outline")) == 1
+    assert wiki._store_entry_id("outline") != before
 
 
-def test_agent_wiki_cache_key_is_stable_across_lazy_client_creation(tmp_path):
+def test_agent_wiki_store_entry_id_is_stable_across_lazy_client_creation(tmp_path):
     bundle = SimpleNamespace(
         entry=SimpleNamespace(
             repo="owner/repo",
@@ -6674,47 +6665,10 @@ def test_agent_wiki_cache_key_is_stable_across_lazy_client_creation(tmp_path):
         manifest=SimpleNamespace(languages=["python"], indexes={}),
     )
     wiki = AgentWiki(bundle, model="fake-model")
-    before = wiki._key("outline")
+    before = wiki._store_entry_id("outline")
     wiki._llm = SimpleNamespace(cache_identity="created-lazily")
 
-    assert wiki._key("outline") == before
-
-
-def test_agent_wiki_adopts_legacy_timestamp_cache_into_stable_key(tmp_path):
-    view = SimpleNamespace(
-        status="fresh",
-        commit="abc123",
-        source_fingerprint="",
-        built_at_epoch=1.0,
-        config={"builder_schema": 1},
-        metadata={},
-    )
-    bundle = SimpleNamespace(
-        entry=SimpleNamespace(
-            repo="owner/repo",
-            repo_dir=str(tmp_path),
-            instance_id="owner__repo-1",
-            commit_short="abc123",
-            language="python",
-        ),
-        vector_store=None,
-        bm25=None,
-        manifest=SimpleNamespace(languages=["python"], indexes={"bm25": view}),
-    )
-    cache_dir = tmp_path / "wiki-cache"
-    wiki = AgentWiki(bundle, model="fake-model", cache_dir=str(cache_dir))
-    stable, legacy = wiki._cache_candidate_paths("outline")
-    payload = {"pages": [{"id": "overview", "title": "Overview"}]}
-    wiki._atomic_write_cache(
-        legacy,
-        {"model": "old-model", "data": payload},
-    )
-
-    assert not os.path.exists(stable)
-    assert wiki._read_cache("outline") == payload
-    assert os.path.isfile(stable)
-    with open(stable, encoding="utf-8") as handle:
-        assert json.load(handle)["model"] == "old-model"
+    assert wiki._store_entry_id("outline") == before
 
 
 def test_agent_wiki_persists_through_injected_store_without_json_mirror(tmp_path):
@@ -6735,7 +6689,6 @@ def test_agent_wiki_persists_through_injected_store_without_json_mirror(tmp_path
     original = AgentWiki(
         bundle,
         model="first-model",
-        cache_dir=str(cache_dir),
         store=store,
     )
     payload = {"pages": [{"id": "overview", "title": "Overview"}]}
@@ -6753,7 +6706,6 @@ def test_agent_wiki_persists_through_injected_store_without_json_mirror(tmp_path
     reloaded = AgentWiki(
         bundle,
         model="different-model",
-        cache_dir=str(cache_dir),
         store=SQLiteWikiStore(cache_dir / "wiki.sqlite3"),
         llm=UnexpectedLLM(),
     )
@@ -6761,19 +6713,15 @@ def test_agent_wiki_persists_through_injected_store_without_json_mirror(tmp_path
     stored = store.read(original._store_entry_id("outline"))
     assert stored is not None
     assert stored.repository_id == "owner__repo-1"
-    assert stored.envelope["model"] == "first-model"
-    assert stored.envelope[_WIKI_CACHE_PROVENANCE_FIELD] == {
-        "schema": 1,
-        "entry_id": original._store_entry_id("outline"),
-        "repository_id": "owner__repo-1",
-        "legacy_filenames": [
-            os.path.basename(path)
-            for path in original._cache_candidate_paths("outline")
-        ],
+    assert stored.envelope == {
+        "model": "first-model",
+        "api_base": "",
+        "llm_identity": "",
+        "data": payload,
     }
 
 
-def test_agent_wiki_lazily_adopts_json_into_store_but_read_only_does_not(tmp_path):
+def test_agent_wiki_reads_store_envelope_with_retired_provenance_field(tmp_path):
     bundle = SimpleNamespace(
         entry=SimpleNamespace(
             repo="owner/repo",
@@ -6786,34 +6734,28 @@ def test_agent_wiki_lazily_adopts_json_into_store_but_read_only_does_not(tmp_pat
         bm25=None,
         manifest=SimpleNamespace(languages=["python"], indexes={}),
     )
-    cache_dir = tmp_path / "wiki-cache"
-    store = SQLiteWikiStore(cache_dir / "wiki.sqlite3")
-    wiki = AgentWiki(
-        bundle,
-        model="fake-model",
-        cache_dir=str(cache_dir),
-        store=store,
-    )
-    stable = wiki._cache_candidate_paths("outline")[0]
+    store = SQLiteWikiStore(tmp_path / "wiki-cache" / "wiki.sqlite3")
+    wiki = AgentWiki(bundle, model="fake-model", store=store)
     payload = {"pages": [{"id": "overview", "title": "Overview"}]}
-    wiki._atomic_write_cache(stable, {"model": "old-model", "data": payload})
     entry_id = wiki._store_entry_id("outline")
-
-    assert wiki._read_cache_read_only("outline") == payload
-    assert store.read(entry_id) is None
+    store.publish(
+        entry_id=entry_id,
+        repository_id="owner__repo-1",
+        envelope={
+            "model": "old-model",
+            "data": payload,
+            "_codenib_cache_provenance": {
+                "schema": 1,
+                "legacy_filenames": ["agentwiki_retired.json"],
+            },
+        },
+    )
 
     assert wiki._read_cache("outline") == payload
-    adopted = store.read(entry_id)
-    assert adopted is not None
-    assert adopted.envelope["model"] == "old-model"
-    assert adopted.envelope[_WIKI_CACHE_PROVENANCE_FIELD]["legacy_filenames"] == [
-        os.path.basename(path) for path in wiki._cache_candidate_paths("outline")
-    ]
+    assert wiki.outline() == payload
 
 
-def test_agent_wiki_rejects_unbounded_legacy_json_before_serving_or_adoption(
-    tmp_path,
-):
+def test_agent_wiki_without_store_does_not_persist_across_instances(tmp_path):
     bundle = SimpleNamespace(
         entry=SimpleNamespace(
             repo="owner/repo",
@@ -6826,56 +6768,17 @@ def test_agent_wiki_rejects_unbounded_legacy_json_before_serving_or_adoption(
         bm25=None,
         manifest=SimpleNamespace(languages=["python"], indexes={}),
     )
-    cache_dir = tmp_path / "wiki-cache"
-    store = SQLiteWikiStore(cache_dir / "wiki.sqlite3")
-    wiki = AgentWiki(
-        bundle,
-        model="fake-model",
-        cache_dir=str(cache_dir),
-        store=store,
-    )
-    nested = {}
-    for _ in range(70):
-        nested = {"child": nested}
-    stable = wiki._cache_candidate_paths("outline")[0]
-    wiki._atomic_write_cache(stable, {"data": nested})
+    payload = {"pages": [{"id": "overview", "title": "Overview"}]}
+    first = AgentWiki(bundle, model="fake-model")
+    second = AgentWiki(bundle, model="fake-model")
 
-    assert wiki._read_cache_read_only("outline") is None
-    assert wiki._read_cache("outline") is None
-    assert store.read(wiki._store_entry_id("outline")) is None
+    first._write_cache("outline", payload)
+
+    assert first._read_cache("outline") is None
+    assert second._read_cache("outline") is None
 
 
-def test_agent_wiki_rejects_overflowed_legacy_json_number(tmp_path):
-    bundle = SimpleNamespace(
-        entry=SimpleNamespace(
-            repo="owner/repo",
-            repo_dir=str(tmp_path),
-            instance_id="owner__repo-1",
-            commit_short="abc123",
-            language="python",
-        ),
-        vector_store=None,
-        bm25=None,
-        manifest=SimpleNamespace(languages=["python"], indexes={}),
-    )
-    cache_dir = tmp_path / "wiki-cache"
-    store = SQLiteWikiStore(cache_dir / "wiki.sqlite3")
-    wiki = AgentWiki(
-        bundle,
-        model="fake-model",
-        cache_dir=str(cache_dir),
-        store=store,
-    )
-    stable = wiki._cache_candidate_paths("outline")[0]
-    with open(stable, "w", encoding="utf-8") as handle:
-        handle.write('{"data":{"score":1e9999}}')
-
-    assert wiki._read_cache_read_only("outline") is None
-    assert wiki._read_cache("outline") is None
-    assert store.read(wiki._store_entry_id("outline")) is None
-
-
-def test_agent_wiki_cached_page_tree_reads_without_generating_or_migrating(
+def test_agent_wiki_cached_page_tree_reads_store_without_generating(
     tmp_path, monkeypatch
 ):
     view = SimpleNamespace(
@@ -6899,15 +6802,13 @@ def test_agent_wiki_cached_page_tree_reads_without_generating_or_migrating(
         manifest=SimpleNamespace(languages=["python"], indexes={"bm25": view}),
     )
     cache_dir = tmp_path / "wiki-cache"
-    wiki = AgentWiki(bundle, model="fake-model", cache_dir=str(cache_dir))
-    stable, legacy = wiki._cache_candidate_paths("outline")
-    wiki._atomic_write_cache(
-        legacy,
-        {
-            "model": "old-model",
-            "data": {"pages": [{"id": "runtime", "title": "Runtime", "children": []}]},
-        },
+    store = SQLiteWikiStore(cache_dir / "wiki.sqlite3")
+    original = AgentWiki(bundle, model="old-model", store=store)
+    original._write_cache(
+        "outline",
+        {"pages": [{"id": "runtime", "title": "Runtime", "children": []}]},
     )
+    wiki = AgentWiki(bundle, model="fake-model", store=store)
     monkeypatch.setattr(
         wiki,
         "outline",
@@ -6924,37 +6825,6 @@ def test_agent_wiki_cached_page_tree_reads_without_generating_or_migrating(
             "children": [],
         }
     ]
-    assert not os.path.exists(stable)
-
-
-def test_agent_wiki_atomic_cache_write_preserves_previous_entry_on_failure(
-    tmp_path, monkeypatch
-):
-    bundle = SimpleNamespace(
-        entry=SimpleNamespace(
-            repo="owner/repo",
-            repo_dir=str(tmp_path),
-            instance_id="owner__repo-1",
-            commit_short="abc123",
-            language="python",
-        ),
-        vector_store=None,
-        bm25=None,
-        manifest=SimpleNamespace(languages=["python"], indexes={}),
-    )
-    cache_dir = tmp_path / "wiki-cache"
-    wiki = AgentWiki(bundle, model="fake-model", cache_dir=str(cache_dir))
-    wiki._write_cache("outline", {"pages": [{"id": "original"}]})
-
-    with monkeypatch.context() as patch:
-        patch.setattr(
-            "codenib.wiki.agent_wiki.json.dump",
-            lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk full")),
-        )
-        wiki._write_cache("outline", {"pages": [{"id": "replacement"}]})
-
-    assert wiki._read_cache("outline") == {"pages": [{"id": "original"}]}
-    assert not list(cache_dir.glob("*.tmp"))
 
 
 def test_agent_wiki_page_cache_key_tracks_outline_metadata():
@@ -7031,7 +6901,7 @@ def test_agent_wiki_page_citations_never_generate_prose_and_are_cached(tmp_path)
         "end_line": 2,
         "content": "def run(request):\n    return dispatch(request)",
     }
-    store = _FakeVectorStore([node])
+    vector_store = _FakeVectorStore([node])
     bundle = SimpleNamespace(
         entry=SimpleNamespace(
             repo="owner/repo",
@@ -7040,7 +6910,7 @@ def test_agent_wiki_page_citations_never_generate_prose_and_are_cached(tmp_path)
             commit_short="abc123",
             language="python",
         ),
-        vector_store=store,
+        vector_store=vector_store,
         bm25=None,
         manifest=SimpleNamespace(languages=["python"], indexes={}),
     )
@@ -7056,7 +6926,8 @@ def test_agent_wiki_page_citations_never_generate_prose_and_are_cached(tmp_path)
         ]
     }
     cache_dir = tmp_path / "wiki-cache"
-    wiki = AgentWiki(bundle, model="fake-model", cache_dir=str(cache_dir))
+    wiki_store = SQLiteWikiStore(cache_dir / "wiki.sqlite3")
+    wiki = AgentWiki(bundle, model="fake-model", store=wiki_store)
     wiki._outline = outline
     wiki._generate_page = lambda _meta: (_ for _ in ()).throw(
         AssertionError("graph evidence must not generate prose")
@@ -7075,14 +6946,18 @@ def test_agent_wiki_page_citations_never_generate_prose_and_are_cached(tmp_path)
             "content": None,
         }
     ]
-    assert len(store.calls) == 1
+    assert len(vector_store.calls) == 1
     assert wiki._pages == {}
 
-    store.calls.clear()
-    reloaded = AgentWiki(bundle, model="other-model", cache_dir=str(cache_dir))
+    vector_store.calls.clear()
+    reloaded = AgentWiki(
+        bundle,
+        model="other-model",
+        store=SQLiteWikiStore(cache_dir / "wiki.sqlite3"),
+    )
     reloaded._outline = outline
     assert reloaded.page_citations("runtime") == citations
-    assert store.calls == []
+    assert vector_store.calls == []
 
 
 def test_agent_wiki_regenerates_cached_diagnostic_fallback(tmp_path):
@@ -7302,8 +7177,7 @@ def test_agent_wiki_coalesces_concurrent_page_generation(tmp_path):
     assert generation_calls == 1
 
 
-@pytest.mark.parametrize("use_store", [False, True])
-def test_agent_wiki_coalesces_generation_across_builder_instances(tmp_path, use_store):
+def test_agent_wiki_coalesces_generation_across_store_instances(tmp_path):
     bundle = SimpleNamespace(
         entry=SimpleNamespace(
             repo="owner/repo",
@@ -7319,19 +7193,14 @@ def test_agent_wiki_coalesces_generation_across_builder_instances(tmp_path, use_
     meta = {"id": "runtime", "title": "Runtime", "children": []}
     outline = {"pages": [meta]}
     cache_dir = tmp_path / "wiki-cache"
-    builders = []
-    for _ in range(2):
-        kwargs = {}
-        if use_store:
-            kwargs["store"] = SQLiteWikiStore(cache_dir / "wiki.sqlite3")
-        builders.append(
-            AgentWiki(
-                bundle,
-                model="fake-model",
-                cache_dir=str(cache_dir),
-                **kwargs,
-            )
+    builders = [
+        AgentWiki(
+            bundle,
+            model="fake-model",
+            store=SQLiteWikiStore(cache_dir / "wiki.sqlite3"),
         )
+        for _ in range(2)
+    ]
     for wiki in builders:
         wiki._outline = outline
     generation_started = threading.Event()

--- a/test/wiki/test_cache_audit.py
+++ b/test/wiki/test_cache_audit.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -34,8 +33,8 @@ def test_cache_audit_is_read_only_and_reports_current_page_quality(tmp_path):
         def get(self, repo_id):
             return bundle if repo_id == info.id else None
 
-    cache_dir = tmp_path / "wiki-cache"
-    wiki = AgentWiki(bundle, model="fake-model", cache_dir=str(cache_dir))
+    store = SQLiteWikiStore(tmp_path / "wiki-cache" / "wiki.sqlite3")
+    wiki = AgentWiki(bundle, model="fake-model", store=store)
     outline = {
         "pages": [
             {
@@ -82,9 +81,10 @@ def test_cache_audit_is_read_only_and_reports_current_page_quality(tmp_path):
     report = audit_wiki_cache(
         Registry(),
         model="fake-model",
-        cache_dir=cache_dir,
+        store=store,
     )
 
+    assert report["schema_version"] == 2
     assert report["coverage"]["all"] == {
         "cached": 1,
         "total": 2,
@@ -102,6 +102,13 @@ def test_cache_audit_is_read_only_and_reports_current_page_quality(tmp_path):
     assert report["missing_overviews"] == []
     assert report["fallback_pages"] == []
     assert report["quality_invalid_pages"] == []
+    assert set(report["storage"]) == {
+        "backend",
+        "entries",
+        "database_payload_bytes",
+        "orphan_entries",
+        "orphan_database_payload_bytes",
+    }
 
 
 def test_cache_audit_does_not_create_a_missing_cache_directory(tmp_path):
@@ -130,53 +137,17 @@ def test_cache_audit_does_not_create_a_missing_cache_directory(tmp_path):
     report = audit_wiki_cache(
         Registry(),
         model="fake-model",
-        cache_dir=cache_dir,
     )
 
     assert report["missing_outlines"] == ["owner__repo"]
+    assert report["storage"] == {
+        "backend": None,
+        "entries": 0,
+        "database_payload_bytes": 0,
+        "orphan_entries": 0,
+        "orphan_database_payload_bytes": 0,
+    }
     assert not cache_dir.exists()
-
-
-def test_cache_audit_applies_runtime_validation_to_legacy_json(tmp_path):
-    bundle = SimpleNamespace(
-        entry=SimpleNamespace(
-            repo="owner/repo",
-            repo_dir=str(tmp_path / "repo"),
-            instance_id="owner__repo",
-            commit_short="abc123",
-            language="python",
-        ),
-        manifest=SimpleNamespace(languages=["python"], indexes={}),
-        vector_store=None,
-        bm25=None,
-    )
-
-    class Registry:
-        def list_infos(self):
-            return [SimpleNamespace(id="owner__repo")]
-
-        def get(self, repo_id):
-            return bundle if repo_id == "owner__repo" else None
-
-    cache_dir = tmp_path / "wiki-cache"
-    cache_dir.mkdir()
-    wiki = AgentWiki(bundle, model="fake-model", cache_dir=str(cache_dir))
-    outline_path = wiki._cache_candidate_paths("outline")[0]
-    outline_path = Path(outline_path)
-    outline_path.write_text(
-        '{"data":{"pages":[]},"data":{"pages":['
-        '{"id":"overview","title":"Overview","children":[]}]}}',
-        encoding="utf-8",
-    )
-
-    report = audit_wiki_cache(
-        Registry(),
-        model="fake-model",
-        cache_dir=cache_dir,
-    )
-
-    assert report["missing_outlines"] == ["owner__repo"]
-    assert report["repositories"] == 1
 
 
 def test_cache_audit_rejects_unknown_repository_selectors(tmp_path):
@@ -191,13 +162,13 @@ def test_cache_audit_rejects_unknown_repository_selectors(tmp_path):
         audit_wiki_cache(
             Registry(),
             model="fake-model",
-            cache_dir=tmp_path / "wiki-cache",
             repo_ids=["typo"],
         )
 
 
 def test_cache_audit_subset_does_not_count_other_repo_as_orphan(tmp_path):
     cache_dir = tmp_path / "wiki-cache"
+    store = SQLiteWikiStore(cache_dir / "wiki.sqlite3")
     bundles = {}
     for repo_id in ("owner__selected", "owner__other"):
         bundle = SimpleNamespace(
@@ -213,7 +184,7 @@ def test_cache_audit_subset_does_not_count_other_repo_as_orphan(tmp_path):
             bm25=None,
         )
         bundles[repo_id] = bundle
-        wiki = AgentWiki(bundle, model="fake-model", cache_dir=str(cache_dir))
+        wiki = AgentWiki(bundle, model="fake-model", store=store)
         wiki._write_cache(
             "outline",
             {
@@ -239,13 +210,13 @@ def test_cache_audit_subset_does_not_count_other_repo_as_orphan(tmp_path):
     report = audit_wiki_cache(
         Registry(),
         model="fake-model",
-        cache_dir=cache_dir,
         repo_ids=["owner__selected"],
+        store=store,
     )
 
     assert report["repositories"] == 1
-    assert report["storage"]["files"] == 1
-    assert report["storage"]["orphan_files"] == 0
+    assert report["storage"]["entries"] == 1
+    assert report["storage"]["orphan_entries"] == 0
 
 
 def test_cache_audit_reads_store_without_publishing_and_reports_orphans(tmp_path):
@@ -281,7 +252,7 @@ def test_cache_audit_reads_store_without_publishing_and_reports_orphans(tmp_path
             }
         ]
     }
-    seed_wiki = AgentWiki(bundle, model="fake-model", cache_dir=str(tmp_path))
+    seed_wiki = AgentWiki(bundle, model="fake-model")
     overview_meta = seed_wiki._overview_page_meta(outline["pages"][0], [])
     page_suffix = seed_wiki._page_cache_suffix(overview_meta)
 
@@ -344,17 +315,11 @@ def test_cache_audit_reads_store_without_publishing_and_reports_orphans(tmp_path
         def generation_guard(self, entry_id):
             raise AssertionError("read-only audit must not take generation guards")
 
-    class ReadOnlyAuditWiki(AgentWiki):
-        def _read_cache(self, suffix):
-            raise AssertionError("audit must use the read-only cache path")
-
     store = MemoryWikiStore()
     report = audit_wiki_cache(
         Registry(),
         model="fake-model",
-        cache_dir=tmp_path / "missing-cache",
         repo_ids=["owner__repo"],
-        wiki_factory=ReadOnlyAuditWiki,
         store=store,
     )
 
@@ -362,8 +327,8 @@ def test_cache_audit_reads_store_without_publishing_and_reports_orphans(tmp_path
     assert report["storage"]["backend"] == "MemoryWikiStore"
     assert report["storage"]["entries"] == 3
     assert report["storage"]["orphan_entries"] == 1
-    assert report["storage"]["files"] == 0
-    assert report["storage"]["orphan_files"] == 0
+    assert report["storage"]["database_payload_bytes"] > 0
+    assert report["storage"]["orphan_database_payload_bytes"] > 0
     assert store.scan_filters == [{"owner__repo"}]
     assert store.read_calls == [
         seed_wiki._store_entry_id("outline"),
@@ -372,7 +337,7 @@ def test_cache_audit_reads_store_without_publishing_and_reports_orphans(tmp_path
     assert not (tmp_path / "missing-cache").exists()
 
 
-def test_cache_audit_reports_database_and_legacy_storage_in_mixed_state(tmp_path):
+def test_cache_audit_reports_database_orphan_storage(tmp_path):
     bundle = SimpleNamespace(
         entry=SimpleNamespace(
             repo="owner/repo",
@@ -394,7 +359,8 @@ def test_cache_audit_reports_database_and_legacy_storage_in_mixed_state(tmp_path
             return bundle if repo_id == "owner__repo" else None
 
     cache_dir = tmp_path / "wiki-cache"
-    legacy = AgentWiki(bundle, model="fake-model", cache_dir=str(cache_dir))
+    store = SQLiteWikiStore(cache_dir / "wiki.sqlite3")
+    wiki = AgentWiki(bundle, model="fake-model", store=store)
     outline = {
         "pages": [
             {
@@ -406,10 +372,10 @@ def test_cache_audit_reports_database_and_legacy_storage_in_mixed_state(tmp_path
             }
         ]
     }
-    legacy._write_cache("outline", outline)
-    overview_meta = legacy._overview_page_meta(outline["pages"][0], [])
-    legacy._write_cache(
-        legacy._page_cache_suffix(overview_meta),
+    wiki._write_cache("outline", outline)
+    overview_meta = wiki._overview_page_meta(outline["pages"][0], [])
+    wiki._write_cache(
+        wiki._page_cache_suffix(overview_meta),
         {
             "id": "overview",
             "title": "Overview",
@@ -417,12 +383,6 @@ def test_cache_audit_reports_database_and_legacy_storage_in_mixed_state(tmp_path
             "quality": {"valid": True},
         },
     )
-    (cache_dir / "agentwiki_orphan.json").write_text(
-        '{"data":{"id":"removed"}}',
-        encoding="utf-8",
-    )
-
-    store = SQLiteWikiStore(cache_dir / "wiki.sqlite3")
     store.publish(
         entry_id="orphan",
         repository_id="owner__repo",
@@ -432,18 +392,12 @@ def test_cache_audit_reports_database_and_legacy_storage_in_mixed_state(tmp_path
     report = audit_wiki_cache(
         Registry(),
         model="fake-model",
-        cache_dir=cache_dir,
         store=store,
     )
 
     storage = report["storage"]
     assert report["coverage"]["all"]["percent"] == 100.0
-    assert storage["entries"] == 1
+    assert storage["entries"] == 3
     assert storage["orphan_entries"] == 1
-    assert storage["files"] == 3
-    assert storage["orphan_files"] == 1
     assert storage["database_payload_bytes"] > 0
-    assert storage["legacy_bytes"] > 0
-    assert storage["bytes"] == storage["legacy_bytes"]
-    assert storage["orphan_bytes"] == storage["orphan_legacy_bytes"]
     assert storage["orphan_database_payload_bytes"] > 0

--- a/test/wiki/test_quality.py
+++ b/test/wiki/test_quality.py
@@ -4,10 +4,6 @@
 
 from __future__ import annotations
 
-import json
-
-import pytest
-
 from codenib.wiki.evidence import EvidenceItem, RelationItem
 from codenib.wiki.quality import (
     audit_cache,
@@ -25,7 +21,6 @@ from codenib.wiki.quality import (
     summarize_page_audits,
 )
 from codenib.wiki.sqlite_store import SQLiteWikiStore
-from codenib.wiki.store import _WIKI_CACHE_PROVENANCE_FIELD
 
 
 def _page(*, repeated_prose: bool) -> dict:
@@ -1151,27 +1146,11 @@ def test_plan_narrative_rejects_relation_only_non_flow_claims():
     assert report["plan_role_integrity_valid"] is False
 
 
-def test_cache_audit_ignores_outline_records_and_summarizes_pages(tmp_path):
-    pages = [_page(repeated_prose=True), _page(repeated_prose=False)]
-    for index, page in enumerate(pages):
-        (tmp_path / f"agentwiki_page_{index}.json").write_text(
-            json.dumps({"model": "test", "data": page})
-        )
-    (tmp_path / "agentwiki_outline.json").write_text(
-        json.dumps({"model": "test", "data": {"pages": []}})
-    )
-    (tmp_path / "agentwiki_broken.json").write_text("{")
-
-    report = audit_cache(tmp_path)
-
-    assert report == summarize_page_audits(pages)
-    assert report["pages"] == 2
-    assert report["publishable"] == 1
-    assert report["narrative_valid"] == 1
-
-
-def test_cache_audit_reads_the_canonical_sqlite_store(tmp_path):
+def test_cache_audit_reads_each_repository_and_ignores_retired_json(tmp_path):
     page = _page(repeated_prose=False)
+    retired_path = tmp_path / "agentwiki_retired.json"
+    retired_payload = '{"data":{"id":"legacy","markdown":"Legacy page."}}'
+    retired_path.write_text(retired_payload, encoding="utf-8")
     store = SQLiteWikiStore(tmp_path / "wiki.sqlite3")
     store.publish(
         entry_id="page:repo-a:overview",
@@ -1183,73 +1162,15 @@ def test_cache_audit_reads_the_canonical_sqlite_store(tmp_path):
         repository_id="repo-a",
         envelope={"model": "test", "data": {"pages": []}},
     )
-
-    report = audit_cache(tmp_path)
-
-    assert list(tmp_path.glob("agentwiki_*.json")) == []
-    assert report == summarize_page_audits([page])
-    assert report["pages"] == 1
-
-
-@pytest.mark.parametrize("migrate_first_page", [False, True])
-def test_cache_audit_includes_unmigrated_legacy_pages(
-    tmp_path,
-    migrate_first_page,
-):
-    pages = [_page(repeated_prose=True), _page(repeated_prose=False)]
-    envelopes = [{"model": "test", "data": page} for page in pages]
-    legacy_paths = [
-        tmp_path / f"agentwiki_page_{index}.json" for index in range(len(pages))
-    ]
-    for path, envelope in zip(legacy_paths, envelopes, strict=True):
-        path.write_text(json.dumps(envelope))
-
-    store = SQLiteWikiStore(tmp_path / "wiki.sqlite3")
-    expected_pages = pages
-    if migrate_first_page:
-        entry_id = "page:repo-a:overview"
-        repository_id = "repo-a"
-        canonical_page = {
-            **pages[0],
-            "markdown": pages[0]["markdown"] + "\n\nCanonical refresh. [E1]",
-        }
-        store.publish(
-            entry_id=entry_id,
-            repository_id=repository_id,
-            envelope={
-                "model": "test",
-                "data": canonical_page,
-                _WIKI_CACHE_PROVENANCE_FIELD: {
-                    "schema": 1,
-                    "entry_id": entry_id,
-                    "repository_id": repository_id,
-                    "legacy_filenames": [legacy_paths[0].name],
-                },
-            },
-        )
-        expected_pages = [canonical_page, pages[1]]
-
-    report = audit_cache(tmp_path)
-
-    assert report == summarize_page_audits(expected_pages)
-    assert report["pages"] == 2
-
-
-def test_cache_audit_does_not_dedupe_marker_free_rows_across_repositories(
-    tmp_path,
-):
-    page = _page(repeated_prose=False)
-    envelope = {"model": "test", "data": page}
-    store = SQLiteWikiStore(tmp_path / "wiki.sqlite3")
     store.publish(
-        entry_id="page:repo-a:overview",
-        repository_id="repo-a",
-        envelope=envelope,
+        entry_id="page:repo-b:overview",
+        repository_id="repo-b",
+        envelope={"model": "test", "data": page},
     )
-    (tmp_path / "agentwiki_repo-b_overview.json").write_text(json.dumps(envelope))
 
     report = audit_cache(tmp_path)
 
+    assert retired_path.read_text(encoding="utf-8") == retired_payload
     assert report == summarize_page_audits([page, page])
     assert report["pages"] == 2
 


### PR DESCRIPTION
## Summary
Retire the one-release AgentWiki JSON compatibility path after the v0.2.3 migration window. `WikiStore` is now the only persistence boundary; an AgentWiki without an injected store is memory-only.

Closes #749.

## Changes
- Remove legacy `agentwiki_*.json` discovery, parsing, adoption, writing, file locks, and provenance markers.
- Make Wiki cache quality and coverage audits store-only; bump the coverage report to schema v2 with database-only storage accounting.
- Preserve SQLite entry identities, schema, existing rows, the `WikiStore` protocol, and the exact eight-symbol `codenib.storage` facade.
- Update Web, CLI, prewarm, benchmark, tests, operating docs, and durable roadmaps for the retired path.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

- `pytest -q test/wiki/test_agent_wiki.py test/wiki/test_cache_audit.py test/wiki/test_quality.py test/web/test_app_runtime.py --tb=short` (251 passed)
- `pytest -q test/wiki/test_store_contract.py test/wiki/test_sqlite_store.py test/test_storage_api.py test/wiki/test_prewarm.py --tb=short` (68 passed)
- `pytest -q test/scripts/test_benchmark_demo_wiki.py test/test_cli.py --tb=short` (90 passed)
- Full local unit tier excluding `test/sandbox/test_docker.py` (6876 passed, 35 skipped, 190 deselected); the unfiltered run reached 3395 passed before the environment-only `/usr/bin/docker` absence stopped it.
- Black, isort (`--profile black`), flake8, compileall, and `git diff --check` pass for the changed surface.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
